### PR TITLE
backend: web: add per-IP rate limiting to HTTP layer (#53)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
  "bytestring",
  "derive_more",
  "encoding_rs",
- "foldhash",
+ "foldhash 0.1.5",
  "futures-core",
  "http 0.2.12",
  "httparse",
@@ -129,7 +129,7 @@ dependencies = [
  "cfg-if",
  "derive_more",
  "encoding_rs",
- "foldhash",
+ "foldhash 0.1.5",
  "futures-core",
  "futures-util",
  "impl-more",
@@ -934,7 +934,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "test-support",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-test",
  "tracing",
@@ -1195,7 +1195,7 @@ dependencies = [
  "tar",
  "tempfile",
  "test-support",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-test",
  "tracing",
@@ -1438,6 +1438,20 @@ dependencies = [
  "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1804,7 +1818,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "typetag",
  "uuid",
 ]
@@ -1895,6 +1909,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1916,6 +1936,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "forwarded-header-value"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
+dependencies = [
+ "nonempty",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2035,6 +2065,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2129,7 +2165,7 @@ checksum = "8df306e4dfc91752e89b74c88ee876c8518890600f82255254828f9192dd003c"
 dependencies = [
  "getset",
  "nom 8.0.0",
- "thiserror",
+ "thiserror 2.0.18",
  "url",
 ]
 
@@ -2164,6 +2200,29 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "governor"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.9.4",
+ "smallvec",
+ "spinning_top",
+ "web-time",
 ]
 
 [[package]]
@@ -2222,7 +2281,7 @@ dependencies = [
  "harmonia-utils-io",
  "nix 0.31.2",
  "pin-project-lite",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -2250,7 +2309,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -2281,7 +2340,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "zerocopy",
@@ -2324,7 +2383,7 @@ dependencies = [
  "md5",
  "ring",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -2351,13 +2410,30 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -2552,6 +2628,19 @@ dependencies = [
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
  "tower-service",
 ]
 
@@ -2851,7 +2940,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
  "windows-link",
 ]
@@ -3384,6 +3473,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonempty"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3717,7 +3818,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -3977,6 +4078,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4057,6 +4178,12 @@ dependencies = [
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -4201,7 +4328,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "parking_lot",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4272,6 +4399,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4295,7 +4437,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.6.3",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -4317,7 +4459,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -4454,6 +4596,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -4640,7 +4791,7 @@ version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94070964579245eb2f76e62a7668fe87bd9969ed6c41256f3bf614e3323dd3cc"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4759,7 +4910,7 @@ dependencies = [
  "http 1.4.0",
  "mime",
  "rand 0.10.1",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5005,7 +5156,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "strum",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tracing",
  "url",
@@ -5105,7 +5256,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5298,7 +5449,7 @@ dependencies = [
  "rand 0.9.4",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "url",
  "uuid",
@@ -5493,7 +5644,7 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -5537,6 +5688,15 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
 dependencies = [
  "lock_api",
 ]
@@ -5594,7 +5754,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-stream",
@@ -5681,7 +5841,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tracing",
  "uuid",
@@ -5724,7 +5884,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tracing",
  "uuid",
@@ -5751,7 +5911,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tracing",
  "url",
@@ -5974,11 +6134,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6185,6 +6365,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2 0.6.3",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6192,9 +6401,12 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.14.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6230,6 +6442,23 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tower_governor"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44de9b94d849d3c46e06a883d72d408c2de6403367b39df2b1c9d9e7b6736fe6"
+dependencies = [
+ "axum",
+ "forwarded-header-value",
+ "governor",
+ "http 1.4.0",
+ "pin-project",
+ "thiserror 2.0.18",
+ "tonic",
+ "tower",
+ "tracing",
+]
 
 [[package]]
 name = "tracing"
@@ -6326,7 +6555,7 @@ dependencies = [
  "native-tls",
  "rand 0.9.4",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6700,6 +6929,7 @@ dependencies = [
  "email_address",
  "entity",
  "git-url-parse",
+ "governor",
  "harmonia-nar",
  "hex",
  "hmac 0.13.0",
@@ -6717,12 +6947,13 @@ dependencies = [
  "sha2 0.11.0",
  "subtle",
  "test-support",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-test",
  "tokio-util",
  "tower",
  "tower-http",
+ "tower_governor",
  "tracing",
  "url",
  "uuid",

--- a/backend/web/Cargo.toml
+++ b/backend/web/Cargo.toml
@@ -47,6 +47,8 @@ subtle        = "2.6"
 tokio-util    = { version = "0.7", features = ["io"] }
 tower         = "0.5"
 tower-http    = { version = "0.6", features = ["cors", "trace"] }
+tower_governor = "0.8"
+governor      = "0.10"
 url           = "2.5"
 
 [dev-dependencies]

--- a/backend/web/src/lib.rs
+++ b/backend/web/src/lib.rs
@@ -15,6 +15,12 @@ use bytes::Bytes;
 use http::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE};
 use http::{HeaderMap, Request, Response};
 use std::time::Duration;
+use governor::middleware::NoOpMiddleware;
+use std::net::{IpAddr, Ipv4Addr};
+use tower_governor::GovernorLayer;
+use tower_governor::errors::GovernorError;
+use tower_governor::governor::{GovernorConfig, GovernorConfigBuilder};
+use tower_governor::key_extractor::{KeyExtractor, SmartIpKeyExtractor};
 use tower_http::classify::ServerErrorsFailureClass;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::trace::TraceLayer;
@@ -25,6 +31,58 @@ use endpoints::{admin, *};
 use proto::proto_router;
 use scheduler::Scheduler;
 use std::sync::Arc;
+
+/// Wraps `SmartIpKeyExtractor` with a constant fallback so requests that
+/// carry no client-IP signal at all (no `X-Forwarded-For` / `X-Real-IP`,
+/// no `ConnectInfo`) share a single bucket instead of returning 500. This
+/// matters in tests (axum-test has no peer socket) and as a defensive
+/// fallback if `into_make_service_with_connect_info` is ever skipped — a
+/// global bucket is still better than failing requests outright.
+#[derive(Debug, Clone, Copy)]
+struct SmartIpOrFallback;
+
+impl KeyExtractor for SmartIpOrFallback {
+    type Key = IpAddr;
+
+    fn extract<T>(&self, req: &Request<T>) -> Result<Self::Key, GovernorError> {
+        match SmartIpKeyExtractor.extract(req) {
+            Ok(ip) => Ok(ip),
+            Err(_) => Ok(IpAddr::V4(Ipv4Addr::UNSPECIFIED)),
+        }
+    }
+}
+
+/// Per-IP token-bucket config. Refill period in seconds and burst (bucket
+/// capacity). Uses `SmartIpKeyExtractor` so deployments behind a reverse
+/// proxy honor `X-Forwarded-For` / `X-Real-IP`.
+fn rl_per_second(
+    per_second: u64,
+    burst: u32,
+) -> Arc<GovernorConfig<SmartIpOrFallback, NoOpMiddleware>> {
+    Arc::new(
+        GovernorConfigBuilder::default()
+            .per_second(per_second)
+            .burst_size(burst)
+            .key_extractor(SmartIpOrFallback)
+            .finish()
+            .expect("rate-limit config valid"),
+    )
+}
+
+/// Sub-second refill granularity, for tiers needing >1 req/s steady-state.
+fn rl_per_ms(
+    per_millisecond: u64,
+    burst: u32,
+) -> Arc<GovernorConfig<SmartIpOrFallback, NoOpMiddleware>> {
+    Arc::new(
+        GovernorConfigBuilder::default()
+            .per_millisecond(per_millisecond)
+            .burst_size(burst)
+            .key_extractor(SmartIpOrFallback)
+            .finish()
+            .expect("rate-limit config valid"),
+    )
+}
 
 /// Build the Axum router with all routes and middleware layered on.
 ///
@@ -297,12 +355,10 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
             authorization::authorize_optional,
         ));
 
-    let api = Router::new()
-        .merge(auth_api)
-        .merge(optional_api)
-        // ── Fully public (no auth required) ─────────────────────────────────
-        .route("/orgs/public", get(orgs::get_public_organizations))
-        .route("/caches/public", get(caches::get_public_caches))
+    // ── Sensitive auth surface (login/register/verification/oauth) ───────
+    // Tight per-IP rate limit: Argon2 verification and email send are
+    // expensive enough that an unthrottled attacker can DoS the server.
+    let auth_sensitive = Router::new()
         .route("/auth/basic/login", post(auth::post_basic_login))
         .route("/auth/basic/register", post(auth::post_basic_register))
         .route("/auth/check-username", post(auth::post_check_username))
@@ -317,6 +373,25 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
         )
         .route("/auth/oidc/login", get(auth::get_oidc_login))
         .route("/auth/oidc/callback", get(auth::get_oidc_callback))
+        .route_layer(GovernorLayer::new(rl_per_second(6, 5)));
+
+    // ── Incoming forge webhooks (unauthenticated, HMAC-verified) ─────────
+    let webhook_routes = Router::new()
+        .route("/hooks/github", post(forge_hooks::github_app_webhook))
+        .route(
+            "/hooks/{forge}/{org}/{integration_name}",
+            post(forge_hooks::forge_webhook),
+        )
+        .route_layer(GovernorLayer::new(rl_per_second(1, 30)));
+
+    let api = Router::new()
+        .merge(auth_api)
+        .merge(optional_api)
+        .merge(auth_sensitive)
+        .merge(webhook_routes)
+        // ── Fully public (no auth required) ─────────────────────────────────
+        .route("/orgs/public", get(orgs::get_public_organizations))
+        .route("/caches/public", get(caches::get_public_caches))
         .route("/auth/logout", post(auth::post_logout))
         .route("/health", get(get_health))
         .route("/config", get(get_config))
@@ -326,24 +401,24 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
         .route(
             "/admin/github-app/callback",
             get(admin::github_app::callback),
-        )
-        // ── Incoming forge webhooks (unauthenticated, HMAC-verified) ─────────
-        .route("/hooks/github", post(forge_hooks::github_app_webhook))
-        .route(
-            "/hooks/{forge}/{org}/{integration_name}",
-            post(forge_hooks::forge_webhook),
         );
 
     let scheduler = Arc::new(Scheduler::new(Arc::clone(&state)));
     scheduler.start();
     proto::outbound::start_outbound_loop(Arc::clone(&scheduler));
 
+    // Default tier covers everything left under /api/v1 (the bulk authenticated
+    // surface) plus the proto WS upgrade.
+    let api = api.route_layer(GovernorLayer::new(rl_per_ms(200, 150)));
+
     let mut app = Router::new()
         .nest("/api/v1", api)
-        .merge(proto_router())
+        .merge(proto_router().route_layer(GovernorLayer::new(rl_per_ms(200, 150))))
         .layer(axum::Extension(scheduler));
 
-    app = app
+    // Public NAR cache surface — substituters issue many requests per build,
+    // so the burst is generous (1000 / 1000).
+    let cache_routes = Router::new()
         .route(
             "/cache/{cache}/gradient-cache-info",
             get(caches::gradient_cache_info),
@@ -354,7 +429,10 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
             "/cache/{cache}/nar/upstream/{upstream_id}/{*path}",
             get(caches::upstream_nar),
         )
-        .route("/cache/{cache}/nar/{path}", get(caches::nar));
+        .route("/cache/{cache}/nar/{path}", get(caches::nar))
+        .route_layer(GovernorLayer::new(rl_per_ms(60, 1000)));
+
+    app = app.merge(cache_routes);
 
     app.fallback(handle_404)
         .layer(cors)
@@ -372,5 +450,9 @@ pub async fn serve_web(state: Arc<ServerState>) -> std::io::Result<()> {
             tracing::error!("Failed to bind to {}: {}", server_url, e);
             e
         })?;
-    axum::serve(listener, app).await
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+    )
+    .await
 }

--- a/backend/web/tests/rate_limit.rs
+++ b/backend/web/tests/rate_limit.rs
@@ -1,0 +1,105 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Integration tests for the per-IP HTTP rate limiter.
+//!
+//! Verifies that the sensitive auth tier rejects bursts beyond its capacity
+//! with HTTP 429, while the public NAR cache tier (`/cache/{cache}/...`) is
+//! sized generously enough that substituters issuing many requests per build
+//! aren't throttled at moderate burst.
+
+use axum_test::TestServer;
+use core::ci::WebhookClient;
+use core::storage::{EmailSender, NarStore};
+use core::types::ServerState;
+use sea_orm::{DatabaseBackend, MockDatabase};
+use std::sync::Arc;
+use test_support::fakes::email::InMemoryEmailSender;
+use test_support::fakes::webhooks::RecordingWebhookClient;
+use test_support::log_storage::NoopLogStorage;
+use test_support::prelude::test_cli;
+use web::create_router;
+
+fn make_state() -> Arc<ServerState> {
+    let cli = test_cli();
+    let nar_storage = NarStore::local(&cli.base_path).expect("create test NarStore");
+    Arc::new(ServerState {
+        web_db: MockDatabase::new(DatabaseBackend::Postgres).into_connection(),
+        db: MockDatabase::new(DatabaseBackend::Postgres).into_connection(),
+        cli,
+        log_storage: Arc::new(NoopLogStorage),
+        webhooks: Arc::new(RecordingWebhookClient::new()) as Arc<dyn WebhookClient>,
+        email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,
+        nar_storage,
+        manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+    })
+}
+
+/// Auth tier burst is 5: requests 1-5 from the same client succeed, request
+/// 6 is rejected with 429 before the handler runs. We use
+/// `/api/v1/auth/check-username` with a too-short username so the handler
+/// returns early without touching the DB.
+#[test]
+fn auth_tier_throttles_burst() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let server = TestServer::new(create_router(make_state()));
+
+        for i in 1..=5 {
+            let resp = server
+                .post("/api/v1/auth/check-username")
+                .json(&serde_json::json!({"username": "x"}))
+                .await;
+            assert_eq!(
+                resp.status_code(),
+                200,
+                "request {} unexpectedly throttled: {:?}",
+                i,
+                resp.status_code()
+            );
+        }
+
+        let throttled = server
+            .post("/api/v1/auth/check-username")
+            .json(&serde_json::json!({"username": "x"}))
+            .await;
+        assert_eq!(
+            throttled.status_code(),
+            429,
+            "6th burst request should be 429, got {:?}",
+            throttled.status_code()
+        );
+    });
+}
+
+/// Cache tier burst is 1000: 50 rapid GETs against `/cache/{cache}/...` all
+/// succeed (or fail through to the handler) — no 429s. The handler itself
+/// 404s for the unknown cache, but the request reaching the handler proves
+/// the rate limiter didn't reject it.
+#[test]
+fn cache_tier_does_not_throttle_moderate_burst() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let server = TestServer::new(create_router(make_state()));
+
+        for i in 1..=50 {
+            let resp = server.get("/cache/missing-cache/nix-cache-info").await;
+            assert_ne!(
+                resp.status_code(),
+                429,
+                "cache request {} unexpectedly throttled",
+                i
+            );
+        }
+    });
+}

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -33,6 +33,22 @@ info:
     - A valid session (`jwt_token` cookie or `Authorization: Bearer` header) belonging
       to a member of the owning organisation.
 
+    ## Rate limiting
+
+    All HTTP endpoints enforce a per-client-IP token-bucket rate limit. Clients
+    that exceed their bucket receive HTTP `429 Too Many Requests`. The tier
+    depends on the route:
+
+    | Tier | Routes | Refill | Burst |
+    |---|---|---|---|
+    | auth | `/auth/basic/login`, `/auth/basic/register`, `/auth/check-username`, `/auth/verify-email`, `/auth/resend-verification`, `/auth/oauth/*`, `/auth/oidc/*` | 1 req / 6 s | 5 |
+    | webhook | `/hooks/*` | 1 req / s | 30 |
+    | cache | `/cache/{cache}/*` (public NAR surface) | 1 req / 60 ms | 1000 |
+    | default | everything else | 1 req / 200 ms | 150 |
+
+    Client IP is taken from `X-Forwarded-For` / `X-Real-IP` (deployments are
+    expected behind a reverse proxy), falling back to the connection peer IP.
+
     ## Common Response Envelope
 
     Every JSON response is wrapped in a standard envelope:

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -411,3 +411,28 @@ Tests (`cargo test -p core --tests ci::reporting`):
   `"Gradient Build wavelens/my-project: my-package"`.
 - `build_context_falls_back_when_org_missing` — degrades correctly when
   the organization is unknown.
+
+## Per-IP HTTP rate limiting
+
+The web layer enforces per-client-IP token-bucket rate limits via
+`tower_governor` (`backend/web/src/lib.rs`). Routes are grouped into four
+fixed tiers (no CLI knobs):
+
+| Tier | Routes | Refill | Burst |
+|---|---|---|---|
+| `auth` | `/api/v1/auth/{basic/login,basic/register,check-username,verify-email,resend-verification,oauth/authorize,oidc/login,oidc/callback}` | 1 req / 6 s | 5 |
+| `webhook` | `/api/v1/hooks/...` | 1 req / s | 30 |
+| `cache` | `/cache/{cache}/...` (public NAR surface) | 1 req / 60 ms | 1000 |
+| `default` | everything else under `/api/v1` and `/proto` | 1 req / 200 ms | 150 |
+
+Client IP is extracted from `X-Forwarded-For` / `X-Real-IP` (deployments
+are expected behind a reverse proxy), falling back to `ConnectInfo`,
+falling back to a single global bucket if no signal is available
+(prevents 500s in tests / direct hits).
+
+Tests (`cargo test -p web --test rate_limit`):
+
+- `auth_tier_throttles_burst` — 5 successive `POST /api/v1/auth/check-username`
+  requests succeed, 6th returns `429`.
+- `cache_tier_does_not_throttle_moderate_burst` — 50 successive GETs to
+  `/cache/{cache}/nix-cache-info` never return `429`.


### PR DESCRIPTION
Closes #53.

## Summary
- `tower_governor` per-IP token-bucket layers on every HTTP route, four fixed tiers (no CLI knobs):
  - **auth** (login/register/verify/oauth/oidc): 1 req / 6 s, burst 5
  - **webhook** (forge hooks): 1 req / s, burst 30
  - **cache** (`/cache/{cache}/*` public NAR surface): 1 req / 60 ms, burst 1000
  - **default** (everything else under `/api/v1` and `/proto`): 1 req / 200 ms, burst 150
- Custom `SmartIpOrFallback` extractor wraps `SmartIpKeyExtractor` with a constant fallback so test transports (no peer IP, no XFF) share a global bucket instead of returning 500.
- `serve_web` now uses `into_make_service_with_connect_info::<SocketAddr>()` so the connection peer IP reaches the extractor when no proxy header is present.

## Out of scope (separate follow-ups)
- NAR bandwidth amplification and outbound webhook fan-out — those are concurrency / bandwidth caps, not request-rate limits.

## Test plan
- [x] `cargo test -p web --test rate_limit` (new): auth tier rejects 6th burst request with 429; cache tier accepts 50 in a row.
- [x] `cargo test -p web --tests` (full web suite still green: 59 + 2 + 8 + 1 + 2 = 72 tests pass).
- [x] `cargo test -p worker --tests` (regression check on the unrelated drv-prefetch fix that landed on main: 98 pass).