### PR TITLE
backend: core: introduce WebDb / WorkerDb newtypes for the two pools (#68)

### DIFF
--- a/backend/cache/src/cacher/cleanup.rs
+++ b/backend/cache/src/cacher/cleanup.rs
@@ -18,7 +18,7 @@ use uuid::Uuid;
 
 pub async fn cleanup_old_evaluations(state: Arc<ServerState>) -> Result<()> {
     let projects = EProject::find()
-        .all(&state.db)
+        .all(&state.worker_db)
         .await
         .context("Failed to query projects for evaluation GC")?;
 
@@ -76,7 +76,7 @@ pub async fn cleanup_stale_cached_nars(state: Arc<ServerState>) -> Result<()> {
     }
 
     let rows = state
-        .db
+        .worker_db
         .query_all(Statement::from_sql_and_values(
             DatabaseBackend::Postgres,
             STALE_CACHED_NARS_SELECT,
@@ -108,18 +108,18 @@ pub async fn cleanup_stale_cached_nars(state: Arc<ServerState>) -> Result<()> {
         // cache_derivation row keeps them alive).
         let outputs = EDerivationOutput::find()
             .filter(CDerivationOutput::Derivation.eq(drv_id))
-            .all(&state.db)
+            .all(&state.worker_db)
             .await
             .unwrap_or_default();
 
         // Drop the cache_derivation row first; revocation of dependents follows.
         if let Some(cd) = ECacheDerivation::find_by_id(cd_id)
-            .one(&state.db)
+            .one(&state.worker_db)
             .await
             .ok()
             .flatten()
         {
-            let _ = cd.into_active_model().delete(&state.db).await;
+            let _ = cd.into_active_model().delete(&state.worker_db).await;
         }
 
         // Drop the cached_path_signature rows that tied each output to THIS
@@ -130,7 +130,7 @@ pub async fn cleanup_stale_cached_nars(state: Arc<ServerState>) -> Result<()> {
         for o in &outputs {
             let cached_paths = ECachedPath::find()
                 .filter(CCachedPath::Hash.eq(&o.hash))
-                .all(&state.db)
+                .all(&state.worker_db)
                 .await
                 .unwrap_or_default();
 
@@ -138,22 +138,22 @@ pub async fn cleanup_stale_cached_nars(state: Arc<ServerState>) -> Result<()> {
                 let sigs_for_cache = ECachedPathSignature::find()
                     .filter(CCachedPathSignature::CachedPath.eq(cp.id))
                     .filter(CCachedPathSignature::Cache.eq(cache_id))
-                    .all(&state.db)
+                    .all(&state.worker_db)
                     .await
                     .unwrap_or_default();
                 for sig in sigs_for_cache {
-                    let _ = sig.into_active_model().delete(&state.db).await;
+                    let _ = sig.into_active_model().delete(&state.worker_db).await;
                 }
 
                 let still_signed = ECachedPathSignature::find()
                     .filter(CCachedPathSignature::CachedPath.eq(cp.id))
-                    .one(&state.db)
+                    .one(&state.worker_db)
                     .await
                     .ok()
                     .flatten()
                     .is_some();
                 if !still_signed {
-                    let _ = cp.into_active_model().delete(&state.db).await;
+                    let _ = cp.into_active_model().delete(&state.worker_db).await;
                 }
             }
         }
@@ -162,7 +162,7 @@ pub async fn cleanup_stale_cached_nars(state: Arc<ServerState>) -> Result<()> {
         // delete when no cache_derivation row remains for the derivation.
         let still_held = ECacheDerivation::find()
             .filter(CCacheDerivation::Derivation.eq(drv_id))
-            .one(&state.db)
+            .one(&state.worker_db)
             .await
             .ok()
             .flatten()
@@ -225,7 +225,7 @@ pub async fn cleanup_orphaned_cache_files(state: Arc<ServerState>) -> Result<()>
 /// referenced; this pass is a safety net for stray files only.
 async fn active_hashes(state: &Arc<ServerState>) -> Result<HashSet<String>> {
     let rows = state
-        .db
+        .worker_db
         .query_all(Statement::from_sql_and_values(
             DatabaseBackend::Postgres,
             r#"
@@ -293,8 +293,8 @@ mod tests {
             .append_query_results([kept.into_iter().map(hash_row).collect::<Vec<_>>()])
             .into_connection();
         Arc::new(ServerState {
-            web_db: MockDatabase::new(DatabaseBackend::Postgres).into_connection(),
-            db,
+            web_db: WebDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
+            worker_db: WorkerDb::new(db),
             cli: test_cli(),
             log_storage: Arc::new(NoopLogStorage),
             webhooks: Arc::new(RecordingWebhookClient::new()),
@@ -370,8 +370,8 @@ mod tests {
         let mut cli = test_cli();
         cli.nar_ttl_hours = 24;
         let state = Arc::new(ServerState {
-            web_db: MockDatabase::new(DatabaseBackend::Postgres).into_connection(),
-            db,
+            web_db: WebDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
+            worker_db: WorkerDb::new(db),
             cli,
             log_storage: Arc::new(NoopLogStorage),
             webhooks: Arc::new(RecordingWebhookClient::new()),

--- a/backend/cache/src/cacher/invalidate.rs
+++ b/backend/cache/src/cacher/invalidate.rs
@@ -34,7 +34,7 @@ pub async fn invalidate_cache_for_path(state: Arc<ServerState>, path: String) ->
                 .add(CDerivationOutput::Package.eq(package.clone()))
                 .add(CDerivationOutput::IsCached.eq(true)),
         )
-        .all(&state.db)
+        .all(&state.worker_db)
         .await
         .context("Database error while finding derivation outputs")?;
 
@@ -44,7 +44,7 @@ pub async fn invalidate_cache_for_path(state: Arc<ServerState>, path: String) ->
         let mut active = output.clone().into_active_model();
         active.is_cached = Set(false);
         active
-            .update(&state.db)
+            .update(&state.worker_db)
             .await
             .context("Failed to update derivation output")?;
 
@@ -57,25 +57,25 @@ pub async fn invalidate_cache_for_path(state: Arc<ServerState>, path: String) ->
         // Delete cached_path + signatures for this output.
         let cached_paths = ECachedPath::find()
             .filter(CCachedPath::Hash.eq(&hash))
-            .all(&state.db)
+            .all(&state.worker_db)
             .await
             .context("Failed to find cached_path rows")?;
 
         for cp in &cached_paths {
             let sigs = ECachedPathSignature::find()
                 .filter(CCachedPathSignature::CachedPath.eq(cp.id))
-                .all(&state.db)
+                .all(&state.worker_db)
                 .await
                 .unwrap_or_default();
             for sig in sigs {
                 sig.into_active_model()
-                    .delete(&state.db)
+                    .delete(&state.worker_db)
                     .await
                     .context("Failed to delete signature")?;
             }
             cp.clone()
                 .into_active_model()
-                .delete(&state.db)
+                .delete(&state.worker_db)
                 .await
                 .context("Failed to delete cached_path")?;
         }
@@ -104,7 +104,7 @@ async fn revoke_cache_derivation_closure(
     while !frontier.is_empty() {
         let edges = EDerivationDependency::find()
             .filter(CDerivationDependency::Dependency.is_in(frontier.clone()))
-            .all(&state.db)
+            .all(&state.worker_db)
             .await
             .context("Failed to walk reverse derivation_dependency")?;
         frontier.clear();
@@ -118,13 +118,13 @@ async fn revoke_cache_derivation_closure(
     let drv_ids: Vec<Uuid> = visited.into_iter().collect();
     let cache_rows = ECacheDerivation::find()
         .filter(CCacheDerivation::Derivation.is_in(drv_ids))
-        .all(&state.db)
+        .all(&state.worker_db)
         .await
         .context("Failed to query cache_derivation rows")?;
 
     for row in cache_rows {
         let active = row.into_active_model();
-        if let Err(e) = active.delete(&state.db).await {
+        if let Err(e) = active.delete(&state.worker_db).await {
             warn!(error = %e, "Failed to delete cache_derivation row");
         }
     }

--- a/backend/cache/src/cacher/sign_sweep.rs
+++ b/backend/cache/src/cacher/sign_sweep.rs
@@ -34,7 +34,7 @@ pub async fn sign_missing_signatures(state: Arc<ServerState>) -> anyhow::Result<
     let pending = ECachedPathSignature::find()
         .filter(CCachedPathSignature::Signature.is_null())
         .limit(SIGN_SWEEP_BATCH)
-        .all(&state.db)
+        .all(&state.worker_db)
         .await?;
 
     if pending.is_empty() {
@@ -51,7 +51,7 @@ pub async fn sign_missing_signatures(state: Arc<ServerState>) -> anyhow::Result<
 
     let caches: HashMap<Uuid, MCache> = ECache::find()
         .filter(CCache::Id.is_in(cache_ids))
-        .all(&state.db)
+        .all(&state.worker_db)
         .await?
         .into_iter()
         .map(|c| (c.id, c))
@@ -59,7 +59,7 @@ pub async fn sign_missing_signatures(state: Arc<ServerState>) -> anyhow::Result<
 
     let cached_paths: HashMap<Uuid, MCachedPath> = ECachedPath::find()
         .filter(CCachedPath::Id.is_in(cached_path_ids))
-        .all(&state.db)
+        .all(&state.worker_db)
         .await?
         .into_iter()
         .map(|c| (c.id, c))
@@ -127,7 +127,7 @@ pub async fn sign_missing_signatures(state: Arc<ServerState>) -> anyhow::Result<
 
         let mut am = row.into_active_model();
         am.signature = Set(Some(sig_b64));
-        if let Err(e) = am.update(&state.db).await {
+        if let Err(e) = am.update(&state.worker_db).await {
             warn!(store_path = %cp.store_path, cache = %cache.id, error = %e, "sign sweep: failed to persist signature");
             continue;
         }
@@ -162,7 +162,7 @@ async fn record_newly_completed_derivations(
 ) -> anyhow::Result<()> {
     let org_ids: Vec<Uuid> = EOrganizationCache::find()
         .filter(COrganizationCache::Cache.eq(cache_id))
-        .all(&state.db)
+        .all(&state.worker_db)
         .await?
         .into_iter()
         .map(|oc| oc.organization)
@@ -174,7 +174,7 @@ async fn record_newly_completed_derivations(
 
     let drvs = EDerivation::find()
         .filter(CDerivation::Organization.is_in(org_ids))
-        .all(&state.db)
+        .all(&state.worker_db)
         .await?;
 
     let now = chrono::Utc::now().naive_utc();
@@ -195,7 +195,7 @@ async fn try_record_cache_derivation(
     let any_uncached = EDerivationOutput::find()
         .filter(CDerivationOutput::Derivation.eq(derivation_id))
         .filter(CDerivationOutput::IsCached.eq(false))
-        .one(&state.db)
+        .one(&state.worker_db)
         .await?
         .is_some();
     if any_uncached {
@@ -204,13 +204,13 @@ async fn try_record_cache_derivation(
 
     let dep_edges = EDerivationDependency::find()
         .filter(CDerivationDependency::Derivation.eq(derivation_id))
-        .all(&state.db)
+        .all(&state.worker_db)
         .await?;
     for edge in dep_edges {
         let present = ECacheDerivation::find()
             .filter(CCacheDerivation::Cache.eq(cache_id))
             .filter(CCacheDerivation::Derivation.eq(edge.dependency))
-            .one(&state.db)
+            .one(&state.worker_db)
             .await?
             .is_some();
         if !present {
@@ -221,7 +221,7 @@ async fn try_record_cache_derivation(
     let already = ECacheDerivation::find()
         .filter(CCacheDerivation::Cache.eq(cache_id))
         .filter(CCacheDerivation::Derivation.eq(derivation_id))
-        .one(&state.db)
+        .one(&state.worker_db)
         .await?
         .is_some();
     if already {
@@ -235,7 +235,7 @@ async fn try_record_cache_derivation(
         cached_at: Set(now),
         last_fetched_at: Set(None),
     };
-    row.insert(&state.db).await?;
+    row.insert(&state.worker_db).await?;
     Ok(())
 }
 

--- a/backend/core/src/ci/integration_lookup.rs
+++ b/backend/core/src/ci/integration_lookup.rs
@@ -84,7 +84,7 @@ pub async fn resolve_outbound_reporter_for_project(
     use sea_orm::QueryFilter;
 
     let link = match EProjectIntegration::find_by_id(project_id)
-        .one(&state.db)
+        .one(&state.worker_db)
         .await
     {
         Ok(Some(l)) => Some(l),
@@ -110,7 +110,7 @@ pub async fn resolve_outbound_reporter_for_project(
 
     let integration = match EIntegration::find_by_id(outbound_id)
         .filter(CIntegration::Kind.eq(IntegrationKind::Outbound.as_i16()))
-        .one(&state.db)
+        .one(&state.worker_db)
         .await
     {
         Ok(Some(i)) => i,
@@ -195,7 +195,7 @@ async fn build_github_app_reporter_for_project(
     let github_app = state.cli.github_app_config()?;
 
     let project = EProject::find_by_id(project_id)
-        .one(&state.db)
+        .one(&state.worker_db)
         .await
         .ok()
         .flatten()?;
@@ -205,7 +205,7 @@ async fn build_github_app_reporter_for_project(
     }
 
     let org = EOrganization::find_by_id(project.organization)
-        .one(&state.db)
+        .one(&state.worker_db)
         .await
         .ok()
         .flatten()?;

--- a/backend/core/src/ci/reporting.rs
+++ b/backend/core/src/ci/reporting.rs
@@ -80,7 +80,7 @@ pub fn ci_status_for_build(status: &BuildStatus) -> Option<CiStatus> {
 pub async fn report_build_ci(state: Arc<ServerState>, build: MBuild, status: CiStatus) {
     let entry_points = match EEntryPoint::find()
         .filter(CEntryPoint::Build.eq(build.id))
-        .all(&state.db)
+        .all(&state.worker_db)
         .await
     {
         Ok(eps) => eps,
@@ -94,7 +94,7 @@ pub async fn report_build_ci(state: Arc<ServerState>, build: MBuild, status: CiS
     }
 
     let evaluation = match EEvaluation::find_by_id(build.evaluation)
-        .one(&state.db)
+        .one(&state.worker_db)
         .await
     {
         Ok(Some(e)) => e,
@@ -112,7 +112,7 @@ pub async fn report_build_ci(state: Arc<ServerState>, build: MBuild, status: CiS
         return;
     };
 
-    let project = match EProject::find_by_id(project_id).one(&state.db).await {
+    let project = match EProject::find_by_id(project_id).one(&state.worker_db).await {
         Ok(Some(p)) => p,
         Ok(None) => {
             warn!(%project_id, "Project missing for build CI report");
@@ -124,7 +124,7 @@ pub async fn report_build_ci(state: Arc<ServerState>, build: MBuild, status: CiS
         }
     };
 
-    let commit = match ECommit::find_by_id(evaluation.commit).one(&state.db).await {
+    let commit = match ECommit::find_by_id(evaluation.commit).one(&state.worker_db).await {
         Ok(Some(c)) => c,
         Ok(None) => {
             warn!(commit_id = %evaluation.commit, "Commit missing for build CI report");
@@ -149,7 +149,7 @@ pub async fn report_build_ci(state: Arc<ServerState>, build: MBuild, status: CiS
     let reporter = resolve_outbound_reporter_for_project(&state, project_id).await;
 
     let org_name = match EOrganization::find_by_id(project.organization)
-        .one(&state.db)
+        .one(&state.worker_db)
         .await
     {
         Ok(Some(o)) => Some(o.name),
@@ -178,7 +178,7 @@ pub async fn report_build_ci(state: Arc<ServerState>, build: MBuild, status: CiS
             Ok(Some(new_id)) => {
                 let mut a = ep.clone().into_active_model();
                 a.repo_check_id = Set(Some(new_id));
-                if let Err(e) = a.update(&state.db).await {
+                if let Err(e) = a.update(&state.worker_db).await {
                     warn!(error = %e, eval = %ep.eval, "Failed to persist entry_point check_run id");
                 }
             }
@@ -207,7 +207,7 @@ pub async fn report_evaluation_ci(
         return;
     };
 
-    let project = match EProject::find_by_id(project_id).one(&state.db).await {
+    let project = match EProject::find_by_id(project_id).one(&state.worker_db).await {
         Ok(Some(p)) => p,
         Ok(None) => {
             warn!(%project_id, "Project not found for evaluation CI report");
@@ -221,7 +221,7 @@ pub async fn report_evaluation_ci(
 
     let reporter = resolve_outbound_reporter_for_project(&state, project_id).await;
 
-    let commit = match ECommit::find_by_id(evaluation.commit).one(&state.db).await {
+    let commit = match ECommit::find_by_id(evaluation.commit).one(&state.worker_db).await {
         Ok(Some(c)) => c,
         Ok(None) => {
             warn!(commit_id = %evaluation.commit, "Commit not found for evaluation CI report");
@@ -247,7 +247,7 @@ pub async fn report_evaluation_ci(
     };
 
     let org_name = match EOrganization::find_by_id(project.organization)
-        .one(&state.db)
+        .one(&state.worker_db)
         .await
     {
         Ok(Some(org)) => Some(org.name),
@@ -278,7 +278,7 @@ pub async fn report_evaluation_ci(
         Ok(Some(new_id)) => {
             let mut a = evaluation.clone().into_active_model();
             a.repo_check_id = Set(Some(new_id));
-            if let Err(e) = a.update(&state.db).await {
+            if let Err(e) = a.update(&state.worker_db).await {
                 warn!(error = %e, evaluation_id = %evaluation.id, "Failed to persist evaluation check_run id");
             }
         }

--- a/backend/core/src/ci/trigger.rs
+++ b/backend/core/src/ci/trigger.rs
@@ -14,8 +14,7 @@ use entity::build::BuildStatus;
 use entity::evaluation::EvaluationStatus;
 use sea_orm::ActiveValue::Set;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, Condition, DatabaseConnection, EntityTrait, QueryFilter,
-    QueryOrder,
+    ActiveModelTrait, ColumnTrait, Condition, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder,
 };
 use thiserror::Error;
 use uuid::Uuid;
@@ -38,8 +37,8 @@ pub enum TriggerError {
 /// - Inserts a `Commit` row, then an `Evaluation` row with status `Queued`.
 /// - Sets `project.force_evaluation = true` and resets `last_check_at` so the
 ///   scheduler picks it up immediately on its next tick.
-pub async fn trigger_evaluation(
-    db: &DatabaseConnection,
+pub async fn trigger_evaluation<C: ConnectionTrait>(
+    db: &C,
     project: &MProject,
     commit_hash: Vec<u8>,
     commit_message: Option<String>,
@@ -120,8 +119,8 @@ pub(crate) fn restart_build_status(prev: BuildStatus) -> BuildStatus {
 ///
 /// Entry points are copied from the previous evaluation and linked to the new builds.
 /// The scheduler's build-dispatch loop will pick up the `Queued` builds on its next tick.
-pub async fn trigger_restart_builds(
-    db: &DatabaseConnection,
+pub async fn trigger_restart_builds<C: ConnectionTrait>(
+    db: &C,
     project: &MProject,
 ) -> Result<MEvaluation, TriggerError> {
     // Guard: reject if an evaluation is already in progress.

--- a/backend/core/src/ci/webhook.rs
+++ b/backend/core/src/ci/webhook.rs
@@ -264,7 +264,7 @@ pub async fn fire_evaluation_webhook(
     };
 
     let org_id = match evaluation.project {
-        Some(project_id) => match EProject::find_by_id(project_id).one(&state.db).await {
+        Some(project_id) => match EProject::find_by_id(project_id).one(&state.worker_db).await {
             Ok(Some(project)) => project.organization,
             Ok(None) => {
                 warn!(evaluation_id = %evaluation.id, "Project not found for webhook delivery");
@@ -305,7 +305,7 @@ pub async fn fire_build_webhook(state: Arc<ServerState>, build: MBuild, status: 
 
     // Look up the derivation path for the webhook payload (best-effort).
     let derivation_path = EDerivation::find_by_id(build.derivation)
-        .one(&state.db)
+        .one(&state.worker_db)
         .await
         .ok()
         .flatten()
@@ -322,7 +322,7 @@ pub async fn fire_build_webhook(state: Arc<ServerState>, build: MBuild, status: 
 }
 
 async fn get_build_org_id(state: &Arc<ServerState>, evaluation_id: Uuid) -> Option<Uuid> {
-    let evaluation = match EEvaluation::find_by_id(evaluation_id).one(&state.db).await {
+    let evaluation = match EEvaluation::find_by_id(evaluation_id).one(&state.worker_db).await {
         Ok(Some(e)) => e,
         Ok(None) => {
             warn!(evaluation_id = %evaluation_id, "Evaluation not found for webhook delivery");
@@ -336,7 +336,7 @@ async fn get_build_org_id(state: &Arc<ServerState>, evaluation_id: Uuid) -> Opti
 
     let project_id = evaluation.project?;
 
-    match EProject::find_by_id(project_id).one(&state.db).await {
+    match EProject::find_by_id(project_id).one(&state.worker_db).await {
         Ok(Some(project)) => Some(project.organization),
         Ok(None) => {
             warn!(project_id = %project_id, "Project not found for webhook delivery");
@@ -358,7 +358,7 @@ async fn fire_webhooks(
     let webhooks = match EWebhook::find()
         .filter(CWebhook::Organization.eq(org_id))
         .filter(CWebhook::Active.eq(true))
-        .all(&state.db)
+        .all(&state.worker_db)
         .await
     {
         Ok(w) => w,

--- a/backend/core/src/db/connection.rs
+++ b/backend/core/src/db/connection.rs
@@ -161,7 +161,7 @@ pub async fn add_features(
         let feature = EFeature::find()
             .filter(CFeature::Name.eq(f.clone()))
             .filter(CFeature::Kind.eq(kind.clone()))
-            .one(&state.db)
+            .one(&state.worker_db)
             .await
             .context("Failed to query feature")?;
 
@@ -175,7 +175,7 @@ pub async fn add_features(
             };
 
             afeature
-                .insert(&state.db)
+                .insert(&state.worker_db)
                 .await
                 .context("Failed to insert feature")?
         };
@@ -202,7 +202,7 @@ pub async fn add_features(
                     .to_owned(),
                 )
                 .do_nothing()
-                .exec(&state.db)
+                .exec(&state.worker_db)
                 .await
                 .context("Failed to insert derivation feature")?;
         }

--- a/backend/core/src/db/gc.rs
+++ b/backend/core/src/db/gc.rs
@@ -34,7 +34,7 @@ pub async fn gc_project_evaluations(
     let all_evals = EEvaluation::find()
         .filter(CEvaluation::Project.eq(project_id))
         .order_by_desc(CEvaluation::CreatedAt)
-        .all(&state.db)
+        .all(&state.worker_db)
         .await
         .context("GC: failed to query evaluations")?;
 
@@ -66,7 +66,7 @@ pub async fn gc_project_evaluations(
     {
         let mut a: AEvaluation = oldest_surviving.clone().into_active_model();
         a.previous = Set(None);
-        a.update(&state.db)
+        a.update(&state.worker_db)
             .await
             .context("GC: failed to unlink oldest surviving evaluation")?;
     }
@@ -77,7 +77,7 @@ pub async fn gc_project_evaluations(
         let mut a: AEvaluation = eval.clone().into_active_model();
         a.previous = Set(None);
         a.next = Set(None);
-        a.update(&state.db)
+        a.update(&state.worker_db)
             .await
             .context("GC: failed to NULL evaluation linked-list pointers")?;
     }
@@ -85,7 +85,7 @@ pub async fn gc_project_evaluations(
     for eval in &to_delete {
         let builds = EBuild::find()
             .filter(CBuild::Evaluation.eq(eval.id))
-            .all(&state.db)
+            .all(&state.worker_db)
             .await
             .context("GC: failed to query builds")?;
 
@@ -103,25 +103,25 @@ pub async fn gc_project_evaluations(
         let commit_id = eval.commit;
 
         let a: AEvaluation = eval.clone().into_active_model();
-        a.delete(&state.db)
+        a.delete(&state.worker_db)
             .await
             .context("GC: failed to delete evaluation")?;
 
         // Clean up the commit record if no other evaluation references it.
         let still_referenced = EEvaluation::find()
             .filter(CEvaluation::Commit.eq(commit_id))
-            .one(&state.db)
+            .one(&state.worker_db)
             .await
             .context("GC: failed to check commit references")?;
 
         if still_referenced.is_none()
             && let Some(c) = ECommit::find_by_id(commit_id)
-                .one(&state.db)
+                .one(&state.worker_db)
                 .await
                 .context("GC: failed to query commit")?
         {
             let ac: ACommit = c.into_active_model();
-            if let Err(e) = ac.delete(&state.db).await {
+            if let Err(e) = ac.delete(&state.worker_db).await {
                 warn!(error = %e, commit_id = %commit_id, "GC: failed to delete orphaned commit");
             }
         }
@@ -146,7 +146,7 @@ pub async fn gc_orphan_derivations(state: Arc<ServerState>, grace_hours: i64) ->
     // Find candidate derivations: no build rows, created before the cutoff.
     // Use raw SQL: SeaORM doesn't have a clean LEFT JOIN ... IS NULL builder.
     let rows = state
-        .db
+        .worker_db
         .query_all(Statement::from_sql_and_values(
             DatabaseBackend::Postgres,
             r#"SELECT d.id
@@ -174,13 +174,13 @@ pub async fn gc_orphan_derivations(state: Arc<ServerState>, grace_hours: i64) ->
         // 1. Cache presence rows + their NAR files.
         let cache_rows = ECacheDerivation::find()
             .filter(CCacheDerivation::Derivation.eq(drv_id))
-            .all(&state.db)
+            .all(&state.worker_db)
             .await
             .context("Failed to query cache_derivation rows")?;
 
         let outputs = EDerivationOutput::find()
             .filter(CDerivationOutput::Derivation.eq(drv_id))
-            .all(&state.db)
+            .all(&state.worker_db)
             .await
             .context("Failed to query derivation outputs")?;
 
@@ -193,18 +193,18 @@ pub async fn gc_orphan_derivations(state: Arc<ServerState>, grace_hours: i64) ->
                     warn!(error = %e, hash = %o.hash, "GC: failed to remove NAR file");
                 }
             }
-            let _ = cache_row.into_active_model().delete(&state.db).await;
+            let _ = cache_row.into_active_model().delete(&state.worker_db).await;
         }
 
         // 2. Delete the derivation row. FK cascade removes outputs / dep edges /
         //    features / signatures.
         if let Some(d) = EDerivation::find_by_id(drv_id)
-            .one(&state.db)
+            .one(&state.worker_db)
             .await
             .context("GC: failed to load derivation")?
         {
             let a: ADerivation = d.into_active_model();
-            if let Err(e) = a.delete(&state.db).await {
+            if let Err(e) = a.delete(&state.worker_db).await {
                 warn!(error = %e, drv_id = %drv_id, "GC: failed to delete orphan derivation");
             }
         }

--- a/backend/core/src/db/permission.rs
+++ b/backend/core/src/db/permission.rs
@@ -44,7 +44,7 @@ pub async fn set_permission(
     let mut arole = role.clone().into_active_model();
     arole.permission = Set(set_permission_bit(role.permission, permission, value));
     arole
-        .save(&state.db)
+        .save(&state.worker_db)
         .await
         .context("Failed to save role permission")?;
     Ok(())
@@ -62,13 +62,13 @@ pub async fn get_permission(
                 .add(COrganizationUser::Organization.eq(organization.id))
                 .add(COrganizationUser::User.eq(user.id)),
         )
-        .one(&state.db)
+        .one(&state.worker_db)
         .await
         .context("Failed to query organization user")?
         .ok_or_else(|| anyhow::anyhow!("User not found in organization"))?;
 
     let role = ERole::find_by_id(organization_user.role)
-        .one(&state.db)
+        .one(&state.worker_db)
         .await
         .context("Failed to query user role")?
         .ok_or_else(|| anyhow::anyhow!("Role not found"))?;

--- a/backend/core/src/db/status.rs
+++ b/backend/core/src/db/status.rs
@@ -73,7 +73,7 @@ pub async fn update_build_status(
     active_build.status = Set(status);
     active_build.updated_at = Set(now);
 
-    match active_build.update(&state.db).await {
+    match active_build.update(&state.worker_db).await {
         Ok(updated_build) => {
             let webhook_state = Arc::clone(&state);
             let webhook_build = updated_build.clone();
@@ -150,7 +150,7 @@ pub async fn update_evaluation_status(
                 .add(CEvaluation::Status.ne(EvaluationStatus::Failed))
                 .add(CEvaluation::Status.ne(EvaluationStatus::Completed)),
         )
-        .exec(&state.db)
+        .exec(&state.worker_db)
         .await;
 
     match update_result {
@@ -158,7 +158,7 @@ pub async fn update_evaluation_status(
             // Row was concurrently transitioned to a terminal state —
             // honor it and return the fresh value instead of clobbering.
             return EEvaluation::find_by_id(evaluation.id)
-                .one(&state.db)
+                .one(&state.worker_db)
                 .await
                 .ok()
                 .flatten()
@@ -172,7 +172,7 @@ pub async fn update_evaluation_status(
     }
 
     let updated_eval = EEvaluation::find_by_id(evaluation.id)
-        .one(&state.db)
+        .one(&state.worker_db)
         .await
         .ok()
         .flatten()
@@ -231,7 +231,7 @@ pub async fn update_evaluation_status_with_error(
         source: Set(source),
         created_at: Set(Utc::now().naive_utc()),
     };
-    if let Err(e) = EEvaluationMessage::insert(msg).exec(&state.db).await {
+    if let Err(e) = EEvaluationMessage::insert(msg).exec(&state.worker_db).await {
         error!(error = %e, evaluation_id = %evaluation.id, "Failed to insert evaluation_message");
     }
 
@@ -257,7 +257,7 @@ pub async fn record_evaluation_message(
         source: Set(source),
         created_at: Set(Utc::now().naive_utc()),
     };
-    if let Err(e) = EEvaluationMessage::insert(msg).exec(&state.db).await {
+    if let Err(e) = EEvaluationMessage::insert(msg).exec(&state.worker_db).await {
         error!(error = %e, %evaluation_id, "Failed to insert evaluation_message");
     }
 }
@@ -275,7 +275,7 @@ pub async fn abort_evaluation(state: Arc<ServerState>, evaluation: MEvaluation) 
                 .add(CBuild::Status.eq(BuildStatus::Queued))
                 .add(CBuild::Status.eq(BuildStatus::Building)),
         )
-        .all(&state.db)
+        .all(&state.worker_db)
         .await
     {
         Ok(builds) => builds,

--- a/backend/core/src/lib.rs
+++ b/backend/core/src/lib.rs
@@ -181,8 +181,8 @@ pub async fn init_state(cli: Cli) -> Arc<ServerState> {
     };
 
     Arc::new(ServerState {
-        db,
-        web_db,
+        worker_db: WorkerDb::new(db),
+        web_db: WebDb::new(web_db),
         cli,
         log_storage,
         webhooks,

--- a/backend/core/src/repo/mod.rs
+++ b/backend/core/src/repo/mod.rs
@@ -12,7 +12,7 @@
 //!
 //! # Usage
 //! ```ignore
-//! let build_repo = BuildRepo::new(&state.db);
+//! let build_repo = BuildRepo::new(&state.worker_db);
 //! let build = build_repo.find(id).await?.ok_or(NotFound)?;
 //! let updated = build_repo.update_status(build, BuildStatus::Completed).await?;
 //! ```

--- a/backend/core/src/sources/git.rs
+++ b/backend/core/src/sources/git.rs
@@ -37,7 +37,7 @@ impl<'a> ProjectGitContext<'a> {
         let url = &project.repository;
         let ssh_creds = if check_repository_url_is_ssh(url) {
             let organization = EOrganization::find_by_id(project.organization)
-                .one(&state.db)
+                .one(&state.worker_db)
                 .await
                 .map_err(|e| SourceError::Database {
                     reason: e.to_string(),
@@ -100,7 +100,7 @@ impl<'a> ProjectGitContext<'a> {
 
         if let Some(last_evaluation) = self.project.last_evaluation {
             let evaluation = EEvaluation::find_by_id(last_evaluation)
-                .one(&self.state.db)
+                .one(&self.state.worker_db)
                 .await
                 .map_err(|e| SourceError::Database {
                     reason: e.to_string(),
@@ -115,7 +115,7 @@ impl<'a> ProjectGitContext<'a> {
             }
 
             let commit = ECommit::find_by_id(evaluation.commit)
-                .one(&self.state.db)
+                .one(&self.state.worker_db)
                 .await
                 .map_err(|e| SourceError::Database {
                     reason: e.to_string(),

--- a/backend/core/src/types/db.rs
+++ b/backend/core/src/types/db.rs
@@ -1,0 +1,138 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Typed wrappers around the two `SeaORM` connection pools held by
+//! [`super::ServerState`].
+//!
+//! Gradient runs two pools so HTTP requests served by the axum layer cannot
+//! be starved by the proto/scheduler/cache work. Before these wrappers
+//! existed, both pools were `DatabaseConnection` fields named `db` and
+//! `web_db`; nothing stopped a web handler from reaching for `state.db` (or
+//! a worker-side caller from grabbing `state.web_db`), and code review had
+//! no compile-time signal to flag the mistake.
+//!
+//! [`WebDb`] and [`WorkerDb`] are newtypes around `DatabaseConnection`. They
+//! both forward `ConnectionTrait` to the inner pool so existing call sites
+//! (`find().one(&state.web_db)`, `state.worker_db.execute(stmt)`, …) work
+//! unchanged. The compile-time defense kicks in at any function boundary
+//! that types its parameter explicitly as `&WebDb` or `&WorkerDb`: the two
+//! newtypes are non-substitutable.
+
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, DbBackend, DbErr, ExecResult, QueryResult, Statement,
+};
+
+/// The pool dedicated to axum/HTTP request handling. Use this from any
+/// `web::endpoints::*` handler so HTTP latency is not coupled to the
+/// proto/scheduler workload.
+#[derive(Debug)]
+pub struct WebDb(DatabaseConnection);
+
+/// The pool used by the proto handler, scheduler, cache GC, and any
+/// fire-and-forget background task spawned from a web handler that should
+/// not contend with foreground HTTP requests.
+#[derive(Debug)]
+pub struct WorkerDb(DatabaseConnection);
+
+impl WebDb {
+    pub fn new(conn: DatabaseConnection) -> Self {
+        Self(conn)
+    }
+
+    /// Borrow the inner `DatabaseConnection` — needed in the few places
+    /// where a function signature is hard-coded to `&DatabaseConnection`
+    /// instead of `&impl ConnectionTrait`.
+    pub fn inner(&self) -> &DatabaseConnection {
+        &self.0
+    }
+}
+
+impl WorkerDb {
+    pub fn new(conn: DatabaseConnection) -> Self {
+        Self(conn)
+    }
+
+    pub fn inner(&self) -> &DatabaseConnection {
+        &self.0
+    }
+}
+
+macro_rules! impl_connection_trait {
+    ($ty:ty) => {
+        #[async_trait::async_trait]
+        impl ConnectionTrait for $ty {
+            fn get_database_backend(&self) -> DbBackend {
+                self.0.get_database_backend()
+            }
+
+            async fn execute(&self, stmt: Statement) -> Result<ExecResult, DbErr> {
+                self.0.execute(stmt).await
+            }
+
+            async fn execute_unprepared(&self, sql: &str) -> Result<ExecResult, DbErr> {
+                self.0.execute_unprepared(sql).await
+            }
+
+            async fn query_one(&self, stmt: Statement) -> Result<Option<QueryResult>, DbErr> {
+                self.0.query_one(stmt).await
+            }
+
+            async fn query_all(&self, stmt: Statement) -> Result<Vec<QueryResult>, DbErr> {
+                self.0.query_all(stmt).await
+            }
+
+            fn support_returning(&self) -> bool {
+                self.0.support_returning()
+            }
+
+            fn is_mock_connection(&self) -> bool {
+                self.0.is_mock_connection()
+            }
+        }
+    };
+}
+
+impl_connection_trait!(WebDb);
+impl_connection_trait!(WorkerDb);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sea_orm::MockDatabase;
+
+    /// Regression for #68: a function typed `fn(&WebDb)` must not accept a
+    /// `&WorkerDb` (and vice versa). The two newtypes are non-substitutable
+    /// at any explicitly-typed function boundary, which is the compile-time
+    /// defense the issue asked for.
+    #[test]
+    fn newtypes_are_non_substitutable() {
+        fn takes_web(_: &WebDb) {}
+        fn takes_worker(_: &WorkerDb) {}
+
+        let web = WebDb::new(MockDatabase::new(DbBackend::Postgres).into_connection());
+        let worker = WorkerDb::new(MockDatabase::new(DbBackend::Postgres).into_connection());
+
+        takes_web(&web);
+        takes_worker(&worker);
+
+        // The following lines, if uncommented, must fail to compile:
+        // takes_web(&worker);
+        // takes_worker(&web);
+    }
+
+    /// `&WebDb` / `&WorkerDb` satisfy `&impl ConnectionTrait`, so existing
+    /// SeaORM call sites keep working without `.inner()` boilerplate.
+    #[tokio::test]
+    async fn forwards_connection_trait() {
+        async fn run<C: ConnectionTrait>(db: &C) -> DbBackend {
+            db.get_database_backend()
+        }
+        let web = WebDb::new(MockDatabase::new(DbBackend::Postgres).into_connection());
+        let worker = WorkerDb::new(MockDatabase::new(DbBackend::Postgres).into_connection());
+        assert_eq!(run(&web).await, DbBackend::Postgres);
+        assert_eq!(run(&worker).await, DbBackend::Postgres);
+    }
+}

--- a/backend/core/src/types/mod.rs
+++ b/backend/core/src/types/mod.rs
@@ -8,6 +8,7 @@ pub mod build_output_metadata;
 pub mod cached_path_info;
 pub mod config;
 pub mod consts;
+pub mod db;
 pub mod input;
 pub mod proto;
 pub mod secret;
@@ -21,6 +22,7 @@ pub use self::build_output_metadata::BuildOutputMetadata;
 pub use self::cached_path_info::CachedPathInfo;
 pub use self::config::{EmailConfig, GitHubAppConfig, OidcConfig, S3Config};
 pub use self::consts::*;
+pub use self::db::{WebDb, WorkerDb};
 pub use self::entity_aliases::*;
 pub use self::input::*;
 pub use self::io::*;
@@ -33,7 +35,6 @@ use super::storage::LogStorage;
 use super::storage::NarStore;
 use super::storage::email::EmailSender;
 use clap::Parser;
-use sea_orm::DatabaseConnection;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -257,10 +258,13 @@ pub struct Cli {
 
 #[derive(Debug)]
 pub struct ServerState {
-    pub db: DatabaseConnection,
+    /// Pool used by the proto handler, scheduler, cache GC, and any
+    /// fire-and-forget background task spawned from a web handler that
+    /// should not contend with foreground HTTP requests.
+    pub worker_db: WorkerDb,
     /// Dedicated DB pool used by the axum/web layer so HTTP requests are
     /// not starved by the busy proto/scheduler pool under heavy NarPush load.
-    pub web_db: DatabaseConnection,
+    pub web_db: WebDb,
     pub cli: Cli,
     pub log_storage: Arc<dyn LogStorage>,
     pub webhooks: Arc<dyn WebhookClient>,

--- a/backend/proto/src/handler/auth.rs
+++ b/backend/proto/src/handler/auth.rs
@@ -39,7 +39,7 @@ pub(super) async fn filter_org_peers_without_cache(
 
     let org_ids: HashSet<Uuid> = match EOrg::find()
         .filter(OCol::Id.is_in(uuid_set.clone()))
-        .all(&state.db)
+        .all(&state.worker_db)
         .await
     {
         Ok(rows) => rows.into_iter().map(|r| r.id).collect(),
@@ -57,7 +57,7 @@ pub(super) async fn filter_org_peers_without_cache(
     } else {
         match EOrgCache::find()
             .filter(OCCol::Organization.is_in(org_ids.iter().copied().collect::<Vec<_>>()))
-            .all(&state.db)
+            .all(&state.worker_db)
             .await
         {
             Ok(rows) => rows.into_iter().map(|r| r.organization).collect(),
@@ -97,7 +97,7 @@ pub(super) async fn lookup_registered_peers(
     match Entity::find()
         .filter(Column::WorkerId.eq(worker_id))
         .filter(Column::Active.eq(true))
-        .all(&state.db)
+        .all(&state.worker_db)
         .await
     {
         Ok(rows) => rows
@@ -144,7 +144,7 @@ pub(super) async fn aggregate_enabled_caps(
     let rows = match Entity::find()
         .filter(Column::WorkerId.eq(worker_id))
         .filter(Column::Active.eq(true))
-        .all(&state.db)
+        .all(&state.worker_db)
         .await
     {
         Ok(rows) => rows,
@@ -174,7 +174,7 @@ pub(super) async fn has_any_registrations(state: &ServerState, worker_id: &str) 
 
     match Entity::find()
         .filter(Column::WorkerId.eq(worker_id))
-        .one(&state.db)
+        .one(&state.worker_db)
         .await
     {
         Ok(row) => row.is_some(),

--- a/backend/proto/src/handler/cache.rs
+++ b/backend/proto/src/handler/cache.rs
@@ -26,7 +26,7 @@ async fn build_local_cache_map(
                     .add(CDerivationOutput::IsCached.eq(true))
                     .add(CDerivationOutput::Hash.is_in(hashes.to_vec())),
             )
-            .all(&state.db)
+            .all(&state.worker_db)
             .await
         {
             Ok(rows) => rows,
@@ -38,7 +38,7 @@ async fn build_local_cache_map(
 
         let cached_paths = match ECachedPath::find()
             .filter(CCachedPath::Hash.is_in(hashes.to_vec()))
-            .all(&state.db)
+            .all(&state.worker_db)
             .await
         {
             Ok(rows) => rows,
@@ -62,7 +62,7 @@ async fn build_local_cache_map(
 async fn load_cached_path_rows(state: &ServerState, hashes: &[&str]) -> Vec<entity::cached_path::Model> {
         match ECachedPath::find()
             .filter(CCachedPath::Hash.is_in(hashes.to_vec()))
-            .all(&state.db)
+            .all(&state.worker_db)
             .await
         {
             Ok(rows) => rows,
@@ -83,7 +83,7 @@ async fn ensure_push_signatures(
     ) {
         let org_caches = EOrganizationCache::find()
             .filter(COrganizationCache::Organization.eq(org_id))
-            .all(&state.db)
+            .all(&state.worker_db)
             .await
             .unwrap_or_default();
 
@@ -92,7 +92,7 @@ async fn ensure_push_signatures(
                 let exists = ECachedPathSignature::find()
                     .filter(CCachedPathSignature::CachedPath.eq(cp.id))
                     .filter(CCachedPathSignature::Cache.eq(oc.cache))
-                    .one(&state.db)
+                    .one(&state.worker_db)
                     .await
                     .unwrap_or(None)
                     .is_some();
@@ -105,7 +105,7 @@ async fn ensure_push_signatures(
                         signature: sea_orm::ActiveValue::Set(None),
                         created_at: sea_orm::ActiveValue::Set(chrono::Utc::now().naive_utc()),
                     };
-                    let _ = sig_row.insert(&state.db).await;
+                    let _ = sig_row.insert(&state.worker_db).await;
                 }
             }
         }
@@ -118,7 +118,7 @@ async fn load_cached_path_signatures(
     ) -> Option<Vec<String>> {
         match ECachedPathSignature::find()
             .filter(CCachedPathSignature::CachedPath.eq(cached_path_id))
-            .all(&state.db)
+            .all(&state.worker_db)
             .await
         {
             Ok(rows) => {
@@ -148,7 +148,7 @@ async fn fetch_pull_metadata(
     ) {
         let cached_row = match ECachedPath::find()
             .filter(CCachedPath::Hash.eq(hash))
-            .one(&state.db)
+            .one(&state.worker_db)
             .await
         {
             Ok(Some(row)) => row,
@@ -289,7 +289,7 @@ async fn extend_with_upstream_results(
                     .add(COrganizationCache::Organization.eq(org_id))
                     .add(COrganizationCache::Mode.ne(CacheSubscriptionMode::WriteOnly)),
             )
-            .all(&state.db)
+            .all(&state.worker_db)
             .await
         {
             Ok(rows) => rows,
@@ -311,7 +311,7 @@ async fn extend_with_upstream_results(
                     .add(CCacheUpstream::Url.is_not_null())
                     .add(CCacheUpstream::Mode.ne(CacheSubscriptionMode::WriteOnly)),
             )
-            .all(&state.db)
+            .all(&state.worker_db)
             .await
         {
             Ok(rows) => rows,

--- a/backend/proto/src/handler/dispatch.rs
+++ b/backend/proto/src/handler/dispatch.rs
@@ -564,7 +564,7 @@ impl<'a> DispatchContext<'a> {
                 let candidates = EDerivation::find()
                     .filter(CDerivation::Organization.eq(org_id))
                     .filter(CDerivation::DerivationPath.is_in(drv_paths))
-                    .all(&self.state.db)
+                    .all(&self.state.worker_db)
                     .await
                     .unwrap_or_default();
 
@@ -581,7 +581,7 @@ impl<'a> DispatchContext<'a> {
                             CBuild::Status
                                 .is_in(vec![BuildStatus::Completed, BuildStatus::Substituted]),
                         )
-                        .all(&self.state.db)
+                        .all(&self.state.worker_db)
                         .await
                         .unwrap_or_default()
                         .into_iter()

--- a/backend/proto/src/handler/nar.rs
+++ b/backend/proto/src/handler/nar.rs
@@ -40,7 +40,7 @@ pub(super) async fn record_nar_push_metric(
 
     let org_cache = EOrganizationCache::find()
         .filter(COrganizationCache::Organization.eq(org_id))
-        .one(&state.db)
+        .one(&state.worker_db)
         .await?
         .ok_or_else(|| anyhow::anyhow!("no cache for org {}", org_id))?;
 
@@ -63,14 +63,14 @@ async fn upsert_cache_metric(
     match ECacheMetric::find()
         .filter(CCacheMetric::Cache.eq(cache_id))
         .filter(CCacheMetric::BucketTime.eq(bucket))
-        .one(&state.db)
+        .one(&state.worker_db)
         .await?
     {
         Some(metric) => {
             let mut am: ACacheMetric = metric.into_active_model();
             am.bytes_sent = Set(am.bytes_sent.unwrap() + bytes);
             am.nar_count = Set(am.nar_count.unwrap() + 1);
-            am.update(&state.db).await?;
+            am.update(&state.worker_db).await?;
         }
         None => {
             let am = ACacheMetric {
@@ -80,7 +80,7 @@ async fn upsert_cache_metric(
                 bytes_sent: Set(bytes),
                 nar_count: Set(1),
             };
-            am.insert(&state.db).await?;
+            am.insert(&state.worker_db).await?;
         }
     }
 
@@ -120,7 +120,7 @@ pub(super) async fn mark_nar_stored(
 
     let cached_path_row = match ECachedPath::find()
         .filter(CCachedPath::Hash.eq(hash))
-        .one(&state.db)
+        .one(&state.worker_db)
         .await?
     {
         Some(row) => {
@@ -135,7 +135,7 @@ pub(super) async fn mark_nar_stored(
             if record.deriver.is_some() {
                 active.deriver = Set(record.deriver.map(str::to_owned));
             }
-            active.update(&state.db).await?
+            active.update(&state.worker_db).await?
         }
         None => {
             let am = ACachedPath {
@@ -152,14 +152,14 @@ pub(super) async fn mark_nar_stored(
                 deriver: Set(record.deriver.map(str::to_owned)),
                 created_at: Set(now),
             };
-            match am.insert(&state.db).await {
+            match am.insert(&state.worker_db).await {
                 Ok(row) => row,
                 Err(e) => {
                     warn!(store_path, error = %e, "failed to insert cached_path (may be a race)");
                     // Try to find the row that was inserted concurrently.
                     match ECachedPath::find()
                         .filter(CCachedPath::Hash.eq(hash))
-                        .one(&state.db)
+                        .one(&state.worker_db)
                         .await?
                     {
                         Some(row) => row,
@@ -178,13 +178,13 @@ pub(super) async fn mark_nar_stored(
     // so this is the field that has to match.
     let outputs = EDerivationOutput::find()
         .filter(CDerivationOutput::Hash.eq(hash))
-        .all(&state.db)
+        .all(&state.worker_db)
         .await?;
     for row in outputs {
         let mut active = row.into_active_model();
         active.is_cached = Set(true);
         active.cached_path = Set(Some(cached_path_row.id));
-        if let Err(e) = active.update(&state.db).await {
+        if let Err(e) = active.update(&state.worker_db).await {
             warn!(store_path, error = %e, "failed to mark derivation_output cached");
         } else {
             info!(
@@ -224,7 +224,7 @@ async fn ensure_signature_placeholders(
 
     let org_caches = match EOrganizationCache::find()
         .filter(COrganizationCache::Organization.eq(org_id))
-        .all(&state.db)
+        .all(&state.worker_db)
         .await
     {
         Ok(v) => v,
@@ -238,7 +238,7 @@ async fn ensure_signature_placeholders(
         let exists = ECachedPathSignature::find()
             .filter(CCachedPathSignature::CachedPath.eq(cached_path_row.id))
             .filter(CCachedPathSignature::Cache.eq(oc.cache))
-            .one(&state.db)
+            .one(&state.worker_db)
             .await
             .unwrap_or(None)
             .is_some();
@@ -253,7 +253,7 @@ async fn ensure_signature_placeholders(
             signature: Set(None),
             created_at: Set(now),
         };
-        if let Err(e) = am.insert(&state.db).await {
+        if let Err(e) = am.insert(&state.worker_db).await {
             warn!(
                 store_path = %cached_path_row.store_path,
                 cache = %oc.cache,

--- a/backend/proto/src/handler/socket.rs
+++ b/backend/proto/src/handler/socket.rs
@@ -258,7 +258,7 @@ pub(super) async fn send_credentials_for_job(
 async fn send_ssh_key_credential(socket: &mut ProtoSocket, state: &ServerState, org_id: Uuid) {
     use gradient_core::types::proto::CredentialKind;
 
-    match EOrganization::find_by_id(org_id).one(&state.db).await {
+    match EOrganization::find_by_id(org_id).one(&state.worker_db).await {
         Ok(Some(org)) => {
             match gradient_core::sources::ssh_key::decrypt_ssh_private_key(
                 &state.cli.crypt_secret_file,

--- a/backend/proto/src/outbound.rs
+++ b/backend/proto/src/outbound.rs
@@ -49,7 +49,7 @@ async fn connect_to_registered_workers(
     // Find all worker registrations that have a URL set.
     let registrations = match EWorkerRegistration::find()
         .filter(Column::Url.is_not_null())
-        .all(&state.db)
+        .all(&state.worker_db)
         .await
     {
         Ok(rows) => rows,

--- a/backend/scheduler/src/build.rs
+++ b/backend/scheduler/src/build.rs
@@ -42,7 +42,7 @@ impl<'a> BuildStateHandler<'a> {
         outputs: Vec<BuildOutput>,
     ) -> Result<()> {
         let build = EBuild::find_by_id(build_id)
-            .one(&self.state.db)
+            .one(&self.state.worker_db)
             .await
             .context("fetch build")?
             .with_context(|| format!("build {} not found", build_id))?;
@@ -53,7 +53,7 @@ impl<'a> BuildStateHandler<'a> {
             let existing = EDerivationOutput::find()
                 .filter(CDerivationOutput::Derivation.eq(derivation_id))
                 .filter(CDerivationOutput::Name.eq(&output.name))
-                .one(&self.state.db)
+                .one(&self.state.worker_db)
                 .await
                 .context("fetch derivation_output")?;
 
@@ -64,14 +64,14 @@ impl<'a> BuildStateHandler<'a> {
                 {
                     active.nar_size = Set(Some(nar_size));
                 }
-                if let Err(e) = active.update(&self.state.db).await {
+                if let Err(e) = active.update(&self.state.worker_db).await {
                     error!(error = %e, %build_id, output_name = %output.name, "failed to update derivation_output");
                 }
 
                 // Delete any prior products for this output (idempotency on retry).
                 if let Err(e) = EBuildProduct::delete_many()
                     .filter(CBuildProduct::DerivationOutput.eq(row_id))
-                    .exec(&self.state.db)
+                    .exec(&self.state.worker_db)
                     .await
                     .context("delete prior build_product rows")
                 {
@@ -89,7 +89,7 @@ impl<'a> BuildStateHandler<'a> {
                         size: Set(product.size.map(|s| s as i64)),
                         created_at: Set(Utc::now().naive_utc()),
                     };
-                    if let Err(e) = am.insert(&self.state.db).await {
+                    if let Err(e) = am.insert(&self.state.worker_db).await {
                         warn!(error = %e, %build_id, output_name = %output.name, "failed to insert build_product");
                     }
                 }
@@ -103,7 +103,7 @@ impl<'a> BuildStateHandler<'a> {
     }
 
     pub async fn handle_build_job_completed(&self, build_id: Uuid) -> Result<()> {
-        let build = match EBuild::find_by_id(build_id).one(&self.state.db).await? {
+        let build = match EBuild::find_by_id(build_id).one(&self.state.worker_db).await? {
             Some(b) => b,
             None => {
                 warn!(%build_id, "build not found on job_completed");
@@ -116,7 +116,7 @@ impl<'a> BuildStateHandler<'a> {
     }
 
     pub async fn handle_build_job_failed(&self, build_id: Uuid, _error: &str) -> Result<()> {
-        let build = match EBuild::find_by_id(build_id).one(&self.state.db).await? {
+        let build = match EBuild::find_by_id(build_id).one(&self.state.worker_db).await? {
             Some(b) => b,
             None => {
                 warn!(%build_id, "build not found on job_failed");
@@ -144,7 +144,7 @@ impl<'a> BuildStateHandler<'a> {
             let dependents = EBuild::find()
                 .filter(CBuild::Evaluation.eq(evaluation_id))
                 .filter(CBuild::Status.is_in(vec![BuildStatus::Created, BuildStatus::Queued]))
-                .all(&self.state.db)
+                .all(&self.state.worker_db)
                 .await
                 .context("fetch builds for cascade")?;
 
@@ -152,7 +152,7 @@ impl<'a> BuildStateHandler<'a> {
                 let dep_edge = EDerivationDependency::find()
                     .filter(CDerivationDependency::Derivation.eq(build.derivation))
                     .filter(CDerivationDependency::Dependency.eq(failed_drv))
-                    .one(&self.state.db)
+                    .one(&self.state.worker_db)
                     .await?;
                 if dep_edge.is_some() {
                     let cascaded_drv = build.derivation;
@@ -182,7 +182,7 @@ impl<'a> BuildStateHandler<'a> {
                 BuildStatus::Queued,
                 BuildStatus::Building,
             ]))
-            .all(&self.state.db)
+            .all(&self.state.worker_db)
             .await
             .context("fetch active builds")?;
 
@@ -191,7 +191,7 @@ impl<'a> BuildStateHandler<'a> {
         }
 
         let Some(eval) = EEvaluation::find_by_id(evaluation_id)
-            .one(&self.state.db)
+            .one(&self.state.worker_db)
             .await?
         else {
             return Ok(());
@@ -204,7 +204,7 @@ impl<'a> BuildStateHandler<'a> {
         let failed_builds = EBuild::find()
             .filter(CBuild::Evaluation.eq(evaluation_id))
             .filter(CBuild::Status.is_in(vec![BuildStatus::Failed, BuildStatus::DependencyFailed]))
-            .all(&self.state.db)
+            .all(&self.state.worker_db)
             .await
             .context("fetch failed builds")?;
 
@@ -214,7 +214,7 @@ impl<'a> BuildStateHandler<'a> {
         let eval_error_messages = EEvaluationMessage::find()
             .filter(CEvaluationMessage::Evaluation.eq(evaluation_id))
             .filter(CEvaluationMessage::Level.eq(entity::evaluation_message::MessageLevel::Error))
-            .all(&self.state.db)
+            .all(&self.state.worker_db)
             .await
             .context("fetch eval error messages")?;
 
@@ -258,7 +258,7 @@ impl<'a> BuildStateHandler<'a> {
                 CEvaluation::Status
                     .is_in(vec![EvaluationStatus::Building, EvaluationStatus::Waiting]),
             )
-            .all(&self.state.db)
+            .all(&self.state.worker_db)
             .await
             .context("fetch in-flight evaluations")?;
         if evals.is_empty() {
@@ -273,7 +273,7 @@ impl<'a> BuildStateHandler<'a> {
                     BuildStatus::Queued,
                     BuildStatus::Building,
                 ]))
-                .all(&self.state.db)
+                .all(&self.state.worker_db)
                 .await
                 .context("fetch pending builds")?;
 
@@ -381,14 +381,14 @@ impl BuildabilityChecker {
     async fn load(state: &Arc<ServerState>, drv_ids: &[Uuid]) -> Result<Self> {
         let drvs = EDerivation::find()
             .filter(CDerivation::Id.is_in(drv_ids.to_vec()))
-            .all(&state.db)
+            .all(&state.worker_db)
             .await
             .context("fetch derivations for pending builds")?;
         let drv_by_id: HashMap<Uuid, MDerivation> = drvs.into_iter().map(|d| (d.id, d)).collect();
 
         let edges = EDerivationFeature::find()
             .filter(CDerivationFeature::Derivation.is_in(drv_ids.to_vec()))
-            .all(&state.db)
+            .all(&state.worker_db)
             .await
             .context("fetch derivation_feature edges")?;
         let mut features_by_drv: HashMap<Uuid, Vec<Uuid>> = HashMap::new();
@@ -405,7 +405,7 @@ impl BuildabilityChecker {
         } else {
             EFeature::find()
                 .filter(CFeature::Id.is_in(feature_ids))
-                .all(&state.db)
+                .all(&state.worker_db)
                 .await
                 .context("fetch feature names")?
         };

--- a/backend/scheduler/src/ci.rs
+++ b/backend/scheduler/src/ci.rs
@@ -35,7 +35,7 @@ pub async fn report_ci_for_entry_points(
 
     let ep_rows = match EEntryPoint::find()
         .filter(CEntryPoint::Evaluation.eq(evaluation_id))
-        .all(&state.db)
+        .all(&state.worker_db)
         .await
     {
         Ok(rows) => rows,
@@ -48,7 +48,7 @@ pub async fn report_ci_for_entry_points(
         return;
     }
 
-    let project = match EProject::find_by_id(project_id).one(&state.db).await {
+    let project = match EProject::find_by_id(project_id).one(&state.worker_db).await {
         Ok(Some(p)) => p,
         Ok(None) => {
             warn!(%project_id, "Project not found for CI reporting");
@@ -62,7 +62,7 @@ pub async fn report_ci_for_entry_points(
 
     let reporter = resolve_outbound_reporter_for_project(&state, project_id).await;
 
-    let commit = match ECommit::find_by_id(commit_id).one(&state.db).await {
+    let commit = match ECommit::find_by_id(commit_id).one(&state.worker_db).await {
         Ok(Some(c)) => c,
         Ok(None) => {
             warn!(%commit_id, "Commit not found for CI reporting");
@@ -88,7 +88,7 @@ pub async fn report_ci_for_entry_points(
     };
 
     let org_name = match EOrganization::find_by_id(project.organization)
-        .one(&state.db)
+        .one(&state.worker_db)
         .await
     {
         Ok(Some(org)) => Some(org.name),
@@ -111,7 +111,7 @@ pub async fn report_ci_for_entry_points(
     let build_ids: Vec<Uuid> = ep_rows.iter().map(|ep| ep.build).collect();
     let build_statuses: HashMap<Uuid, entity::build::BuildStatus> = match EBuild::find()
         .filter(CBuild::Id.is_in(build_ids))
-        .all(&state.db)
+        .all(&state.worker_db)
         .await
     {
         Ok(rows) => rows.into_iter().map(|b| (b.id, b.status)).collect(),
@@ -141,7 +141,7 @@ pub async fn report_ci_for_entry_points(
             Ok(Some(new_id)) => {
                 let mut a = ep.clone().into_active_model();
                 a.repo_check_id = Set(Some(new_id));
-                if let Err(e) = a.update(&state.db).await {
+                if let Err(e) = a.update(&state.worker_db).await {
                     warn!(error = %e, eval = %ep.eval, "Failed to persist entry_point check_run id");
                 }
             }
@@ -169,7 +169,7 @@ pub async fn report_ci_for_evaluation(
     evaluation_id: Uuid,
     status: CiStatus,
 ) {
-    let project = match EProject::find_by_id(project_id).one(&state.db).await {
+    let project = match EProject::find_by_id(project_id).one(&state.worker_db).await {
         Ok(Some(p)) => p,
         Ok(None) => {
             warn!(%project_id, "Project not found for CI evaluation report");
@@ -183,7 +183,7 @@ pub async fn report_ci_for_evaluation(
 
     let reporter = resolve_outbound_reporter_for_project(&state, project_id).await;
 
-    let commit = match ECommit::find_by_id(commit_id).one(&state.db).await {
+    let commit = match ECommit::find_by_id(commit_id).one(&state.worker_db).await {
         Ok(Some(c)) => c,
         Ok(None) => {
             warn!(%commit_id, "Commit not found for CI evaluation report");
@@ -209,7 +209,7 @@ pub async fn report_ci_for_evaluation(
     };
 
     let org_name = match EOrganization::find_by_id(project.organization)
-        .one(&state.db)
+        .one(&state.worker_db)
         .await
     {
         Ok(Some(org)) => Some(org.name),
@@ -225,7 +225,7 @@ pub async fn report_ci_for_evaluation(
         )
     });
 
-    let evaluation = match EEvaluation::find_by_id(evaluation_id).one(&state.db).await {
+    let evaluation = match EEvaluation::find_by_id(evaluation_id).one(&state.worker_db).await {
         Ok(Some(e)) => e,
         Ok(None) => {
             warn!(%evaluation_id, "Evaluation not found for CI evaluation report");
@@ -252,7 +252,7 @@ pub async fn report_ci_for_evaluation(
         Ok(Some(new_id)) => {
             let mut a = evaluation.into_active_model();
             a.repo_check_id = Set(Some(new_id));
-            if let Err(e) = a.update(&state.db).await {
+            if let Err(e) = a.update(&state.worker_db).await {
                 warn!(error = %e, %evaluation_id, "Failed to persist evaluation check_run id");
             }
         }

--- a/backend/scheduler/src/dispatch.rs
+++ b/backend/scheduler/src/dispatch.rs
@@ -110,7 +110,7 @@ pub(crate) async fn poll_projects_for_evaluations(scheduler: &Scheduler) -> anyh
         ),
     );
 
-    let projects = EProject::find().from_raw_sql(sql).all(&state.db).await?;
+    let projects = EProject::find().from_raw_sql(sql).all(&state.worker_db).await?;
 
     for project in &projects {
         let (has_update, commit_hash) = match check_project_updates(Arc::clone(state), project)
@@ -127,7 +127,7 @@ pub(crate) async fn poll_projects_for_evaluations(scheduler: &Scheduler) -> anyh
             // Update last_check_at so we don't re-check immediately.
             let mut ap: AProject = project.clone().into();
             ap.last_check_at = sea_orm::ActiveValue::Set(Utc::now().naive_utc());
-            if let Err(e) = ap.update(&state.db).await {
+            if let Err(e) = ap.update(&state.worker_db).await {
                 warn!(project = %project.name, error = %e, "failed to update last_check_at");
             }
             continue;
@@ -143,7 +143,7 @@ pub(crate) async fn poll_projects_for_evaluations(scheduler: &Scheduler) -> anyh
             };
 
         match gradient_core::ci::trigger_evaluation(
-            &state.db,
+            state.worker_db.inner(),
             project,
             commit_hash,
             Some(commit_message),
@@ -158,7 +158,7 @@ pub(crate) async fn poll_projects_for_evaluations(scheduler: &Scheduler) -> anyh
                 let mut ap: AProject = project.clone().into();
                 ap.force_evaluation = sea_orm::ActiveValue::Set(false);
                 ap.last_check_at = sea_orm::ActiveValue::Set(Utc::now().naive_utc());
-                if let Err(e) = ap.update(&state.db).await {
+                if let Err(e) = ap.update(&state.worker_db).await {
                     warn!(project = %project.name, error = %e, "failed to clear force_evaluation");
                 }
             }
@@ -192,7 +192,7 @@ pub(crate) async fn dispatch_queued_evals(scheduler: &Scheduler) -> anyhow::Resu
 
     let evals = EEvaluation::find()
         .filter(CEvaluation::Status.eq(EvaluationStatus::Queued))
-        .all(&state.db)
+        .all(&state.worker_db)
         .await?;
 
     for eval in evals {
@@ -203,7 +203,7 @@ pub(crate) async fn dispatch_queued_evals(scheduler: &Scheduler) -> anyhow::Resu
             continue;
         }
 
-        let commit = match ECommit::find_by_id(eval.commit).one(&state.db).await? {
+        let commit = match ECommit::find_by_id(eval.commit).one(&state.worker_db).await? {
             Some(c) => c,
             None => {
                 error!(evaluation_id = %eval.id, "commit not found for evaluation");
@@ -310,7 +310,7 @@ impl BuildDispatchMaps {
 
         let derivations: HashMap<Uuid, MDerivation> = EDerivation::find()
             .filter(CDerivation::Id.is_in(drv_ids.clone()))
-            .all(&state.db)
+            .all(&state.worker_db)
             .await?
             .into_iter()
             .map(|d| (d.id, d))
@@ -318,7 +318,7 @@ impl BuildDispatchMaps {
 
         let evaluations: HashMap<Uuid, MEvaluation> = EEvaluation::find()
             .filter(CEvaluation::Id.is_in(eval_ids))
-            .all(&state.db)
+            .all(&state.worker_db)
             .await?
             .into_iter()
             .map(|e| (e.id, e))
@@ -336,7 +336,7 @@ impl BuildDispatchMaps {
         } else {
             EProject::find()
                 .filter(CProject::Id.is_in(project_ids))
-                .all(&state.db)
+                .all(&state.worker_db)
                 .await?
                 .into_iter()
                 .map(|p| (p.id, p.organization))
@@ -353,7 +353,7 @@ impl BuildDispatchMaps {
             } else {
                 EDirectBuild::find()
                     .filter(CDirectBuild::Evaluation.is_in(evals_without_project))
-                    .all(&state.db)
+                    .all(&state.worker_db)
                     .await?
                     .into_iter()
                     .map(|db| (db.evaluation, db.organization))
@@ -364,7 +364,7 @@ impl BuildDispatchMaps {
         // Required features: per-derivation list of feature names.
         let feature_edges = EDerivationFeature::find()
             .filter(CDerivationFeature::Derivation.is_in(drv_ids.clone()))
-            .all(&state.db)
+            .all(&state.worker_db)
             .await
             .unwrap_or_default();
         let mut features_by_drv: HashMap<Uuid, Vec<Uuid>> = HashMap::new();
@@ -381,7 +381,7 @@ impl BuildDispatchMaps {
             EFeature::find()
                 .filter(CFeature::Id.is_in(feature_ids))
                 .filter(CFeature::Kind.eq(entity::feature::FeatureKind::Feature))
-                .all(&state.db)
+                .all(&state.worker_db)
                 .await
                 .unwrap_or_default()
                 .into_iter()
@@ -393,7 +393,7 @@ impl BuildDispatchMaps {
         let dep_counts: HashMap<Uuid, u32> = {
             let edges = EDerivationDependency::find()
                 .filter(CDerivationDependency::Derivation.is_in(drv_ids))
-                .all(&state.db)
+                .all(&state.worker_db)
                 .await
                 .unwrap_or_default();
             let mut counts: HashMap<Uuid, u32> = HashMap::new();
@@ -513,7 +513,7 @@ pub(crate) async fn dispatch_ready_builds(scheduler: &Scheduler) -> anyhow::Resu
     let started = std::time::Instant::now();
     let builds = EBuild::find()
         .from_raw_sql(builds_sql)
-        .all(&state.db)
+        .all(&state.worker_db)
         .await?;
     if builds.is_empty() {
         return Ok(());
@@ -555,7 +555,7 @@ pub(crate) async fn dispatch_ready_builds(scheduler: &Scheduler) -> anyhow::Resu
 
 async fn organization_id_for_eval(state: &Arc<ServerState>, eval: &MEvaluation) -> Option<Uuid> {
     if let Some(project_id) = eval.project {
-        match EProject::find_by_id(project_id).one(&state.db).await {
+        match EProject::find_by_id(project_id).one(&state.worker_db).await {
             Ok(Some(p)) => return Some(p.organization),
             Ok(None) => return None,
             Err(e) => {
@@ -568,7 +568,7 @@ async fn organization_id_for_eval(state: &Arc<ServerState>, eval: &MEvaluation) 
     // Direct build: look up DirectBuild record.
     match EDirectBuild::find()
         .filter(CDirectBuild::Evaluation.eq(eval.id))
-        .one(&state.db)
+        .one(&state.worker_db)
         .await
     {
         Ok(Some(db)) => Some(db.organization),

--- a/backend/scheduler/src/eval.rs
+++ b/backend/scheduler/src/eval.rs
@@ -107,7 +107,7 @@ impl DerivationInsertBatch {
         if !self.new_derivations.is_empty() {
             for chunk in self.new_derivations.chunks(BATCH_SIZE) {
                 if let Err(e) = EDerivation::insert_many(chunk.to_vec())
-                    .exec(&state.db)
+                    .exec(&state.worker_db)
                     .await
                 {
                     error!(error = %e, "failed to insert derivations");
@@ -126,7 +126,7 @@ impl DerivationInsertBatch {
         if !self.new_outputs.is_empty() {
             for chunk in self.new_outputs.chunks(BATCH_SIZE) {
                 if let Err(e) = EDerivationOutput::insert_many(chunk.to_vec())
-                    .exec(&state.db)
+                    .exec(&state.worker_db)
                     .await
                 {
                     error!(error = %e, "failed to insert derivation outputs");
@@ -178,7 +178,7 @@ impl<'a> EvalResultProcessor<'a> {
         EDerivation::find()
             .filter(CDerivation::Organization.eq(self.organization_id))
             .filter(CDerivation::DerivationPath.is_in(paths))
-            .all(&self.state.db)
+            .all(&self.state.worker_db)
             .await
             .context("query existing derivations")
     }
@@ -217,7 +217,7 @@ impl<'a> EvalResultProcessor<'a> {
         if !builds.is_empty() {
             for chunk in builds.chunks(BATCH_SIZE) {
                 if let Err(e) = EBuild::insert_many(chunk.to_vec())
-                    .exec(&self.state.db)
+                    .exec(&self.state.worker_db)
                     .await
                 {
                     error!(error = %e, "failed to insert builds");
@@ -302,7 +302,7 @@ impl<'a> EvalResultProcessor<'a> {
         // Build a lookup: derivation_uuid → build_uuid for this evaluation.
         let eval_builds = EBuild::find()
             .filter(CBuild::Evaluation.eq(self.evaluation_id))
-            .all(&self.state.db)
+            .all(&self.state.worker_db)
             .await
             .unwrap_or_default();
         let drv_id_to_build: HashMap<Uuid, Uuid> =
@@ -335,7 +335,7 @@ impl<'a> EvalResultProcessor<'a> {
         if !active_entry_points.is_empty() {
             for chunk in active_entry_points.chunks(BATCH_SIZE) {
                 if let Err(e) = EEntryPoint::insert_many(chunk.to_vec())
-                    .exec(&self.state.db)
+                    .exec(&self.state.worker_db)
                     .await
                 {
                     error!(error = %e, "failed to insert entry points");
@@ -364,7 +364,7 @@ impl<'a> EvalResultProcessor<'a> {
         }
 
         // GC: remove old evaluations beyond keep_evaluations for this project.
-        if let Ok(Some(project)) = EProject::find_by_id(project_id).one(&self.state.db).await {
+        if let Ok(Some(project)) = EProject::find_by_id(project_id).one(&self.state.worker_db).await {
             let gc_state = Arc::clone(self.state);
             let gc_keep = project.keep_evaluations as usize;
             tokio::spawn(async move {
@@ -420,7 +420,7 @@ async fn expand_substituted_closure(state: &Arc<ServerState>, evaluation_id: Uui
     );
 
     let rows = state
-        .db
+        .worker_db
         .query_all(find_sql)
         .await
         .context("expand_substituted_closure: query")?;
@@ -448,7 +448,7 @@ async fn expand_substituted_closure(state: &Arc<ServerState>, evaluation_id: Uui
 
     let count = builds.len();
     for chunk in builds.chunks(BATCH_SIZE) {
-        if let Err(e) = EBuild::insert_many(chunk.to_vec()).exec(&state.db).await {
+        if let Err(e) = EBuild::insert_many(chunk.to_vec()).exec(&state.worker_db).await {
             error!(error = %e, %evaluation_id, "expand_substituted_closure: failed to insert builds");
         }
     }
@@ -469,7 +469,7 @@ pub async fn handle_eval_result(
     let organization_id = job.peer_id;
 
     let current = EEvaluation::find_by_id(evaluation_id)
-        .one(&state.db)
+        .one(&state.worker_db)
         .await
         .context("fetch evaluation")?;
     let evaluation = match current {
@@ -543,7 +543,7 @@ pub async fn handle_eval_job_completed(
     let created = EBuild::find()
         .filter(CBuild::Evaluation.eq(evaluation_id))
         .filter(CBuild::Status.eq(BuildStatus::Created))
-        .all(&state.db)
+        .all(&state.worker_db)
         .await
         .unwrap_or_default();
     let queued_now = created.len();
@@ -552,7 +552,7 @@ pub async fn handle_eval_job_completed(
     }
 
     if let Some(eval) = EEvaluation::find_by_id(evaluation_id)
-        .one(&state.db)
+        .one(&state.worker_db)
         .await?
         && matches!(
             eval.status,
@@ -603,7 +603,7 @@ pub async fn flush_deferred_deps(
     let drv_path_to_id: std::collections::HashMap<String, Uuid> = EDerivation::find()
         .filter(CDerivation::Organization.eq(organization_id))
         .filter(CDerivation::DerivationPath.is_in(all_paths))
-        .all(&state.db)
+        .all(&state.worker_db)
         .await
         .context("flush_deferred_deps: query derivations")?
         .into_iter()
@@ -642,7 +642,7 @@ pub async fn flush_deferred_deps(
                     .to_owned(),
                 )
                 .do_nothing()
-                .exec(&state.db)
+                .exec(&state.worker_db)
                 .await
             {
                 error!(error = %e, "flush_deferred_deps: failed to insert edges");
@@ -665,7 +665,7 @@ pub async fn handle_eval_job_failed(
     error: &str,
 ) -> Result<()> {
     if let Some(eval) = EEvaluation::find_by_id(evaluation_id)
-        .one(&state.db)
+        .one(&state.worker_db)
         .await?
         && !matches!(
             eval.status,

--- a/backend/scheduler/src/job_handlers.rs
+++ b/backend/scheduler/src/job_handlers.rs
@@ -191,7 +191,7 @@ impl Scheduler {
             }
         };
         match EEvaluation::find_by_id(evaluation_id)
-            .one(&self.state.db)
+            .one(&self.state.worker_db)
             .await
         {
             Ok(Some(eval)) => {
@@ -247,7 +247,7 @@ impl Scheduler {
             flake_source: Set(Some(path)),
             ..Default::default()
         };
-        if let Err(e) = am.update(&self.state.db).await {
+        if let Err(e) = am.update(&self.state.worker_db).await {
             warn!(error = %e, %evaluation_id, "failed to persist flake_source");
         }
     }
@@ -262,7 +262,7 @@ impl Scheduler {
         };
         use entity::build::BuildStatus;
         use sea_orm::{ActiveModelTrait, IntoActiveModel, Set};
-        match EBuild::find_by_id(build_id).one(&self.state.db).await {
+        match EBuild::find_by_id(build_id).one(&self.state.worker_db).await {
             Ok(Some(build)) => {
                 // Record which worker is handling this build. Persisting here
                 // (rather than at dispatch time) means the worker that actually
@@ -271,7 +271,7 @@ impl Scheduler {
                 if build.worker.as_deref() != Some(worker_id) {
                     let mut am: ABuild = build.clone().into_active_model();
                     am.worker = Set(Some(worker_id.to_string()));
-                    if let Err(e) = am.update(&self.state.db).await {
+                    if let Err(e) = am.update(&self.state.worker_db).await {
                         warn!(error = %e, %build_id, %worker_id, "failed to persist worker on build");
                     }
                 }
@@ -448,7 +448,7 @@ impl Scheduler {
             }
         };
 
-        let log_id = match EBuild::find_by_id(build_id).one(&self.state.db).await? {
+        let log_id = match EBuild::find_by_id(build_id).one(&self.state.worker_db).await? {
             Some(b) => b.log_id.unwrap_or(b.id),
             None => build_id,
         };
@@ -536,7 +536,7 @@ impl Scheduler {
             }
         };
 
-        EvalRepo::new(&self.state.db)
+        EvalRepo::new(self.state.worker_db.inner())
             .insert_message(evaluation_id, entity_level, message, Some(source))
             .await
     }

--- a/backend/test-support/src/state.rs
+++ b/backend/test-support/src/state.rs
@@ -11,7 +11,7 @@ use crate::log_storage::NoopLogStorage;
 use gradient_core::ci::WebhookClient;
 use gradient_core::storage::EmailSender;
 use gradient_core::storage::NarStore;
-use gradient_core::types::ServerState;
+use gradient_core::types::{ServerState, WebDb, WorkerDb};
 use sea_orm::{DatabaseBackend, DatabaseConnection, MockDatabase};
 use std::sync::Arc;
 
@@ -24,8 +24,8 @@ pub fn test_state(db: DatabaseConnection) -> Arc<ServerState> {
     let cli = test_cli();
     let nar_storage = NarStore::local(&cli.base_path).expect("create test NarStore");
     Arc::new(ServerState {
-        web_db: MockDatabase::new(DatabaseBackend::Postgres).into_connection(),
-        db,
+        web_db: WebDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
+        worker_db: WorkerDb::new(db),
         cli,
         log_storage: Arc::new(NoopLogStorage),
         webhooks: Arc::new(RecordingWebhookClient::new()) as Arc<dyn WebhookClient>,
@@ -46,8 +46,8 @@ pub fn test_state_recorded(
     let nar_storage = NarStore::local(&cli.base_path).expect("create test NarStore");
     let recorder = Arc::new(RecordingWebhookClient::new());
     let state = Arc::new(ServerState {
-        web_db: MockDatabase::new(DatabaseBackend::Postgres).into_connection(),
-        db,
+        web_db: WebDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
+        worker_db: WorkerDb::new(db),
         cli,
         log_storage: Arc::new(NoopLogStorage),
         webhooks: Arc::clone(&recorder) as Arc<dyn WebhookClient>,

--- a/backend/web/src/endpoints/caches/nar.rs
+++ b/backend/web/src/endpoints/caches/nar.rs
@@ -12,7 +12,7 @@ use axum::http::{HeaderMap, HeaderValue, header};
 use axum::response::Response;
 use core::sources::get_hash_from_url;
 use core::types::*;
-use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -91,8 +91,8 @@ async fn resolve_effective_hash(state: &Arc<ServerState>, path_hash: &str) -> We
     resolve_effective_hash_db(&state.web_db, path_hash).await
 }
 
-pub(crate) async fn resolve_effective_hash_db(
-    db: &DatabaseConnection,
+pub(crate) async fn resolve_effective_hash_db<C: ConnectionTrait>(
+    db: &C,
     path_hash: &str,
 ) -> WebResult<String> {
     let file_hash_prefixed = format!("sha256:{}", path_hash);
@@ -115,12 +115,16 @@ fn spawn_nar_traffic_metric(state: Arc<ServerState>, cache_id: Uuid, bytes_len: 
     });
 }
 
+/// Bookkeeping update spawned after every successful NAR fetch. Uses
+/// `worker_db` (not `web_db`) on purpose: under heavy NAR traffic this
+/// fire-and-forget UPDATE would otherwise contend with foreground HTTP
+/// requests on the web pool.
 fn spawn_cache_derivation_fetch_update(state: Arc<ServerState>, cache_id: Uuid, hash: String) {
     tokio::spawn(async move {
         use sea_orm::{ConnectionTrait, DatabaseBackend, Statement};
         let now = chrono::Utc::now().naive_utc();
         let _ = state
-            .db
+            .worker_db
             .execute(Statement::from_sql_and_values(
                 DatabaseBackend::Postgres,
                 "UPDATE cache_derivation SET last_fetched_at = $1 \

--- a/backend/web/src/endpoints/orgs/mod.rs
+++ b/backend/web/src/endpoints/orgs/mod.rs
@@ -122,6 +122,7 @@ mod tests {
     use core::ci::WebhookClient;
     use core::storage::{EmailSender, NarStore};
     use core::types::consts::{BASE_ROLE_ADMIN_ID, BASE_ROLE_VIEW_ID};
+    use core::types::{WebDb, WorkerDb};
     use sea_orm::{DatabaseBackend, MockDatabase};
     use test_support::cli::test_cli;
     use test_support::fakes::email::InMemoryEmailSender;
@@ -165,8 +166,8 @@ mod tests {
         let cli = test_cli();
         let nar_storage = NarStore::local(&cli.base_path).expect("nar store");
         Arc::new(ServerState {
-            web_db: db,
-            db: MockDatabase::new(DatabaseBackend::Postgres).into_connection(),
+            web_db: WebDb::new(db),
+            worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
             cli,
             log_storage: Arc::new(NoopLogStorage),
             webhooks: Arc::new(RecordingWebhookClient::new()) as Arc<dyn WebhookClient>,

--- a/backend/web/src/endpoints/projects/metrics.rs
+++ b/backend/web/src/endpoints/projects/metrics.rs
@@ -38,8 +38,8 @@ pub struct ProjectMetricsResponse {
 /// BFS over `derivation_dependency` starting from `seed_drv_ids`.
 ///
 /// Returns all reachable derivation UUIDs (including the seeds themselves).
-async fn derivation_closure_reachable(
-    db: &sea_orm::DatabaseConnection,
+async fn derivation_closure_reachable<C: sea_orm::ConnectionTrait>(
+    db: &C,
     seed_drv_ids: Vec<Uuid>,
 ) -> WebResult<HashSet<Uuid>> {
     let mut visited: HashSet<Uuid> = seed_drv_ids.iter().cloned().collect();
@@ -68,8 +68,8 @@ async fn derivation_closure_reachable(
 /// as a per-output total.
 ///
 /// Returns `Some(total)` when the total is > 0, `None` otherwise.
-async fn sum_output_sizes(
-    db: &sea_orm::DatabaseConnection,
+async fn sum_output_sizes<C: sea_orm::ConnectionTrait>(
+    db: &C,
     drv_ids: Vec<Uuid>,
 ) -> WebResult<Option<i64>> {
     if drv_ids.is_empty() {

--- a/backend/web/src/endpoints/projects/mod.rs
+++ b/backend/web/src/endpoints/projects/mod.rs
@@ -255,8 +255,8 @@ mod tests {
         let cli = test_cli();
         let nar_storage = NarStore::local(&cli.base_path).expect("nar store");
         Arc::new(ServerState {
-            web_db: db,
-            db: MockDatabase::new(DatabaseBackend::Postgres).into_connection(),
+            web_db: WebDb::new(db),
+            worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
             cli,
             log_storage: Arc::new(NoopLogStorage),
             webhooks: Arc::new(RecordingWebhookClient::new()) as Arc<dyn WebhookClient>,

--- a/backend/web/src/endpoints/stats.rs
+++ b/backend/web/src/endpoints/stats.rs
@@ -94,8 +94,8 @@ fn build_record_nar_traffic_stmt(cache_id: Uuid, bucket: NaiveDateTime, bytes: i
     )
 }
 
-async fn aggregate_traffic(
-    db: &sea_orm::DatabaseConnection,
+async fn aggregate_traffic<C: sea_orm::ConnectionTrait>(
+    db: &C,
     cache_id: Uuid,
     trunc_unit: &str,
     back_interval: &str,
@@ -146,8 +146,8 @@ async fn aggregate_traffic(
     Ok(points)
 }
 
-async fn aggregate_storage(
-    db: &sea_orm::DatabaseConnection,
+async fn aggregate_storage<C: sea_orm::ConnectionTrait>(
+    db: &C,
     cache_id: Uuid,
     trunc_unit: &str,
     back_interval: &str,
@@ -215,7 +215,7 @@ pub async fn get_cache_stats(
 
     // Total compressed bytes and package count for this cache.
     let total_row = state
-        .db
+        .web_db
         .query_one(Statement::from_sql_and_values(
             DatabaseBackend::Postgres,
             r#"SELECT COALESCE(SUM(cp.file_size), 0)::bigint AS total_bytes,

--- a/backend/web/tests/body_size_limit.rs
+++ b/backend/web/tests/body_size_limit.rs
@@ -18,7 +18,7 @@
 use axum_test::TestServer;
 use core::ci::WebhookClient;
 use core::storage::{EmailSender, NarStore};
-use core::types::ServerState;
+use core::types::{ServerState, WebDb, WorkerDb};
 use sea_orm::{DatabaseBackend, MockDatabase};
 use std::sync::Arc;
 use test_support::fakes::email::InMemoryEmailSender;
@@ -37,8 +37,8 @@ fn make_state_with_limits(
     cli.max_direct_build_size = max_direct_build_size;
     let nar_storage = NarStore::local(&cli.base_path).expect("create test NarStore");
     Arc::new(ServerState {
-        web_db: MockDatabase::new(DatabaseBackend::Postgres).into_connection(),
-        db: MockDatabase::new(DatabaseBackend::Postgres).into_connection(),
+        web_db: WebDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
+        worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
         cli,
         log_storage: Arc::new(NoopLogStorage),
         webhooks: Arc::new(RecordingWebhookClient::new()) as Arc<dyn WebhookClient>,

--- a/backend/web/tests/builds_download.rs
+++ b/backend/web/tests/builds_download.rs
@@ -18,7 +18,7 @@ use axum_test::TestServer;
 use bytes::Bytes;
 use core::ci::WebhookClient;
 use core::storage::{EmailSender, NarStore};
-use core::types::ServerState;
+use core::types::{ServerState, WebDb, WorkerDb};
 use entity::build::BuildStatus;
 use entity::evaluation::EvaluationStatus;
 use harmonia_nar::archive::test_data::{TestNarEvent, TestNarEvents};
@@ -244,8 +244,8 @@ fn listing_returns_products_from_db() {
 
         let db = mock_db_for_downloads();
         let state = Arc::new(ServerState {
-            web_db: db,
-            db: MockDatabase::new(DatabaseBackend::Postgres).into_connection(),
+            web_db: WebDb::new(db),
+            worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
             cli,
             log_storage: Arc::new(NoopLogStorage),
             webhooks: Arc::new(RecordingWebhookClient::new()) as Arc<dyn WebhookClient>,
@@ -315,8 +315,8 @@ fn download_streams_file_from_nar() {
             .into_connection();
 
         let state = Arc::new(ServerState {
-            web_db: db,
-            db: MockDatabase::new(DatabaseBackend::Postgres).into_connection(),
+            web_db: WebDb::new(db),
+            worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
             cli,
             log_storage: Arc::new(NoopLogStorage),
             webhooks: Arc::new(RecordingWebhookClient::new()) as Arc<dyn WebhookClient>,

--- a/backend/web/tests/forge_hooks.rs
+++ b/backend/web/tests/forge_hooks.rs
@@ -17,7 +17,7 @@
 use axum_test::TestServer;
 use core::ci::{WebhookClient, encrypt_webhook_secret};
 use core::storage::{EmailSender, NarStore};
-use core::types::ServerState;
+use core::types::{ServerState, WebDb, WorkerDb};
 use entity::evaluation::EvaluationStatus;
 use hmac::{Hmac, KeyInit, Mac};
 use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
@@ -76,8 +76,8 @@ fn make_state(
     }
     let nar_storage = NarStore::local(&cli.base_path).expect("create test NarStore");
     Arc::new(ServerState {
-        web_db: db,
-        db: MockDatabase::new(DatabaseBackend::Postgres).into_connection(),
+        web_db: WebDb::new(db),
+        worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
         cli,
         log_storage: Arc::new(NoopLogStorage),
         webhooks: Arc::new(RecordingWebhookClient::new()) as Arc<dyn WebhookClient>,

--- a/backend/web/tests/narinfo.rs
+++ b/backend/web/tests/narinfo.rs
@@ -9,7 +9,7 @@
 use axum_test::TestServer;
 use core::ci::WebhookClient;
 use core::storage::{EmailSender, NarStore};
-use core::types::ServerState;
+use core::types::{ServerState, WebDb, WorkerDb};
 use sea_orm::{DatabaseBackend, MockDatabase};
 use std::sync::Arc;
 use test_support::fakes::email::InMemoryEmailSender;
@@ -170,8 +170,8 @@ async fn narinfo_served_from_db_inner() {
     let cli = test_cli();
     let nar_storage = NarStore::local(&cli.base_path).expect("create test NarStore");
     let state = Arc::new(ServerState {
-        web_db: db,
-        db: MockDatabase::new(DatabaseBackend::Postgres).into_connection(),
+        web_db: WebDb::new(db),
+        worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
         cli,
         log_storage: Arc::new(NoopLogStorage),
         webhooks: Arc::new(RecordingWebhookClient::new()) as Arc<dyn WebhookClient>,

--- a/backend/web/tests/rate_limit.rs
+++ b/backend/web/tests/rate_limit.rs
@@ -14,7 +14,7 @@
 use axum_test::TestServer;
 use core::ci::WebhookClient;
 use core::storage::{EmailSender, NarStore};
-use core::types::ServerState;
+use core::types::{ServerState, WebDb, WorkerDb};
 use sea_orm::{DatabaseBackend, MockDatabase};
 use std::sync::Arc;
 use test_support::fakes::email::InMemoryEmailSender;
@@ -27,8 +27,8 @@ fn make_state() -> Arc<ServerState> {
     let cli = test_cli();
     let nar_storage = NarStore::local(&cli.base_path).expect("create test NarStore");
     Arc::new(ServerState {
-        web_db: MockDatabase::new(DatabaseBackend::Postgres).into_connection(),
-        db: MockDatabase::new(DatabaseBackend::Postgres).into_connection(),
+        web_db: WebDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
+        worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
         cli,
         log_storage: Arc::new(NoopLogStorage),
         webhooks: Arc::new(RecordingWebhookClient::new()) as Arc<dyn WebhookClient>,

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -755,3 +755,33 @@ Tests (`cargo test -p worker --bins reconnect`):
   is threaded through every attempt, proving the typestate-preservation
   contract that the real `Worker<Disconnected>` relies on for cached
   resources.
+
+## Typed DB pools — `WebDb` / `WorkerDb`
+
+`ServerState` previously held two raw `DatabaseConnection` fields named `db`
+and `web_db`; nothing in the type system stopped a web handler from
+reaching for `state.db` (the proto/scheduler/cache pool) or vice versa.
+The `db` field is now `worker_db: WorkerDb` and `web_db: WebDb`
+(`backend/core/src/types/db.rs`). Both newtypes forward `ConnectionTrait`
+to the inner pool so existing call sites
+(`find().one(&state.web_db)`, `state.worker_db.execute(stmt)`, …) work
+unchanged. The compile-time defense kicks in at any function boundary
+that types its parameter explicitly as `&WebDb` or `&WorkerDb`: the two
+newtypes are non-substitutable.
+
+While auditing, one inconsistency was fixed in
+`web::endpoints::stats::get_cache_stats` — the cache-totals query was
+reading from the worker pool while every other query in the same handler
+used `web_db`; it now uses `web_db` consistently. The fire-and-forget
+NAR-fetch bookkeeping in `web::endpoints::caches::nar` keeps using
+`worker_db` on purpose (it should not contend with foreground HTTP
+requests) and now carries a comment explaining the choice.
+
+Tests (`cargo test -p core --lib types::db`):
+
+- `types::db::tests::newtypes_are_non_substitutable` — regression for
+  #68: a function typed `fn(&WebDb)` must not accept a `&WorkerDb` and
+  vice versa, which is the compile-time defense the issue asked for.
+- `types::db::tests::forwards_connection_trait` — `&WebDb` / `&WorkerDb`
+  satisfy `&impl ConnectionTrait`, so existing SeaORM call sites keep
+  working without `.inner()` boilerplate.


### PR DESCRIPTION
Fixes #68.

## Summary
- `ServerState` held two raw `DatabaseConnection` fields named `db` and `web_db`. Nothing in the type system stopped a web handler from reaching for `state.db` (the busy proto/scheduler/cache pool) — names alone weren't self-documenting and code review had no compile-time signal. The issue called out `web::endpoints::caches::nar::spawn_cache_derivation_fetch_update` as "unclear if intentional".
- Add `WebDb(DatabaseConnection)` and `WorkerDb(DatabaseConnection)` newtypes in `backend/core/src/types/db.rs`. Both forward `ConnectionTrait` to the inner pool so existing call sites (`find().one(&state.web_db)`, `state.worker_db.execute(stmt)`, …) work unchanged. The compile-time defense kicks in at any function boundary that types its parameter explicitly as `&WebDb` or `&WorkerDb`: the two newtypes are non-substitutable.
- Rename `ServerState.db` → `worker_db` so both fields are self-documenting. Update every construction site (~14) to wrap in the newtypes.
- Generalise a few helpers in `core::ci::trigger`, `web::endpoints::caches::nar`, `web::endpoints::projects::metrics`, `web::endpoints::stats` that hard-coded `&DatabaseConnection` to `&impl ConnectionTrait` so the Deref-less newtypes flow through generic seams.
- **Audit fix**: `web::endpoints::stats::get_cache_stats` was reading the cache-totals query from the worker pool while every other query in the same handler used `web_db` — clearly inconsistent. Now uses `web_db` consistently.
- The fire-and-forget UPDATE in `spawn_cache_derivation_fetch_update` keeps using `worker_db` on purpose (heavy NAR traffic must not contend with foreground HTTP requests on the web pool) and now carries a comment explaining why.

## Test plan
- [x] `cargo build --workspace` — clean.
- [x] `cargo test --workspace --tests` — 1063 tests pass across 21 binaries (incl. 2 new `types::db` regression tests).
- [ ] Manual: confirm `/api/v1/caches/:name` and the cache stats UI still render.
- [ ] Manual: confirm a NAR fetch still records `last_fetched_at` and the cache traffic graph still updates.