### PR TITLE
backend: collapse `Created` build status to `Queued` for API responses

### DIFF
--- a/backend/entity/src/build.rs
+++ b/backend/entity/src/build.rs
@@ -46,6 +46,16 @@ impl BuildStatus {
             Self::Substituted => 7,
         }
     }
+
+    /// Maps internal-only states onto their API-facing equivalents.
+    /// `Created` is a transient pre-queue state the scheduler flips to
+    /// `Queued` almost immediately, so it is collapsed to `Queued` for clients.
+    pub const fn for_api(self) -> Self {
+        match self {
+            Self::Created => Self::Queued,
+            other => other,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Deserialize, Serialize)]
@@ -83,3 +93,28 @@ pub enum Relation {
 }
 
 impl ActiveModelBehavior for ActiveModel {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn for_api_collapses_created_to_queued() {
+        assert_eq!(BuildStatus::Created.for_api(), BuildStatus::Queued);
+    }
+
+    #[test]
+    fn for_api_passes_through_other_states() {
+        for status in [
+            BuildStatus::Queued,
+            BuildStatus::Building,
+            BuildStatus::Completed,
+            BuildStatus::Failed,
+            BuildStatus::Aborted,
+            BuildStatus::DependencyFailed,
+            BuildStatus::Substituted,
+        ] {
+            assert_eq!(status.clone().for_api(), status);
+        }
+    }
+}

--- a/backend/web/src/endpoints/builds/query.rs
+++ b/backend/web/src/endpoints/builds/query.rs
@@ -65,7 +65,7 @@ pub async fn get_build(
     let build_with_outputs = BuildWithOutputs {
         id: build.id,
         evaluation: build.evaluation,
-        status: build.status,
+        status: build.status.for_api(),
         derivation_path: derivation.derivation_path,
         architecture: derivation.architecture,
         worker: build.worker,

--- a/backend/web/src/endpoints/evals/query.rs
+++ b/backend/web/src/endpoints/evals/query.rs
@@ -70,7 +70,8 @@ pub async fn get_evaluation(
                 let build_status = builds
                     .get(&ep.build)
                     .cloned()
-                    .unwrap_or(entity::build::BuildStatus::Created);
+                    .unwrap_or(entity::build::BuildStatus::Queued)
+                    .for_api();
                 EntryPointBrief {
                     id: ep.id,
                     eval: ep.eval,
@@ -165,7 +166,7 @@ pub async fn get_evaluation_builds(
             Some(BuildItem {
                 id: b.id,
                 name: drv.derivation_path.clone(),
-                status: format!("{:?}", b.status),
+                status: format!("{:?}", b.status.clone().for_api()),
                 has_artefacts: *has_artefacts_map.get(&b.derivation).unwrap_or(&false),
                 updated_at: b.updated_at,
                 build_time_ms: b.build_time_ms,

--- a/backend/web/src/endpoints/projects/evaluations.rs
+++ b/backend/web/src/endpoints/projects/evaluations.rs
@@ -421,7 +421,7 @@ impl EntryPointRelatedData {
                 build_id: build.id,
                 derivation_path: drv.derivation_path.clone(),
                 eval: ep.eval.clone(),
-                build_status: build.status.clone(),
+                build_status: build.status.clone().for_api(),
                 has_artefacts: *self.has_products.get(&build.derivation).unwrap_or(&false),
                 architecture: drv.architecture.clone(),
                 evaluation_id: evaluation.id,

--- a/backend/web/src/endpoints/projects/metrics.rs
+++ b/backend/web/src/endpoints/projects/metrics.rs
@@ -247,7 +247,7 @@ pub async fn get_entry_point_metrics(
         points.push(EntryPointMetricPoint {
             evaluation_id: evaluation.id,
             created_at: evaluation.created_at,
-            build_status: build.status,
+            build_status: build.status.for_api(),
             build_time_ms,
             output_size_bytes,
             closure_size_bytes,

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -785,3 +785,19 @@ Tests (`cargo test -p core --lib types::db`):
 - `types::db::tests::forwards_connection_trait` — `&WebDb` / `&WorkerDb`
   satisfy `&impl ConnectionTrait`, so existing SeaORM call sites keep
   working without `.inner()` boilerplate.
+
+## Build status — `Created` collapsed to `Queued` for API responses
+
+Issue #120: the frontend renders a coloured dot via
+`status-{{ build.status.toLowerCase() }}`, but no `status-created` style
+exists. `Created` is an internal-only transient state — the scheduler
+flips builds to `Queued` almost immediately — so the API now collapses
+it via `BuildStatus::for_api()` (`backend/entity/src/build.rs`) at every
+response boundary (`evals::query`, `projects::evaluations`,
+`projects::metrics`, `builds::query`).
+
+Unit tests in `backend/entity/src/build.rs`:
+
+- `for_api_collapses_created_to_queued` — `Created.for_api() == Queued`.
+- `for_api_passes_through_other_states` — every other variant is
+  returned unchanged.


### PR DESCRIPTION
## Summary
- `Created` is an internal-only transient state — the scheduler flips builds to `Queued` almost immediately — but it was leaking through to the frontend, where the evaluation log renders coloured status dots via `status-{{ status.toLowerCase() }}` and has no `status-created` style, producing an uncoloured dot (#120).
- Add `BuildStatus::for_api()` (`backend/entity/src/build.rs`) that maps `Created → Queued` and is the identity for every other variant.
- Apply it at every endpoint that serialises a build status to clients: `evals::query` (entry-point briefs + builds list), `projects::evaluations` (entry-point summaries), `projects::metrics` (per-EP metric points), `builds::query` (single-build response).
- The OpenAPI schema (`docs/gradient-api.yaml`) already excludes `Created` from `BuildStatus`, so this change brings the implementation in line with the documented contract.

## Test plan
- [x] `cargo test --manifest-path backend/Cargo.toml -p entity --tests` — new `for_api_*` unit tests pass.
- [x] `cargo build --manifest-path backend/Cargo.toml -p web -p entity` — full workspace compiles.
- [ ] Manual: trigger an evaluation, observe that builds in the log page appear with the `status-queued` dot during the brief pre-queue window instead of an uncoloured dot.

Fixes #120