### PR TITLE
backend: core: secret_file param &str instead of owned String (#60)

### DIFF
--- a/backend/cache/src/cacher/sign_sweep.rs
+++ b/backend/cache/src/cacher/sign_sweep.rs
@@ -74,7 +74,7 @@ pub async fn sign_missing_signatures(state: Arc<ServerState>) -> anyhow::Result<
         let nar_hash_nix32 = hex_hash_to_nix32(nar_hash);
 
         let sig_token = match gradient_core::sources::sign_narinfo_fingerprint(
-            state.cli.crypt_secret_file.clone(),
+            &state.cli.crypt_secret_file,
             cache.clone(),
             state.cli.serve_url.clone(),
             &cp.store_path,

--- a/backend/core/src/sources/cache_key.rs
+++ b/backend/core/src/sources/cache_key.rs
@@ -13,8 +13,8 @@ use ed25519_compact::{KeyPair, PublicKey, SecretKey, Signature};
 /// Returns `(encrypted_private_key, public_key_b64)`.
 /// The private key is the full 64-byte ed25519 keypair encrypted and base64-encoded.
 /// The public key is the last 32 bytes of the keypair, base64-encoded in plaintext.
-pub fn generate_signing_key(secret_file: String) -> Result<(String, String), SourceError> {
-    let secret = crate::types::input::load_secret_bytes(&secret_file);
+pub fn generate_signing_key(secret_file: &str) -> Result<(String, String), SourceError> {
+    let secret = crate::types::input::load_secret_bytes(secret_file);
 
     let keypair = KeyPair::generate();
     // Base64-encode the full 64-byte keypair (seed || public key)
@@ -32,7 +32,7 @@ pub fn generate_signing_key(secret_file: String) -> Result<(String, String), Sou
 }
 
 pub fn format_cache_public_key(
-    secret_file: String,
+    secret_file: &str,
     cache: MCache,
     url: String,
 ) -> Result<String, SourceError> {
@@ -62,8 +62,8 @@ pub fn format_cache_public_key(
     Ok(format!("{}-{}:{}", base_url, cache.name, pubkey_b64))
 }
 
-pub fn decrypt_signing_key(secret_file: String, cache: MCache) -> Result<String, SourceError> {
-    let secret = crate::types::input::load_secret_bytes(&secret_file);
+pub fn decrypt_signing_key(secret_file: &str, cache: MCache) -> Result<String, SourceError> {
+    let secret = crate::types::input::load_secret_bytes(secret_file);
 
     let encrypted_private_key = general_purpose::STANDARD
         .decode(cache.clone().private_key)
@@ -83,7 +83,7 @@ pub fn decrypt_signing_key(secret_file: String, cache: MCache) -> Result<String,
 }
 
 pub fn format_cache_key(
-    secret_file: String,
+    secret_file: &str,
     cache: MCache,
     url: String,
 ) -> Result<String, SourceError> {
@@ -110,7 +110,7 @@ pub fn format_cache_key(
 /// References should be bare store-path names (without `/nix/store/` prefix);
 /// this function adds the prefix before sorting and joining.
 pub fn sign_narinfo_fingerprint(
-    secret_file: String,
+    secret_file: &str,
     cache: MCache,
     serve_url: String,
     store_path: &str,
@@ -278,9 +278,9 @@ mod tests {
     fn generate_decrypt_roundtrip() {
         let (_f, path) = temp_secret_file();
         let (encrypted_priv, pub_b64) =
-            generate_signing_key(path.clone()).expect("generate failed");
+            generate_signing_key(&path).expect("generate failed");
         let cache = make_cache("testcache", &pub_b64, &encrypted_priv);
-        let decrypted = decrypt_signing_key(path, cache).expect("decrypt failed");
+        let decrypted = decrypt_signing_key(&path, cache).expect("decrypt failed");
         // Decrypted should be base64-encoded 64-byte keypair
         let bytes = general_purpose::STANDARD
             .decode(decrypted.trim())
@@ -292,9 +292,9 @@ mod tests {
     fn format_cache_public_key_stored() {
         let (_f, path) = temp_secret_file();
         let (encrypted_priv, pub_b64) =
-            generate_signing_key(path.clone()).expect("generate failed");
+            generate_signing_key(&path).expect("generate failed");
         let cache = make_cache("mycache", &pub_b64, &encrypted_priv);
-        let result = format_cache_public_key(path, cache, "https://cache.example.com".to_string())
+        let result = format_cache_public_key(&path, cache, "https://cache.example.com".to_string())
             .expect("format failed");
         // format: {base_url}-{name}:{pubkey}
         assert!(
@@ -316,9 +316,9 @@ mod tests {
         // Empty public_key → derive from private key
         let (_f, path) = temp_secret_file();
         let (encrypted_priv, _pub_b64) =
-            generate_signing_key(path.clone()).expect("generate failed");
+            generate_signing_key(&path).expect("generate failed");
         let cache = make_cache("legacy", "", &encrypted_priv);
-        let result = format_cache_public_key(path, cache, "https://cache.example.com".to_string())
+        let result = format_cache_public_key(&path, cache, "https://cache.example.com".to_string())
             .expect("format failed");
         assert!(
             result.starts_with("cache.example.com-legacy:"),
@@ -330,10 +330,10 @@ mod tests {
     fn sign_narinfo_fingerprint_format() {
         let (_f, path) = temp_secret_file();
         let (encrypted_priv, pub_b64) =
-            generate_signing_key(path.clone()).expect("generate failed");
+            generate_signing_key(&path).expect("generate failed");
         let cache = make_cache("sigcache", &pub_b64, &encrypted_priv);
         let result = sign_narinfo_fingerprint(
-            path,
+            &path,
             cache,
             "https://cache.example.com".to_string(),
             "/nix/store/aaaa-hello",
@@ -353,7 +353,7 @@ mod tests {
     fn sign_narinfo_sorts_references() {
         let (_f, path) = temp_secret_file();
         let (encrypted_priv, pub_b64) =
-            generate_signing_key(path.clone()).expect("generate failed");
+            generate_signing_key(&path).expect("generate failed");
         let cache = make_cache("sigcache", &pub_b64, &encrypted_priv);
         // Sign once with sorted order, once with reversed order — signatures must match
         let refs_sorted = vec![
@@ -367,7 +367,7 @@ mod tests {
             "aaaa-a".to_string(),
         ];
         let sig1 = sign_narinfo_fingerprint(
-            path.clone(),
+            &path,
             cache.clone(),
             "https://cache.example.com".to_string(),
             "/nix/store/aaaa-hello",
@@ -377,7 +377,7 @@ mod tests {
         )
         .expect("sign failed");
         let sig2 = sign_narinfo_fingerprint(
-            path,
+            &path,
             cache,
             "https://cache.example.com".to_string(),
             "/nix/store/aaaa-hello",
@@ -393,7 +393,7 @@ mod tests {
     fn decrypt_corrupted_base64_fails() {
         let (_f, path) = temp_secret_file();
         let cache = make_cache("badcache", "", "!!!not-base64!!!");
-        let result = decrypt_signing_key(path, cache);
+        let result = decrypt_signing_key(&path, cache);
         assert!(result.is_err(), "expected error for corrupted base64");
     }
 
@@ -404,12 +404,12 @@ mod tests {
         // "last 32 bytes" slice drifting.
         let (_f, path) = temp_secret_file();
         let (encrypted_priv, pub_b64) =
-            generate_signing_key(path.clone()).expect("generate failed");
+            generate_signing_key(&path).expect("generate failed");
         let stored = make_cache("c", &pub_b64, &encrypted_priv);
         let legacy = make_cache("c", "", &encrypted_priv);
         let url = "https://cache.example.com".to_string();
-        let r_stored = format_cache_public_key(path.clone(), stored, url.clone()).unwrap();
-        let r_legacy = format_cache_public_key(path, legacy, url).unwrap();
+        let r_stored = format_cache_public_key(&path, stored, url.clone()).unwrap();
+        let r_legacy = format_cache_public_key(&path, legacy, url).unwrap();
         assert_eq!(r_stored, r_legacy);
     }
 
@@ -417,9 +417,9 @@ mod tests {
     fn format_cache_public_key_strips_http_and_port() {
         let (_f, path) = temp_secret_file();
         let (encrypted_priv, pub_b64) =
-            generate_signing_key(path.clone()).expect("generate failed");
+            generate_signing_key(&path).expect("generate failed");
         let cache = make_cache("c", &pub_b64, &encrypted_priv);
-        let r = format_cache_public_key(path, cache, "http://cache.example.com:8080".to_string())
+        let r = format_cache_public_key(&path, cache, "http://cache.example.com:8080".to_string())
             .expect("format failed");
         assert!(
             r.starts_with("cache.example.com-8080-c:"),
@@ -433,7 +433,7 @@ mod tests {
         // as signing with fully-qualified `/nix/store/...` refs.
         let (_f, path) = temp_secret_file();
         let (encrypted_priv, pub_b64) =
-            generate_signing_key(path.clone()).expect("generate failed");
+            generate_signing_key(&path).expect("generate failed");
         let cache = make_cache("c", &pub_b64, &encrypted_priv);
         let url = "https://cache.example.com".to_string();
         let bare = vec!["aaaa-a".to_string(), "bbbb-b".to_string()];
@@ -442,7 +442,7 @@ mod tests {
             "/nix/store/bbbb-b".to_string(),
         ];
         let s1 = sign_narinfo_fingerprint(
-            path.clone(),
+            &path,
             cache.clone(),
             url.clone(),
             "/nix/store/x-y",
@@ -452,7 +452,7 @@ mod tests {
         )
         .unwrap();
         let s2 =
-            sign_narinfo_fingerprint(path, cache, url, "/nix/store/x-y", "sha256:AAAA", 42, &full)
+            sign_narinfo_fingerprint(&path, cache, url, "/nix/store/x-y", "sha256:AAAA", 42, &full)
                 .unwrap();
         assert_eq!(s1, s2);
     }
@@ -461,11 +461,11 @@ mod tests {
     fn sign_narinfo_nar_size_affects_signature() {
         let (_f, path) = temp_secret_file();
         let (encrypted_priv, pub_b64) =
-            generate_signing_key(path.clone()).expect("generate failed");
+            generate_signing_key(&path).expect("generate failed");
         let cache = make_cache("c", &pub_b64, &encrypted_priv);
         let url = "https://cache.example.com".to_string();
         let s1 = sign_narinfo_fingerprint(
-            path.clone(),
+            &path,
             cache.clone(),
             url.clone(),
             "/nix/store/x-y",
@@ -475,7 +475,7 @@ mod tests {
         )
         .unwrap();
         let s2 =
-            sign_narinfo_fingerprint(path, cache, url, "/nix/store/x-y", "sha256:AAAA", 101, &[])
+            sign_narinfo_fingerprint(&path, cache, url, "/nix/store/x-y", "sha256:AAAA", 101, &[])
                 .unwrap();
         assert_ne!(s1, s2, "nar_size must participate in the fingerprint");
     }
@@ -484,11 +484,11 @@ mod tests {
     fn sign_narinfo_store_path_affects_signature() {
         let (_f, path) = temp_secret_file();
         let (encrypted_priv, pub_b64) =
-            generate_signing_key(path.clone()).expect("generate failed");
+            generate_signing_key(&path).expect("generate failed");
         let cache = make_cache("c", &pub_b64, &encrypted_priv);
         let url = "https://cache.example.com".to_string();
         let s1 = sign_narinfo_fingerprint(
-            path.clone(),
+            &path,
             cache.clone(),
             url.clone(),
             "/nix/store/aaaa-a",
@@ -498,7 +498,7 @@ mod tests {
         )
         .unwrap();
         let s2 =
-            sign_narinfo_fingerprint(path, cache, url, "/nix/store/bbbb-b", "sha256:AAAA", 1, &[])
+            sign_narinfo_fingerprint(&path, cache, url, "/nix/store/bbbb-b", "sha256:AAAA", 1, &[])
                 .unwrap();
         assert_ne!(s1, s2);
     }
@@ -513,7 +513,7 @@ mod tests {
         let enc_b64 = general_purpose::STANDARD.encode(enc);
         let cache = make_cache("c", "ignored", &enc_b64);
         let result = sign_narinfo_fingerprint(
-            path,
+            &path,
             cache,
             "https://cache.example.com".to_string(),
             "/nix/store/x-y",
@@ -531,14 +531,14 @@ mod tests {
     fn signed_narinfo_fixture() -> (String, String) {
         let (_f, path) = temp_secret_file();
         let (encrypted_priv, pub_b64) =
-            generate_signing_key(path.clone()).expect("generate failed");
+            generate_signing_key(&path).expect("generate failed");
         let cache = make_cache("upstream", &pub_b64, &encrypted_priv);
         let store_path = "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-foo";
         let nar_hash = "sha256:0000000000000000000000000000000000000000000000000000";
         let nar_size: u64 = 1234;
         let refs = vec!["bbbb-b".to_string(), "cccc-c".to_string()];
         let sig = sign_narinfo_fingerprint(
-            path,
+            &path,
             cache,
             "https://cache.example.com".to_string(),
             store_path,
@@ -576,7 +576,7 @@ mod tests {
         let (body, _real_key) = signed_narinfo_fixture();
         // Different keypair, same key name.
         let (_f, path) = temp_secret_file();
-        let (_, other_pub_b64) = generate_signing_key(path).expect("generate failed");
+        let (_, other_pub_b64) = generate_signing_key(&path).expect("generate failed");
         let name = _real_key.rsplit_once(':').unwrap().0;
         let wrong = format!("{name}:{other_pub_b64}");
         assert!(!verify_narinfo_signature(&wrong, &body));
@@ -620,7 +620,7 @@ mod tests {
     fn verify_narinfo_signature_rejects_missing_fingerprint_fields() {
         let public_key = {
             let (_f, path) = temp_secret_file();
-            let (_, pub_b64) = generate_signing_key(path).expect("generate failed");
+            let (_, pub_b64) = generate_signing_key(&path).expect("generate failed");
             format!("upstream:{pub_b64}")
         };
         let body = "URL: nar/x.nar.xz\nSig: upstream:AAAA\n";

--- a/backend/core/src/sources/git.rs
+++ b/backend/core/src/sources/git.rs
@@ -47,7 +47,7 @@ impl<'a> ProjectGitContext<'a> {
                     id: project.organization,
                 })?;
             Some(super::ssh_key::decrypt_ssh_private_key(
-                state.cli.crypt_secret_file.clone(),
+                &state.cli.crypt_secret_file,
                 organization,
                 &state.cli.serve_url,
             )?)
@@ -280,7 +280,7 @@ async fn prefetch_flake_inner(
     debug!("SSH repository – cloning via libgit2: {}", repository);
 
     let (private_key, public_key) =
-        super::ssh_key::decrypt_ssh_private_key(crypt_secret_file, organization, &serve_url)?;
+        super::ssh_key::decrypt_ssh_private_key(&crypt_secret_file, organization, &serve_url)?;
 
     let (git_url, rev) = parse_nix_git_url(&repository)?;
 

--- a/backend/core/src/sources/ssh_key.rs
+++ b/backend/core/src/sources/ssh_key.rs
@@ -13,8 +13,8 @@ use ssh_key::{
     Algorithm, LineEnding, PrivateKey, private::Ed25519Keypair, private::Ed25519PrivateKey,
     private::KeypairData, public::Ed25519PublicKey,
 };
-pub fn generate_ssh_key(secret_file: String) -> Result<(String, String), SourceError> {
-    let secret = crate::types::input::load_secret_bytes(&secret_file);
+pub fn generate_ssh_key(secret_file: &str) -> Result<(String, String), SourceError> {
+    let secret = crate::types::input::load_secret_bytes(secret_file);
 
     let keypair = KeyPair::generate();
 
@@ -66,11 +66,11 @@ pub fn generate_ssh_key(secret_file: String) -> Result<(String, String), SourceE
 }
 
 pub fn decrypt_ssh_private_key(
-    secret_file: String,
+    secret_file: &str,
     organization: MOrganization,
     serve_url: &str,
 ) -> Result<(String, String), SourceError> {
-    let secret = crate::types::input::load_secret_bytes(&secret_file);
+    let secret = crate::types::input::load_secret_bytes(secret_file);
 
     let encrypted_private_key = general_purpose::STANDARD
         .decode(organization.clone().private_key)
@@ -174,7 +174,7 @@ mod tests {
         let path = f.path().to_string_lossy().to_string();
         let mut org = make_org("o", "ssh-ed25519 AAAA");
         org.private_key = "!!!not-base64!!!".to_string();
-        let result = decrypt_ssh_private_key(path, org, "https://example.com");
+        let result = decrypt_ssh_private_key(&path, org, "https://example.com");
         assert!(matches!(
             result,
             Err(SourceError::OrganizationKeyDecoding { .. })
@@ -191,7 +191,7 @@ mod tests {
         let pem = "-----BEGIN OPENSSH PRIVATE KEY-----\nfake\n-----END OPENSSH PRIVATE KEY-----";
         let mut org = make_org("o", "ssh-ed25519 AAAA");
         org.private_key = general_purpose::STANDARD.encode(pem);
-        let result = decrypt_ssh_private_key(path, org, "https://example.com");
+        let result = decrypt_ssh_private_key(&path, org, "https://example.com");
         assert!(matches!(result, Err(SourceError::KeyDecryption { .. })));
     }
 
@@ -203,7 +203,7 @@ mod tests {
         let path = f.path().to_string_lossy().to_string();
         let mut org = make_org("o", "ssh-ed25519 AAAA");
         org.private_key = general_purpose::STANDARD.encode(b"random garbage not a key");
-        let result = decrypt_ssh_private_key(path, org, "https://example.com");
+        let result = decrypt_ssh_private_key(&path, org, "https://example.com");
         assert!(matches!(result, Err(SourceError::KeyDecryption { .. })));
     }
 
@@ -214,13 +214,13 @@ mod tests {
         let mut f = tempfile::NamedTempFile::new().unwrap();
         std::io::Write::write_all(&mut f, b"test-secret-key-32-bytes-padding!").unwrap();
         let path = f.path().to_string_lossy().to_string();
-        let (enc_priv, pub_openssh) = generate_ssh_key(path.clone()).expect("generate failed");
+        let (enc_priv, pub_openssh) = generate_ssh_key(&path).expect("generate failed");
         assert!(pub_openssh.starts_with("ssh-ed25519 "));
 
         let mut org = make_org("myorg", &pub_openssh);
         org.private_key = enc_priv;
         let (priv_pem, pub_formatted) =
-            decrypt_ssh_private_key(path, org, "https://example.com").expect("decrypt failed");
+            decrypt_ssh_private_key(&path, org, "https://example.com").expect("decrypt failed");
         assert!(priv_pem.starts_with("-----BEGIN OPENSSH PRIVATE KEY-----"));
         assert!(pub_formatted.starts_with(&pub_openssh));
         assert!(pub_formatted.ends_with(" example.com-myorg"));

--- a/backend/core/tests/sources.rs
+++ b/backend/core/tests/sources.rs
@@ -145,7 +145,7 @@ fn generate_ssh_key_produces_valid_ed25519_keypair() {
     secret_file.write_all(encoded.as_bytes()).unwrap();
 
     let (private_key, public_key) =
-        generate_ssh_key(secret_file.path().to_str().unwrap().to_string()).unwrap();
+        generate_ssh_key(secret_file.path().to_str().unwrap()).unwrap();
 
     assert!(!private_key.is_empty());
     assert!(
@@ -165,7 +165,7 @@ fn generate_ssh_key_different_secrets_produce_different_keys() {
         let mut f = NamedTempFile::new().unwrap();
         let enc = base64::engine::general_purpose::STANDARD.encode(secret);
         f.write_all(enc.as_bytes()).unwrap();
-        generate_ssh_key(f.path().to_str().unwrap().to_string()).unwrap()
+        generate_ssh_key(f.path().to_str().unwrap()).unwrap()
     };
 
     let (_, pub1) = make_key(b"secret_key_one__________________");

--- a/backend/proto/src/handler/socket.rs
+++ b/backend/proto/src/handler/socket.rs
@@ -247,7 +247,7 @@ async fn send_ssh_key_credential(socket: &mut ProtoSocket, state: &ServerState, 
     match EOrganization::find_by_id(org_id).one(&state.db).await {
         Ok(Some(org)) => {
             match gradient_core::sources::ssh_key::decrypt_ssh_private_key(
-                state.cli.crypt_secret_file.clone(),
+                &state.cli.crypt_secret_file,
                 org,
                 &state.cli.serve_url,
             ) {

--- a/backend/web/src/endpoints/caches/keys.rs
+++ b/backend/web/src/endpoints/caches/keys.rs
@@ -61,7 +61,7 @@ pub async fn get_cache_key(
     let cache = load_cache_for_owner(&state, user.id, cache).await?;
 
     let cache_key = format_cache_key(
-        state.cli.crypt_secret_file.clone(),
+        &state.cli.crypt_secret_file,
         cache,
         state.cli.serve_url.clone(),
     )
@@ -84,7 +84,7 @@ pub async fn get_cache_public_key(
     let cache = load_cache_readable(&state, &maybe_user, cache).await?;
 
     let public_key = format_cache_public_key(
-        state.cli.crypt_secret_file.clone(),
+        &state.cli.crypt_secret_file,
         cache,
         state.cli.serve_url.clone(),
     )

--- a/backend/web/src/endpoints/caches/management.rs
+++ b/backend/web/src/endpoints/caches/management.rs
@@ -170,7 +170,7 @@ pub async fn put(
         return Err(WebError::already_exists("Cache Name"));
     }
 
-    let (private_key, public_key) = generate_signing_key(state.cli.crypt_secret_file.clone())
+    let (private_key, public_key) = generate_signing_key(&state.cli.crypt_secret_file)
         .map_err(|e| {
             tracing::error!("Failed to generate signing key: {}", e);
             WebError::InternalServerError("Failed to generate signing key".to_string())
@@ -244,7 +244,7 @@ pub async fn get_cache(
     }
 
     let public_key = format_cache_public_key(
-        state.cli.crypt_secret_file.clone(),
+        &state.cli.crypt_secret_file,
         cache.clone(),
         state.cli.serve_url.clone(),
     )

--- a/backend/web/src/endpoints/orgs/management.rs
+++ b/backend/web/src/endpoints/orgs/management.rs
@@ -249,7 +249,7 @@ pub async fn put(
     }
 
     let (private_key, public_key) =
-        generate_ssh_key(state.cli.crypt_secret_file.clone()).map_err(|e| {
+        generate_ssh_key(&state.cli.crypt_secret_file).map_err(|e| {
             tracing::error!("Failed to generate SSH key: {}", e);
             WebError::failed_ssh_key_generation()
         })?;

--- a/backend/web/src/endpoints/orgs/ssh.rs
+++ b/backend/web/src/endpoints/orgs/ssh.rs
@@ -35,7 +35,7 @@ pub async fn post_organization_ssh(
     let organization = load_editable_org(&state, user.id, organization).await?;
 
     let (private_key, public_key) =
-        generate_ssh_key(state.cli.crypt_secret_file.clone()).map_err(|e| {
+        generate_ssh_key(&state.cli.crypt_secret_file).map_err(|e| {
             tracing::error!("Failed to generate SSH key: {}", e);
             WebError::failed_ssh_key_generation()
         })?;


### PR DESCRIPTION
## Summary
- Change `secret_file`/`crypt_secret_file` parameters in cache_key, ssh_key, and per-callsite helpers to `&str`.
- Drops ~10 `.clone()` sites that existed only to transfer ownership the function never used.
- Async `FlakePrefetcher` trait keeps `String` (lifetime constraint on async-trait Future).

## Test plan
- [ ] CI builds workspace + tests
- [ ] CI tests pass
Closes #60