### PR TITLE
backend: migration: rename build_depencdency typo, preserve canonical ID (#70)

### DIFF
--- a/backend/migration/src/lib.rs
+++ b/backend/migration/src/lib.rs
@@ -14,7 +14,7 @@ mod m20241107_140545_create_table_commit;
 mod m20241107_140550_create_table_server;
 mod m20241107_140560_create_table_build;
 mod m20241107_140600_create_table_evaluation;
-mod m20241107_155000_create_table_build_depencdency;
+mod m20241107_155000_create_table_build_dependency;
 mod m20241107_155020_create_table_api;
 mod m20241107_156000_create_table_build_feature;
 mod m20241107_156100_create_table_server_feature;
@@ -94,7 +94,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20241107_140600_create_table_evaluation::Migration),
             Box::new(m20241107_140550_create_table_server::Migration),
             Box::new(m20241107_140560_create_table_build::Migration),
-            Box::new(m20241107_155000_create_table_build_depencdency::Migration),
+            Box::new(m20241107_155000_create_table_build_dependency::Migration),
             Box::new(m20241107_155020_create_table_api::Migration),
             Box::new(m20241107_156000_create_table_build_feature::Migration),
             Box::new(m20241107_156100_create_table_server_feature::Migration),

--- a/backend/migration/src/m20241107_155000_create_table_build_dependency.rs
+++ b/backend/migration/src/m20241107_155000_create_table_build_dependency.rs
@@ -6,8 +6,15 @@
 
 use sea_orm_migration::prelude::*;
 
-#[derive(DeriveMigrationName)]
 pub struct Migration;
+
+// The canonical migration ID stored in `seaql_migrations` matches the original
+// (typo'd) module name so renaming the file does not orphan existing installs.
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20241107_155000_create_table_build_depencdency"
+    }
+}
 
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {


### PR DESCRIPTION
## Summary
- Rename file/module `build_depencdency` → `build_dependency`.
- Drop `#[derive(DeriveMigrationName)]` and impl `MigrationName` manually, returning the original typo'd string so existing installs see the same canonical ID in `seaql_migrations`.

## Test plan
- [ ] CI builds workspace
- [ ] CI tests pass
- [ ] Verify on a real DB that the migration is not re-applied
Closes #70