### PR TITLE
backend: worker: retry reconnect indefinitely with backoff (#99)

### DIFF
--- a/backend/worker/src/main.rs
+++ b/backend/worker/src/main.rs
@@ -10,6 +10,7 @@ mod connection_state;
 mod executor;
 mod nix;
 mod proto;
+mod reconnect;
 mod traits;
 mod worker;
 mod worker_pool;
@@ -22,6 +23,7 @@ use tracing::{error, info, warn};
 
 use config::WorkerConfig;
 use connection_state::RunOutcome;
+use reconnect::retry_reconnect;
 use tracing_subscriber::EnvFilter;
 use worker::Worker;
 
@@ -102,20 +104,18 @@ fn main() -> Result<()> {
                 }
             }
 
-            tokio::time::sleep(backoff).await;
-
-            match disconnected.reconnect().await {
-                Ok(w) => {
-                    worker = w;
-                    info!("reconnected successfully");
-                    backoff = INITIAL_BACKOFF;
-                }
-                Err(e) => {
-                    error!(error = %e, "reconnect failed; will retry");
-                    // Loop will break because `worker` has been moved — exit gracefully.
-                    break;
-                }
-            }
+            // Reconnect with exponential backoff. Never give up — a transient
+            // network blip must not kill the worker.
+            worker = retry_reconnect(
+                disconnected,
+                |d| async move { d.reconnect().await },
+                |delay| tokio::time::sleep(delay),
+                backoff,
+                MAX_BACKOFF,
+            )
+            .await;
+            info!("reconnected successfully");
+            backoff = INITIAL_BACKOFF;
         }
 
         Ok(())

--- a/backend/worker/src/reconnect.rs
+++ b/backend/worker/src/reconnect.rs
@@ -1,0 +1,151 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Reconnect-with-backoff helper.
+//!
+//! Drives `Worker::reconnect` (and any Disconnected → Connected transition that
+//! returns its state on failure) until it succeeds, doubling the delay between
+//! attempts up to `max_backoff`. Lives in its own module so the loop can be
+//! unit-tested without standing up a real `Worker`.
+
+use std::future::Future;
+use std::time::Duration;
+
+use tracing::error;
+
+/// Retry `attempt` indefinitely with exponential backoff.
+///
+/// `attempt` consumes the current state and returns either the next state on
+/// success, or `(error, state)` on failure so the next iteration can keep
+/// driving the same state. `sleep` is parameterised so tests can substitute a
+/// no-op timer.
+pub async fn retry_reconnect<S, T, E, F, Fut, Sleep, SleepFut>(
+    initial_state: S,
+    mut attempt: F,
+    mut sleep: Sleep,
+    initial_backoff: Duration,
+    max_backoff: Duration,
+) -> T
+where
+    F: FnMut(S) -> Fut,
+    Fut: Future<Output = Result<T, (E, S)>>,
+    Sleep: FnMut(Duration) -> SleepFut,
+    SleepFut: Future<Output = ()>,
+    E: std::fmt::Display,
+{
+    let mut state = initial_state;
+    let mut backoff = initial_backoff;
+    loop {
+        sleep(backoff).await;
+        match attempt(state).await {
+            Ok(t) => return t,
+            Err((e, s)) => {
+                error!(
+                    error = %e,
+                    delay_secs = backoff.as_secs(),
+                    "reconnect failed; retrying"
+                );
+                state = s;
+                backoff = (backoff * 2).min(max_backoff);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    /// Regression for #99: the loop must keep retrying after a single failure
+    /// instead of breaking out and shutting the worker down.
+    #[tokio::test]
+    async fn keeps_retrying_after_failure() {
+        let attempts = RefCell::new(0u32);
+        let result: u32 = retry_reconnect(
+            (),
+            |()| async {
+                *attempts.borrow_mut() += 1;
+                if *attempts.borrow() < 4 {
+                    Err::<u32, (String, ())>(("transient".into(), ()))
+                } else {
+                    Ok(42)
+                }
+            },
+            |_d| async {},
+            Duration::from_millis(1),
+            Duration::from_millis(8),
+        )
+        .await;
+
+        assert_eq!(result, 42);
+        assert_eq!(*attempts.borrow(), 4);
+    }
+
+    /// Backoff must double until it hits `max_backoff` and then plateau —
+    /// guards against an off-by-one where an unbounded multiplication could
+    /// overflow `Duration` after enough retries.
+    #[tokio::test]
+    async fn backoff_caps_at_max() {
+        let delays = RefCell::new(Vec::<Duration>::new());
+        let attempts = RefCell::new(0u32);
+        let _: u32 = retry_reconnect(
+            (),
+            |()| async {
+                *attempts.borrow_mut() += 1;
+                if *attempts.borrow() < 8 {
+                    Err::<u32, (String, ())>(("nope".into(), ()))
+                } else {
+                    Ok(0)
+                }
+            },
+            |d| {
+                delays.borrow_mut().push(d);
+                async {}
+            },
+            Duration::from_secs(1),
+            Duration::from_secs(8),
+        )
+        .await;
+
+        let observed = delays.borrow().clone();
+        assert_eq!(observed[0], Duration::from_secs(1));
+        assert_eq!(observed[1], Duration::from_secs(2));
+        assert_eq!(observed[2], Duration::from_secs(4));
+        assert_eq!(observed[3], Duration::from_secs(8));
+        assert_eq!(observed[4], Duration::from_secs(8));
+        assert_eq!(observed[5], Duration::from_secs(8));
+    }
+
+    /// Verifies the typestate-preservation contract: each retry receives the
+    /// same state value the previous attempt returned, so cached resources
+    /// (executor, scorer, credentials in the real `Worker<Disconnected>`)
+    /// are not lost across retries.
+    #[tokio::test]
+    async fn state_threads_through_retries() {
+        let attempts = RefCell::new(0u32);
+        let result: String = retry_reconnect(
+            String::from("session-A"),
+            |s| {
+                *attempts.borrow_mut() += 1;
+                let attempt = *attempts.borrow();
+                async move {
+                    if attempt < 3 {
+                        Err::<String, (String, String)>(("retry".into(), s))
+                    } else {
+                        Ok(s)
+                    }
+                }
+            },
+            |_d| async {},
+            Duration::from_millis(1),
+            Duration::from_millis(2),
+        )
+        .await;
+
+        assert_eq!(result, "session-A");
+    }
+}

--- a/backend/worker/src/worker/mod.rs
+++ b/backend/worker/src/worker/mod.rs
@@ -113,7 +113,21 @@ impl Worker<Disconnected> {
     ///
     /// Preserves the executor, scorer, credentials, and job caches from the
     /// previous connection so reconnects are cheap.
-    pub async fn reconnect(self) -> Result<Worker<Connected>> {
+    ///
+    /// On failure, returns the original `Worker<Disconnected>` alongside the
+    /// error so the caller can retry with backoff without losing the cached
+    /// executor/scorer/credentials state.
+    pub async fn reconnect(
+        self,
+    ) -> std::result::Result<Worker<Connected>, (anyhow::Error, Self)> {
+        let mut conn = match ProtoConnection::open(&self.config.server_url).await {
+            Ok(c) => c,
+            Err(e) => return Err((e, self)),
+        };
+        if let Err(e) = Self::do_reconnect_handshake(&mut conn, &self.config).await {
+            return Err((e, self));
+        }
+
         let Worker {
             config,
             executor,
@@ -123,9 +137,6 @@ impl Worker<Disconnected> {
             last_scores,
             ..
         } = self;
-
-        let mut conn = ProtoConnection::open(&config.server_url).await?;
-        Self::do_reconnect_handshake(&mut conn, &config).await?;
 
         Ok(Worker {
             config,

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -732,3 +732,26 @@ Tests (`cargo test -p proto`):
 - `tests::handshake_timeout_is_sane` — regression for #110: deadline stays
   in `[5 s, 60 s]` so a real auth round-trip still fits but a stalled peer
   is dropped quickly.
+
+## Worker — reconnect retries forever
+
+`Worker<Disconnected>::reconnect` (`backend/worker/src/worker/mod.rs`) now
+returns `Result<Worker<Connected>, (anyhow::Error, Self)>`: on failure, the
+disconnected typestate (and the cached executor / scorer / credentials /
+candidate maps) is handed back so the caller can retry without losing
+state. The reconnect-with-backoff loop in `main.rs` is extracted to
+`backend/worker/src/reconnect.rs::retry_reconnect` so it is unit-testable
+without standing up a real `Worker`. The loop never gives up — a transient
+network blip cannot terminate the worker process anymore (#99).
+
+Tests (`cargo test -p worker --bins reconnect`):
+
+- `reconnect::tests::keeps_retrying_after_failure` — regression for #99:
+  the loop returns `Ok` only after several failed attempts, so a single
+  transient error no longer breaks out and shuts the worker down.
+- `reconnect::tests::backoff_caps_at_max` — delay sequence doubles from the
+  initial backoff and plateaus at `max_backoff`.
+- `reconnect::tests::state_threads_through_retries` — the same state value
+  is threaded through every attempt, proving the typestate-preservation
+  contract that the real `Worker<Disconnected>` relies on for cached
+  resources.


### PR DESCRIPTION
Fixes #99.

## Summary
- The reconnect loop in `backend/worker/src/main.rs` `break`d out after the first reconnect failure, terminating the worker process on any transient network blip. The comment ("Loop will break because `worker` has been moved — exit gracefully") admitted the structural issue: `Worker<Disconnected>::reconnect(self)` consumed the typestate, leaving the caller with no value to retry against.
- Change `Worker::reconnect` to return `Result<Worker<Connected>, (anyhow::Error, Self)>`. The function now opens the connection and runs the handshake before destructuring `self`, so on failure the disconnected typestate (and the cached executor / scorer / credentials / candidate maps) is handed back to the caller.
- Extract the reconnect-with-backoff inner loop into `backend/worker/src/reconnect.rs::retry_reconnect` — generic over the attempt closure and the sleep clock so it can be unit-tested without standing up a real `Worker`. The helper retries forever, doubling the delay from `INITIAL_BACKOFF` to `MAX_BACKOFF`.
- 3 unit tests cover the never-give-up contract (`keeps_retrying_after_failure`), the backoff cap (`backoff_caps_at_max`), and the state-preservation contract (`state_threads_through_retries`).
- Docs entry added to `docs/src/tests.md`.

## Test plan
- [x] `cargo test -p worker --bins` — 101 tests pass (incl. 3 new reconnect tests).
- [x] `cargo build -p worker --bins` — clean.
- [ ] Manual: stop the server, observe the worker log a sequence of "reconnect failed; retrying" messages with doubling backoff, then "reconnected successfully" once the server comes back. The worker process must remain alive throughout.