### PR TITLE
backend: web: require Admin/Write role for project active toggle and repo check (#49)

### DIFF
--- a/backend/web/src/endpoints/projects/management.rs
+++ b/backend/web/src/endpoints/projects/management.rs
@@ -415,7 +415,8 @@ pub async fn post_project_active(
     Extension(user): Extension<MUser>,
     Path((organization, project)): Path<(String, String)>,
 ) -> WebResult<Json<BaseResponse<String>>> {
-    let (_organization, project) = load_project(&state, user.id, organization, project).await?;
+    let (_organization, project) =
+        load_editable_project(&state, user.id, organization, project).await?;
     let mut aproject: AProject = project.into();
     aproject.active = Set(true);
     aproject.update(&state.web_db).await?;
@@ -433,7 +434,8 @@ pub async fn delete_project_active(
     Extension(user): Extension<MUser>,
     Path((organization, project)): Path<(String, String)>,
 ) -> WebResult<Json<BaseResponse<String>>> {
-    let (_organization, project) = load_project(&state, user.id, organization, project).await?;
+    let (_organization, project) =
+        load_editable_project(&state, user.id, organization, project).await?;
     let mut aproject: AProject = project.into();
     aproject.active = Set(false);
     aproject.update(&state.web_db).await?;
@@ -451,7 +453,8 @@ pub async fn post_project_check_repository(
     Extension(user): Extension<MUser>,
     Path((organization, project)): Path<(String, String)>,
 ) -> WebResult<Json<BaseResponse<String>>> {
-    let (_organization, project) = load_project(&state, user.id, organization, project).await?;
+    let (_organization, project) =
+        load_editable_project(&state, user.id, organization, project).await?;
 
     let (_has_updates, remote_hash) = check_project_updates(Arc::clone(&state), &project)
         .await

--- a/backend/web/src/endpoints/projects/mod.rs
+++ b/backend/web/src/endpoints/projects/mod.rs
@@ -174,3 +174,179 @@ pub(crate) async fn user_can_edit(
         None => false,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::ci::WebhookClient;
+    use core::storage::{EmailSender, NarStore};
+    use core::types::consts::{BASE_ROLE_ADMIN_ID, BASE_ROLE_VIEW_ID, BASE_ROLE_WRITE_ID};
+    use sea_orm::{DatabaseBackend, MockDatabase};
+    use test_support::cli::test_cli;
+    use test_support::fakes::email::InMemoryEmailSender;
+    use test_support::fakes::webhooks::RecordingWebhookClient;
+    use test_support::log_storage::NoopLogStorage;
+    use uuid::uuid;
+
+    fn fixture_date() -> chrono::NaiveDateTime {
+        chrono::NaiveDate::from_ymd_opt(2026, 1, 1)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap()
+    }
+
+    fn org_fixture(managed: bool) -> entity::organization::Model {
+        entity::organization::Model {
+            id: uuid!("b0000000-0000-0000-0000-000000000001"),
+            name: "test-org".into(),
+            display_name: "Test".into(),
+            description: String::new(),
+            public_key: "ssh".into(),
+            private_key: "enc".into(),
+            public: false,
+            created_by: uuid!("b0000000-0000-0000-0000-000000000004"),
+            created_at: fixture_date(),
+            managed,
+            github_installation_id: None,
+        }
+    }
+
+    fn project_fixture(managed: bool) -> entity::project::Model {
+        entity::project::Model {
+            id: uuid!("b0000000-0000-0000-0000-000000000002"),
+            organization: uuid!("b0000000-0000-0000-0000-000000000001"),
+            name: "test-project".into(),
+            display_name: "Test".into(),
+            description: String::new(),
+            repository: "git@example.com:test/test.git".into(),
+            evaluation_wildcard: "*".into(),
+            active: true,
+            last_evaluation: None,
+            last_check_at: fixture_date(),
+            force_evaluation: false,
+            created_by: uuid!("b0000000-0000-0000-0000-000000000004"),
+            created_at: fixture_date(),
+            managed,
+            keep_evaluations: 30,
+        }
+    }
+
+    fn membership_fixture(role: Uuid) -> entity::organization_user::Model {
+        entity::organization_user::Model {
+            id: uuid!("b0000000-0000-0000-0000-000000000010"),
+            organization: uuid!("b0000000-0000-0000-0000-000000000001"),
+            user: uuid!("b0000000-0000-0000-0000-000000000004"),
+            role,
+        }
+    }
+
+    fn make_state(db: sea_orm::DatabaseConnection) -> Arc<ServerState> {
+        let cli = test_cli();
+        let nar_storage = NarStore::local(&cli.base_path).expect("nar store");
+        Arc::new(ServerState {
+            web_db: db,
+            db: MockDatabase::new(DatabaseBackend::Postgres).into_connection(),
+            cli,
+            log_storage: Arc::new(NoopLogStorage),
+            webhooks: Arc::new(RecordingWebhookClient::new()) as Arc<dyn WebhookClient>,
+            email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,
+            nar_storage,
+            manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        })
+    }
+
+    fn run<F: std::future::Future>(fut: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(fut)
+    }
+
+    #[test]
+    fn editable_project_admin_passes() {
+        run(async {
+            let user_id = uuid!("b0000000-0000-0000-0000-000000000004");
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([vec![org_fixture(false)]])
+                .append_query_results([vec![project_fixture(false)]])
+                .append_query_results([vec![membership_fixture(BASE_ROLE_ADMIN_ID)]])
+                .into_connection();
+            let state = make_state(db);
+            let res =
+                load_editable_project(&state, user_id, "test-org".into(), "test-project".into())
+                    .await;
+            assert!(res.is_ok(), "admin should pass: {:?}", res.err());
+        });
+    }
+
+    #[test]
+    fn editable_project_write_passes() {
+        run(async {
+            let user_id = uuid!("b0000000-0000-0000-0000-000000000004");
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([vec![org_fixture(false)]])
+                .append_query_results([vec![project_fixture(false)]])
+                .append_query_results([vec![membership_fixture(BASE_ROLE_WRITE_ID)]])
+                .into_connection();
+            let state = make_state(db);
+            let res =
+                load_editable_project(&state, user_id, "test-org".into(), "test-project".into())
+                    .await;
+            assert!(res.is_ok(), "write role should pass: {:?}", res.err());
+        });
+    }
+
+    #[test]
+    fn editable_project_view_is_forbidden() {
+        run(async {
+            let user_id = uuid!("b0000000-0000-0000-0000-000000000004");
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([vec![org_fixture(false)]])
+                .append_query_results([vec![project_fixture(false)]])
+                .append_query_results([vec![membership_fixture(BASE_ROLE_VIEW_ID)]])
+                .into_connection();
+            let state = make_state(db);
+            let err =
+                load_editable_project(&state, user_id, "test-org".into(), "test-project".into())
+                    .await
+                    .expect_err("view-only role must be rejected");
+            assert!(matches!(err, WebError::Forbidden(_)), "got {:?}", err);
+        });
+    }
+
+    #[test]
+    fn editable_project_non_member_is_not_found() {
+        run(async {
+            let user_id = uuid!("b0000000-0000-0000-0000-000000000099");
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([Vec::<entity::organization::Model>::new()])
+                .into_connection();
+            let state = make_state(db);
+            let err =
+                load_editable_project(&state, user_id, "test-org".into(), "test-project".into())
+                    .await
+                    .expect_err("non-member must be rejected");
+            assert!(matches!(err, WebError::NotFound(_)), "got {:?}", err);
+        });
+    }
+
+    #[test]
+    fn editable_project_managed_is_forbidden() {
+        run(async {
+            let user_id = uuid!("b0000000-0000-0000-0000-000000000004");
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([vec![org_fixture(false)]])
+                .append_query_results([vec![project_fixture(true)]])
+                .append_query_results([vec![membership_fixture(BASE_ROLE_ADMIN_ID)]])
+                .into_connection();
+            let state = make_state(db);
+            let err =
+                load_editable_project(&state, user_id, "test-org".into(), "test-project".into())
+                    .await
+                    .expect_err("state-managed project must be rejected");
+            assert!(matches!(err, WebError::Forbidden(_)), "got {:?}", err);
+        });
+    }
+}

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -1300,7 +1300,10 @@ paths:
     post:
       tags: [projects]
       summary: Check repository accessibility
-      description: Tests whether Gradient can clone the project's repository using the organization's SSH key.
+      description: >-
+        Tests whether Gradient can clone the project's repository using the
+        organization's SSH key. Requires Admin or Write role; rejects
+        state-managed projects.
       operationId: checkProjectRepository
       responses:
         '200':
@@ -1313,6 +1316,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
 
@@ -1349,7 +1354,9 @@ paths:
     post:
       tags: [projects]
       summary: Enable project
-      description: Sets the project's active flag to true so it will be evaluated on new commits.
+      description: >-
+        Sets the project's active flag to true so it will be evaluated on new
+        commits. Requires Admin or Write role; rejects state-managed projects.
       operationId: enableProject
       responses:
         '200':
@@ -1367,7 +1374,9 @@ paths:
     delete:
       tags: [projects]
       summary: Disable project
-      description: Sets the project's active flag to false, pausing automatic evaluations.
+      description: >-
+        Sets the project's active flag to false, pausing automatic evaluations.
+        Requires Admin or Write role; rejects state-managed projects.
       operationId: disableProject
       responses:
         '200':

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -21,6 +21,27 @@ JWKS, `iss`/`aud`/`exp`/`nonce` checks, identity bound to
 `(oidc_issuer, oidc_subject)` rather than email) is enforced in
 `oidc_login_verify` and exercised end-to-end via the
 `/auth/oauth/authorize` and `/auth/oidc/callback` endpoints.
+## Project write RBAC — `load_editable_project`
+
+Toggling a project's `active` flag and triggering a repository check are
+write operations and must require the caller to hold an Admin or Write role
+in the organization. The check is centralised in `load_editable_project`
+(`backend/web/src/endpoints/projects/mod.rs`) and now gates
+`post_project_active`, `delete_project_active`, and
+`post_project_check_repository`.
+
+Unit tests in the same file cover the role matrix and the managed-project
+guard:
+
+- `editable_project_admin_passes` — Admin role → `Ok((org, project))`.
+- `editable_project_write_passes` — Write role → `Ok((org, project))`.
+- `editable_project_view_is_forbidden` — view-only role → `WebError::Forbidden`.
+- `editable_project_non_member_is_not_found` — caller is not in the org →
+  `WebError::NotFound` (no leak between "missing" and "not a member").
+- `editable_project_managed_is_forbidden` — state-managed project →
+  `WebError::Forbidden` even for admins.
+
+Run with: `cargo test -p web --lib endpoints::projects::tests`.
 
 ## Org admin RBAC — `load_admin_org`
 


### PR DESCRIPTION
## Summary
- Gate `post_project_active`, `delete_project_active`, and `post_project_check_repository` on `load_editable_project` so view-only members can no longer flip the active flag or trigger outbound git requests.
- Add five unit tests in `backend/web/src/endpoints/projects/mod.rs` covering admin / write / view / non-member / managed-project paths for `load_editable_project`.
- Update `docs/gradient-api.yaml` (now documents 403 + role requirement) and add a section to `docs/src/tests.md`.

Fixes #49.

## Test plan
- [x] `cargo test -p web --lib endpoints::projects::tests` — 5 new tests pass
- [x] `cargo test -p web --tests` — all integration tests still green
- [x] `cargo test -p web --lib` — full lib suite green (64 passed)