### PR TITLE
backend: web: explicit re-exports in endpoint mod.rs (#63)

### DIFF
--- a/backend/web/src/endpoints/builds/mod.rs
+++ b/backend/web/src/endpoints/builds/mod.rs
@@ -10,11 +10,17 @@ pub mod graph;
 pub mod log;
 pub mod query;
 
-pub use self::direct::*;
-pub use self::downloads::*;
-pub use self::graph::*;
-pub use self::log::*;
-pub use self::query::*;
+pub use self::direct::{
+    DirectBuildInfo, DirectBuildRequest, get_recent_direct_builds, post_direct_build,
+};
+pub use self::downloads::{
+    BuildProduct, DownloadQuery, get_build_download, get_build_download_token, get_build_downloads,
+};
+pub use self::graph::{
+    BuildGraph, DependencyEdge, DependencyNode, get_build_dependencies, get_build_graph,
+};
+pub use self::log::{get_build_log, post_build_log};
+pub use self::query::{BuildWithOutputs, get_build};
 
 use crate::endpoints::user_is_org_member;
 use crate::error::{WebError, WebResult};

--- a/backend/web/src/endpoints/caches/mod.rs
+++ b/backend/web/src/endpoints/caches/mod.rs
@@ -11,8 +11,14 @@ mod nar;
 mod narinfo;
 mod upstreams;
 
-pub use self::keys::*;
-pub use self::management::*;
-pub use self::nar::*;
-pub use self::narinfo::*;
-pub use self::upstreams::*;
+pub use self::keys::{get_cache_key, get_cache_public_key};
+pub use self::management::{
+    delete_cache, delete_cache_active, delete_cache_public, get, get_cache,
+    get_cache_name_available, get_public_caches, patch_cache, post_cache_active, post_cache_public,
+    put,
+};
+pub use self::nar::{nar, upstream_nar};
+pub use self::narinfo::{gradient_cache_info, nix_cache_info, path};
+pub use self::upstreams::{
+    delete_cache_upstream, get_cache_upstreams, patch_cache_upstream, put_cache_upstream,
+};

--- a/backend/web/src/endpoints/orgs/mod.rs
+++ b/backend/web/src/endpoints/orgs/mod.rs
@@ -11,12 +11,29 @@ pub mod settings;
 pub mod ssh;
 pub mod workers;
 
-pub use self::integrations::*;
-pub use self::management::*;
-pub use self::members::*;
-pub use self::settings::*;
-pub use self::ssh::*;
-pub use self::workers::*;
+pub use self::integrations::{
+    CreateIntegrationRequest, IntegrationResponse, PatchIntegrationRequest, delete_integration,
+    get_integration, get_integrations, patch_integration, put_integration,
+};
+pub use self::management::{
+    MakeOrganizationRequest, OrgResponse, OrganizationSummary, PatchOrganizationRequest,
+    delete_organization, get, get_org_name_available, get_organization, get_public_organizations,
+    patch_organization, put,
+};
+pub use self::members::{
+    AddUserRequest, RemoveUserRequest, StringListItem, delete_organization_users,
+    get_organization_users, patch_organization_users, post_organization_users,
+};
+pub use self::settings::{
+    CacheSubscriptionItem, SubscribeCacheRequest, delete_organization_public,
+    delete_organization_subscribe_cache, get_organization_subscribe, post_organization_public,
+    post_organization_subscribe_cache,
+};
+pub use self::ssh::{get_organization_ssh, post_organization_ssh};
+pub use self::workers::{
+    OrgWorkerEntry, PatchWorkerRequest, RegisterWorkerRequest, RegisterWorkerResponse,
+    WorkerLiveInfo, delete_org_worker, get_org_workers, patch_org_worker, post_org_worker,
+};
 
 use crate::error::{WebError, WebResult};
 use core::db::get_organization_by_name;

--- a/backend/web/src/endpoints/projects/mod.rs
+++ b/backend/web/src/endpoints/projects/mod.rs
@@ -9,10 +9,21 @@ pub mod integrations;
 pub mod management;
 pub mod metrics;
 
-pub use self::evaluations::*;
-pub use self::integrations::*;
-pub use self::management::*;
-pub use self::metrics::*;
+pub use self::evaluations::{
+    EntryPointDownloadQuery, EntryPointsQuery, EvaluateRequest, get_entry_point_download,
+    get_project_details, get_project_entry_points, get_project_evaluations, post_project_evaluate,
+};
+pub use self::integrations::{
+    delete_project_integration, get_project_integration, put_project_integration,
+};
+pub use self::management::{
+    MakeProjectRequest, PatchProjectRequest, TransferOwnershipRequest, delete_project,
+    delete_project_active, get, get_project, get_project_name_available, patch_project,
+    post_project_active, post_project_check_repository, post_project_transfer, put,
+};
+pub use self::metrics::{
+    EntryPointMetricsQuery, get_entry_point_metrics, get_project_metrics,
+};
 
 use crate::endpoints::get_org_readable;
 use crate::error::{WebError, WebResult};


### PR DESCRIPTION
## Summary
- Replace `pub use self::*::*` globs in `caches/`, `projects/`, `orgs/`, and `builds/` `mod.rs` with explicit named re-exports.
- Restores grep / goto-definition behaviour for those submodule items.

## Test plan
- [x] CI builds workspace
- [x] CI tests pass
Closes #63