### PR TITLE
fix: block SSRF in outgoing webhooks — validate URLs and resolved IPs (#40)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1199,6 +1199,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tracing",
+ "url",
  "uuid",
  "wiremock",
  "zstd",

--- a/backend/core/Cargo.toml
+++ b/backend/core/Cargo.toml
@@ -60,6 +60,7 @@ rand_core        = "0.10"
 ssh-key          = { version = "0.6", features = ["ed25519"] }
 object_store     = { workspace = true }
 tempfile         = "3.27"
+url              = "2.5"
 
 [dev-dependencies]
 bytes        = { workspace = true }

--- a/backend/core/src/ci/webhook.rs
+++ b/backend/core/src/ci/webhook.rs
@@ -14,12 +14,138 @@ use entity::evaluation::EvaluationStatus;
 use hmac::{Hmac, KeyInit, Mac};
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use sha2::Sha256;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{error, warn};
 use uuid::Uuid;
 
 type HmacSha256 = Hmac<Sha256>;
+
+/// Validate a user-supplied webhook URL against SSRF-style abuse.
+///
+/// Rejects:
+/// - schemes other than `http`/`https`,
+/// - URLs without a host,
+/// - IP literals in loopback / private / link-local / multicast /
+///   unspecified / broadcast / shared (CGNAT) ranges,
+/// - IPv6 literals in loopback / unspecified / multicast / unique-local
+///   (`fc00::/7`) / link-local (`fe80::/10`) / IPv4-mapped unsafe ranges.
+///
+/// Hostnames are accepted at validation time; delivery-time DNS resolution
+/// is re-checked in `ReqwestWebhookClient::deliver` to defend against DNS
+/// pointing at internal addresses.
+pub fn validate_webhook_url(url: &str) -> Result<reqwest::Url, String> {
+    let parsed = reqwest::Url::parse(url).map_err(|e| format!("Invalid URL: {}", e))?;
+    match parsed.scheme() {
+        "http" | "https" => {}
+        s => return Err(format!("URL scheme must be http or https, got '{}'", s)),
+    }
+    let host = parsed
+        .host()
+        .ok_or_else(|| "URL must include a host".to_string())?;
+    match host {
+        url::Host::Ipv4(ip) => {
+            if is_unsafe_ipv4(&ip) {
+                return Err(format!(
+                    "URL points to a disallowed address ({}); private/loopback/link-local/cloud-metadata addresses are blocked",
+                    ip
+                ));
+            }
+        }
+        url::Host::Ipv6(ip) => {
+            if is_unsafe_ipv6(&ip) {
+                return Err(format!(
+                    "URL points to a disallowed address ({}); private/loopback/link-local addresses are blocked",
+                    ip
+                ));
+            }
+        }
+        url::Host::Domain(d) => {
+            if d.is_empty() {
+                return Err("URL host is empty".to_string());
+            }
+            // Reject literal "localhost" — common typo bypass.
+            if d.eq_ignore_ascii_case("localhost") {
+                return Err("URL host 'localhost' is not allowed".to_string());
+            }
+        }
+    }
+    Ok(parsed)
+}
+
+/// Block IPv4 ranges that should never be reachable by an outbound webhook.
+fn is_unsafe_ipv4(ip: &Ipv4Addr) -> bool {
+    if ip.is_loopback()
+        || ip.is_private()
+        || ip.is_link_local()
+        || ip.is_broadcast()
+        || ip.is_multicast()
+        || ip.is_unspecified()
+    {
+        return true;
+    }
+    let o = ip.octets();
+    // Shared address space (CGNAT) 100.64.0.0/10.
+    if o[0] == 100 && (o[1] & 0xC0) == 64 {
+        return true;
+    }
+    // 0.0.0.0/8 — current network.
+    if o[0] == 0 {
+        return true;
+    }
+    // 192.0.0.0/24 — IETF protocol assignments.
+    if o[0] == 192 && o[1] == 0 && o[2] == 0 {
+        return true;
+    }
+    // Reserved 240.0.0.0/4 (excluding 255.255.255.255 already caught).
+    if o[0] >= 240 {
+        return true;
+    }
+    false
+}
+
+/// Block IPv6 ranges that should never be reachable by an outbound webhook.
+fn is_unsafe_ipv6(ip: &Ipv6Addr) -> bool {
+    if ip.is_loopback() || ip.is_unspecified() || ip.is_multicast() {
+        return true;
+    }
+    let segs = ip.segments();
+    // Unique-local fc00::/7
+    if (segs[0] & 0xfe00) == 0xfc00 {
+        return true;
+    }
+    // Link-local fe80::/10
+    if (segs[0] & 0xffc0) == 0xfe80 {
+        return true;
+    }
+    // IPv4-mapped ::ffff:0:0/96 — check the embedded v4.
+    if segs[0] == 0
+        && segs[1] == 0
+        && segs[2] == 0
+        && segs[3] == 0
+        && segs[4] == 0
+        && segs[5] == 0xffff
+    {
+        let v4 = Ipv4Addr::new(
+            (segs[6] >> 8) as u8,
+            (segs[6] & 0xff) as u8,
+            (segs[7] >> 8) as u8,
+            (segs[7] & 0xff) as u8,
+        );
+        if is_unsafe_ipv4(&v4) {
+            return true;
+        }
+    }
+    false
+}
+
+fn is_unsafe_ip(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => is_unsafe_ipv4(v4),
+        IpAddr::V6(v6) => is_unsafe_ipv6(v6),
+    }
+}
 
 /// HTTP delivery for webhook payloads. Production impl uses `reqwest`; tests
 /// can substitute an in-memory recorder.
@@ -40,6 +166,7 @@ impl ReqwestWebhookClient {
     pub fn new() -> Result<Self> {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(10))
+            .redirect(reqwest::redirect::Policy::none())
             .build()?;
         Ok(Self { client })
     }
@@ -48,9 +175,31 @@ impl ReqwestWebhookClient {
 #[async_trait]
 impl WebhookClient for ReqwestWebhookClient {
     async fn deliver(&self, url: &str, signature: &str, event: &str, body: String) -> Result<u16> {
+        let parsed = validate_webhook_url(url).map_err(|e| anyhow::anyhow!(e))?;
+
+        // DNS-rebinding defence: resolve the host now and reject if any
+        // resolved IP is in a disallowed range. We still hand the URL to
+        // reqwest, which performs its own resolution — so this is a guard,
+        // not a substitute for proper SSRF-aware connection wiring.
+        if let Some(host) = parsed.host_str() {
+            if matches!(parsed.host(), Some(url::Host::Domain(_))) {
+                let port = parsed.port_or_known_default().unwrap_or(0);
+                let lookup = tokio::net::lookup_host((host, port)).await?;
+                for sa in lookup {
+                    if is_unsafe_ip(&sa.ip()) {
+                        anyhow::bail!(
+                            "Webhook host '{}' resolved to a disallowed address ({})",
+                            host,
+                            sa.ip()
+                        );
+                    }
+                }
+            }
+        }
+
         let resp = self
             .client
-            .post(url)
+            .post(parsed)
             .header("Content-Type", "application/json")
             .header("X-Gradient-Signature", signature)
             .header("X-Gradient-Event", event)
@@ -357,6 +506,128 @@ mod tests {
         let a = sign_webhook_payload("secret", "body-one");
         let b = sign_webhook_payload("secret", "body-two");
         assert_ne!(a, b);
+    }
+
+    // ── validate_webhook_url ─────────────────────────────────────────────────
+
+    #[test]
+    fn validate_url_accepts_public_https() {
+        assert!(validate_webhook_url("https://example.com/hook").is_ok());
+        assert!(validate_webhook_url("http://example.com:8080/hook").is_ok());
+        assert!(validate_webhook_url("https://example.com").is_ok());
+    }
+
+    #[test]
+    fn validate_url_rejects_invalid_scheme() {
+        assert!(validate_webhook_url("file:///etc/passwd").is_err());
+        assert!(validate_webhook_url("ftp://example.com/").is_err());
+        assert!(validate_webhook_url("gopher://example.com/").is_err());
+        assert!(validate_webhook_url("javascript:alert(1)").is_err());
+    }
+
+    #[test]
+    fn validate_url_rejects_unparseable() {
+        assert!(validate_webhook_url("not a url").is_err());
+        assert!(validate_webhook_url("").is_err());
+    }
+
+    #[test]
+    fn validate_url_rejects_localhost_name() {
+        assert!(validate_webhook_url("http://localhost/").is_err());
+        assert!(validate_webhook_url("http://LOCALHOST/").is_err());
+        assert!(validate_webhook_url("http://Localhost:8080/path").is_err());
+    }
+
+    #[test]
+    fn validate_url_rejects_loopback_ipv4() {
+        assert!(validate_webhook_url("http://127.0.0.1/").is_err());
+        assert!(validate_webhook_url("http://127.255.255.254/").is_err());
+    }
+
+    #[test]
+    fn validate_url_rejects_aws_metadata_ip() {
+        // The motivating attack: cloud metadata service.
+        assert!(validate_webhook_url("http://169.254.169.254/latest/meta-data/").is_err());
+        // Generic link-local block.
+        assert!(validate_webhook_url("http://169.254.0.1/").is_err());
+    }
+
+    #[test]
+    fn validate_url_rejects_rfc1918_ranges() {
+        assert!(validate_webhook_url("http://10.0.0.1/").is_err());
+        assert!(validate_webhook_url("http://10.255.255.255/").is_err());
+        assert!(validate_webhook_url("http://172.16.0.1/").is_err());
+        assert!(validate_webhook_url("http://172.31.255.255/").is_err());
+        assert!(validate_webhook_url("http://192.168.0.1/").is_err());
+        assert!(validate_webhook_url("http://192.168.255.255/").is_err());
+    }
+
+    #[test]
+    fn validate_url_rejects_cgnat_shared_space() {
+        // 100.64.0.0/10 — RFC 6598.
+        assert!(validate_webhook_url("http://100.64.0.1/").is_err());
+        assert!(validate_webhook_url("http://100.127.255.254/").is_err());
+        // Boundary: 100.128.0.0 is public.
+        assert!(validate_webhook_url("http://100.128.0.1/").is_ok());
+        assert!(validate_webhook_url("http://100.63.255.255/").is_ok());
+    }
+
+    #[test]
+    fn validate_url_rejects_unspecified_and_broadcast() {
+        assert!(validate_webhook_url("http://0.0.0.0/").is_err());
+        assert!(validate_webhook_url("http://255.255.255.255/").is_err());
+    }
+
+    #[test]
+    fn validate_url_rejects_multicast_ipv4() {
+        assert!(validate_webhook_url("http://224.0.0.1/").is_err());
+        assert!(validate_webhook_url("http://239.255.255.255/").is_err());
+    }
+
+    #[test]
+    fn validate_url_rejects_reserved_ipv4() {
+        // 240.0.0.0/4 reserved for future use.
+        assert!(validate_webhook_url("http://240.0.0.1/").is_err());
+    }
+
+    #[test]
+    fn validate_url_rejects_ipv6_loopback_and_unspecified() {
+        assert!(validate_webhook_url("http://[::1]/").is_err());
+        assert!(validate_webhook_url("http://[::]/").is_err());
+    }
+
+    #[test]
+    fn validate_url_rejects_ipv6_link_and_unique_local() {
+        assert!(validate_webhook_url("http://[fe80::1]/").is_err());
+        assert!(validate_webhook_url("http://[febf::1]/").is_err());
+        assert!(validate_webhook_url("http://[fc00::1]/").is_err());
+        assert!(validate_webhook_url("http://[fdff::1]/").is_err());
+    }
+
+    #[test]
+    fn validate_url_rejects_ipv6_multicast() {
+        assert!(validate_webhook_url("http://[ff00::1]/").is_err());
+        assert!(validate_webhook_url("http://[ff02::1]/").is_err());
+    }
+
+    #[test]
+    fn validate_url_rejects_ipv4_mapped_loopback_in_ipv6() {
+        // ::ffff:127.0.0.1
+        assert!(validate_webhook_url("http://[::ffff:7f00:1]/").is_err());
+        // ::ffff:169.254.169.254 — metadata IP via v4-mapped v6.
+        assert!(validate_webhook_url("http://[::ffff:a9fe:a9fe]/").is_err());
+    }
+
+    #[test]
+    fn validate_url_accepts_public_ipv4_literal() {
+        // 8.8.8.8 is a public address — this is allowed.
+        assert!(validate_webhook_url("http://8.8.8.8/").is_ok());
+    }
+
+    #[test]
+    fn validate_url_accepts_public_ipv6_literal() {
+        // 2001:4860:4860::8888 (Google public DNS) — allowed.
+        assert!(validate_webhook_url("http://[2001:4860:4860::8888]/").is_ok());
     }
 
     #[test]

--- a/backend/web/src/endpoints/webhooks.rs
+++ b/backend/web/src/endpoints/webhooks.rs
@@ -8,7 +8,7 @@ use crate::error::{WebError, WebResult};
 use axum::extract::{Path, State};
 use axum::{Extension, Json};
 use chrono::Utc;
-use core::ci::{decrypt_webhook_secret, encrypt_webhook_secret};
+use core::ci::{decrypt_webhook_secret, encrypt_webhook_secret, validate_webhook_url};
 use core::db::get_any_organization_by_name;
 use core::types::*;
 use sea_orm::ActiveValue::Set;
@@ -137,6 +137,7 @@ pub async fn put(
             "Webhook URL cannot be empty.".to_string(),
         ));
     }
+    validate_webhook_url(&body.url).map_err(WebError::BadRequest)?;
     if body.secret.is_empty() {
         return Err(WebError::BadRequest(
             "Webhook secret cannot be empty.".to_string(),
@@ -202,6 +203,7 @@ pub async fn patch_webhook(
         active_webhook.name = Set(name);
     }
     if let Some(url) = body.url {
+        validate_webhook_url(&url).map_err(WebError::BadRequest)?;
         active_webhook.url = Set(url);
     }
     if let Some(secret) = body.secret {

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -4832,7 +4832,15 @@ components:
         url:
           type: string
           format: uri
-          description: URL to send webhook POST requests to
+          description: |-
+            URL to send webhook POST requests to. Must use `http` or `https`.
+            URLs whose host is a loopback / private (RFC1918) / link-local /
+            multicast / CGNAT (`100.64.0.0/10`) / unspecified / reserved IP,
+            an IPv6 unique-local (`fc00::/7`) or link-local (`fe80::/10`)
+            literal, or the literal name `localhost` are rejected with
+            `400 Bad Request`. Cloud-metadata addresses (e.g.
+            `169.254.169.254`) are blocked by the link-local rule. HTTP
+            redirects on outbound delivery are not followed.
           example: https://example.com/hooks/gradient
         secret:
           type: string
@@ -4856,7 +4864,9 @@ components:
         url:
           type: string
           format: uri
-          description: New URL
+          description: |-
+            New URL. Must use `http`/`https`; private/loopback/link-local IP
+            literals and `localhost` are rejected (see `CreateWebhookRequest`).
         secret:
           type: string
           description: New signing secret

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -483,3 +483,44 @@ Unit tests (`backend/web/src/endpoints/builds/direct.rs::tests`):
 - `rejects_null_bytes` — NUL byte inside a filename.
 
 Run with: `cargo test -p web --tests endpoints::builds::direct`
+
+## Outgoing webhook URL — SSRF validation
+
+`validate_webhook_url` (in `backend/core/src/ci/webhook.rs`) is the gate
+between user-supplied webhook URLs and the outbound HTTP client. It is
+called at create/update time (in `web::endpoints::webhooks::{put,
+patch_webhook}`) and again at delivery time inside
+`ReqwestWebhookClient::deliver`, which also performs DNS resolution and
+rejects any resolved IP in a disallowed range. Redirects are disabled on
+the production reqwest client.
+
+Unit tests (`cargo test -p core --tests ci::webhook`):
+
+- `validate_url_accepts_public_https` — `https://`/`http://` to public
+  hostnames pass.
+- `validate_url_rejects_invalid_scheme` — `file://`, `ftp://`,
+  `gopher://`, `javascript:` are rejected.
+- `validate_url_rejects_unparseable` — empty / non-URL strings rejected.
+- `validate_url_rejects_localhost_name` — `localhost` (any case) is
+  rejected.
+- `validate_url_rejects_loopback_ipv4` — `127.0.0.0/8` blocked.
+- `validate_url_rejects_aws_metadata_ip` — covers the motivating attack
+  (`169.254.169.254`) plus the wider link-local block.
+- `validate_url_rejects_rfc1918_ranges` — `10.x`, `172.16-31.x`,
+  `192.168.x`.
+- `validate_url_rejects_cgnat_shared_space` — `100.64.0.0/10` blocked,
+  with boundary asserts that adjacent public space (`100.63.255.255`,
+  `100.128.0.1`) is allowed.
+- `validate_url_rejects_unspecified_and_broadcast` — `0.0.0.0`,
+  `255.255.255.255`.
+- `validate_url_rejects_multicast_ipv4` — `224.0.0.0/4`.
+- `validate_url_rejects_reserved_ipv4` — `240.0.0.0/4`.
+- `validate_url_rejects_ipv6_loopback_and_unspecified` — `::1`, `::`.
+- `validate_url_rejects_ipv6_link_and_unique_local` — `fe80::/10`,
+  `fc00::/7`.
+- `validate_url_rejects_ipv6_multicast` — `ff00::/8`.
+- `validate_url_rejects_ipv4_mapped_loopback_in_ipv6` — `::ffff:127.0.0.1`
+  and `::ffff:169.254.169.254` blocked via the embedded-v4 check.
+- `validate_url_accepts_public_ipv4_literal` /
+  `validate_url_accepts_public_ipv6_literal` — sanity asserts that
+  legitimate public IP literals (`8.8.8.8`, `2001:4860:4860::8888`) pass.


### PR DESCRIPTION
## Summary
- Closes #40 — outgoing webhook URLs were stored and fetched without scheme or host validation. An authenticated org member could register `http://169.254.169.254/latest/meta-data/` to exfiltrate cloud-metadata credentials, probe RFC1918 services, or use the server as a confused deputy. Reqwest's default redirect policy followed up to 10 hops silently.
- Add `core::ci::webhook::validate_webhook_url` enforcing `http`/`https` scheme + a comprehensive IP literal blocklist (loopback, RFC1918, link-local incl. cloud metadata, multicast, broadcast, CGNAT `100.64.0.0/10`, `0.0.0.0/8`, `192.0.0.0/24`, reserved `240.0.0.0/4`, IPv6 unique-local/link-local/multicast, and `::ffff:`-mapped variants). Hostname `localhost` rejected.
- Apply at create/update (`webhooks::put`, `webhooks::patch_webhook`) and re-validate at delivery time. `ReqwestWebhookClient::deliver` now also resolves the host via `tokio::net::lookup_host` and rejects any resolved IP in a disallowed range (DNS-rebinding defence in depth).
- Production reqwest client built with `redirect(Policy::none())`.

## Test plan
- [x] `cargo test -p core --tests ci::webhook` — 25 tests pass, including 17 new `validate_webhook_url` cases (public hosts, all IPv4/IPv6 blocklists, scheme/parse failures, CGNAT boundaries, public-IP positives).
- [x] `cargo test -p web --tests` — full web suite green.
- [x] `cargo build --workspace` — clean.