### PR TITLE
Fix #37: require admin role for org member and management ops

### DIFF
--- a/backend/web/src/endpoints/orgs/management.rs
+++ b/backend/web/src/endpoints/orgs/management.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-use super::load_editable_org;
+use super::load_admin_org;
 use crate::authorization::MaybeUser;
 use crate::endpoints::get_org_readable;
 use crate::error::{WebError, WebResult};
@@ -363,7 +363,7 @@ pub async fn patch_organization(
     Path(organization): Path<String>,
     Json(body): Json<PatchOrganizationRequest>,
 ) -> WebResult<Json<BaseResponse<String>>> {
-    let organization = load_editable_org(&state, user.id, organization).await?;
+    let organization = load_admin_org(&state, user.id, organization).await?;
     let mut aorganization: AOrganization = organization.into();
 
     if let Some(name) = body.name {
@@ -410,7 +410,7 @@ pub async fn delete_organization(
     Extension(user): Extension<MUser>,
     Path(organization): Path<String>,
 ) -> WebResult<Json<BaseResponse<String>>> {
-    let organization = load_editable_org(&state, user.id, organization).await?;
+    let organization = load_admin_org(&state, user.id, organization).await?;
     let aorganization: AOrganization = organization.into();
     aorganization.delete(&state.web_db).await?;
 

--- a/backend/web/src/endpoints/orgs/members.rs
+++ b/backend/web/src/endpoints/orgs/members.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-use super::load_org_member;
+use super::load_admin_org;
 use crate::authorization::MaybeUser;
 use crate::endpoints::get_org_readable;
 use crate::error::{WebError, WebResult};
@@ -114,7 +114,7 @@ pub async fn post_organization_users(
     Path(organization): Path<String>,
     Json(body): Json<AddUserRequest>,
 ) -> WebResult<Json<BaseResponse<String>>> {
-    let organization = load_org_member(&state, user.id, organization).await?;
+    let organization = load_admin_org(&state, user.id, organization).await?;
     let target_user = find_user_by_username(&state, &body.user).await?;
 
     if find_org_membership(&state, organization.id, target_user.id)
@@ -157,7 +157,7 @@ pub async fn patch_organization_users(
     Path(organization): Path<String>,
     Json(body): Json<AddUserRequest>,
 ) -> WebResult<Json<BaseResponse<String>>> {
-    let organization = load_org_member(&state, user.id, organization).await?;
+    let organization = load_admin_org(&state, user.id, organization).await?;
     let target_user = find_user_by_username(&state, &body.user).await?;
 
     let membership = find_org_membership(&state, organization.id, target_user.id)
@@ -186,7 +186,7 @@ pub async fn delete_organization_users(
     Path(organization): Path<String>,
     Json(body): Json<RemoveUserRequest>,
 ) -> WebResult<Json<BaseResponse<String>>> {
-    let organization = load_org_member(&state, user.id, organization).await?;
+    let organization = load_admin_org(&state, user.id, organization).await?;
     let target_user = find_user_by_username(&state, &body.user).await?;
 
     let membership = find_org_membership(&state, organization.id, target_user.id)

--- a/backend/web/src/endpoints/orgs/mod.rs
+++ b/backend/web/src/endpoints/orgs/mod.rs
@@ -20,7 +20,11 @@ pub use self::workers::*;
 
 use crate::error::{WebError, WebResult};
 use core::db::get_organization_by_name;
-use core::types::{MOrganization, ServerState};
+use core::types::consts::BASE_ROLE_ADMIN_ID;
+use core::types::{
+    COrganizationUser, EOrganizationUser, MOrganization, MOrganizationUser, ServerState,
+};
+use sea_orm::{ColumnTrait, Condition, EntityTrait, QueryFilter};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -52,4 +56,161 @@ pub(super) async fn load_editable_org(
         ));
     }
     Ok(org)
+}
+
+/// Load the caller's membership row for `org_id`, or `None` if not a member.
+pub(super) async fn load_org_membership(
+    state: &Arc<ServerState>,
+    user_id: Uuid,
+    org_id: Uuid,
+) -> WebResult<Option<MOrganizationUser>> {
+    Ok(EOrganizationUser::find()
+        .filter(
+            Condition::all()
+                .add(COrganizationUser::Organization.eq(org_id))
+                .add(COrganizationUser::User.eq(user_id)),
+        )
+        .one(&state.web_db)
+        .await?)
+}
+
+/// Load an organization that the user administers.
+///
+/// Requires (1) the org exists, (2) the user is a member, and
+/// (3) the user holds the admin role. Also rejects state-managed orgs.
+pub(super) async fn load_admin_org(
+    state: &Arc<ServerState>,
+    user_id: Uuid,
+    org_name: String,
+) -> WebResult<MOrganization> {
+    let org = load_editable_org(state, user_id, org_name).await?;
+    let membership = load_org_membership(state, user_id, org.id)
+        .await?
+        .ok_or_else(|| WebError::not_found("Organization"))?;
+    if membership.role != BASE_ROLE_ADMIN_ID {
+        return Err(WebError::Forbidden(
+            "Admin role required for this operation".to_string(),
+        ));
+    }
+    Ok(org)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::WebError;
+    use core::ci::WebhookClient;
+    use core::storage::{EmailSender, NarStore};
+    use core::types::consts::{BASE_ROLE_ADMIN_ID, BASE_ROLE_VIEW_ID};
+    use sea_orm::{DatabaseBackend, MockDatabase};
+    use test_support::cli::test_cli;
+    use test_support::fakes::email::InMemoryEmailSender;
+    use test_support::fakes::webhooks::RecordingWebhookClient;
+    use test_support::log_storage::NoopLogStorage;
+    use uuid::uuid;
+
+    fn fixture_date() -> chrono::NaiveDateTime {
+        chrono::NaiveDate::from_ymd_opt(2026, 1, 1)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap()
+    }
+
+    fn org_fixture() -> entity::organization::Model {
+        entity::organization::Model {
+            id: uuid!("a0000000-0000-0000-0000-000000000001"),
+            name: "test-org".into(),
+            display_name: "Test".into(),
+            description: String::new(),
+            public_key: "ssh".into(),
+            private_key: "enc".into(),
+            public: false,
+            created_by: uuid!("a0000000-0000-0000-0000-000000000004"),
+            created_at: fixture_date(),
+            managed: false,
+            github_installation_id: None,
+        }
+    }
+
+    fn membership_fixture(role: Uuid) -> entity::organization_user::Model {
+        entity::organization_user::Model {
+            id: uuid!("a0000000-0000-0000-0000-000000000010"),
+            organization: uuid!("a0000000-0000-0000-0000-000000000001"),
+            user: uuid!("a0000000-0000-0000-0000-000000000004"),
+            role,
+        }
+    }
+
+    fn make_state(db: sea_orm::DatabaseConnection) -> Arc<ServerState> {
+        let cli = test_cli();
+        let nar_storage = NarStore::local(&cli.base_path).expect("nar store");
+        Arc::new(ServerState {
+            web_db: db,
+            db: MockDatabase::new(DatabaseBackend::Postgres).into_connection(),
+            cli,
+            log_storage: Arc::new(NoopLogStorage),
+            webhooks: Arc::new(RecordingWebhookClient::new()) as Arc<dyn WebhookClient>,
+            email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,
+            nar_storage,
+            manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        })
+    }
+
+    #[test]
+    fn admin_member_passes() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let user_id = uuid!("a0000000-0000-0000-0000-000000000004");
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([vec![org_fixture()]])
+                .append_query_results([vec![membership_fixture(BASE_ROLE_ADMIN_ID)]])
+                .into_connection();
+            let state = make_state(db);
+            let result = load_admin_org(&state, user_id, "test-org".into()).await;
+            assert!(result.is_ok(), "admin should pass: {:?}", result.err());
+        });
+    }
+
+    #[test]
+    fn non_admin_member_is_forbidden() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let user_id = uuid!("a0000000-0000-0000-0000-000000000004");
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([vec![org_fixture()]])
+                .append_query_results([vec![membership_fixture(BASE_ROLE_VIEW_ID)]])
+                .into_connection();
+            let state = make_state(db);
+            let err = load_admin_org(&state, user_id, "test-org".into())
+                .await
+                .expect_err("view-only role must be rejected");
+            assert!(matches!(err, WebError::Forbidden(_)), "got {:?}", err);
+        });
+    }
+
+    #[test]
+    fn non_member_is_not_found() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let user_id = uuid!("a0000000-0000-0000-0000-000000000099");
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([Vec::<entity::organization::Model>::new()])
+                .into_connection();
+            let state = make_state(db);
+            let err = load_admin_org(&state, user_id, "test-org".into())
+                .await
+                .expect_err("non-member must be rejected");
+            assert!(matches!(err, WebError::NotFound(_)), "got {:?}", err);
+        });
+    }
 }

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -751,7 +751,10 @@ paths:
     patch:
       tags: [orgs]
       summary: Update organization
-      description: Updates one or more organization fields. Managed organizations cannot be edited via the API.
+      description: |
+        Updates one or more organization fields. Managed organizations cannot
+        be edited via the API. Requires the caller to hold the **admin** role
+        in the organization.
       operationId: patchOrg
       requestBody:
         required: true
@@ -779,7 +782,9 @@ paths:
     delete:
       tags: [orgs]
       summary: Delete organization
-      description: Permanently deletes the organization and all its resources.
+      description: |
+        Permanently deletes the organization and all its resources. Requires
+        the caller to hold the **admin** role in the organization.
       operationId: deleteOrg
       responses:
         '200':
@@ -823,7 +828,9 @@ paths:
     post:
       tags: [orgs]
       summary: Add member
-      description: Adds a user to the organization by username.
+      description: |
+        Adds a user to the organization by username. Requires the caller to
+        hold the **admin** role in the organization.
       operationId: addOrgUser
       requestBody:
         required: true
@@ -842,6 +849,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
         '409':
@@ -849,7 +858,9 @@ paths:
     patch:
       tags: [orgs]
       summary: Update member role
-      description: Updates the role or permissions of an existing organization member.
+      description: |
+        Updates the role or permissions of an existing organization member.
+        Requires the caller to hold the **admin** role in the organization.
       operationId: patchOrgUser
       requestBody:
         required: true
@@ -866,12 +877,16 @@ paths:
                 $ref: '#/components/schemas/StringResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
     delete:
       tags: [orgs]
       summary: Remove member
-      description: Removes a user from the organization.
+      description: |
+        Removes a user from the organization. Requires the caller to hold the
+        **admin** role in the organization.
       operationId: removeOrgUser
       requestBody:
         required: true
@@ -888,6 +903,8 @@ paths:
                 $ref: '#/components/schemas/StringResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
 

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -2,6 +2,21 @@
 
 This page tracks notable tests added to Gradient and where they live.
 
+## Org admin RBAC — `load_admin_org`
+
+Adding/promoting/kicking organization members and renaming/deleting an
+organization all require the caller to hold the org **admin** role. The check
+is centralised in `load_admin_org` (`backend/web/src/endpoints/orgs/mod.rs`).
+
+Unit tests in the same file cover three cases:
+
+- `admin_member_passes` — admin role → `Ok(org)`.
+- `non_admin_member_is_forbidden` — view/write role → `WebError::Forbidden`.
+- `non_member_is_not_found` — caller is not in the org → `WebError::NotFound`
+  (no leak between "org missing" and "not a member").
+
+Run with: `cargo test -p web --lib endpoints::orgs::tests`.
+
 ## Proto handshake — organization peer filtering
 
 Helper `filter_org_peers_without_cache` runs during the `/proto` handshake's


### PR DESCRIPTION
## Summary
- `load_org_member` / `load_editable_org` only checked the caller was *some* member of the org — never the role. Any view-role member could promote themselves, kick the founder, or rename/delete the org (#37).
- New `load_admin_org` helper gates `post/patch/delete_organization_users` and `patch/delete_organization` on the admin role. Non-admin members now get `403 Forbidden`; non-members continue to get `404` (no enumeration leak).
- API docs updated (admin note + 403 responses) and `docs/src/tests.md` entry added for the new unit tests.

## Test plan
- [x] `cargo test -p web --lib endpoints::orgs::tests` — 3/3 pass (admin / non-admin / non-member)
- [x] `cargo build -p web` clean

Fixes #37