### PR TITLE
backend: web: cap request bodies to prevent OOM via unbounded payloads (#51)

### DIFF
--- a/backend/core/src/types/config.rs
+++ b/backend/core/src/types/config.rs
@@ -176,6 +176,8 @@ mod tests {
             state_file: None,
             delete_state: true,
             keep_evaluations: 30,
+            max_request_size: 2 * 1024 * 1024,
+            max_direct_build_size: 1024 * 1024 * 1024,
             keep_orphan_derivations_hours: 24,
             eval_workers: 1,
             max_evaluations_per_worker: 0,

--- a/backend/core/src/types/mod.rs
+++ b/backend/core/src/types/mod.rs
@@ -128,6 +128,28 @@ pub struct Cli {
     pub delete_state: bool,
     #[arg(long, env = "GRADIENT_KEEP_EVALUATIONS", default_value = "0")]
     pub keep_evaluations: usize,
+    /// Maximum size in bytes of an HTTP request body for most endpoints
+    /// (default 2 MiB). Caps webhook payloads, JSON bodies, etc. so an
+    /// attacker cannot exhaust server memory by sending an unbounded body.
+    /// The direct-build multipart upload endpoint uses
+    /// `--max-direct-build-size` instead.
+    #[arg(
+        long,
+        env = "GRADIENT_MAX_REQUEST_SIZE",
+        value_parser = greater_than_zero::<usize>,
+        default_value_t = 2 * 1024 * 1024,
+    )]
+    pub max_request_size: usize,
+    /// Maximum size in bytes of a `POST /api/v1/builds` multipart upload
+    /// (default 1 GiB). Direct-build uploads carry an entire repository
+    /// snapshot, so the limit is larger than `--max-request-size`.
+    #[arg(
+        long,
+        env = "GRADIENT_MAX_DIRECT_BUILD_SIZE",
+        value_parser = greater_than_zero::<usize>,
+        default_value_t = 1024 * 1024 * 1024,
+    )]
+    pub max_direct_build_size: usize,
     /// Number of long-lived Nix evaluator worker subprocesses to keep around.
     /// Each worker hosts one persistent embedded `NixEvaluator`, paying the
     /// libnix init cost only once. Must be at least `1`: in-process evaluation

--- a/backend/test-support/src/cli.rs
+++ b/backend/test-support/src/cli.rs
@@ -53,6 +53,8 @@ pub fn test_cli_with_crypt(crypt_secret_file: String) -> Cli {
         state_file: None,
         delete_state: true,
         keep_evaluations: 30,
+        max_request_size: 2 * 1024 * 1024,
+        max_direct_build_size: 1024 * 1024 * 1024,
         keep_orphan_derivations_hours: 24,
         eval_workers: 1,
         max_evaluations_per_worker: 0,

--- a/backend/web/src/lib.rs
+++ b/backend/web/src/lib.rs
@@ -9,6 +9,7 @@ pub mod endpoints;
 pub mod error;
 
 use axum::body::Body;
+use axum::extract::DefaultBodyLimit;
 use axum::routing::{get, patch, post, put};
 use axum::{Router, middleware};
 use bytes::Bytes;
@@ -219,7 +220,11 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
             "/builds/{build}/download-token",
             get(builds::get_build_download_token),
         )
-        .route("/builds", post(builds::post_direct_build))
+        .route(
+            "/builds",
+            post(builds::post_direct_build)
+                .layer(DefaultBodyLimit::max(state.cli.max_direct_build_size)),
+        )
         .route(
             "/builds/direct/recent",
             get(builds::get_recent_direct_builds),
@@ -410,6 +415,7 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
     // Default tier covers everything left under /api/v1 (the bulk authenticated
     // surface) plus the proto WS upgrade.
     let api = api.route_layer(GovernorLayer::new(rl_per_ms(200, 150)));
+    let api = api.layer(DefaultBodyLimit::max(state.cli.max_request_size));
 
     let mut app = Router::new()
         .nest("/api/v1", api)

--- a/backend/web/tests/body_size_limit.rs
+++ b/backend/web/tests/body_size_limit.rs
@@ -1,0 +1,151 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Regression for #51: oversized request bodies must be rejected with
+//! 413 Payload Too Large *before* the handler can buffer them, so a 10 GB
+//! webhook payload cannot exhaust server memory. The cap is configurable
+//! via `--max-request-size` (default 2 MiB) and applied as a
+//! `DefaultBodyLimit` layer on the API router; the per-route override on
+//! `POST /api/v1/builds` raises it to `--max-direct-build-size` for
+//! direct-build multipart uploads.
+//!
+//! Uses manual Tokio runtimes because `#[tokio::test]` expands to
+//! `::core::…` which clashes with the local `core` crate name.
+
+use axum_test::TestServer;
+use core::ci::WebhookClient;
+use core::storage::{EmailSender, NarStore};
+use core::types::ServerState;
+use sea_orm::{DatabaseBackend, MockDatabase};
+use std::sync::Arc;
+use test_support::fakes::email::InMemoryEmailSender;
+use test_support::fakes::webhooks::RecordingWebhookClient;
+use test_support::log_storage::NoopLogStorage;
+use test_support::prelude::test_cli;
+use uuid::Uuid;
+use web::create_router;
+
+fn make_state_with_limits(
+    max_request_size: usize,
+    max_direct_build_size: usize,
+) -> Arc<ServerState> {
+    let mut cli = test_cli();
+    cli.max_request_size = max_request_size;
+    cli.max_direct_build_size = max_direct_build_size;
+    let nar_storage = NarStore::local(&cli.base_path).expect("create test NarStore");
+    Arc::new(ServerState {
+        web_db: MockDatabase::new(DatabaseBackend::Postgres).into_connection(),
+        db: MockDatabase::new(DatabaseBackend::Postgres).into_connection(),
+        cli,
+        log_storage: Arc::new(NoopLogStorage),
+        webhooks: Arc::new(RecordingWebhookClient::new()) as Arc<dyn WebhookClient>,
+        email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,
+        nar_storage,
+        manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+    })
+}
+
+/// A POST whose body exceeds `max_request_size` is rejected with 413
+/// before the webhook handler ever runs (so signature verification is
+/// never attempted, which is exactly the OOM-prevention property we want).
+#[test]
+fn webhook_body_over_limit_returns_413() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let state = make_state_with_limits(1024, 1024 * 1024);
+        let router = create_router(state);
+        let server = TestServer::new(router);
+
+        let oversized = vec![b'x'; 4096];
+
+        let response = server
+            .post("/api/v1/hooks/github")
+            .add_header("X-Hub-Signature-256", "sha256=deadbeef")
+            .add_header("X-GitHub-Event", "push")
+            .bytes(oversized.into())
+            .await;
+
+        assert_eq!(
+            response.status_code(),
+            axum::http::StatusCode::PAYLOAD_TOO_LARGE,
+            "body over max_request_size must be rejected with 413, got {}",
+            response.status_code()
+        );
+    });
+}
+
+/// A body within the limit reaches the handler. The webhook then rejects
+/// with 401 (invalid signature) — we don't care about that, only that the
+/// body limit didn't trip.
+#[test]
+fn webhook_body_within_limit_reaches_handler() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let state = make_state_with_limits(1024, 1024 * 1024);
+        let router = create_router(state);
+        let server = TestServer::new(router);
+
+        let small = vec![b'x'; 256];
+
+        let response = server
+            .post("/api/v1/hooks/github")
+            .add_header("X-Hub-Signature-256", "sha256=deadbeef")
+            .add_header("X-GitHub-Event", "push")
+            .bytes(small.into())
+            .await;
+
+        assert_ne!(
+            response.status_code(),
+            axum::http::StatusCode::PAYLOAD_TOO_LARGE,
+            "body within max_request_size must not be rejected with 413"
+        );
+    });
+}
+
+/// `POST /api/v1/builds` (direct-build multipart) gets a per-route layer
+/// raising the limit to `max_direct_build_size`, so a payload that would
+/// fail the global `max_request_size` is allowed through. We send the
+/// request unauthenticated — it will fail with 401, but the point is that
+/// a 413 response would mean the per-route override isn't in effect.
+#[test]
+fn direct_build_route_uses_higher_limit() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        // Global limit 1 KiB; per-route limit 1 MiB.
+        let state = make_state_with_limits(1024, 1024 * 1024);
+        let router = create_router(state);
+        let server = TestServer::new(router);
+
+        // Payload over the global limit but under the per-route limit.
+        let body = vec![b'x'; 16 * 1024];
+
+        let response = server
+            .post("/api/v1/builds")
+            .add_header("Content-Type", "multipart/form-data; boundary=----abc")
+            .bytes(body.into())
+            .await;
+
+        assert_ne!(
+            response.status_code(),
+            axum::http::StatusCode::PAYLOAD_TOO_LARGE,
+            "direct-build route must not enforce the smaller global limit, got {}",
+            response.status_code()
+        );
+        // Auth middleware rejects unauthenticated requests; that's the
+        // expected outcome here, distinct from a body-limit rejection.
+        let _ = Uuid::nil();
+    });
+}

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -48,6 +48,8 @@ openssl rand -base64 48 > /run/secrets/gradient-crypt
 | `discoverable` | `true` | Accept incoming `/proto` WebSocket connections from workers |
 | `settings.maxProtoConnections` | `256` | Max simultaneous worker WebSocket connections |
 | `settings.keepEvaluations` | `5` | Number of evaluations kept per project |
+| `settings.maxRequestSize` | `2097152` (2 MiB) | Max HTTP request body in bytes for most endpoints (caps webhook/JSON payloads to prevent OOM) |
+| `settings.maxDirectBuildSize` | `1073741824` (1 GiB) | Max body size in bytes for `POST /api/v1/builds` direct-build multipart uploads |
 | `settings.logLevel.default` | `info` | Log level: `trace` `debug` `info` `warn` `error` |
 | `settings.logLevel.cache` | null | Cache log level override (null inherits default) |
 | `settings.logLevel.web` | null | Web log level override (null inherits default) |

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -564,3 +564,27 @@ Tests (`backend/core/src/sources/ssh_key.rs`):
   also fails with `KeyDecryption`.
 - `generate_ssh_key_decrypts_to_openssh_pem` — properly encrypted keys
   still round-trip through decrypt.
+## Body-size limits — webhook and direct-build (#51)
+
+Without a body-size cap, `field.bytes().await` and the `body: Bytes`
+extractor used by `forge_hooks` and `direct_build` would buffer entire
+request bodies into memory, allowing a single 10 GB payload to OOM the
+server. `create_router` (`backend/web/src/lib.rs`) now applies an
+`axum::extract::DefaultBodyLimit::max(cli.max_request_size)` layer to the
+whole API router (default 2 MiB) and overrides it on `POST /api/v1/builds`
+with `cli.max_direct_build_size` (default 1 GiB) for legitimate
+multi-file repository uploads.
+
+Tests (`cargo test -p web --test body_size_limit`):
+
+- `webhook_body_over_limit_returns_413` — a 4 KiB POST to
+  `/api/v1/hooks/github` with `max_request_size = 1024` is rejected with
+  `413 Payload Too Large` *before* the handler runs (so the OOM-prone
+  `body: Bytes` read never happens).
+- `webhook_body_within_limit_reaches_handler` — a 256 B body under the
+  same 1 KiB cap is *not* short-circuited with 413; the handler runs and
+  returns its normal response.
+- `direct_build_route_uses_higher_limit` — a 16 KiB body to
+  `POST /api/v1/builds` with `max_request_size = 1024` and
+  `max_direct_build_size = 1 MiB` is *not* rejected with 413, proving
+  the per-route override is wired up.

--- a/nix/modules/gradient.nix
+++ b/nix/modules/gradient.nix
@@ -266,6 +266,28 @@ in {
           default = 5;
         };
 
+        maxRequestSize = lib.mkOption {
+          description = ''
+            Maximum size in bytes of an HTTP request body for most endpoints.
+            Caps webhook payloads, JSON bodies, etc. so an unbounded body
+            cannot exhaust server memory. The direct-build multipart upload
+            endpoint uses `maxDirectBuildSize` instead.
+          '';
+          type = lib.types.ints.positive;
+          default = 2 * 1024 * 1024;
+        };
+
+        maxDirectBuildSize = lib.mkOption {
+          description = ''
+            Maximum size in bytes of a direct-build multipart upload
+            (`POST /api/v1/builds`). These uploads carry an entire
+            repository snapshot, so the limit is larger than
+            `maxRequestSize`.
+          '';
+          type = lib.types.ints.positive;
+          default = 1024 * 1024 * 1024;
+        };
+
         logLevel = lib.mkOption {
           default = { };
           description = ''
@@ -392,6 +414,8 @@ in {
         GRADIENT_JWT_SECRET_FILE = "%d/gradient_jwt_secret";
         GRADIENT_REPORT_ERRORS = lib.boolToString cfg.reportErrors;
         GRADIENT_KEEP_EVALUATIONS = toString cfg.settings.keepEvaluations;
+        GRADIENT_MAX_REQUEST_SIZE = toString cfg.settings.maxRequestSize;
+        GRADIENT_MAX_DIRECT_BUILD_SIZE = toString cfg.settings.maxDirectBuildSize;
         GRADIENT_MAX_PROTO_CONNECTIONS = toString cfg.settings.maxProtoConnections;
         GRADIENT_LOG_LEVEL = cfg.settings.logLevel.default;
         GRADIENT_USE_TLS = lib.boolToString cfg.useTls;


### PR DESCRIPTION
## Summary
- Adds `axum::extract::DefaultBodyLimit` as an outer layer on the API router (default **2 MiB**, env `GRADIENT_MAX_REQUEST_SIZE` / `settings.maxRequestSize`). Oversized webhook/JSON payloads are now rejected with **413 Payload Too Large** before the handler can buffer them — fixes the `body: Bytes` OOM vector in `forge_hooks::github_app_webhook` and `forge_hooks::forge_webhook`.
- `POST /api/v1/builds` (direct-build multipart) is the only route that legitimately uploads large payloads (an entire repo snapshot), so it gets a per-route override at `GRADIENT_MAX_DIRECT_BUILD_SIZE` / `settings.maxDirectBuildSize` (default **1 GiB**). The `field.bytes().await` calls in `direct.rs` are now bounded by this limit.
- Adds three integration tests covering both the global cap and the per-route override; updates the NixOS module and docs (`configuration.md`, `tests.md`).

Fixes #51.

## Test plan
- [x] `cargo test -p web --test body_size_limit` — three new tests pass
- [x] `cargo test --workspace --tests` — full workspace stays green