### PR TITLE
backend: web: patch_field! / patch_field_with! macros (#76)

### DIFF
--- a/backend/web/src/endpoints/orgs/management.rs
+++ b/backend/web/src/endpoints/orgs/management.rs
@@ -383,9 +383,9 @@ pub async fn patch_organization(
         aorganization.display_name = Set(display_name);
     }
 
-    if let Some(description) = body.description {
-        aorganization.description = Set(description.trim().to_string());
-    }
+    crate::patch_field_with!(aorganization, body, description, |s: String| s
+        .trim()
+        .to_string());
 
     let organization = aorganization.update(&state.web_db).await?;
 

--- a/backend/web/src/lib.rs
+++ b/backend/web/src/lib.rs
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+#[macro_use]
+pub mod patch;
+
 pub mod authorization;
 pub mod endpoints;
 pub mod error;

--- a/backend/web/src/patch.rs
+++ b/backend/web/src/patch.rs
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Helpers for the `PATCH` endpoint pattern.
+//!
+//! Every mutating PATCH handler walks an `Option<T>` field on a request DTO
+//! and, when `Some`, optionally validates and assigns to the matching
+//! `ActiveModel` field. The two macros here capture the trivial and
+//! validated shapes so handlers don't repeat 5–10 lines of boilerplate per
+//! field.
+//!
+//! For complex per-field logic (cross-field validation, uniqueness checks
+//! that must hit the DB, post-processing) keep the explicit `if let Some`
+//! block — these helpers are deliberately scoped to the mechanical cases.
+
+/// Set `active.$field = Set(value)` when `$body.$field` is `Some`.
+///
+/// ```ignore
+/// patch_field!(aorg, body, description);
+/// ```
+#[macro_export]
+macro_rules! patch_field {
+    ($active:expr, $body:expr, $field:ident) => {
+        if let Some(v) = $body.$field {
+            $active.$field = ::sea_orm::Set(v);
+        }
+    };
+}
+
+/// Like [`patch_field!`] but applies `$transform` (a closure) to the value
+/// before assigning. Useful for `.trim().to_string()` shaping.
+///
+/// ```ignore
+/// patch_field_with!(aorg, body, description, |s: String| s.trim().to_string());
+/// ```
+#[macro_export]
+macro_rules! patch_field_with {
+    ($active:expr, $body:expr, $field:ident, $transform:expr) => {
+        if let Some(v) = $body.$field {
+            let f = $transform;
+            $active.$field = ::sea_orm::Set(f(v));
+        }
+    };
+}


### PR DESCRIPTION
## Summary
- Add `patch_field!` and `patch_field_with!` declarative macros for the trivial PATCH shapes.
- Migrate `orgs/management.rs` description as the first call-site demonstration.
- A full `#[derive(Patch)]` proc-macro (the issue's eventual target) is out of scope; the declarative macros cover the simple cases. Complex per-field validation deliberately stays explicit.

## Test plan
- [x] CI builds workspace
- [x] CI tests pass
Closes #76