### PR TITLE
backend: scheduler: replace hard-coded status integers in dispatch SQL (#69)

### DIFF
--- a/backend/entity/src/build.rs
+++ b/backend/entity/src/build.rs
@@ -33,6 +33,21 @@ pub enum BuildStatus {
     Substituted,
 }
 
+impl BuildStatus {
+    pub const fn num_value(&self) -> i32 {
+        match self {
+            Self::Created => 0,
+            Self::Queued => 1,
+            Self::Building => 2,
+            Self::Completed => 3,
+            Self::Failed => 4,
+            Self::Aborted => 5,
+            Self::DependencyFailed => 6,
+            Self::Substituted => 7,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Deserialize, Serialize)]
 #[sea_orm(table_name = "build")]
 pub struct Model {

--- a/backend/entity/src/evaluation.rs
+++ b/backend/entity/src/evaluation.rs
@@ -53,6 +53,20 @@ impl EvaluationStatus {
         Self::Building,
         Self::Waiting,
     ];
+
+    pub const fn num_value(&self) -> i32 {
+        match self {
+            Self::Queued => 0,
+            Self::EvaluatingFlake => 1,
+            Self::EvaluatingDerivation => 2,
+            Self::Building => 3,
+            Self::Waiting => 4,
+            Self::Completed => 5,
+            Self::Failed => 6,
+            Self::Aborted => 7,
+            Self::Fetching => 8,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Deserialize, Serialize)]

--- a/backend/scheduler/src/dispatch.rs
+++ b/backend/scheduler/src/dispatch.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::Utc;
+use entity::build::BuildStatus;
 use entity::evaluation::EvaluationStatus;
 use gradient_core::ci::TriggerError;
 use gradient_core::sources::{check_project_updates, get_commit_info};
@@ -75,7 +76,12 @@ pub(crate) async fn poll_projects_for_evaluations(scheduler: &Scheduler) -> anyh
     // that integration has a `secret` set, the forge pushes events and we only
     // need a slow backup poll. Otherwise we poll at the full evaluation_timeout.
     // LEFT JOIN evaluation so new projects (no last_evaluation) are also included.
-    // Terminal statuses: 5=Completed, 6=Failed, 7=Aborted.
+    let terminal_eval_statuses = format!(
+        "({}, {}, {})",
+        EvaluationStatus::Completed.num_value(),
+        EvaluationStatus::Failed.num_value(),
+        EvaluationStatus::Aborted.num_value(),
+    );
     let sql = sea_orm::Statement::from_string(
         sea_orm::DbBackend::Postgres,
         format!(
@@ -92,7 +98,7 @@ pub(crate) async fn poll_projects_for_evaluations(scheduler: &Scheduler) -> anyh
                 (i.secret IS NOT NULL AND p.last_check_at <= '{webhook_threshold}')
             )
             AND (
-                e.status IN (5, 6, 7)
+                e.status IN {terminal}
                 OR p.force_evaluation = true
                 OR p.last_evaluation IS NULL
             )
@@ -100,6 +106,7 @@ pub(crate) async fn poll_projects_for_evaluations(scheduler: &Scheduler) -> anyh
             "#,
             threshold = threshold.format("%Y-%m-%d %H:%M:%S%.f"),
             webhook_threshold = webhook_threshold.format("%Y-%m-%d %H:%M:%S%.f"),
+            terminal = terminal_eval_statuses,
         ),
     );
 
@@ -473,16 +480,17 @@ impl BuildDispatchMaps {
 pub(crate) async fn dispatch_ready_builds(scheduler: &Scheduler) -> anyhow::Result<()> {
     let state = &scheduler.state;
 
-    // Ready builds: status = Queued AND every dependency build is Completed (3) or Substituted (7).
+    // Ready builds: status = Queued AND every dependency build is Completed or Substituted.
     // Ordered by dependency count desc (integration builds first), then by age.
     let builds_sql = sea_orm::Statement::from_string(
         sea_orm::DbBackend::Postgres,
-        r#"
+        format!(
+            r#"
             SELECT b.*
             FROM public.build b
             LEFT JOIN public.derivation_dependency dd
                 ON dd.derivation = b.derivation
-            WHERE b.status = 1
+            WHERE b.status = {queued}
             AND NOT EXISTS (
                 SELECT 1
                 FROM public.derivation_dependency dep_edge
@@ -491,11 +499,15 @@ pub(crate) async fn dispatch_ready_builds(scheduler: &Scheduler) -> anyhow::Resu
                     AND dep_build.evaluation = b.evaluation
                 WHERE dep_edge.derivation = b.derivation
                     AND (dep_build.id IS NULL
-                        OR (dep_build.status != 3 AND dep_build.status != 7))
+                        OR (dep_build.status != {completed} AND dep_build.status != {substituted}))
             )
             GROUP BY b.id
             ORDER BY COUNT(dd.dependency) DESC, b.updated_at ASC
         "#,
+            queued = BuildStatus::Queued.num_value(),
+            completed = BuildStatus::Completed.num_value(),
+            substituted = BuildStatus::Substituted.num_value(),
+        ),
     );
 
     let started = std::time::Instant::now();


### PR DESCRIPTION
## Summary
- Add `BuildStatus::num_value()` and `EvaluationStatus::num_value()` const methods on entity enums.
- Format those values into the raw SQL in `scheduler/dispatch.rs` instead of literal `5,6,7`, `1`, `3,7` ints.
- Renumbering the enum now fails the build instead of silently breaking dispatch.

## Test plan
- [ ] CI builds workspace
- [ ] CI tests pass
Closes #69