### PR TITLE
backend: ssh key — remove plaintext fallback on decrypt failure (#42)

### DIFF
--- a/backend/core/src/sources/ssh_key.rs
+++ b/backend/core/src/sources/ssh_key.rs
@@ -110,36 +110,15 @@ pub fn decrypt_ssh_private_key(
             reason: format!("{}. The private key in the database appears to be corrupted or not properly base64-encoded.", e)
         })?;
 
-    let decrypted_private_key = if let Some(p) =
-        crypter::decrypt_with_password(secret.expose(), encrypted_private_key.clone())
-    {
-        String::from_utf8(p).map_err(|_| SourceError::KeyUtf8Conversion)?
-    } else {
-        tracing::warn!(
-            "Failed to decrypt private key for organization '{}', attempting to decode as plaintext base64",
-            organization.name
-        );
-        match String::from_utf8(encrypted_private_key) {
-            Ok(plaintext) => {
-                if plaintext.starts_with("-----BEGIN") {
-                    tracing::warn!(
-                        "Organization '{}' private key appears to be stored as plaintext base64",
-                        organization.name
-                    );
-                    plaintext
-                } else {
-                    return Err(SourceError::KeyDecryption {
-                        org: organization.name.clone(),
-                    });
-                }
-            }
-            Err(_) => {
+    let decrypted_private_key =
+        match crypter::decrypt_with_password(secret.expose(), encrypted_private_key) {
+            Some(p) => String::from_utf8(p).map_err(|_| SourceError::KeyUtf8Conversion)?,
+            None => {
                 return Err(SourceError::KeyDecryption {
                     org: organization.name.clone(),
                 });
             }
-        }
-    };
+        };
 
     let formatted_public_key = format_public_key(organization, serve_url);
     let decrypted_private_key = format!("{}\n", decrypted_private_key);
@@ -251,22 +230,17 @@ mod tests {
     }
 
     #[test]
-    fn decrypt_ssh_key_plaintext_fallback_accepts_pem() {
-        // Legacy rows may store the OpenSSH PEM as plaintext base64.
+    fn decrypt_ssh_key_plaintext_pem_rejected() {
+        // Plaintext PEM stored in the column must NOT be accepted —
+        // doing so would let anyone with DB write access bypass encryption.
         let mut f = tempfile::NamedTempFile::new().unwrap();
         std::io::Write::write_all(&mut f, b"test-secret-key-32-bytes-padding!").unwrap();
         let path = f.path().to_string_lossy().to_string();
         let pem = "-----BEGIN OPENSSH PRIVATE KEY-----\nfake\n-----END OPENSSH PRIVATE KEY-----";
         let mut org = make_org("o", "ssh-ed25519 AAAA");
         org.private_key = general_purpose::STANDARD.encode(pem);
-        let (priv_out, pub_out) =
-            decrypt_ssh_private_key(path, org, "https://example.com").expect("should succeed");
-        assert!(priv_out.starts_with("-----BEGIN"));
-        assert!(
-            priv_out.ends_with('\n'),
-            "trailing newline must be appended"
-        );
-        assert_eq!(pub_out, "ssh-ed25519 AAAA example.com-o");
+        let result = decrypt_ssh_private_key(path, org, "https://example.com");
+        assert!(matches!(result, Err(SourceError::KeyDecryption { .. })));
     }
 
     #[test]

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -524,3 +524,22 @@ Unit tests (`cargo test -p core --tests ci::webhook`):
 - `validate_url_accepts_public_ipv4_literal` /
   `validate_url_accepts_public_ipv6_literal` — sanity asserts that
   legitimate public IP literals (`8.8.8.8`, `2001:4860:4860::8888`) pass.
+## SSH private key decryption — no plaintext fallback
+
+`decrypt_ssh_private_key` in `backend/core/src/sources/ssh_key.rs`
+decrypts the per-organization SSH key from `organization.private_key`.
+Decryption failure must NOT silently fall back to interpreting the
+stored value as a plaintext PEM, otherwise anyone with write access to
+that column could bypass encryption entirely.
+
+Tests (`backend/core/src/sources/ssh_key.rs`):
+
+- `decrypt_ssh_key_corrupt_base64_fails` — non-base64 column rejected
+  with `OrganizationKeyDecoding`.
+- `decrypt_ssh_key_plaintext_pem_rejected` — a base64-encoded plaintext
+  OpenSSH PEM placed directly in the column is rejected with
+  `KeyDecryption`, not accepted.
+- `decrypt_ssh_key_plaintext_non_pem_rejected` — random base64 garbage
+  also fails with `KeyDecryption`.
+- `generate_ssh_key_decrypts_to_openssh_pem` — properly encrypted keys
+  still round-trip through decrypt.


### PR DESCRIPTION
Fixes #42.

## Summary
- `decrypt_ssh_private_key` no longer falls back to treating the stored ciphertext as a plaintext PEM when `crypter::decrypt_with_password` returns `None`. Decryption failures now fail closed with `KeyDecryption`.
- Without this, anyone with write access to `organization.private_key` could store a base64-encoded plaintext OpenSSH PEM and have it loaded verbatim, bypassing at-rest encryption.

## Test plan
- [x] `cargo test -p core --tests sources::ssh_key::` passes (11/11)
- [x] `decrypt_ssh_key_plaintext_pem_rejected` now asserts the fallback is rejected
- [x] `generate_ssh_key_decrypts_to_openssh_pem` still round-trips properly encrypted keys
- [x] docs/src/tests.md updated