### PR TITLE
Remove unused write_key/clear_key footgun in sources::ssh_key (#48)

### DIFF
--- a/backend/core/src/sources/mod.rs
+++ b/backend/core/src/sources/mod.rs
@@ -13,7 +13,7 @@ pub use self::cache_key::*;
 pub use self::git::{Libgit2Prefetcher, accept_cert, check_project_updates, get_commit_info};
 pub use self::nar_path::*;
 pub use self::ssh_key::{
-    clear_key, decrypt_ssh_private_key, format_public_key, generate_ssh_key, write_key,
+    decrypt_ssh_private_key, format_public_key, generate_ssh_key,
 };
 
 use crate::types::*;
@@ -26,12 +26,6 @@ use thiserror::Error;
 pub enum SourceError {
     #[error("Failed to read file: {reason}")]
     FileRead { reason: String },
-    #[error("Failed to write key file: {path}")]
-    KeyFileWrite { path: String },
-    #[error("Failed to set key file permissions: {path}")]
-    KeyFilePermissions { path: String },
-    #[error("Failed to remove key file: {path}")]
-    KeyFileRemoval { path: String },
     #[error("Invalid SSH key format")]
     InvalidSshKey,
     #[error("SSH key generation failed")]

--- a/backend/core/src/sources/ssh_key.rs
+++ b/backend/core/src/sources/ssh_key.rs
@@ -13,37 +13,6 @@ use ssh_key::{
     Algorithm, LineEnding, PrivateKey, private::Ed25519Keypair, private::Ed25519PrivateKey,
     private::KeypairData, public::Ed25519PublicKey,
 };
-use std::fs;
-use std::io::Write;
-use std::os::unix::fs::PermissionsExt;
-use tempfile::NamedTempFile;
-
-pub fn write_key(private_key: String) -> Result<String, SourceError> {
-    let mut temp_file = NamedTempFile::with_suffix(".key").map_err(|e| SourceError::FileRead {
-        reason: e.to_string(),
-    })?;
-
-    let path = temp_file.path().to_string_lossy().to_string();
-
-    fs::set_permissions(temp_file.path(), fs::Permissions::from_mode(0o600))
-        .map_err(|_| SourceError::KeyFilePermissions { path: path.clone() })?;
-
-    temp_file
-        .write_all(private_key.as_bytes())
-        .map_err(|_| SourceError::KeyFileWrite { path: path.clone() })?;
-
-    temp_file
-        .keep()
-        .map_err(|_| SourceError::KeyFileWrite { path: path.clone() })?;
-
-    Ok(path)
-}
-
-pub fn clear_key(path: String) -> Result<(), SourceError> {
-    fs::remove_file(&path).map_err(|_| SourceError::KeyFileRemoval { path })?;
-    Ok(())
-}
-
 pub fn generate_ssh_key(secret_file: String) -> Result<(String, String), SourceError> {
     let secret = crate::types::input::load_secret_bytes(&secret_file);
 
@@ -217,23 +186,6 @@ mod tests {
         let org = make_org("myorg", "ssh-ed25519 AAAA");
         let result = format_public_key(org, "example.com");
         assert_eq!(result, "ssh-ed25519 AAAA example.com-myorg");
-    }
-
-    #[test]
-    fn write_and_clear_key_roundtrip() {
-        let path = write_key("hello-key".to_string()).expect("write_key failed");
-        let contents = std::fs::read_to_string(&path).expect("read failed");
-        assert_eq!(contents, "hello-key");
-        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
-        assert_eq!(mode, 0o600, "key file must be mode 0600");
-        clear_key(path.clone()).expect("clear_key failed");
-        assert!(!std::path::Path::new(&path).exists());
-    }
-
-    #[test]
-    fn clear_key_nonexistent_fails() {
-        let result = clear_key("/tmp/definitely-does-not-exist-gradient-test".to_string());
-        assert!(matches!(result, Err(SourceError::KeyFileRemoval { .. })));
     }
 
     #[test]


### PR DESCRIPTION
Closes #48.

## Summary
- Delete `write_key`, `clear_key`, their unit tests, and the now-unused `SourceError` variants `KeyFileWrite`, `KeyFilePermissions`, `KeyFileRemoval` from `backend/core/src/sources/`.
- `write_key` called `NamedTempFile::with_suffix(\".key\").keep()`, which removes the RAII auto-delete guard — any panic or early return between `keep()` and `clear_key()` would leak a decrypted SSH private key to `/tmp`.
- Audit confirms no production caller exists; only the function's own unit tests referenced it. The active SSH-key-on-disk path (`backend/core/src/nix/flake.rs`) already does it correctly with RAII (no `.keep()`).
- Future callers needing a temp SSH key file should follow the `flake.rs` pattern.

## Test plan
- [x] `cargo check -p core --tests` — clean
- [x] `cargo test -p core --tests sources::` — 16 passing, 0 failing
- [x] No docs/openapi references to the removed symbols