### PR TITLE
backend: web: rename load_editable_org → load_unmanaged_org (#54)

### DIFF
--- a/backend/web/src/endpoints/orgs/integrations.rs
+++ b/backend/web/src/endpoints/orgs/integrations.rs
@@ -15,7 +15,7 @@
 //! and never returned in responses — responses only expose a boolean
 //! "has_secret" / "has_access_token" flag.
 
-use super::{load_editable_org, load_org_member};
+use super::{load_unmanaged_org, load_org_member};
 use crate::error::{WebError, WebResult};
 use axum::extract::{Path, State};
 use axum::{Extension, Json};
@@ -175,7 +175,7 @@ pub async fn put_integration(
     Path(organization): Path<String>,
     Json(body): Json<CreateIntegrationRequest>,
 ) -> WebResult<Json<BaseResponse<IntegrationResponse>>> {
-    let org = load_editable_org(&state, user.id, organization).await?;
+    let org = load_unmanaged_org(&state, user.id, organization).await?;
 
     if check_index_name(&body.name).is_err() {
         return Err(WebError::invalid_name("Integration Name"));
@@ -276,7 +276,7 @@ pub async fn patch_integration(
     Path((organization, integration_id)): Path<(String, Uuid)>,
     Json(body): Json<PatchIntegrationRequest>,
 ) -> WebResult<Json<BaseResponse<IntegrationResponse>>> {
-    let org = load_editable_org(&state, user.id, organization).await?;
+    let org = load_unmanaged_org(&state, user.id, organization).await?;
     let integration = load_integration(&state, org.id, integration_id).await?;
     let kind = integration.kind;
 
@@ -368,7 +368,7 @@ pub async fn delete_integration(
     Extension(user): Extension<MUser>,
     Path((organization, integration_id)): Path<(String, Uuid)>,
 ) -> WebResult<Json<BaseResponse<bool>>> {
-    let org = load_editable_org(&state, user.id, organization).await?;
+    let org = load_unmanaged_org(&state, user.id, organization).await?;
     let integration = load_integration(&state, org.id, integration_id).await?;
     integration.into_active_model().delete(&state.web_db).await?;
     Ok(Json(BaseResponse {

--- a/backend/web/src/endpoints/orgs/mod.rs
+++ b/backend/web/src/endpoints/orgs/mod.rs
@@ -43,8 +43,11 @@ pub(super) async fn load_org_member(
 }
 
 /// Load an organization that the user is a member of AND that is not
-/// state-managed (i.e. editable via the API).
-pub(super) async fn load_editable_org(
+/// state-managed.
+///
+/// Membership ≠ edit rights: this only filters state-managed orgs. Mutating
+/// handlers that need admin should additionally call [`load_admin_org`].
+pub(super) async fn load_unmanaged_org(
     state: &Arc<ServerState>,
     user_id: Uuid,
     org_name: String,
@@ -83,7 +86,7 @@ pub(super) async fn load_admin_org(
     user_id: Uuid,
     org_name: String,
 ) -> WebResult<MOrganization> {
-    let org = load_editable_org(state, user_id, org_name).await?;
+    let org = load_unmanaged_org(state, user_id, org_name).await?;
     let membership = load_org_membership(state, user_id, org.id)
         .await?
         .ok_or_else(|| WebError::not_found("Organization"))?;

--- a/backend/web/src/endpoints/orgs/settings.rs
+++ b/backend/web/src/endpoints/orgs/settings.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-use super::{load_editable_org, load_org_member};
+use super::{load_unmanaged_org, load_org_member};
 use crate::error::{WebError, WebResult};
 use axum::extract::{Path, State};
 use axum::{Extension, Json};
@@ -88,7 +88,7 @@ pub async fn post_organization_public(
     Extension(user): Extension<MUser>,
     Path(organization): Path<String>,
 ) -> WebResult<Json<BaseResponse<String>>> {
-    let org = load_editable_org(&state, user.id, organization).await?;
+    let org = load_unmanaged_org(&state, user.id, organization).await?;
     let mut active: AOrganization = org.into();
     active.public = Set(true);
     active.update(&state.web_db).await?;
@@ -104,7 +104,7 @@ pub async fn delete_organization_public(
     Extension(user): Extension<MUser>,
     Path(organization): Path<String>,
 ) -> WebResult<Json<BaseResponse<String>>> {
-    let org = load_editable_org(&state, user.id, organization).await?;
+    let org = load_unmanaged_org(&state, user.id, organization).await?;
     let mut active: AOrganization = org.into();
     active.public = Set(false);
     active.update(&state.web_db).await?;

--- a/backend/web/src/endpoints/orgs/ssh.rs
+++ b/backend/web/src/endpoints/orgs/ssh.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-use super::{load_editable_org, load_org_member};
+use super::{load_unmanaged_org, load_org_member};
 use crate::error::{WebError, WebResult};
 use axum::extract::{Path, State};
 use axum::{Extension, Json};
@@ -32,7 +32,7 @@ pub async fn post_organization_ssh(
     Extension(user): Extension<MUser>,
     Path(organization): Path<String>,
 ) -> WebResult<Json<BaseResponse<String>>> {
-    let organization = load_editable_org(&state, user.id, organization).await?;
+    let organization = load_unmanaged_org(&state, user.id, organization).await?;
 
     let (private_key, public_key) =
         generate_ssh_key(&state.cli.crypt_secret_file).map_err(|e| {


### PR DESCRIPTION
## Summary
- Rename `load_editable_org` → `load_unmanaged_org`.
- Doc clarifies that membership ≠ edit rights and that mutating handlers must call `load_admin_org` for the role check.

## Test plan
- [ ] CI builds workspace
- [ ] CI tests pass
Closes #54