### PR TITLE
only restart the gradient-server up to 5 times on failure

### DIFF
--- a/nix/modules/gradient.nix
+++ b/nix/modules/gradient.nix
@@ -347,6 +347,8 @@ in {
         ReadWritePaths = [ cfg.baseDir ];
         Restart = "on-failure";
         RestartSec = 10;
+        StartLimitIntervalSec = 60;
+        StartLimitBurst = 5;
         LimitNOFILE = 65535;
         RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
         RestrictNamespaces = true;


### PR DESCRIPTION
i propose this change as the core dumps filled my disk, as described in #29 