### PR TITLE
backend: proto: cap /proto WS message size + add handshake timeout (#110)

### DIFF
--- a/backend/proto/src/handler/mod.rs
+++ b/backend/proto/src/handler/mod.rs
@@ -22,7 +22,10 @@ use gradient_core::types::*;
 use scheduler::Scheduler;
 
 pub(crate) use session::handle_socket;
-pub(crate) use socket::ProtoSocket;
+pub(crate) use socket::{MAX_PROTO_MESSAGE_SIZE, ProtoSocket};
+
+#[cfg(test)]
+pub(crate) use socket::{HANDSHAKE_TIMEOUT, NAR_PUSH_CHUNK_SIZE};
 
 /// Returns the axum [`Router`] that serves the `/proto` WebSocket endpoint.
 pub fn proto_router() -> Router<Arc<ServerState>> {
@@ -34,7 +37,9 @@ async fn ws_upgrade(
     State(state): State<Arc<ServerState>>,
     Extension(scheduler): Extension<Arc<Scheduler>>,
 ) -> impl IntoResponse {
-    ws.on_upgrade(move |sock| {
-        session::handle_socket(socket::ProtoSocket::Axum(sock), state, scheduler, false)
-    })
+    ws.max_message_size(MAX_PROTO_MESSAGE_SIZE)
+        .max_frame_size(MAX_PROTO_MESSAGE_SIZE)
+        .on_upgrade(move |sock| {
+            session::handle_socket(socket::ProtoSocket::Axum(sock), state, scheduler, false)
+        })
 }

--- a/backend/proto/src/handler/session.rs
+++ b/backend/proto/src/handler/session.rs
@@ -24,7 +24,8 @@ use super::auth::{
 };
 use super::dispatch::DispatchContext;
 use super::socket::{
-    JOB_OFFER_CHUNK_SIZE, ProtoSocket, recv_client_msg, send_error, send_reject, send_server_msg,
+    HANDSHAKE_TIMEOUT, JOB_OFFER_CHUNK_SIZE, ProtoSocket, recv_client_msg, send_error,
+    send_reject, send_server_msg,
 };
 
 // ── Session state markers ─────────────────────────────────────────────────────
@@ -362,8 +363,22 @@ pub(crate) async fn handle_socket(
 ) {
     info!(server_initiated, "WebSocket connection opened");
     let session = ProtoSession::new(socket, state, scheduler);
-    let Some(session) = session.handshake(server_initiated).await else {
-        return;
+    let session = match tokio::time::timeout(
+        HANDSHAKE_TIMEOUT,
+        session.handshake(server_initiated),
+    )
+    .await
+    {
+        Ok(Some(s)) => s,
+        Ok(None) => return,
+        Err(_) => {
+            warn!(
+                timeout_secs = HANDSHAKE_TIMEOUT.as_secs(),
+                server_initiated,
+                "WebSocket handshake timed out; dropping connection"
+            );
+            return;
+        }
     };
     let Some(session) = session.register().await else {
         return;

--- a/backend/proto/src/handler/socket.rs
+++ b/backend/proto/src/handler/socket.rs
@@ -26,7 +26,21 @@ use scheduler::Scheduler;
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 pub(super) const JOB_OFFER_CHUNK_SIZE: usize = 1_000;
-pub(super) const NAR_PUSH_CHUNK_SIZE: usize = 64 * 1024;
+pub const NAR_PUSH_CHUNK_SIZE: usize = 64 * 1024;
+
+/// Hard upper bound on any single inbound or outbound `/proto` WebSocket
+/// frame/message. Comfortably above the largest legitimate frame
+/// (`NarPush` carries 64 KiB chunks plus rkyv overhead and metadata) while
+/// preventing a peer from pinning gigabytes of memory with a single send.
+/// Applied to both the inbound axum upgrade and the outbound tungstenite
+/// connect.
+pub const MAX_PROTO_MESSAGE_SIZE: usize = 1024 * 1024;
+
+/// Maximum time the server will wait for a peer to complete the handshake
+/// (Discoverable check → InitConnection → AuthChallenge → AuthResponse →
+/// InitAck). A peer that opens the WebSocket and then stalls is dropped after
+/// this deadline so it cannot pin a tokio task and FD indefinitely.
+pub const HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 
 // ── Socket abstraction ────────────────────────────────────────────────────────
 

--- a/backend/proto/src/outbound.rs
+++ b/backend/proto/src/outbound.rs
@@ -18,12 +18,13 @@ use std::time::Duration;
 
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use tokio::sync::Mutex;
-use tokio_tungstenite::connect_async;
+use tokio_tungstenite::connect_async_with_config;
+use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
 use tracing::{debug, error, info, warn};
 
 use entity::worker_registration::{Column, Entity as EWorkerRegistration};
 
-use crate::handler::{ProtoSocket, handle_socket};
+use crate::handler::{MAX_PROTO_MESSAGE_SIZE, ProtoSocket, handle_socket};
 use scheduler::Scheduler;
 
 /// Spawn the outbound connection loop as a detached tokio task.
@@ -90,7 +91,14 @@ async fn connect_to_registered_workers(
         tokio::spawn(async move {
             debug!(%worker_id, %url, "connecting outbound to worker");
 
-            let result = tokio::time::timeout(Duration::from_secs(10), connect_async(&url)).await;
+            let config = WebSocketConfig::default()
+                .max_message_size(Some(MAX_PROTO_MESSAGE_SIZE))
+                .max_frame_size(Some(MAX_PROTO_MESSAGE_SIZE));
+            let result = tokio::time::timeout(
+                Duration::from_secs(10),
+                connect_async_with_config(&url, Some(config), false),
+            )
+            .await;
 
             match result {
                 Ok(Ok((stream, _response))) => {

--- a/backend/proto/src/tests.rs
+++ b/backend/proto/src/tests.rs
@@ -241,5 +241,33 @@ fn proto_version_is_nonzero() {
     assert!(version >= 1);
 }
 
+/// Regression for #110: the `/proto` WebSocket cap must:
+/// - exceed the largest legitimate frame (`NarPush` at 64 KiB plus rkyv
+///   overhead, plus headroom for `LogChunk`/`CacheQuery` arrays), and
+/// - stay well below tungstenite's 64 MiB default so a malicious peer can't
+///   ask the server to allocate gigabytes from a single send.
+#[test]
+fn max_proto_message_size_is_sane() {
+    use crate::handler::{MAX_PROTO_MESSAGE_SIZE, NAR_PUSH_CHUNK_SIZE};
+    assert!(
+        MAX_PROTO_MESSAGE_SIZE >= NAR_PUSH_CHUNK_SIZE * 2,
+        "must fit a NarPush chunk plus framing/metadata"
+    );
+    assert!(
+        MAX_PROTO_MESSAGE_SIZE <= 16 * 1024 * 1024,
+        "guard against accidental relaxation back toward defaults"
+    );
+}
+
+/// Regression for #110: the handshake deadline must be long enough to cover
+/// a real auth round-trip but short enough that a stalled peer cannot pin a
+/// task and FD for minutes.
+#[test]
+fn handshake_timeout_is_sane() {
+    use crate::handler::HANDSHAKE_TIMEOUT;
+    assert!(HANDSHAKE_TIMEOUT.as_secs() >= 5);
+    assert!(HANDSHAKE_TIMEOUT.as_secs() <= 60);
+}
+
 // Full WebSocket handshake integration tests (InitConnection → InitAck) live in
 // the `web` crate's integration tests where `test-support` is available.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -706,3 +706,29 @@ Unit tests (`cargo test -p core --lib sources::cache_key`):
 
 The pre-existing `cacher::sign_sweep::tests::hex_hash_to_nix32_*`
 suite continues to cover the hash-format conversion path.
+
+## Proto WebSocket — message-size cap & handshake timeout
+
+The `/proto` WebSocket caps every inbound and outbound frame at
+`MAX_PROTO_MESSAGE_SIZE` (1 MiB) — applied to both the inbound
+`axum::extract::ws::WebSocketUpgrade` and the outbound
+`tokio_tungstenite::connect_async_with_config` call in
+`backend/proto/src/outbound.rs`. The cap comfortably exceeds any legitimate
+frame (`NarPush` chunks are 64 KiB plus rkyv overhead) while preventing a
+peer from forcing a multi-megabyte allocation per message.
+
+`handle_socket` additionally wraps the entire handshake
+(Discoverable check → InitConnection → AuthChallenge → AuthResponse →
+InitAck) in a `HANDSHAKE_TIMEOUT` (15 s) `tokio::time::timeout`, so a peer
+that completes the WebSocket upgrade and then stalls cannot pin a tokio task
+or file descriptor indefinitely.
+
+Tests (`cargo test -p proto`):
+
+- `tests::max_proto_message_size_is_sane` — regression for #110: cap stays
+  at least `2 × NAR_PUSH_CHUNK_SIZE` (room for chunk + framing) and well
+  below 16 MiB so a future refactor cannot silently relax the bound back
+  toward tungstenite's 64 MiB default.
+- `tests::handshake_timeout_is_sane` — regression for #110: deadline stays
+  in `[5 s, 60 s]` so a real auth round-trip still fits but a stalled peer
+  is dropped quickly.


### PR DESCRIPTION
Fixes #110.

## Summary
- The `/proto` WebSocket inherited tungstenite's 64 MiB default `max_message_size` and never bounded how long a peer could take to complete the handshake. A peer could ship a 100 MB `id` in `InitConnection`, or complete the WS upgrade and then stall, pinning a tokio task + FD until the process restarts.
- Add `MAX_PROTO_MESSAGE_SIZE = 1 MiB` and apply it to **both** the inbound `axum::extract::ws::WebSocketUpgrade` (`handler/mod.rs`) and the outbound `tokio_tungstenite::connect_async_with_config` (`outbound.rs`). The cap comfortably fits the largest legitimate frame (`NarPush` 64 KiB chunks + rkyv overhead) while preventing megabyte-class allocations from a single send.
- Add `HANDSHAKE_TIMEOUT = 15 s` and wrap `session.handshake()` in `tokio::time::timeout` inside `handle_socket`. A stalled peer is logged and dropped instead of held forever. Workers can simply reconnect.
- No CLI/env knobs — both bounds are constants, per the issue's framing as a hard safety net.
- Regression tests (`tests::max_proto_message_size_is_sane`, `tests::handshake_timeout_is_sane`) assert the constants stay within sane bounds so a future refactor cannot silently relax them.
- Docs entry added to `docs/src/tests.md`.

## Test plan
- [x] `cargo test -p proto` — 64 tests pass (incl. 2 new regression tests).
- [x] `cargo build --workspace` — clean.
- [ ] Manual: confirm a worker that opens the WS upgrade and sends nothing is dropped after ~15 s with the "WebSocket handshake timed out" warning.
- [ ] Manual: confirm a peer sending a >1 MiB frame is rejected by tungstenite (frame-size error), not accepted into the handler.