### PR TITLE
backend: web: route auth middleware errors through WebError (#55)

### DIFF
--- a/backend/web/src/authorization/middleware.rs
+++ b/backend/web/src/authorization/middleware.rs
@@ -7,15 +7,15 @@
 use anyhow::{Context, Result};
 use axum::body::Body;
 use axum::extract::{Request, State};
-use axum::http::StatusCode;
 use axum::middleware::Next;
-use axum::response::{Json, Response};
+use axum::response::Response;
 
 use core::types::*;
 use sea_orm::{ActiveModelTrait, ActiveValue::Set, EntityTrait};
 use std::sync::Arc;
 
 use super::jwt::{decode_jwt, extract_bearer_or_cookie, token_from_cookie};
+use crate::error::{WebError, WebResult};
 
 /// Extension type for optional authentication.
 /// Inserted by `authorize_optional` into every request regardless of whether
@@ -27,79 +27,33 @@ pub async fn authorize(
     state: State<Arc<ServerState>>,
     mut req: Request,
     next: Next,
-) -> Result<Response<Body>, (StatusCode, Json<BaseResponse<String>>)> {
+) -> WebResult<Response<Body>> {
     let auth_header = req.headers().get(axum::http::header::AUTHORIZATION);
 
     let token_str: String = if let Some(header) = auth_header {
-        let val = header.to_str().map_err(|_| {
-            (
-                StatusCode::FORBIDDEN,
-                Json(BaseResponse {
-                    error: true,
-                    message: "Authorization header empty".to_string(),
-                }),
-            )
-        })?;
+        let val = header
+            .to_str()
+            .map_err(|_| WebError::forbidden("Authorization header empty"))?;
         let mut parts = val.split_whitespace();
         let (bearer, token) = (parts.next(), parts.next());
         if bearer != Some("Bearer") || token.is_none() {
-            return Err((
-                StatusCode::FORBIDDEN,
-                Json(BaseResponse {
-                    error: true,
-                    message: "Invalid Authorization header".to_string(),
-                }),
-            ));
+            return Err(WebError::forbidden("Invalid Authorization header"));
         }
         token.unwrap().to_string()
     } else if let Some(t) = token_from_cookie(&req) {
         t
     } else {
-        return Err((
-            StatusCode::FORBIDDEN,
-            Json(BaseResponse {
-                error: true,
-                message: "Authorization header not found".to_string(),
-            }),
-        ));
+        return Err(WebError::forbidden("Authorization header not found"));
     };
 
-    let token_data = match decode_jwt(state.clone(), token_str).await {
-        Ok(data) => data,
-        Err(_) => {
-            return Err((
-                StatusCode::UNAUTHORIZED,
-                Json(BaseResponse {
-                    error: true,
-                    message: "Unable to decode token".to_string(),
-                }),
-            ));
-        }
-    };
-
-    let current_user = match EUser::find_by_id(token_data.claims.id)
-        .one(&state.web_db)
+    let token_data = decode_jwt(state.clone(), token_str)
         .await
-        .map_err(|_| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(BaseResponse {
-                    error: true,
-                    message: "Database error".to_string(),
-                }),
-            )
-        })? {
-        Some(user) => user,
-        None => {
-            return Err((
-                StatusCode::UNAUTHORIZED,
-                Json(BaseResponse {
-                    error: true,
-                    message: "User not found".to_string(),
-                }),
-            ));
-        }
-    };
+        .map_err(|_| WebError::unauthorized("Unable to decode token"))?;
+
+    let current_user = EUser::find_by_id(token_data.claims.id)
+        .one(&state.web_db)
+        .await?
+        .ok_or_else(|| WebError::unauthorized("User not found"))?;
 
     req.extensions_mut().insert(current_user);
     Ok(next.run(req).await)

--- a/backend/web/tests/auth_middleware.rs
+++ b/backend/web/tests/auth_middleware.rs
@@ -1,0 +1,99 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Wire-format regression tests for `authorization::authorize` middleware.
+//!
+//! Locks in the `BaseResponse<String>` envelope and HTTP status codes so the
+//! refactor that routes middleware errors through `WebError::IntoResponse`
+//! stays observably equivalent to the prior hand-built responses.
+
+use axum_test::TestServer;
+use core::storage::{EmailSender, NarStore};
+use core::types::{ServerState, WebDb, WorkerDb};
+use sea_orm::{DatabaseBackend, MockDatabase};
+use serde_json::Value;
+use std::sync::Arc;
+use test_support::cli::test_cli;
+use test_support::fakes::email::InMemoryEmailSender;
+use test_support::fakes::webhooks::RecordingWebhookClient;
+use test_support::log_storage::NoopLogStorage;
+use uuid::Uuid;
+use web::create_router;
+
+/// Build a `ServerState` whose `jwt_secret_file` points at a real on-disk
+/// file — required because `load_secret` calls `process::exit(1)` if the
+/// file is missing, which would tear down the test process before assertions
+/// run.
+fn server() -> TestServer {
+    let jwt_path = std::env::temp_dir().join(format!("gradient-test-jwt-{}", Uuid::new_v4()));
+    std::fs::write(&jwt_path, "test-jwt-secret").expect("write jwt secret file");
+
+    let mut cli = test_cli();
+    cli.jwt_secret_file = jwt_path.to_string_lossy().into_owned();
+
+    let nar_storage = NarStore::local(&cli.base_path).expect("create test NarStore");
+    let state = Arc::new(ServerState {
+        web_db: WebDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
+        worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
+        cli,
+        log_storage: Arc::new(NoopLogStorage),
+        webhooks: Arc::new(RecordingWebhookClient::new())
+            as Arc<dyn core::ci::WebhookClient>,
+        email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,
+        nar_storage,
+        manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+    });
+    TestServer::new(create_router(state))
+}
+
+fn assert_envelope(body: &Value, expected_message: &str) {
+    assert_eq!(body["error"], Value::Bool(true), "error flag must be true");
+    assert_eq!(
+        body["message"],
+        Value::String(expected_message.to_string()),
+        "message must match"
+    );
+}
+
+#[test]
+fn missing_auth_header_returns_403_envelope() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let s = server();
+        let res = s.get("/api/v1/user").await;
+        res.assert_status_forbidden();
+        assert_envelope(&res.json::<Value>(), "Authorization header not found");
+    });
+}
+
+#[test]
+fn malformed_bearer_returns_403_envelope() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let s = server();
+        let res = s
+            .get("/api/v1/user")
+            .add_header("authorization", "NotBearer xyz")
+            .await;
+        res.assert_status_forbidden();
+        assert_envelope(&res.json::<Value>(), "Invalid Authorization header");
+    });
+}
+
+#[test]
+fn undecodable_token_returns_401_envelope() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let s = server();
+        let res = s
+            .get("/api/v1/user")
+            .add_header("authorization", "Bearer not-a-real-jwt")
+            .await;
+        res.assert_status_unauthorized();
+        assert_envelope(&res.json::<Value>(), "Unable to decode token");
+    });
+}

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -83,6 +83,21 @@ a banner instructing the admin to subscribe to a cache before workers can run.
 - `WorkersComponent — no-cache banner` — banner show/hide specs at
   `frontend/src/app/features/organizations/workers/workers.component.spec.ts`
 
+## Auth middleware response envelope
+
+Integration tests in `backend/web/tests/auth_middleware.rs` lock in the
+HTTP-status + `BaseResponse<String>` body returned by the `authorize`
+middleware after it was rewritten to return `WebError` instead of building
+the envelope by hand (issue #55).
+
+Run with: `cargo test -p web --test auth_middleware`
+
+| Test | Scenario | Expected |
+|------|----------|----------|
+| `missing_auth_header_returns_403_envelope` | request to a protected route with no `Authorization` header and no cookie | 403, `error=true`, `message="Authorization header not found"` |
+| `malformed_bearer_returns_403_envelope` | `Authorization` header present but not `Bearer <token>` | 403, `message="Invalid Authorization header"` |
+| `undecodable_token_returns_401_envelope` | `Bearer` token that JWT can't decode | 401, `message="Unable to decode token"` |
+
 ## Inbound forge webhook response-body (BaseResponse envelope)
 
 Integration tests in `backend/web/tests/forge_hooks.rs` verify that both


### PR DESCRIPTION
## Summary

Closes the remaining manual `Json(BaseResponse { error: true, ... })` constructions identified in #55.

Most of the 122 occurrences cited by the issue had already been converted to `ok_json` in earlier sweeps (#821af74, #b1f0fef). What was left:

- **6 sites in `authorization/middleware.rs`** — built the response envelope by hand, bypassing `WebError::IntoResponse`. This was the actual source of the double-wrapping risk the issue calls out.
- 2 sites in `endpoints/auth.rs` (soft-error returns from `post_check_username`) — intentionally kept: they return HTTP 200 with `error: true` for username-availability checks, and the frontend's UX depends on the 200 status. Converting them to `WebError` would change observable behavior.

After this PR, the only places that construct the envelope literal are `error.rs` (canonical error path) and `helpers.rs` (the `ok_json` helper).

## Changes

- `authorization::authorize` now returns `WebResult<Response<Body>>` instead of `Result<_, (StatusCode, Json<BaseResponse<String>>)>`. All four early-exit paths produce the same status codes and message strings as before.
- New `backend/web/tests/auth_middleware.rs` — three integration tests pinning the wire format (status + envelope + message) for the missing-header, malformed-bearer, and undecodable-token paths.
- `docs/src/tests.md` updated with a section describing the new tests.

## Test plan

- [x] `cargo test -p web --test auth_middleware` — 3 new tests pass
- [x] `cargo test --workspace --tests` — full suite green
- [x] `cargo clippy -p web --tests` — no new warnings