### PR TITLE
backend: ci — name checks with org/project context (#122)

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/wavelens/gradient"
 
 [workspace]
 members = [".", "core", "web", "cache", "entity", "migration", "proto", "scheduler", "test-support", "worker"]
-default-members = [".", "worker"]
+default-members = [".", "cache", "core", "entity", "migration", "proto", "scheduler", "test-support", "web", "worker"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/backend/core/src/ci/reporting.rs
+++ b/backend/core/src/ci/reporting.rs
@@ -17,6 +17,27 @@ use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, Query
 use std::sync::Arc;
 use tracing::{error, warn};
 
+/// `"{org}/{project}"` when both are known, falling back to `"{project}"` when
+/// the organization lookup turned up nothing. Used as the scope segment of
+/// every CI check name so multiple Gradient projects reporting to the same
+/// repository remain distinguishable.
+pub fn format_check_scope(org_name: Option<&str>, project_name: &str) -> String {
+    match org_name {
+        Some(org) => format!("{}/{}", org, project_name),
+        None => project_name.to_string(),
+    }
+}
+
+/// CI check name for the per-evaluation roll-up status.
+pub fn evaluation_check_context(scope: &str) -> String {
+    format!("Gradient Evaluation {}", scope)
+}
+
+/// CI check name for a single entry-point build under an evaluation.
+pub fn build_check_context(scope: &str, entry_point: &str) -> String {
+    format!("Gradient Build {}: {}", scope, entry_point)
+}
+
 /// Maps an [`EvaluationStatus`] to the [`CiStatus`] reported to external forges.
 ///
 /// Returns `None` for non-terminal/intermediate states that do not produce a
@@ -134,7 +155,8 @@ pub async fn report_build_ci(state: Arc<ServerState>, build: MBuild, status: CiS
         Ok(Some(o)) => Some(o.name),
         _ => None,
     };
-    let details_url = org_name.map(|org| {
+    let scope = format_check_scope(org_name.as_deref(), &project.name);
+    let details_url = org_name.as_ref().map(|org| {
         format!(
             "{}/organization/{}/log/{}",
             state.cli.frontend_url, org, evaluation.id
@@ -146,7 +168,7 @@ pub async fn report_build_ci(state: Arc<ServerState>, build: MBuild, status: CiS
             owner: owner.clone(),
             repo: repo.clone(),
             sha: sha.clone(),
-            context: format!("gradient/{}", ep.eval),
+            context: build_check_context(&scope, &ep.eval),
             status: status.clone(),
             description: None,
             details_url: details_url.clone(),
@@ -232,7 +254,9 @@ pub async fn report_evaluation_ci(
         _ => None,
     };
 
-    let details_url = org_name.map(|org| {
+    let scope = format_check_scope(org_name.as_deref(), &project.name);
+
+    let details_url = org_name.as_ref().map(|org| {
         format!(
             "{}/organization/{}/log/{}",
             state.cli.frontend_url, org, evaluation.id
@@ -243,7 +267,7 @@ pub async fn report_evaluation_ci(
         owner,
         repo,
         sha,
-        context: "Gradient Evaluation".to_string(),
+        context: evaluation_check_context(&scope),
         status,
         description: None,
         details_url,
@@ -266,6 +290,44 @@ pub async fn report_evaluation_ci(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn check_scope_with_org() {
+        assert_eq!(
+            format_check_scope(Some("wavelens"), "my-project"),
+            "wavelens/my-project"
+        );
+    }
+
+    #[test]
+    fn check_scope_without_org_falls_back_to_project() {
+        assert_eq!(format_check_scope(None, "my-project"), "my-project");
+    }
+
+    #[test]
+    fn evaluation_context_format() {
+        assert_eq!(
+            evaluation_check_context("wavelens/my-project"),
+            "Gradient Evaluation wavelens/my-project"
+        );
+    }
+
+    #[test]
+    fn build_context_format() {
+        assert_eq!(
+            build_check_context("wavelens/my-project", "my-package"),
+            "Gradient Build wavelens/my-project: my-package"
+        );
+    }
+
+    #[test]
+    fn build_context_falls_back_when_org_missing() {
+        let scope = format_check_scope(None, "solo-project");
+        assert_eq!(
+            build_check_context(&scope, "pkg"),
+            "Gradient Build solo-project: pkg"
+        );
+    }
 
     #[test]
     fn maps_terminal_states() {

--- a/backend/scheduler/src/ci.rs
+++ b/backend/scheduler/src/ci.rs
@@ -5,8 +5,8 @@
  */
 
 use gradient_core::ci::{
-    CiReport, CiStatus, ci_status_for_build, parse_owner_repo,
-    resolve_outbound_reporter_for_project,
+    CiReport, CiStatus, build_check_context, ci_status_for_build, evaluation_check_context,
+    format_check_scope, parse_owner_repo, resolve_outbound_reporter_for_project,
 };
 use gradient_core::types::*;
 use sea_orm::ActiveValue::Set;
@@ -95,7 +95,9 @@ pub async fn report_ci_for_entry_points(
         _ => None,
     };
 
-    let details_url = org_name.map(|org| {
+    let scope = format_check_scope(org_name.as_deref(), &project.name);
+
+    let details_url = org_name.as_ref().map(|org| {
         format!(
             "{}/organization/{}/log/{}",
             state.cli.frontend_url, org, evaluation_id
@@ -128,7 +130,7 @@ pub async fn report_ci_for_entry_points(
             owner: owner.clone(),
             repo: repo.clone(),
             sha: sha.clone(),
-            context: format!("gradient/{}", ep.eval),
+            context: build_check_context(&scope, &ep.eval),
             status: initial_status,
             description: None,
             details_url: details_url.clone(),
@@ -214,7 +216,9 @@ pub async fn report_ci_for_evaluation(
         _ => None,
     };
 
-    let details_url = org_name.map(|org| {
+    let scope = format_check_scope(org_name.as_deref(), &project.name);
+
+    let details_url = org_name.as_ref().map(|org| {
         format!(
             "{}/organization/{}/log/{}",
             state.cli.frontend_url, org, evaluation_id
@@ -237,7 +241,7 @@ pub async fn report_ci_for_evaluation(
         owner,
         repo,
         sha,
-        context: "Gradient Evaluation".to_string(),
+        context: evaluation_check_context(&scope),
         status,
         description: None,
         details_url,

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -383,3 +383,31 @@ Specs (vitest + jsdom):
   validator covers length + character class requirements; cross-field
   `confirm()` validates against the named control.
   (`shared/components/form/form-fields-builder.spec.ts`)
+
+## CI check names — org/project context
+
+CI check names reported to GitHub/Gitea now include the organization
+and project so multiple Gradient instances/projects sharing a forge
+repository remain distinguishable. Helpers live in
+`backend/core/src/ci/reporting.rs` and are reused by the scheduler
+(`backend/scheduler/src/ci.rs`) and the core reporters
+(`backend/core/src/ci/reporting.rs`):
+
+- Evaluation roll-up: `Gradient Evaluation {org}/{project}` (e.g.
+  `Gradient Evaluation wavelens/my-project`).
+- Per-entry-point build: `Gradient Build {org}/{project}: {entry_point}`.
+- When the organization lookup returns `None`, the scope degrades to
+  just `{project}`.
+
+Tests (`cargo test -p core --tests ci::reporting`):
+
+- `check_scope_with_org` — `Some("wavelens"), "my-project"` →
+  `"wavelens/my-project"`.
+- `check_scope_without_org_falls_back_to_project` — `None, "my-project"`
+  → `"my-project"`.
+- `evaluation_context_format` — produces the new
+  `"Gradient Evaluation …"` string.
+- `build_context_format` — produces
+  `"Gradient Build wavelens/my-project: my-package"`.
+- `build_context_falls_back_when_org_missing` — degrades correctly when
+  the organization is unknown.


### PR DESCRIPTION
Fixes #122.

## Summary
- CI check names now include organization + project context so multiple Gradient projects reporting to the same forge repository remain distinguishable.
  - Evaluation roll-up: `Gradient Evaluation {org}/{project}`
  - Per-entry-point build: `Gradient Build {org}/{project}: {entry_point}`
- Falls back to just `{project}` when the org lookup returns `None` (preserves prior behavior for orphaned rows).
- Extracted `format_check_scope`, `evaluation_check_context`, `build_check_context` into `core::ci::reporting` and reused them from both reporters (`backend/scheduler/src/ci.rs` and `backend/core/src/ci/reporting.rs`).

## Test plan
- [x] `cargo test -p core --tests ci::reporting` — 5 new tests cover the formatting and the org-missing fallback.
- [x] `cargo test --tests --workspace` — all green.
- [x] docs/src/tests.md updated.