### PR TITLE
backend: entity: EvaluationStatus::is_active + ACTIVE const (#56)

### DIFF
--- a/backend/core/src/db/connection.rs
+++ b/backend/core/src/db/connection.rs
@@ -90,15 +90,7 @@ async fn update_db(db: &DatabaseConnection) -> Result<(), DbErr> {
     }
 
     let evaluations = EEvaluation::find()
-        .filter(
-            Condition::any()
-                .add(CEvaluation::Status.eq(EvaluationStatus::Queued))
-                .add(CEvaluation::Status.eq(EvaluationStatus::Fetching))
-                .add(CEvaluation::Status.eq(EvaluationStatus::EvaluatingFlake))
-                .add(CEvaluation::Status.eq(EvaluationStatus::EvaluatingDerivation))
-                .add(CEvaluation::Status.eq(EvaluationStatus::Building))
-                .add(CEvaluation::Status.eq(EvaluationStatus::Waiting)),
-        )
+        .filter(CEvaluation::Status.is_in(EvaluationStatus::ACTIVE))
         .all(db)
         .await?;
 

--- a/backend/core/src/db/gc.rs
+++ b/backend/core/src/db/gc.rs
@@ -6,7 +6,6 @@
 
 use anyhow::{Context, Result};
 use chrono::{Duration as ChronoDuration, Utc};
-use entity::evaluation::EvaluationStatus;
 use sea_orm::ActiveValue::Set;
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, ConnectionTrait, DatabaseBackend, EntityTrait, IntoActiveModel,
@@ -46,17 +45,7 @@ pub async fn gc_project_evaluations(
     // Never GC evaluations that are still running.
     let to_delete: Vec<MEvaluation> = all_evals[keep..]
         .iter()
-        .filter(|e| {
-            !matches!(
-                e.status,
-                EvaluationStatus::Queued
-                    | EvaluationStatus::Fetching
-                    | EvaluationStatus::EvaluatingFlake
-                    | EvaluationStatus::EvaluatingDerivation
-                    | EvaluationStatus::Building
-                    | EvaluationStatus::Waiting
-            )
-        })
+        .filter(|e| !e.status.is_active())
         .cloned()
         .collect();
 

--- a/backend/core/src/sources/git.rs
+++ b/backend/core/src/sources/git.rs
@@ -9,7 +9,6 @@ use crate::types::input::{check_repository_url_is_ssh, vec_to_hex};
 use crate::types::*;
 use anyhow::Result;
 use async_trait::async_trait;
-use entity::evaluation::EvaluationStatus;
 use git2::{Direction, RemoteCallbacks};
 use sea_orm::EntityTrait;
 use std::sync::Arc;
@@ -110,13 +109,7 @@ impl<'a> ProjectGitContext<'a> {
                     reason: "Evaluation not found".to_string(),
                 })?;
 
-            if evaluation.status == EvaluationStatus::Queued
-                || evaluation.status == EvaluationStatus::Fetching
-                || evaluation.status == EvaluationStatus::EvaluatingFlake
-                || evaluation.status == EvaluationStatus::EvaluatingDerivation
-                || evaluation.status == EvaluationStatus::Building
-                || evaluation.status == EvaluationStatus::Waiting
-            {
+            if evaluation.status.is_active() {
                 debug!(status = ?evaluation.status, "Evaluation already in progress, skipping");
                 return Ok((false, remote_hash));
             }

--- a/backend/entity/src/evaluation.rs
+++ b/backend/entity/src/evaluation.rs
@@ -32,6 +32,29 @@ pub enum EvaluationStatus {
     Fetching,
 }
 
+impl EvaluationStatus {
+    pub fn is_active(&self) -> bool {
+        matches!(
+            self,
+            Self::Queued
+                | Self::Fetching
+                | Self::EvaluatingFlake
+                | Self::EvaluatingDerivation
+                | Self::Building
+                | Self::Waiting
+        )
+    }
+
+    pub const ACTIVE: [Self; 6] = [
+        Self::Queued,
+        Self::Fetching,
+        Self::EvaluatingFlake,
+        Self::EvaluatingDerivation,
+        Self::Building,
+        Self::Waiting,
+    ];
+}
+
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Deserialize, Serialize)]
 #[sea_orm(table_name = "evaluation")]
 pub struct Model {

--- a/backend/web/src/endpoints/orgs/management.rs
+++ b/backend/web/src/endpoints/orgs/management.rs
@@ -17,7 +17,7 @@ use core::types::input::{check_index_name, validate_display_name};
 use core::types::*;
 use sea_orm::ActiveValue::Set;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, Condition, EntityTrait, JoinType, PaginatorTrait, QueryFilter,
+    ActiveModelTrait, ColumnTrait, EntityTrait, JoinType, PaginatorTrait, QueryFilter,
     QueryOrder, QuerySelect,
 };
 use serde::{Deserialize, Serialize};
@@ -127,15 +127,7 @@ async fn count_running_evaluations(
     if !project_ids.is_empty() {
         let running = EEvaluation::find()
             .filter(CEvaluation::Project.is_in(project_ids))
-            .filter(
-                Condition::any()
-                    .add(CEvaluation::Status.eq(EvaluationStatus::Queued))
-                    .add(CEvaluation::Status.eq(EvaluationStatus::Fetching))
-                    .add(CEvaluation::Status.eq(EvaluationStatus::EvaluatingFlake))
-                    .add(CEvaluation::Status.eq(EvaluationStatus::EvaluatingDerivation))
-                    .add(CEvaluation::Status.eq(EvaluationStatus::Building))
-                    .add(CEvaluation::Status.eq(EvaluationStatus::Waiting)),
-            )
+            .filter(CEvaluation::Status.is_in(EvaluationStatus::ACTIVE))
             .all(&state.web_db)
             .await?;
         for eval in running {


### PR DESCRIPTION
## Summary
- Add `EvaluationStatus::is_active()` method and `ACTIVE: [Self; 6]` const.
- Replace duplicated 6-arm OR / `Condition::any()` patterns at 4 call sites.

## Test plan
- [x] CI builds workspace
- [x] CI tests pass
Closes #56