### PR TITLE
backend: core: cache_key_host helper for URL scheme stripping (#61)

### DIFF
--- a/backend/core/src/sources/cache_key.rs
+++ b/backend/core/src/sources/cache_key.rs
@@ -54,10 +54,7 @@ pub fn format_cache_public_key(
         cache.public_key.clone()
     };
 
-    let base_url = url
-        .replace("https://", "")
-        .replace("http://", "")
-        .replace(":", "-");
+    let base_url = super::cache_key_host(&url);
 
     Ok(format!("{}-{}:{}", base_url, cache.name, pubkey_b64))
 }
@@ -89,10 +86,7 @@ pub fn format_cache_key(
 ) -> Result<String, SourceError> {
     let decrypted_key = decrypt_signing_key(secret_file, cache.clone())?;
 
-    let base_url = url
-        .replace("https://", "")
-        .replace("http://", "")
-        .replace(":", "-");
+    let base_url = super::cache_key_host(&url);
 
     Ok(format!(
         "{}-{}:{}",
@@ -146,10 +140,7 @@ pub fn sign_narinfo_fingerprint(
     let sig = secret_key.sign(fingerprint.as_bytes(), None);
     let sig_b64 = general_purpose::STANDARD.encode(*sig);
 
-    let base_url = serve_url
-        .replace("https://", "")
-        .replace("http://", "")
-        .replace(":", "-");
+    let base_url = super::cache_key_host(&serve_url);
 
     Ok(format!("{}-{}:{}", base_url, cache.name, sig_b64))
 }

--- a/backend/core/src/sources/mod.rs
+++ b/backend/core/src/sources/mod.rs
@@ -22,6 +22,15 @@ use async_trait::async_trait;
 use std::path::PathBuf;
 use thiserror::Error;
 
+/// Strips the URL scheme and replaces `:` with `-` to form the host portion of
+/// a cache signing key name (`{base_url}-{cache_name}:{sig_or_pubkey}`).
+pub fn cache_key_host(serve_url: &str) -> String {
+    serve_url
+        .replace("https://", "")
+        .replace("http://", "")
+        .replace(":", "-")
+}
+
 #[derive(Debug, Clone, Error)]
 pub enum SourceError {
     #[error("Failed to read file: {reason}")]

--- a/backend/web/src/endpoints/caches/helpers.rs
+++ b/backend/web/src/endpoints/caches/helpers.rs
@@ -189,13 +189,7 @@ impl<'a> CacheOpsHandler<'a> {
         let deriver = cached_path_row.deriver.clone();
         let ca = cached_path_row.ca.clone();
 
-        let sig_url = self
-            .state
-            .cli
-            .serve_url
-            .replace("https://", "")
-            .replace("http://", "")
-            .replace(":", "-");
+        let sig_url = core::sources::cache_key_host(&self.state.cli.serve_url);
 
         let sig = format!("{}-{}:{}", sig_url, cache.name, signature);
 
@@ -266,13 +260,7 @@ impl<'a> CacheOpsHandler<'a> {
             .signature
             .ok_or_else(|| WebError::not_found("Signature not yet computed"))?;
 
-        let sig_url = self
-            .state
-            .cli
-            .serve_url
-            .replace("https://", "")
-            .replace("http://", "")
-            .replace(":", "-");
+        let sig_url = core::sources::cache_key_host(&self.state.cli.serve_url);
         let sig = format!("{}-{}:{}", sig_url, cache.name, signature);
 
         let file_hash = cached_path_row


### PR DESCRIPTION
## Summary
- Extract `serve_url.replace("https://","").replace("http://","").replace(":", "-")` (copy-pasted 5×) into `core::sources::cache_key_host`.

## Test plan
- [ ] CI builds workspace
- [ ] CI tests pass
Closes #61