### PR TITLE
backend: worker: include full error chain in JobFailed payload (#142)

### DIFF
--- a/backend/worker/src/worker/dispatch.rs
+++ b/backend/worker/src/worker/dispatch.rs
@@ -153,10 +153,11 @@ fn on_job_done(
             writer.send(ClientMessage::JobCompleted { job_id })?;
         }
         Err(e) => {
-            error!(%job_id, error = %e, "job failed");
+            let error_chain = format!("{e:#}");
+            error!(%job_id, error = %error_chain, "job failed");
             writer.send(ClientMessage::JobFailed {
                 job_id,
-                error: e.to_string(),
+                error: error_chain,
             })?;
         }
     }


### PR DESCRIPTION
## Summary

Fixes #142. For a fetch-stage failure (e.g. `git2` clone hitting DNS / unreachable host), the eval error log in Gradient previously showed only `failed to clone <url>` while the libgit2 root cause (`failed to resolve address ...; class=Net (12)`) was silently dropped.

Root cause: `anyhow::Error`'s `Display` impl (used by both `e.to_string()` and the `%e` tracing sigil) renders only the outermost context layer. The chain trace from `clone_and_checkout` → `fetch_repository` → `execute_flake_job` → `run_job` → `on_job_done` preserves the source chain end-to-end, so the only place the chain was being lost was `dispatch.rs:155-161`. The `JobFailed` payload from there becomes the `evaluation_message.message` row that the UI displays.

Switched both the `error!` log and the `JobFailed { error }` payload to `format!("{e:#}")`, which walks the full source chain.

## Test plan

- [x] `cargo build -p worker` succeeds
- [ ] Reproduce against an unreachable repo URL and confirm the eval error log shows the libgit2 root cause (`Could not resolve host: ...` / `failed to resolve address ...`) appended after `failed to clone <url>`