### PR TITLE
fix: reject path-traversal filenames in direct-build multipart upload (#39)

### DIFF
--- a/backend/web/src/endpoints/builds/direct.rs
+++ b/backend/web/src/endpoints/builds/direct.rs
@@ -12,6 +12,7 @@ use sea_orm::{ActiveModelTrait, ActiveValue::Set, EntityTrait};
 use sea_orm::{ColumnTrait, QueryFilter, QueryOrder, QuerySelect};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
@@ -30,6 +31,33 @@ pub struct DirectBuildInfo {
     pub created_at: String,
     pub evaluation_id: String,
     pub status: String,
+}
+
+/// Reject filenames from multipart uploads that would escape the upload root.
+///
+/// Allows nested relative paths (e.g. `src/main.rs`) but rejects absolute
+/// paths, parent (`..`) / current (`.`) components, Windows path prefixes,
+/// empty names, and embedded null bytes.
+pub(crate) fn validate_upload_filename(filename: &str) -> WebResult<()> {
+    if filename.is_empty() {
+        return Err(WebError::BadRequest("Empty filename".to_string()));
+    }
+    if filename.contains('\0') {
+        return Err(WebError::BadRequest("Invalid filename".to_string()));
+    }
+    let path = Path::new(filename);
+    for component in path.components() {
+        match component {
+            Component::Normal(_) => {}
+            _ => {
+                return Err(WebError::BadRequest(format!(
+                    "Invalid file path: {}",
+                    filename
+                )));
+            }
+        }
+    }
+    Ok(())
 }
 
 pub async fn post_direct_build(
@@ -63,6 +91,7 @@ pub async fn post_direct_build(
                 Some(f) => f.to_string(),
                 None => return Err(WebError::BadRequest("Invalid file field name".to_string())),
             };
+            validate_upload_filename(&filename)?;
             let data = field.bytes().await.map_err(|e| {
                 WebError::BadRequest(format!("Failed to read file {}: {}", filename, e))
             })?;
@@ -93,12 +122,19 @@ pub async fn post_direct_build(
         WebError::InternalServerError(format!("Failed to create temp directory: {}", e))
     })?;
 
-    // Write files to temp directory
+    let temp_root = PathBuf::from(&temp_dir);
     for (filename, data) in files {
-        let file_path = format!("{}/{}", temp_dir, filename);
+        validate_upload_filename(&filename)?;
+        let file_path = temp_root.join(&filename);
 
-        // Create parent directories if needed
-        if let Some(parent) = std::path::Path::new(&file_path).parent() {
+        if !file_path.starts_with(&temp_root) {
+            return Err(WebError::BadRequest(format!(
+                "Invalid file path: {}",
+                filename
+            )));
+        }
+
+        if let Some(parent) = file_path.parent() {
             fs::create_dir_all(parent).await.map_err(|e| {
                 WebError::InternalServerError(format!("Failed to create directory: {}", e))
             })?;
@@ -230,4 +266,48 @@ pub async fn get_recent_direct_builds(
     };
 
     Ok(Json(res))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_upload_filename;
+
+    #[test]
+    fn accepts_simple_filenames() {
+        assert!(validate_upload_filename("flake.nix").is_ok());
+        assert!(validate_upload_filename("default.nix").is_ok());
+        assert!(validate_upload_filename("src/main.rs").is_ok());
+        assert!(validate_upload_filename("a/b/c/d.txt").is_ok());
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(validate_upload_filename("").is_err());
+    }
+
+    #[test]
+    fn rejects_parent_traversal() {
+        assert!(validate_upload_filename("..").is_err());
+        assert!(validate_upload_filename("../etc/passwd").is_err());
+        assert!(validate_upload_filename("../../../../../etc/cron.d/owned").is_err());
+        assert!(validate_upload_filename("foo/../../bar").is_err());
+        assert!(validate_upload_filename("foo/..").is_err());
+    }
+
+    #[test]
+    fn rejects_absolute_paths() {
+        assert!(validate_upload_filename("/etc/passwd").is_err());
+        assert!(validate_upload_filename("/").is_err());
+    }
+
+    #[test]
+    fn rejects_current_dir_components() {
+        assert!(validate_upload_filename(".").is_err());
+        assert!(validate_upload_filename("./foo").is_err());
+    }
+
+    #[test]
+    fn rejects_null_bytes() {
+        assert!(validate_upload_filename("foo\0bar").is_err());
+    }
 }

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -1857,6 +1857,11 @@ paths:
         | `derivation` | text | Nix attribute path or store path to build |
         | `file:<name>` | file | One or more Nix expression files |
 
+        `<name>` is treated as a path relative to a per-upload temp directory.
+        Names containing `..`, `.`, leading `/`, NUL bytes, or any other
+        non-normal path components are rejected with `400 Bad Request`.
+        Nested relative paths (e.g. `src/main.nix`) are allowed.
+
         Returns the evaluation UUID that can be used to track progress.
       operationId: submitDirectBuild
       requestBody:

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -456,3 +456,30 @@ Tests (`cargo test -p web --test rate_limit`):
   requests succeed, 6th returns `429`.
 - `cache_tier_does_not_throttle_moderate_burst` — 50 successive GETs to
   `/cache/{cache}/nix-cache-info` never return `429`.
+
+## Direct-build multipart upload — filename validation
+
+`POST /api/v1/builds/direct` accepts arbitrary file uploads via multipart
+fields named `file:<filename>`. Without sanitisation, an authenticated
+org-member could submit `file:../../../../../etc/cron.d/owned` and have
+the server write attacker-controlled bytes anywhere the process can
+reach. `validate_upload_filename` (in
+`backend/web/src/endpoints/builds/direct.rs`) rejects any name whose
+path components are not all `Component::Normal` — i.e. absolute paths,
+parent (`..`) and current (`.`) components, Windows path prefixes, empty
+strings, and embedded NUL bytes. The endpoint also re-checks that the
+joined target stays under the per-upload temp directory as defence in
+depth.
+
+Unit tests (`backend/web/src/endpoints/builds/direct.rs::tests`):
+
+- `accepts_simple_filenames` — `flake.nix`, `src/main.rs`, `a/b/c/d.txt`.
+- `rejects_empty` — empty string is rejected.
+- `rejects_parent_traversal` — `..`, `../etc/passwd`, deep traversal,
+  and traversals embedded inside otherwise-normal paths
+  (`foo/../../bar`, `foo/..`).
+- `rejects_absolute_paths` — `/etc/passwd`, `/`.
+- `rejects_current_dir_components` — `.`, `./foo`.
+- `rejects_null_bytes` — NUL byte inside a filename.
+
+Run with: `cargo test -p web --tests endpoints::builds::direct`


### PR DESCRIPTION
## Summary
- Closes #39 — `POST /api/v1/builds` accepted attacker-controlled multipart field names like `file:../../../../../etc/cron.d/owned` and wrote them under the server's process privileges.
- Add `validate_upload_filename` that requires every `Path::Component` to be `Normal`, rejecting empty names, NUL bytes, absolute paths, and `.`/`..` components. Allows nested relative paths (e.g. `src/main.nix`).
- Re-check that the joined target stays under the per-upload temp root as defence in depth.
- Document the constraint in `docs/gradient-api.yaml` and the new tests in `docs/src/tests.md`.

## Test plan
- [x] `cargo test -p web --tests endpoints::builds::direct` — 6 new unit tests pass (simple names, empty, parent traversal, absolute paths, current-dir components, NUL bytes).
- [x] `cargo test -p web --tests` — full web suite still passes (62 + integration tests).