### PR TITLE
backend: cache: batch sign sweep + reuse decrypted cache keys (#105)

### DIFF
--- a/backend/cache/src/cacher/sign_sweep.rs
+++ b/backend/cache/src/cacher/sign_sweep.rs
@@ -13,12 +13,19 @@
 //! records `cache_derivation` rows when a derivation's full closure has
 //! become cached for a given cache.
 
+use gradient_core::sources::CacheSigner;
 use gradient_core::types::*;
-use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, Set};
-use std::collections::HashSet;
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, QuerySelect, Set,
+};
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tracing::{debug, warn};
 use uuid::Uuid;
+
+/// Max pending rows processed per sweep pass. Bounds memory + time per
+/// invocation; remaining rows are picked up by the next scheduled pass.
+const SIGN_SWEEP_BATCH: u64 = 1000;
 
 /// One pass: sign every pending `cached_path_signature` row and update
 /// `cache_derivation` where newly-signed paths complete a derivation
@@ -26,6 +33,7 @@ use uuid::Uuid;
 pub async fn sign_missing_signatures(state: Arc<ServerState>) -> anyhow::Result<()> {
     let pending = ECachedPathSignature::find()
         .filter(CCachedPathSignature::Signature.is_null())
+        .limit(SIGN_SWEEP_BATCH)
         .all(&state.db)
         .await?;
 
@@ -33,33 +41,69 @@ pub async fn sign_missing_signatures(state: Arc<ServerState>) -> anyhow::Result<
         return Ok(());
     }
 
+    let cache_ids: Vec<Uuid> = pending.iter().map(|r| r.cache).collect::<HashSet<_>>().into_iter().collect();
+    let cached_path_ids: Vec<Uuid> = pending
+        .iter()
+        .map(|r| r.cached_path)
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+
+    let caches: HashMap<Uuid, MCache> = ECache::find()
+        .filter(CCache::Id.is_in(cache_ids))
+        .all(&state.db)
+        .await?
+        .into_iter()
+        .map(|c| (c.id, c))
+        .collect();
+
+    let cached_paths: HashMap<Uuid, MCachedPath> = ECachedPath::find()
+        .filter(CCachedPath::Id.is_in(cached_path_ids))
+        .all(&state.db)
+        .await?
+        .into_iter()
+        .map(|c| (c.id, c))
+        .collect();
+
+    // Build a per-cache signer once (one crypt-secret read + one private-key
+    // decryption per cache, not per row). `None` marks caches whose key
+    // failed to decode — we skip their rows for this pass.
+    let mut signers: HashMap<Uuid, Option<CacheSigner>> = HashMap::new();
+    for (cache_id, cache) in &caches {
+        if cache.private_key.is_empty() {
+            signers.insert(*cache_id, None);
+            continue;
+        }
+        let signer = match CacheSigner::from_cache(
+            &state.cli.crypt_secret_file,
+            cache,
+            &state.cli.serve_url,
+        ) {
+            Ok(s) => Some(s),
+            Err(e) => {
+                warn!(cache_name = %cache.name, error = %e, "sign sweep: failed to prepare signer");
+                None
+            }
+        };
+        signers.insert(*cache_id, signer);
+    }
+
     let mut touched_caches: HashSet<Uuid> = HashSet::new();
     let mut signed = 0usize;
 
     for row in pending {
-        let cache = match ECache::find_by_id(row.cache).one(&state.db).await {
-            Ok(Some(c)) if !c.private_key.is_empty() => c,
-            Ok(_) => continue,
-            Err(e) => {
-                warn!(cache = %row.cache, error = %e, "sign sweep: failed to load cache");
-                continue;
-            }
+        let Some(cache) = caches.get(&row.cache) else {
+            continue;
+        };
+        let Some(Some(signer)) = signers.get(&row.cache) else {
+            continue;
         };
 
-        let cp = match ECachedPath::find_by_id(row.cached_path)
-            .one(&state.db)
-            .await
-        {
-            Ok(Some(c)) => c,
-            Ok(None) => continue,
-            Err(e) => {
-                warn!(cached_path = %row.cached_path, error = %e, "sign sweep: failed to load cached_path");
-                continue;
-            }
+        let Some(cp) = cached_paths.get(&row.cached_path) else {
+            continue;
         };
 
         let (Some(nar_hash), Some(nar_size)) = (cp.nar_hash.as_deref(), cp.nar_size) else {
-            // Metadata not yet recorded — try again next pass.
             continue;
         };
 
@@ -73,21 +117,8 @@ pub async fn sign_missing_signatures(state: Arc<ServerState>) -> anyhow::Result<
 
         let nar_hash_nix32 = hex_hash_to_nix32(nar_hash);
 
-        let sig_token = match gradient_core::sources::sign_narinfo_fingerprint(
-            &state.cli.crypt_secret_file,
-            cache.clone(),
-            state.cli.serve_url.clone(),
-            &cp.store_path,
-            &nar_hash_nix32,
-            nar_size as u64,
-            &refs,
-        ) {
-            Ok(s) => s,
-            Err(e) => {
-                warn!(cache_name = %cache.name, store_path = %cp.store_path, error = %e, "sign sweep: narinfo signing failed");
-                continue;
-            }
-        };
+        let sig_token =
+            signer.sign_narinfo(&cp.store_path, &nar_hash_nix32, nar_size as u64, &refs);
 
         let sig_b64 = sig_token
             .split_once(':')

--- a/backend/core/src/sources/cache_key.rs
+++ b/backend/core/src/sources/cache_key.rs
@@ -96,6 +96,69 @@ pub fn format_cache_key(
     ))
 }
 
+/// A pre-decrypted signer for a single cache, reusable across many
+/// signatures without re-reading the crypt-secret file or re-decrypting
+/// the cache's private key.
+pub struct CacheSigner {
+    secret_key: SecretKey,
+    cache_name: String,
+    base_url: String,
+}
+
+impl CacheSigner {
+    /// Build a signer from the encrypted cache row by reading the crypt
+    /// secret from `secret_file` once. Subsequent `sign_*` calls reuse the
+    /// in-memory `SecretKey`.
+    pub fn from_cache(
+        secret_file: &str,
+        cache: &MCache,
+        serve_url: &str,
+    ) -> Result<Self, SourceError> {
+        let key_b64 = decrypt_signing_key(secret_file, cache.clone())?;
+        let key_bytes = general_purpose::STANDARD
+            .decode(key_b64.trim())
+            .map_err(|e| SourceError::CacheKeyDecoding {
+                cache: cache.name.clone(),
+                reason: format!("Failed to base64-decode signing key: {}", e),
+            })?;
+        let secret_key =
+            SecretKey::from_slice(&key_bytes).map_err(|_| SourceError::KeyPairConversion)?;
+        Ok(Self {
+            secret_key,
+            cache_name: cache.name.clone(),
+            base_url: super::cache_key_host(serve_url),
+        })
+    }
+
+    /// Sign a narinfo fingerprint with the pre-decoded key.
+    pub fn sign_narinfo(
+        &self,
+        store_path: &str,
+        nar_hash: &str,
+        nar_size: u64,
+        references: &[String],
+    ) -> String {
+        let mut full_refs: Vec<String> = references
+            .iter()
+            .map(|r| {
+                if r.starts_with("/nix/store/") {
+                    r.clone()
+                } else {
+                    format!("/nix/store/{}", r)
+                }
+            })
+            .collect();
+        full_refs.sort();
+        let refs_str = full_refs.join(",");
+
+        let fingerprint = format!("1;{};{};{};{}", store_path, nar_hash, nar_size, refs_str);
+        let sig = self.secret_key.sign(fingerprint.as_bytes(), None);
+        let sig_b64 = general_purpose::STANDARD.encode(*sig);
+
+        format!("{}-{}:{}", self.base_url, self.cache_name, sig_b64)
+    }
+}
+
 /// Signs a Nix narinfo fingerprint directly with the cache's Ed25519 key.
 ///
 /// Fingerprint format: `1;{store_path};{nar_hash};{nar_size};{refs_sorted_comma}`
@@ -103,6 +166,9 @@ pub fn format_cache_key(
 ///
 /// References should be bare store-path names (without `/nix/store/` prefix);
 /// this function adds the prefix before sorting and joining.
+///
+/// One-shot wrapper around [`CacheSigner`] — prefer [`CacheSigner::from_cache`]
+/// when signing many paths for the same cache.
 pub fn sign_narinfo_fingerprint(
     secret_file: &str,
     cache: MCache,
@@ -112,37 +178,8 @@ pub fn sign_narinfo_fingerprint(
     nar_size: u64,
     references: &[String],
 ) -> Result<String, SourceError> {
-    let key_b64 = decrypt_signing_key(secret_file, cache.clone())?;
-    let key_bytes = general_purpose::STANDARD
-        .decode(key_b64.trim())
-        .map_err(|e| SourceError::CacheKeyDecoding {
-            cache: cache.name.clone(),
-            reason: format!("Failed to base64-decode signing key: {}", e),
-        })?;
-
-    let secret_key =
-        SecretKey::from_slice(&key_bytes).map_err(|_| SourceError::KeyPairConversion)?;
-
-    let mut full_refs: Vec<String> = references
-        .iter()
-        .map(|r| {
-            if r.starts_with("/nix/store/") {
-                r.clone()
-            } else {
-                format!("/nix/store/{}", r)
-            }
-        })
-        .collect();
-    full_refs.sort();
-    let refs_str = full_refs.join(",");
-
-    let fingerprint = format!("1;{};{};{};{}", store_path, nar_hash, nar_size, refs_str);
-    let sig = secret_key.sign(fingerprint.as_bytes(), None);
-    let sig_b64 = general_purpose::STANDARD.encode(*sig);
-
-    let base_url = super::cache_key_host(&serve_url);
-
-    Ok(format!("{}-{}:{}", base_url, cache.name, sig_b64))
+    let signer = CacheSigner::from_cache(secret_file, &cache, &serve_url)?;
+    Ok(signer.sign_narinfo(store_path, nar_hash, nar_size, references))
 }
 
 /// Verifies that `narinfo_body` carries at least one `Sig:` line signed by the
@@ -338,6 +375,60 @@ mod tests {
             result.starts_with("cache.example.com-sigcache:"),
             "unexpected prefix: {result}"
         );
+    }
+
+    #[test]
+    fn cache_signer_matches_one_shot_signer() {
+        // CacheSigner reuses the decrypted key across many signatures.
+        // Each output must byte-match the legacy one-shot fingerprint signer
+        // so the sign-sweep batching change is provably side-effect-free.
+        let (_f, path) = temp_secret_file();
+        let (encrypted_priv, pub_b64) =
+            generate_signing_key(&path).expect("generate failed");
+        let cache = make_cache("sigcache", &pub_b64, &encrypted_priv);
+        let serve_url = "https://cache.example.com".to_string();
+
+        let signer = CacheSigner::from_cache(&path, &cache, &serve_url).expect("signer build");
+
+        let cases: &[(&str, &str, u64, &[&str])] = &[
+            ("/nix/store/aaaa-a", "sha256:AAAA", 1, &[]),
+            ("/nix/store/bbbb-b", "sha256:BBBB", 4242, &["aaaa-a"]),
+            (
+                "/nix/store/cccc-c",
+                "sha256:CCCC",
+                999999,
+                &["zzzz-z", "aaaa-a", "/nix/store/yyyy-y"],
+            ),
+        ];
+
+        for (sp, hash, size, refs) in cases {
+            let refs_owned: Vec<String> = refs.iter().map(|s| (*s).to_string()).collect();
+            let one_shot = sign_narinfo_fingerprint(
+                &path,
+                cache.clone(),
+                serve_url.clone(),
+                sp,
+                hash,
+                *size,
+                &refs_owned,
+            )
+            .expect("one-shot sign");
+            let batched = signer.sign_narinfo(sp, hash, *size, &refs_owned);
+            assert_eq!(
+                one_shot, batched,
+                "CacheSigner output must match sign_narinfo_fingerprint for {sp}"
+            );
+        }
+    }
+
+    #[test]
+    fn cache_signer_rejects_bad_key_at_build_time() {
+        // Construction surfaces decryption errors up front so the sweep can
+        // skip the cache for the rest of the pass instead of failing each row.
+        let (_f, path) = temp_secret_file();
+        let cache = make_cache("badcache", "", "!!!not-base64!!!");
+        let res = CacheSigner::from_cache(&path, &cache, "https://cache.example.com");
+        assert!(res.is_err(), "expected build error for corrupt key");
     }
 
     #[test]

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -662,3 +662,37 @@ Backend tests (`cargo test -p proto --lib handler::auth`):
   `password_auth`; lowercase hex routes to constant-time SHA-256.
 - The pre-existing `validate_tokens_*` tests using `sha256_hex` continue
   to cover the legacy-format compatibility path.
+
+## Sign sweep — batched, bounded, single crypt-secret read (#105)
+
+`sign_missing_signatures` (in `backend/cache/src/cacher/sign_sweep.rs`)
+used to issue 2 SELECTs per pending row (cache + cached_path), reload
+the crypt-secret file from disk, and re-decrypt each cache's private
+key on every row, with no `LIMIT` on the initial query — at scale this
+became 50k+ DB calls plus 50k+ crypt-secret reads per minute, and a
+single backlog could pin one DB connection indefinitely.
+
+The sweep is now `LIMIT`-bounded (`SIGN_SWEEP_BATCH = 1000` rows per
+pass) and batches the `cache` / `cached_path` lookups into one
+`is_in(...)` query each. Per-cache decrypted keys are wrapped in a new
+`CacheSigner` (in `backend/core/src/sources/cache_key.rs`) built once
+per pass per cache — the crypt secret is read at most once per cache,
+not once per signature. `sign_narinfo_fingerprint` is now a thin
+one-shot wrapper around `CacheSigner::sign_narinfo` so existing
+callers keep working byte-for-byte.
+
+Unit tests (`cargo test -p core --lib sources::cache_key`):
+
+- `cache_signer_matches_one_shot_signer` — for several
+  `(store_path, nar_hash, nar_size, refs)` tuples, asserts that the
+  signature produced by `CacheSigner::sign_narinfo` is byte-identical
+  to the one produced by `sign_narinfo_fingerprint`. Guards against the
+  batching refactor silently changing the on-wire fingerprint.
+- `cache_signer_rejects_bad_key_at_build_time` — a cache row whose
+  `private_key` cannot be base64-decoded fails at
+  `CacheSigner::from_cache`, so the sweep can mark the cache as
+  unsignable for the rest of the pass instead of repeating the
+  decryption error per row.
+
+The pre-existing `cacher::sign_sweep::tests::hex_hash_to_nix32_*`
+suite continues to cover the hash-format conversion path.


### PR DESCRIPTION
Fixes #105.

## Summary
- `sign_missing_signatures` now caps each pass at
  `SIGN_SWEEP_BATCH = 1000` rows (the next scheduled pass picks up the
  rest), so a large backlog can no longer pin a DB connection.
- Distinct `cache_id`s and `cached_path_id`s are collected from the
  pending rows and loaded with a single `is_in(...)` query each,
  removing the per-row 2x SELECT N+1.
- New `gradient_core::sources::CacheSigner` pre-decrypts each cache's
  private key once per pass and signs many narinfo fingerprints from
  memory. The crypt-secret file is read at most once per cache, not
  once per signature.
- `sign_narinfo_fingerprint` is now a thin one-shot wrapper around
  `CacheSigner::sign_narinfo`. A new test
  (`cache_signer_matches_one_shot_signer`) asserts the batched signer
  produces byte-identical signatures to the legacy one-shot path.

## Test plan
- [x] `cargo test --manifest-path backend/Cargo.toml -p core --lib sources::cache_key`
      (21 passed, 2 new)
- [x] `cargo test --manifest-path backend/Cargo.toml -p cache --lib`
      (10 passed)
- [x] `cargo build --manifest-path backend/Cargo.toml --workspace`
- [x] `docs/src/tests.md` updated with the new test list.