### PR TITLE
backend: decompose Cli god object into typed Args + RuntimeConfig (#65)

### DIFF
--- a/backend/cache/src/cacher/cleanup.rs
+++ b/backend/cache/src/cacher/cleanup.rs
@@ -70,7 +70,7 @@ const STALE_CACHED_NARS_SELECT: &str = r#"SELECT cd.id, cd.cache, cd.derivation
                  )"#;
 
 pub async fn cleanup_stale_cached_nars(state: Arc<ServerState>) -> Result<()> {
-    let ttl_hours = state.cli.nar_ttl_hours;
+    let ttl_hours = state.cli.storage.nar_ttl_hours;
     if ttl_hours == 0 {
         return Ok(());
     }
@@ -347,7 +347,7 @@ mod tests {
 
         let mut state = make_state(tmp.path(), vec![]);
         // SAFETY: only this test holds a clone; mutate before any await.
-        Arc::get_mut(&mut state).unwrap().cli.nar_ttl_hours = 0;
+        Arc::get_mut(&mut state).unwrap().cli.storage.nar_ttl_hours = 0;
 
         cleanup_stale_cached_nars(state).await.unwrap();
         assert!(nar_file_exists(tmp.path(), h));
@@ -368,7 +368,7 @@ mod tests {
             .append_query_results::<BTreeMap<String, Value>, _, _>([vec![]])
             .into_connection();
         let mut cli = test_cli();
-        cli.nar_ttl_hours = 24;
+        cli.storage.nar_ttl_hours = 24;
         let state = Arc::new(ServerState {
             web_db: WebDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
             worker_db: WorkerDb::new(db),

--- a/backend/cache/src/cacher/cleanup.rs
+++ b/backend/cache/src/cacher/cleanup.rs
@@ -70,7 +70,7 @@ const STALE_CACHED_NARS_SELECT: &str = r#"SELECT cd.id, cd.cache, cd.derivation
                  )"#;
 
 pub async fn cleanup_stale_cached_nars(state: Arc<ServerState>) -> Result<()> {
-    let ttl_hours = state.cli.storage.nar_ttl_hours;
+    let ttl_hours = state.config.storage.nar_ttl_hours;
     if ttl_hours == 0 {
         return Ok(());
     }
@@ -295,7 +295,7 @@ mod tests {
         Arc::new(ServerState {
             web_db: WebDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
             worker_db: WorkerDb::new(db),
-            cli: test_cli(),
+            config: Arc::new(RuntimeConfig::from_cli(&test_cli())),
             log_storage: Arc::new(NoopLogStorage),
             webhooks: Arc::new(RecordingWebhookClient::new()),
             email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,
@@ -347,7 +347,7 @@ mod tests {
 
         let mut state = make_state(tmp.path(), vec![]);
         // SAFETY: only this test holds a clone; mutate before any await.
-        Arc::get_mut(&mut state).unwrap().cli.storage.nar_ttl_hours = 0;
+        Arc::make_mut(&mut Arc::get_mut(&mut state).unwrap().config).storage.nar_ttl_hours = 0;
 
         cleanup_stale_cached_nars(state).await.unwrap();
         assert!(nar_file_exists(tmp.path(), h));
@@ -369,10 +369,11 @@ mod tests {
             .into_connection();
         let mut cli = test_cli();
         cli.storage.nar_ttl_hours = 24;
+        let config = Arc::new(RuntimeConfig::from_cli(&cli));
         let state = Arc::new(ServerState {
             web_db: WebDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
             worker_db: WorkerDb::new(db),
-            cli,
+            config,
             log_storage: Arc::new(NoopLogStorage),
             webhooks: Arc::new(RecordingWebhookClient::new()),
             email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,

--- a/backend/cache/src/cacher/mod.rs
+++ b/backend/cache/src/cacher/mod.rs
@@ -28,7 +28,7 @@ use tokio::time;
 use tracing::{error, info};
 
 pub async fn cache_loop(state: Arc<ServerState>) {
-    let _guard = if state.cli.registration.report_errors {
+    let _guard = if state.config.registration.report_errors {
         Some(sentry::init(
             "https://5895e5a5d35f4dbebbcc47d5a722c402@reports.wavelens.io/1",
         ))
@@ -55,7 +55,7 @@ pub async fn cache_loop(state: Arc<ServerState>) {
         }
         if let Err(e) = gradient_core::db::gc_orphan_derivations(
             Arc::clone(&state),
-            state.cli.storage.keep_orphan_derivations_hours,
+            state.config.storage.keep_orphan_derivations_hours,
         )
         .await
         {
@@ -63,7 +63,7 @@ pub async fn cache_loop(state: Arc<ServerState>) {
         } else {
             info!("Derivation GC completed successfully");
         }
-        if state.cli.storage.nar_ttl_hours > 0
+        if state.config.storage.nar_ttl_hours > 0
             && let Err(e) = cleanup_stale_cached_nars(Arc::clone(&state)).await
         {
             error!(error = %e, "NAR TTL GC failed");
@@ -74,7 +74,7 @@ pub async fn cache_loop(state: Arc<ServerState>) {
 /// Periodic sweep that fills in `cached_path_signature` rows whose
 /// `signature` column is still NULL. Ticks every 60 seconds.
 pub async fn sign_sweep_loop(state: Arc<ServerState>) {
-    let _guard = if state.cli.registration.report_errors {
+    let _guard = if state.config.registration.report_errors {
         Some(sentry::init(
             "https://5895e5a5d35f4dbebbcc47d5a722c402@reports.wavelens.io/1",
         ))

--- a/backend/cache/src/cacher/mod.rs
+++ b/backend/cache/src/cacher/mod.rs
@@ -28,7 +28,7 @@ use tokio::time;
 use tracing::{error, info};
 
 pub async fn cache_loop(state: Arc<ServerState>) {
-    let _guard = if state.cli.report_errors {
+    let _guard = if state.cli.registration.report_errors {
         Some(sentry::init(
             "https://5895e5a5d35f4dbebbcc47d5a722c402@reports.wavelens.io/1",
         ))
@@ -55,7 +55,7 @@ pub async fn cache_loop(state: Arc<ServerState>) {
         }
         if let Err(e) = gradient_core::db::gc_orphan_derivations(
             Arc::clone(&state),
-            state.cli.keep_orphan_derivations_hours,
+            state.cli.storage.keep_orphan_derivations_hours,
         )
         .await
         {
@@ -63,7 +63,7 @@ pub async fn cache_loop(state: Arc<ServerState>) {
         } else {
             info!("Derivation GC completed successfully");
         }
-        if state.cli.nar_ttl_hours > 0
+        if state.cli.storage.nar_ttl_hours > 0
             && let Err(e) = cleanup_stale_cached_nars(Arc::clone(&state)).await
         {
             error!(error = %e, "NAR TTL GC failed");
@@ -74,7 +74,7 @@ pub async fn cache_loop(state: Arc<ServerState>) {
 /// Periodic sweep that fills in `cached_path_signature` rows whose
 /// `signature` column is still NULL. Ticks every 60 seconds.
 pub async fn sign_sweep_loop(state: Arc<ServerState>) {
-    let _guard = if state.cli.report_errors {
+    let _guard = if state.cli.registration.report_errors {
         Some(sentry::init(
             "https://5895e5a5d35f4dbebbcc47d5a722c402@reports.wavelens.io/1",
         ))

--- a/backend/cache/src/cacher/sign_sweep.rs
+++ b/backend/cache/src/cacher/sign_sweep.rs
@@ -75,9 +75,9 @@ pub async fn sign_missing_signatures(state: Arc<ServerState>) -> anyhow::Result<
             continue;
         }
         let signer = match CacheSigner::from_cache(
-            &state.cli.crypt_secret_file,
+            &state.cli.secrets.crypt_secret_file,
             cache,
-            &state.cli.serve_url,
+            &state.cli.server.serve_url,
         ) {
             Ok(s) => Some(s),
             Err(e) => {

--- a/backend/cache/src/cacher/sign_sweep.rs
+++ b/backend/cache/src/cacher/sign_sweep.rs
@@ -75,9 +75,9 @@ pub async fn sign_missing_signatures(state: Arc<ServerState>) -> anyhow::Result<
             continue;
         }
         let signer = match CacheSigner::from_cache(
-            &state.cli.secrets.crypt_secret_file,
+            &state.config.secrets.crypt_secret_file,
             cache,
-            &state.cli.server.serve_url,
+            &state.config.server.serve_url,
         ) {
             Ok(s) => Some(s),
             Err(e) => {

--- a/backend/core/src/ci/integration_lookup.rs
+++ b/backend/core/src/ci/integration_lookup.rs
@@ -128,7 +128,7 @@ pub async fn resolve_outbound_reporter_for_project(
 
     // Decrypt access token if present.
     let token = match integration.access_token.as_deref() {
-        Some(enc) => match decrypt_webhook_secret(&state.cli.secrets.crypt_secret_file, enc) {
+        Some(enc) => match decrypt_webhook_secret(&state.config.secrets.crypt_secret_file, enc) {
             Ok(t) => Some(t),
             Err(e) => {
                 warn!(error = %e, integration_id = %integration.id, "Failed to decrypt integration access token");
@@ -192,7 +192,7 @@ async fn build_github_app_reporter_for_project(
     state: &Arc<ServerState>,
     project_id: Uuid,
 ) -> Option<Arc<dyn CiReporter>> {
-    let github_app = state.cli.github_app_config()?;
+    let github_app = state.config.github_app.clone()?;
 
     let project = EProject::find_by_id(project_id)
         .one(&state.worker_db)

--- a/backend/core/src/ci/integration_lookup.rs
+++ b/backend/core/src/ci/integration_lookup.rs
@@ -128,7 +128,7 @@ pub async fn resolve_outbound_reporter_for_project(
 
     // Decrypt access token if present.
     let token = match integration.access_token.as_deref() {
-        Some(enc) => match decrypt_webhook_secret(&state.cli.crypt_secret_file, enc) {
+        Some(enc) => match decrypt_webhook_secret(&state.cli.secrets.crypt_secret_file, enc) {
             Ok(t) => Some(t),
             Err(e) => {
                 warn!(error = %e, integration_id = %integration.id, "Failed to decrypt integration access token");

--- a/backend/core/src/ci/reporting.rs
+++ b/backend/core/src/ci/reporting.rs
@@ -159,7 +159,7 @@ pub async fn report_build_ci(state: Arc<ServerState>, build: MBuild, status: CiS
     let details_url = org_name.as_ref().map(|org| {
         format!(
             "{}/organization/{}/log/{}",
-            state.cli.server.frontend_url, org, evaluation.id
+            state.config.server.frontend_url, org, evaluation.id
         )
     });
 
@@ -259,7 +259,7 @@ pub async fn report_evaluation_ci(
     let details_url = org_name.as_ref().map(|org| {
         format!(
             "{}/organization/{}/log/{}",
-            state.cli.server.frontend_url, org, evaluation.id
+            state.config.server.frontend_url, org, evaluation.id
         )
     });
 

--- a/backend/core/src/ci/reporting.rs
+++ b/backend/core/src/ci/reporting.rs
@@ -159,7 +159,7 @@ pub async fn report_build_ci(state: Arc<ServerState>, build: MBuild, status: CiS
     let details_url = org_name.as_ref().map(|org| {
         format!(
             "{}/organization/{}/log/{}",
-            state.cli.frontend_url, org, evaluation.id
+            state.cli.server.frontend_url, org, evaluation.id
         )
     });
 
@@ -259,7 +259,7 @@ pub async fn report_evaluation_ci(
     let details_url = org_name.as_ref().map(|org| {
         format!(
             "{}/organization/{}/log/{}",
-            state.cli.frontend_url, org, evaluation.id
+            state.cli.server.frontend_url, org, evaluation.id
         )
     });
 

--- a/backend/core/src/ci/webhook.rs
+++ b/backend/core/src/ci/webhook.rs
@@ -397,7 +397,7 @@ async fn fire_webhooks(
         }
 
         let plaintext_secret = match decrypt_webhook_secret(
-            &state.cli.secrets.crypt_secret_file,
+            &state.config.secrets.crypt_secret_file,
             &webhook.secret,
         ) {
             Ok(s) => s,

--- a/backend/core/src/ci/webhook.rs
+++ b/backend/core/src/ci/webhook.rs
@@ -397,7 +397,7 @@ async fn fire_webhooks(
         }
 
         let plaintext_secret = match decrypt_webhook_secret(
-            &state.cli.crypt_secret_file,
+            &state.cli.secrets.crypt_secret_file,
             &webhook.secret,
         ) {
             Ok(s) => s,

--- a/backend/core/src/db/connection.rs
+++ b/backend/core/src/db/connection.rs
@@ -22,9 +22,9 @@ use crate::types::consts::{BASE_ROLE_ADMIN_ID, BASE_ROLE_VIEW_ID, BASE_ROLE_WRIT
 use crate::types::*;
 
 fn db_url(cli: &Cli) -> Result<String> {
-    if let Some(file) = &cli.database_url_file {
+    if let Some(file) = &cli.database.database_url_file {
         Ok(std::fs::read_to_string(file).context("Failed to read database url from file")?)
-    } else if let Some(url) = &cli.database_url {
+    } else if let Some(url) = &cli.database.database_url {
         Ok(url.clone())
     } else {
         anyhow::bail!("No database url provided")
@@ -35,7 +35,7 @@ fn make_connect_options(cli: &Cli, max_connections: u32, min_connections: u32) -
     let mut opt = ConnectOptions::new(db_url(cli)?);
 
     // Only enable SQL logging at trace level
-    if cli.log_level == "trace" {
+    if cli.logging.log_level == "trace" {
         opt.sqlx_logging(true)
             .sqlx_logging_level(LevelFilter::Trace);
     } else {

--- a/backend/core/src/lib.rs
+++ b/backend/core/src/lib.rs
@@ -34,6 +34,8 @@ pub async fn init_state(cli: Cli) -> Arc<ServerState> {
     println!("Starting Gradient Server on {}:{}", cli.server.ip, cli.server.port);
     println!("State file configured: {:?}", cli.storage.state_file);
 
+    let config = Arc::new(RuntimeConfig::from_cli(&cli));
+
     let db = match connect_db(&cli).await {
         Ok(db) => db,
         Err(e) => {
@@ -183,7 +185,7 @@ pub async fn init_state(cli: Cli) -> Arc<ServerState> {
     Arc::new(ServerState {
         worker_db: WorkerDb::new(db),
         web_db: WebDb::new(web_db),
-        cli,
+        config,
         log_storage,
         webhooks,
         email,

--- a/backend/core/src/lib.rs
+++ b/backend/core/src/lib.rs
@@ -31,8 +31,8 @@ use storage::{FileLogStorage, S3LogStorage};
 use types::*;
 
 pub async fn init_state(cli: Cli) -> Arc<ServerState> {
-    println!("Starting Gradient Server on {}:{}", cli.ip, cli.port);
-    println!("State file configured: {:?}", cli.state_file);
+    println!("Starting Gradient Server on {}:{}", cli.server.ip, cli.server.port);
+    println!("State file configured: {:?}", cli.storage.state_file);
 
     let db = match connect_db(&cli).await {
         Ok(db) => db,
@@ -53,9 +53,9 @@ pub async fn init_state(cli: Cli) -> Arc<ServerState> {
     // Load and apply state configuration if provided
     if let Err(e) = load_and_apply_state(
         &db,
-        cli.state_file.as_deref(),
-        &cli.crypt_secret_file,
-        cli.delete_state,
+        cli.storage.state_file.as_deref(),
+        &cli.secrets.crypt_secret_file,
+        cli.storage.delete_state,
     )
     .await
     {
@@ -64,8 +64,8 @@ pub async fn init_state(cli: Cli) -> Arc<ServerState> {
     }
 
     // Cap keep_evaluations on all projects that exceed the configured maximum.
-    if cli.keep_evaluations > 0 {
-        let max = cli.keep_evaluations as i32;
+    if cli.storage.keep_evaluations > 0 {
+        let max = cli.storage.keep_evaluations as i32;
         let over_limit = EProject::find()
             .filter(CProject::KeepEvaluations.gt(max))
             .all(&db)
@@ -89,7 +89,7 @@ pub async fn init_state(cli: Cli) -> Arc<ServerState> {
         }
     }
 
-    let local_log_storage = match FileLogStorage::new(Path::new(&cli.base_path)).await {
+    let local_log_storage = match FileLogStorage::new(Path::new(&cli.storage.base_path)).await {
         Ok(s) => s,
         Err(e) => {
             eprintln!("Failed to initialize log storage: {}", e);
@@ -157,9 +157,9 @@ pub async fn init_state(cli: Cli) -> Arc<ServerState> {
         );
         store
     } else {
-        match NarStore::local(&cli.base_path) {
+        match NarStore::local(&cli.storage.base_path) {
             Ok(store) => {
-                println!("NAR storage: local ({})", cli.base_path);
+                println!("NAR storage: local ({})", cli.storage.base_path);
                 store
             }
             Err(e) => {

--- a/backend/core/src/sources/git.rs
+++ b/backend/core/src/sources/git.rs
@@ -46,9 +46,9 @@ impl<'a> ProjectGitContext<'a> {
                     id: project.organization,
                 })?;
             Some(super::ssh_key::decrypt_ssh_private_key(
-                &state.cli.crypt_secret_file,
+                &state.cli.secrets.crypt_secret_file,
                 organization,
-                &state.cli.serve_url,
+                &state.cli.server.serve_url,
             )?)
         } else {
             None

--- a/backend/core/src/sources/git.rs
+++ b/backend/core/src/sources/git.rs
@@ -46,9 +46,9 @@ impl<'a> ProjectGitContext<'a> {
                     id: project.organization,
                 })?;
             Some(super::ssh_key::decrypt_ssh_private_key(
-                &state.cli.secrets.crypt_secret_file,
+                &state.config.secrets.crypt_secret_file,
                 organization,
-                &state.cli.server.serve_url,
+                &state.config.server.serve_url,
             )?)
         } else {
             None

--- a/backend/core/src/types/cli/database.rs
+++ b/backend/core/src/types/cli/database.rs
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use clap::Args;
+
+#[derive(Args, Debug, Clone, Default)]
+pub struct DatabaseArgs {
+    #[arg(long, env = "GRADIENT_DATABASE_URL")]
+    pub database_url: Option<String>,
+    #[arg(long, env = "GRADIENT_DATABASE_URL_FILE")]
+    pub database_url_file: Option<String>,
+}

--- a/backend/core/src/types/cli/email.rs
+++ b/backend/core/src/types/cli/email.rs
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use clap::Args;
+
+#[derive(Args, Debug, Clone)]
+pub struct EmailArgs {
+    #[arg(long, env = "GRADIENT_EMAIL_ENABLED", default_value = "false")]
+    pub email_enabled: bool,
+    #[arg(
+        long,
+        env = "GRADIENT_EMAIL_REQUIRE_VERIFICATION",
+        default_value = "false"
+    )]
+    pub email_require_verification: bool,
+    #[arg(long, env = "GRADIENT_EMAIL_SMTP_HOST")]
+    pub email_smtp_host: Option<String>,
+    #[arg(long, env = "GRADIENT_EMAIL_SMTP_PORT", default_value = "587")]
+    pub email_smtp_port: u16,
+    #[arg(long, env = "GRADIENT_EMAIL_SMTP_USERNAME")]
+    pub email_smtp_username: Option<String>,
+    #[arg(long, env = "GRADIENT_EMAIL_SMTP_PASSWORD_FILE")]
+    pub email_smtp_password_file: Option<String>,
+    #[arg(long, env = "GRADIENT_EMAIL_FROM_ADDRESS")]
+    pub email_from_address: Option<String>,
+    #[arg(long, env = "GRADIENT_EMAIL_FROM_NAME", default_value = "Gradient")]
+    pub email_from_name: String,
+    #[arg(long, env = "GRADIENT_EMAIL_ENABLE_TLS", default_value = "true")]
+    pub email_enable_tls: bool,
+}
+
+impl Default for EmailArgs {
+    fn default() -> Self {
+        Self {
+            email_enabled: false,
+            email_require_verification: false,
+            email_smtp_host: None,
+            email_smtp_port: 587,
+            email_smtp_username: None,
+            email_smtp_password_file: None,
+            email_from_address: None,
+            email_from_name: "Gradient".into(),
+            email_enable_tls: true,
+        }
+    }
+}

--- a/backend/core/src/types/cli/eval.rs
+++ b/backend/core/src/types/cli/eval.rs
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use crate::types::input::greater_than_zero;
+use clap::Args;
+
+#[derive(Args, Debug, Clone)]
+pub struct EvalArgs {
+    #[arg(long, env = "GRADIENT_MAX_CONCURRENT_EVALUATIONS", value_parser = greater_than_zero::<usize>, default_value = "10")]
+    pub max_concurrent_evaluations: usize,
+    #[arg(long, env = "GRADIENT_MAX_CONCURRENT_BUILDS", value_parser = greater_than_zero::<usize>, default_value = "1000")]
+    pub max_concurrent_builds: usize,
+    #[arg(long, env = "GRADIENT_EVALUATION_TIMEOUT", value_parser = greater_than_zero::<i64>, default_value = "10")]
+    pub evaluation_timeout: i64,
+    /// Number of long-lived Nix evaluator worker subprocesses to keep around.
+    /// Each worker hosts one persistent embedded `NixEvaluator`, paying the
+    /// libnix init cost only once. Must be at least `1`: in-process evaluation
+    /// is unsafe because the Nix C API `EvalState` is not thread-safe and the
+    /// embedded Boehm GC conflicts with Tokio's signal handling.
+    #[arg(long, env = "GRADIENT_EVAL_WORKERS", value_parser = greater_than_zero::<usize>, default_value = "1")]
+    pub eval_workers: usize,
+    /// Recycle an eval-worker subprocess after it has served this many
+    /// `list` / `resolve` calls. Nix's Boehm GC never releases memory
+    /// back to the OS, so long-lived workers grow monotonically; this
+    /// cap bounds RSS growth by forcing a respawn. Set to 0 to disable.
+    #[arg(long, env = "GRADIENT_MAX_EVALUATIONS_PER_WORKER", default_value = "1")]
+    pub max_evaluations_per_worker: usize,
+}
+
+impl Default for EvalArgs {
+    fn default() -> Self {
+        Self {
+            max_concurrent_evaluations: 10,
+            max_concurrent_builds: 1000,
+            evaluation_timeout: 10,
+            eval_workers: 1,
+            max_evaluations_per_worker: 1,
+        }
+    }
+}

--- a/backend/core/src/types/cli/github_app.rs
+++ b/backend/core/src/types/cli/github_app.rs
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use clap::Args;
+
+#[derive(Args, Debug, Clone, Default)]
+pub struct GitHubAppArgs {
+    /// GitHub App ID. Required to enable GitHub App webhook and CI reporting.
+    #[arg(long, env = "GRADIENT_GITHUB_APP_ID")]
+    pub github_app_id: Option<u64>,
+    /// Path to the GitHub App RS256 private key PEM file.
+    #[arg(long, env = "GRADIENT_GITHUB_APP_PRIVATE_KEY_FILE")]
+    pub github_app_private_key_file: Option<String>,
+    /// Path to a file containing the shared secret used to verify incoming
+    /// GitHub App webhook payloads (`X-Hub-Signature-256`). The file's
+    /// contents must match the value configured on the GitHub App's webhook
+    /// settings page.
+    #[arg(long, env = "GRADIENT_GITHUB_APP_WEBHOOK_SECRET_FILE")]
+    pub github_app_webhook_secret_file: Option<String>,
+}

--- a/backend/core/src/types/cli/limits.rs
+++ b/backend/core/src/types/cli/limits.rs
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use crate::types::input::greater_than_zero;
+use clap::Args;
+
+#[derive(Args, Debug, Clone)]
+pub struct LimitsArgs {
+    /// Maximum size in bytes of an HTTP request body for most endpoints
+    /// (default 2 MiB). Caps webhook payloads, JSON bodies, etc. so an
+    /// attacker cannot exhaust server memory by sending an unbounded body.
+    /// The direct-build multipart upload endpoint uses
+    /// `--max-direct-build-size` instead.
+    #[arg(
+        long,
+        env = "GRADIENT_MAX_REQUEST_SIZE",
+        value_parser = greater_than_zero::<usize>,
+        default_value_t = 2 * 1024 * 1024,
+    )]
+    pub max_request_size: usize,
+    /// Maximum size in bytes of a `POST /api/v1/builds` multipart upload
+    /// (default 1 GiB). Direct-build uploads carry an entire repository
+    /// snapshot, so the limit is larger than `--max-request-size`.
+    #[arg(
+        long,
+        env = "GRADIENT_MAX_DIRECT_BUILD_SIZE",
+        value_parser = greater_than_zero::<usize>,
+        default_value_t = 1024 * 1024 * 1024,
+    )]
+    pub max_direct_build_size: usize,
+}
+
+impl Default for LimitsArgs {
+    fn default() -> Self {
+        Self {
+            max_request_size: 2 * 1024 * 1024,
+            max_direct_build_size: 1024 * 1024 * 1024,
+        }
+    }
+}

--- a/backend/core/src/types/cli/logging.rs
+++ b/backend/core/src/types/cli/logging.rs
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use clap::Args;
+
+#[derive(Args, Debug, Clone)]
+pub struct LoggingArgs {
+    /// Default log level for the whole binary. Per-component overrides:
+    /// `--builder-log-level`, `--cache-log-level`, `--web-log-level`.
+    #[arg(long, env = "GRADIENT_LOG_LEVEL", default_value = "info")]
+    pub log_level: String,
+    /// Log level for the `builder` crate. Defaults to `--log-level`.
+    #[arg(long, env = "GRADIENT_BUILDER_LOG_LEVEL")]
+    pub builder_log_level: Option<String>,
+    /// Log level for the `cache` crate. Defaults to `--log-level`.
+    #[arg(long, env = "GRADIENT_CACHE_LOG_LEVEL")]
+    pub cache_log_level: Option<String>,
+    /// Log level for the `web` crate. Defaults to `--log-level`.
+    #[arg(long, env = "GRADIENT_WEB_LOG_LEVEL")]
+    pub web_log_level: Option<String>,
+    /// Log level for the `proto` crate. Defaults to `--log-level`.
+    #[arg(long, env = "GRADIENT_PROTO_LOG_LEVEL")]
+    pub proto_log_level: Option<String>,
+}
+
+impl Default for LoggingArgs {
+    fn default() -> Self {
+        Self {
+            log_level: "info".into(),
+            builder_log_level: None,
+            cache_log_level: None,
+            web_log_level: None,
+            proto_log_level: None,
+        }
+    }
+}

--- a/backend/core/src/types/cli/mod.rs
+++ b/backend/core/src/types/cli/mod.rs
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Typed `clap::Args` clusters that compose the top-level [`super::Cli`].
+//!
+//! Each module groups the flags of one feature so handlers and tests can
+//! depend on a narrow slice instead of the full 65-field god struct. Field
+//! names, env vars, defaults and doc comments are preserved verbatim — only
+//! the Rust access path changes (e.g. `cli.port` → `cli.server.port`).
+
+mod database;
+mod email;
+mod eval;
+mod github_app;
+mod limits;
+mod logging;
+mod oidc;
+mod proto;
+mod registration;
+mod s3;
+mod secrets;
+mod server;
+mod storage;
+
+pub use database::DatabaseArgs;
+pub use email::EmailArgs;
+pub use eval::EvalArgs;
+pub use github_app::GitHubAppArgs;
+pub use limits::LimitsArgs;
+pub use logging::LoggingArgs;
+pub use oidc::OidcArgs;
+pub use proto::ProtoArgs;
+pub use registration::RegistrationArgs;
+pub use s3::S3Args;
+pub use secrets::SecretsArgs;
+pub use server::ServerArgs;
+pub use storage::StorageArgs;

--- a/backend/core/src/types/cli/oidc.rs
+++ b/backend/core/src/types/cli/oidc.rs
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use clap::Args;
+
+#[derive(Args, Debug, Clone, Default)]
+pub struct OidcArgs {
+    #[arg(long, env = "GRADIENT_OIDC_ENABLED", default_value = "false")]
+    pub oidc_enabled: bool,
+    #[arg(long, env = "GRADIENT_OIDC_REQUIRED", default_value = "false")]
+    pub oidc_required: bool,
+    #[arg(long, env = "GRADIENT_OIDC_CLIENT_ID")]
+    pub oidc_client_id: Option<String>,
+    #[arg(long, env = "GRADIENT_OIDC_CLIENT_SECRET_FILE")]
+    pub oidc_client_secret_file: Option<String>,
+    #[arg(long, env = "GRADIENT_OIDC_SCOPES")]
+    pub oidc_scopes: Option<String>,
+    #[arg(long, env = "GRADIENT_OIDC_DISCOVERY_URL")]
+    pub oidc_discovery_url: Option<String>,
+}

--- a/backend/core/src/types/cli/proto.rs
+++ b/backend/core/src/types/cli/proto.rs
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use clap::Args;
+
+#[derive(Args, Debug, Clone)]
+pub struct ProtoArgs {
+    /// Advertise HTTP/3 (QUIC) support to connecting clients.
+    /// Enabling this does NOT change the backend transport — configure nginx
+    /// with `listen 443 quic` and set the `Alt-Svc` header there.
+    /// This flag is surfaced via `GET /api/v1/config` so clients can choose
+    /// whether to attempt an HTTP/3 upgrade.
+    #[arg(long, env = "GRADIENT_QUIC", default_value = "false")]
+    pub quic: bool,
+
+    /// Maximum number of simultaneous proto WebSocket connections.
+    #[arg(long, env = "GRADIENT_MAX_PROTO_CONNECTIONS", default_value = "256")]
+    pub max_proto_connections: usize,
+
+    /// Accept incoming connections on `/proto` (workers and federated servers).
+    /// Enabled by default — disable to reject all `/proto` connections.
+    #[arg(long, env = "GRADIENT_DISCOVERABLE", default_value = "true")]
+    pub discoverable: bool,
+
+    /// Accept federated connections from other Gradient servers on `/proto`.
+    /// Requires `discoverable` to be enabled.
+    #[arg(long, env = "GRADIENT_FEDERATE_PROTO", default_value = "false")]
+    pub federate_proto: bool,
+
+    /// Expose `GET /api/v1/workers` and worker stats without authentication.
+    /// When `false` (default), only superusers can access those endpoints.
+    #[arg(long, env = "GRADIENT_GLOBAL_STATS_PUBLIC", default_value = "false")]
+    pub global_stats_public: bool,
+}
+
+impl Default for ProtoArgs {
+    fn default() -> Self {
+        Self {
+            quic: false,
+            max_proto_connections: 256,
+            discoverable: true,
+            federate_proto: false,
+            global_stats_public: false,
+        }
+    }
+}

--- a/backend/core/src/types/cli/registration.rs
+++ b/backend/core/src/types/cli/registration.rs
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use clap::Args;
+
+#[derive(Args, Debug, Clone)]
+pub struct RegistrationArgs {
+    #[arg(long, env = "GRADIENT_ENABLE_REGISTRATION", default_value = "true")]
+    pub enable_registration: bool,
+    #[arg(long, env = "GRADIENT_REPORT_ERRORS", default_value = "false")]
+    pub report_errors: bool,
+}
+
+impl Default for RegistrationArgs {
+    fn default() -> Self {
+        Self {
+            enable_registration: true,
+            report_errors: false,
+        }
+    }
+}

--- a/backend/core/src/types/cli/s3.rs
+++ b/backend/core/src/types/cli/s3.rs
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use clap::Args;
+
+#[derive(Args, Debug, Clone)]
+pub struct S3Args {
+    /// S3 bucket name. When set, NARs are stored in S3 instead of local disk.
+    #[arg(long, env = "GRADIENT_S3_BUCKET")]
+    pub s3_bucket: Option<String>,
+    /// AWS region for the S3 bucket.
+    #[arg(long, env = "GRADIENT_S3_REGION", default_value = "us-east-1")]
+    pub s3_region: String,
+    /// Custom S3-compatible endpoint URL (MinIO, Cloudflare R2, …).
+    #[arg(long, env = "GRADIENT_S3_ENDPOINT")]
+    pub s3_endpoint: Option<String>,
+    /// AWS access key ID. Falls back to instance credentials when absent.
+    #[arg(long, env = "GRADIENT_S3_ACCESS_KEY_ID")]
+    pub s3_access_key_id: Option<String>,
+    /// File containing the AWS secret access key.
+    #[arg(long, env = "GRADIENT_S3_SECRET_ACCESS_KEY_FILE")]
+    pub s3_secret_access_key_file: Option<String>,
+    /// Key prefix within the S3 bucket (e.g. "gradient/").
+    #[arg(long, env = "GRADIENT_S3_PREFIX", default_value = "")]
+    pub s3_prefix: String,
+}
+
+impl Default for S3Args {
+    fn default() -> Self {
+        Self {
+            s3_bucket: None,
+            s3_region: "us-east-1".into(),
+            s3_endpoint: None,
+            s3_access_key_id: None,
+            s3_secret_access_key_file: None,
+            s3_prefix: String::new(),
+        }
+    }
+}

--- a/backend/core/src/types/cli/secrets.rs
+++ b/backend/core/src/types/cli/secrets.rs
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use clap::Args;
+
+#[derive(Args, Debug, Clone, Default)]
+pub struct SecretsArgs {
+    #[arg(long, env = "GRADIENT_CRYPT_SECRET_FILE")]
+    pub crypt_secret_file: String,
+    #[arg(long, env = "GRADIENT_JWT_SECRET_FILE")]
+    pub jwt_secret_file: String,
+}

--- a/backend/core/src/types/cli/server.rs
+++ b/backend/core/src/types/cli/server.rs
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use crate::types::input::port_in_range;
+use clap::Args;
+
+#[derive(Args, Debug, Clone)]
+pub struct ServerArgs {
+    #[arg(long, env = "GRADIENT_IP", default_value = "127.0.0.1")]
+    pub ip: String,
+    #[arg(long, env = "GRADIENT_PORT", value_parser = port_in_range, default_value_t = 3000)]
+    pub port: u16,
+    #[arg(
+        long,
+        env = "GRADIENT_SERVE_URL",
+        default_value = "http://127.0.0.1:8000"
+    )]
+    pub serve_url: String,
+    /// Public URL of the Gradient frontend, used to build links in CI status
+    /// reports (e.g. `https://gradient.example.com`). Defaults to `serve_url`.
+    #[arg(
+        long,
+        env = "GRADIENT_FRONTEND_URL",
+        default_value = "http://127.0.0.1:8000"
+    )]
+    pub frontend_url: String,
+    /// Whether the server is served over TLS (HTTPS). Controls the `Secure`
+    /// flag on session cookies. Set to `false` for plain HTTP deployments.
+    #[arg(long, env = "GRADIENT_USE_TLS", default_value = "true")]
+    pub use_tls: bool,
+}
+
+impl Default for ServerArgs {
+    fn default() -> Self {
+        Self {
+            ip: "127.0.0.1".into(),
+            port: 3000,
+            serve_url: "http://127.0.0.1:8000".into(),
+            frontend_url: "http://127.0.0.1:8000".into(),
+            use_tls: true,
+        }
+    }
+}

--- a/backend/core/src/types/cli/storage.rs
+++ b/backend/core/src/types/cli/storage.rs
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use clap::Args;
+
+#[derive(Args, Debug, Clone)]
+pub struct StorageArgs {
+    #[arg(long, env = "GRADIENT_STORE_PATH")]
+    pub store_path: Option<String>,
+    #[arg(long, env = "GRADIENT_BASE_PATH", default_value = ".")]
+    pub base_path: String,
+    #[arg(long, env = "GRADIENT_STATE_FILE")]
+    pub state_file: Option<String>,
+    #[arg(long, env = "GRADIENT_DELETE_STATE", default_value = "true")]
+    pub delete_state: bool,
+    #[arg(long, env = "GRADIENT_KEEP_EVALUATIONS", default_value = "0")]
+    pub keep_evaluations: usize,
+    /// TTL in hours for cached NAR files that have not been fetched recently.
+    /// When expired the NAR is removed from storage and its GC root is deleted.
+    /// Set to 0 to disable (default).
+    #[arg(long, env = "GRADIENT_NAR_TTL_HOURS", default_value_t = 0)]
+    pub nar_ttl_hours: u64,
+    /// Grace period in hours before the GC pass deletes a `derivation` row
+    /// that no longer has any referencing `build` rows. The grace lets rapid
+    /// re-evaluations reuse a freshly-orphaned derivation without
+    /// re-inserting it. Set to 0 to GC immediately.
+    #[arg(
+        long,
+        env = "GRADIENT_KEEP_ORPHAN_DERIVATIONS_HOURS",
+        default_value_t = 24
+    )]
+    pub keep_orphan_derivations_hours: i64,
+}
+
+impl Default for StorageArgs {
+    fn default() -> Self {
+        Self {
+            store_path: None,
+            base_path: ".".into(),
+            state_file: None,
+            delete_state: true,
+            keep_evaluations: 0,
+            nar_ttl_hours: 0,
+            keep_orphan_derivations_hours: 24,
+        }
+    }
+}

--- a/backend/core/src/types/config.rs
+++ b/backend/core/src/types/config.rs
@@ -13,6 +13,10 @@
 //! field is present and the feature can be used.
 
 use super::Cli;
+use super::cli::{
+    DatabaseArgs, EvalArgs, LimitsArgs, LoggingArgs, ProtoArgs, RegistrationArgs, SecretsArgs,
+    ServerArgs, StorageArgs,
+};
 
 /// OIDC configuration — only present when `oidc_enabled` is true and all
 /// required fields are configured.
@@ -23,6 +27,8 @@ pub struct OidcConfig {
     /// Optional space-separated scope list; defaults to `"openid email profile"`.
     pub scopes: Option<String>,
     pub discovery_url: String,
+    /// Whether OIDC is the only allowed login method.
+    pub required: bool,
 }
 
 /// Email/SMTP configuration — only present when `email_enabled` is true and
@@ -36,6 +42,8 @@ pub struct EmailConfig {
     pub from_address: String,
     pub from_name: String,
     pub enable_tls: bool,
+    /// Whether new users must verify their email before logging in.
+    pub require_verification: bool,
 }
 
 /// GitHub App configuration — only present when all three fields are set.
@@ -78,6 +86,7 @@ impl Cli {
             client_secret_file: self.oidc.oidc_client_secret_file.clone()?,
             scopes: self.oidc.oidc_scopes.clone(),
             discovery_url: self.oidc.oidc_discovery_url.clone()?,
+            required: self.oidc.oidc_required,
         })
     }
 
@@ -94,6 +103,7 @@ impl Cli {
             from_address: self.email.email_from_address.clone()?,
             from_name: self.email.email_from_name.clone(),
             enable_tls: self.email.email_enable_tls,
+            require_verification: self.email.email_require_verification,
         })
     }
 
@@ -117,6 +127,54 @@ impl Cli {
             secret_access_key_file: self.s3.s3_secret_access_key_file.clone(),
             prefix: self.s3.s3_prefix.clone(),
         })
+    }
+}
+
+/// Resolved runtime configuration carried by `ServerState`.
+///
+/// Built once at startup from a parsed [`Cli`]. Handlers depend on the slice
+/// they need (`state.config.<group>.<field>`) instead of the full 65-field
+/// parser DTO.
+///
+/// Optional features (`oidc`, `email`, `s3`, `github_app`) are `None` when
+/// disabled or incompletely configured — the `Some` variant guarantees the
+/// feature is fully usable.
+#[derive(Debug, Clone)]
+pub struct RuntimeConfig {
+    pub logging: LoggingArgs,
+    pub server: ServerArgs,
+    pub database: DatabaseArgs,
+    pub eval: EvalArgs,
+    pub storage: StorageArgs,
+    pub secrets: SecretsArgs,
+    pub limits: LimitsArgs,
+    pub registration: RegistrationArgs,
+    pub proto: ProtoArgs,
+    pub oidc: Option<OidcConfig>,
+    pub email: Option<EmailConfig>,
+    pub s3: Option<S3Config>,
+    pub github_app: Option<GitHubAppConfig>,
+}
+
+impl RuntimeConfig {
+    /// Resolve a parsed [`Cli`] into a runtime configuration. Optional
+    /// features collapse to `None` exactly when their accessor methods do.
+    pub fn from_cli(cli: &Cli) -> Self {
+        Self {
+            logging: cli.logging.clone(),
+            server: cli.server.clone(),
+            database: cli.database.clone(),
+            eval: cli.eval.clone(),
+            storage: cli.storage.clone(),
+            secrets: cli.secrets.clone(),
+            limits: cli.limits.clone(),
+            registration: cli.registration.clone(),
+            proto: cli.proto.clone(),
+            oidc: cli.oidc_config(),
+            email: cli.email_config(),
+            s3: cli.s3_config(),
+            github_app: cli.github_app_config(),
+        }
     }
 }
 
@@ -267,5 +325,43 @@ mod tests {
         assert_eq!(config.bucket, "my-bucket");
         assert_eq!(config.region, "us-east-1");
         assert!(config.endpoint.is_none());
+    }
+
+    #[test]
+    fn runtime_config_from_default_cli_has_no_optional_features() {
+        let runtime = RuntimeConfig::from_cli(&base_cli());
+        assert!(runtime.oidc.is_none());
+        assert!(runtime.email.is_none());
+        assert!(runtime.s3.is_none());
+        assert!(runtime.github_app.is_none());
+        assert_eq!(runtime.storage.base_path, "/tmp/gradient-test");
+    }
+
+    #[test]
+    fn runtime_config_populates_optional_features_when_configured() {
+        let mut cli = base_cli();
+        cli.oidc.oidc_enabled = true;
+        cli.oidc.oidc_required = true;
+        cli.oidc.oidc_client_id = Some("cid".into());
+        cli.oidc.oidc_client_secret_file = Some("/run/secrets/oidc".into());
+        cli.oidc.oidc_discovery_url = Some("https://idp.example.com".into());
+        cli.email.email_enabled = true;
+        cli.email.email_require_verification = true;
+        cli.email.email_smtp_host = Some("smtp.example.com".into());
+        cli.email.email_smtp_username = Some("u".into());
+        cli.email.email_smtp_password_file = Some("/run/secrets/smtp".into());
+        cli.email.email_from_address = Some("g@example.com".into());
+        cli.s3.s3_bucket = Some("bkt".into());
+        cli.github_app.github_app_id = Some(1);
+        cli.github_app.github_app_private_key_file = Some("/k".into());
+        cli.github_app.github_app_webhook_secret_file = Some("/w".into());
+
+        let runtime = RuntimeConfig::from_cli(&cli);
+        let oidc = runtime.oidc.expect("oidc populated");
+        assert!(oidc.required);
+        let email = runtime.email.expect("email populated");
+        assert!(email.require_verification);
+        assert!(runtime.s3.is_some());
+        assert!(runtime.github_app.is_some());
     }
 }

--- a/backend/core/src/types/config.rs
+++ b/backend/core/src/types/config.rs
@@ -69,66 +69,53 @@ pub struct S3Config {
 
 impl Cli {
     /// Returns the typed OIDC config when OIDC is enabled and fully configured.
-    ///
-    /// Returns `None` when `oidc_enabled` is `false` or any required field
-    /// (`oidc_client_id`, `oidc_client_secret_file`, `oidc_discovery_url`) is
-    /// absent.
     pub fn oidc_config(&self) -> Option<OidcConfig> {
-        if !self.oidc_enabled {
+        if !self.oidc.oidc_enabled {
             return None;
         }
         Some(OidcConfig {
-            client_id: self.oidc_client_id.clone()?,
-            client_secret_file: self.oidc_client_secret_file.clone()?,
-            scopes: self.oidc_scopes.clone(),
-            discovery_url: self.oidc_discovery_url.clone()?,
+            client_id: self.oidc.oidc_client_id.clone()?,
+            client_secret_file: self.oidc.oidc_client_secret_file.clone()?,
+            scopes: self.oidc.oidc_scopes.clone(),
+            discovery_url: self.oidc.oidc_discovery_url.clone()?,
         })
     }
 
     /// Returns the typed email config when email is enabled and fully configured.
-    ///
-    /// Returns `None` when `email_enabled` is `false` or any required field
-    /// (`email_smtp_host`, `email_smtp_username`, `email_smtp_password_file`,
-    /// `email_from_address`) is absent.
     pub fn email_config(&self) -> Option<EmailConfig> {
-        if !self.email_enabled {
+        if !self.email.email_enabled {
             return None;
         }
         Some(EmailConfig {
-            smtp_host: self.email_smtp_host.clone()?,
-            smtp_port: self.email_smtp_port,
-            smtp_username: self.email_smtp_username.clone()?,
-            smtp_password_file: self.email_smtp_password_file.clone()?,
-            from_address: self.email_from_address.clone()?,
-            from_name: self.email_from_name.clone(),
-            enable_tls: self.email_enable_tls,
+            smtp_host: self.email.email_smtp_host.clone()?,
+            smtp_port: self.email.email_smtp_port,
+            smtp_username: self.email.email_smtp_username.clone()?,
+            smtp_password_file: self.email.email_smtp_password_file.clone()?,
+            from_address: self.email.email_from_address.clone()?,
+            from_name: self.email.email_from_name.clone(),
+            enable_tls: self.email.email_enable_tls,
         })
     }
 
     /// Returns the typed GitHub App config when all three GitHub App fields
     /// are configured.
-    ///
-    /// Returns `None` when any of `github_app_id`, `github_app_private_key_file`,
-    /// or `github_app_webhook_secret_file` is absent.
     pub fn github_app_config(&self) -> Option<GitHubAppConfig> {
         Some(GitHubAppConfig {
-            app_id: self.github_app_id?,
-            private_key_file: self.github_app_private_key_file.clone()?,
-            webhook_secret_file: self.github_app_webhook_secret_file.clone()?,
+            app_id: self.github_app.github_app_id?,
+            private_key_file: self.github_app.github_app_private_key_file.clone()?,
+            webhook_secret_file: self.github_app.github_app_webhook_secret_file.clone()?,
         })
     }
 
     /// Returns the typed S3 config when an S3 bucket is configured.
-    ///
-    /// Returns `None` when `s3_bucket` is not set (local storage is used).
     pub fn s3_config(&self) -> Option<S3Config> {
-        self.s3_bucket.as_ref().map(|bucket| S3Config {
+        self.s3.s3_bucket.as_ref().map(|bucket| S3Config {
             bucket: bucket.clone(),
-            region: self.s3_region.clone(),
-            endpoint: self.s3_endpoint.clone(),
-            access_key_id: self.s3_access_key_id.clone(),
-            secret_access_key_file: self.s3_secret_access_key_file.clone(),
-            prefix: self.s3_prefix.clone(),
+            region: self.s3.s3_region.clone(),
+            endpoint: self.s3.s3_endpoint.clone(),
+            access_key_id: self.s3.s3_access_key_id.clone(),
+            secret_access_key_file: self.s3.s3_secret_access_key_file.clone(),
+            prefix: self.s3.s3_prefix.clone(),
         })
     }
 }
@@ -138,66 +125,52 @@ mod tests {
     use super::*;
 
     fn base_cli() -> Cli {
+        use crate::types::cli::*;
         Cli {
-            log_level: "error".into(),
-            builder_log_level: None,
-            cache_log_level: None,
-            web_log_level: None,
-            proto_log_level: None,
-            ip: "127.0.0.1".into(),
-            port: 3000,
-            serve_url: "http://127.0.0.1:3000".into(),
-            database_url: None,
-            database_url_file: None,
-            max_concurrent_evaluations: 2,
-            max_concurrent_builds: 10,
-            evaluation_timeout: 5,
-            store_path: None,
-            base_path: "/tmp/gradient-test".into(),
-            enable_registration: false,
-            oidc_enabled: false,
-            oidc_required: false,
-            oidc_client_id: None,
-            oidc_client_secret_file: None,
-            oidc_scopes: None,
-            oidc_discovery_url: None,
-            crypt_secret_file: "test-secret".into(),
-            jwt_secret_file: "test-jwt".into(),
-            report_errors: false,
-            email_enabled: false,
-            email_require_verification: false,
-            email_smtp_host: None,
-            email_smtp_port: 587,
-            email_smtp_username: None,
-            email_smtp_password_file: None,
-            email_from_address: None,
-            email_from_name: "Gradient Test".into(),
-            email_enable_tls: false,
-            state_file: None,
-            delete_state: true,
-            keep_evaluations: 30,
-            max_request_size: 2 * 1024 * 1024,
-            max_direct_build_size: 1024 * 1024 * 1024,
-            keep_orphan_derivations_hours: 24,
-            eval_workers: 1,
-            max_evaluations_per_worker: 0,
-            nar_ttl_hours: 0,
-            s3_bucket: None,
-            s3_region: "us-east-1".into(),
-            s3_endpoint: None,
-            s3_access_key_id: None,
-            s3_secret_access_key_file: None,
-            s3_prefix: String::new(),
-            frontend_url: "http://127.0.0.1:8000".into(),
-            github_app_id: None,
-            github_app_private_key_file: None,
-            github_app_webhook_secret_file: None,
-            quic: false,
-            max_proto_connections: 16,
-            discoverable: false,
-            federate_proto: false,
-            global_stats_public: false,
-            use_tls: false,
+            logging: LoggingArgs {
+                log_level: "error".into(),
+                ..Default::default()
+            },
+            server: ServerArgs {
+                serve_url: "http://127.0.0.1:3000".into(),
+                use_tls: false,
+                ..Default::default()
+            },
+            database: DatabaseArgs::default(),
+            eval: EvalArgs {
+                max_concurrent_evaluations: 2,
+                max_concurrent_builds: 10,
+                evaluation_timeout: 5,
+                eval_workers: 1,
+                max_evaluations_per_worker: 0,
+            },
+            storage: StorageArgs {
+                base_path: "/tmp/gradient-test".into(),
+                keep_evaluations: 30,
+                ..Default::default()
+            },
+            secrets: SecretsArgs {
+                crypt_secret_file: "test-secret".into(),
+                jwt_secret_file: "test-jwt".into(),
+            },
+            limits: LimitsArgs::default(),
+            registration: RegistrationArgs {
+                enable_registration: false,
+                report_errors: false,
+            },
+            proto: ProtoArgs {
+                max_proto_connections: 16,
+                discoverable: false,
+                ..Default::default()
+            },
+            oidc: OidcArgs::default(),
+            email: EmailArgs {
+                email_from_name: "Gradient Test".into(),
+                email_enable_tls: false,
+                ..Default::default()
+            },
+            s3: S3Args::default(),
+            github_app: GitHubAppArgs::default(),
         }
     }
 
@@ -210,7 +183,7 @@ mod tests {
     #[test]
     fn oidc_config_enabled_missing_fields_returns_none() {
         let mut cli = base_cli();
-        cli.oidc_enabled = true;
+        cli.oidc.oidc_enabled = true;
         // oidc_client_id, oidc_client_secret_file, oidc_discovery_url all None
         assert!(cli.oidc_config().is_none());
     }
@@ -218,10 +191,10 @@ mod tests {
     #[test]
     fn oidc_config_fully_configured_returns_some() {
         let mut cli = base_cli();
-        cli.oidc_enabled = true;
-        cli.oidc_client_id = Some("client-id".into());
-        cli.oidc_client_secret_file = Some("/run/secrets/oidc".into());
-        cli.oidc_discovery_url = Some("https://idp.example.com".into());
+        cli.oidc.oidc_enabled = true;
+        cli.oidc.oidc_client_id = Some("client-id".into());
+        cli.oidc.oidc_client_secret_file = Some("/run/secrets/oidc".into());
+        cli.oidc.oidc_discovery_url = Some("https://idp.example.com".into());
         let config = cli.oidc_config().expect("should return Some");
         assert_eq!(config.client_id, "client-id");
         assert!(config.scopes.is_none());
@@ -236,7 +209,7 @@ mod tests {
     #[test]
     fn email_config_enabled_missing_host_returns_none() {
         let mut cli = base_cli();
-        cli.email_enabled = true;
+        cli.email.email_enabled = true;
         // email_smtp_host is None
         assert!(cli.email_config().is_none());
     }
@@ -244,11 +217,11 @@ mod tests {
     #[test]
     fn email_config_fully_configured_returns_some() {
         let mut cli = base_cli();
-        cli.email_enabled = true;
-        cli.email_smtp_host = Some("smtp.example.com".into());
-        cli.email_smtp_username = Some("user".into());
-        cli.email_smtp_password_file = Some("/run/secrets/smtp".into());
-        cli.email_from_address = Some("gradient@example.com".into());
+        cli.email.email_enabled = true;
+        cli.email.email_smtp_host = Some("smtp.example.com".into());
+        cli.email.email_smtp_username = Some("user".into());
+        cli.email.email_smtp_password_file = Some("/run/secrets/smtp".into());
+        cli.email.email_from_address = Some("gradient@example.com".into());
         let config = cli.email_config().expect("should return Some");
         assert_eq!(config.smtp_host, "smtp.example.com");
         assert_eq!(config.smtp_port, 587);
@@ -263,7 +236,7 @@ mod tests {
     #[test]
     fn github_app_config_partial_returns_none() {
         let mut cli = base_cli();
-        cli.github_app_id = Some(42);
+        cli.github_app.github_app_id = Some(42);
         // private_key_file and webhook_secret_file still None
         assert!(cli.github_app_config().is_none());
     }
@@ -271,9 +244,9 @@ mod tests {
     #[test]
     fn github_app_config_fully_configured_returns_some() {
         let mut cli = base_cli();
-        cli.github_app_id = Some(12345);
-        cli.github_app_private_key_file = Some("/run/secrets/github-app.pem".into());
-        cli.github_app_webhook_secret_file = Some("/run/secrets/github-webhook".into());
+        cli.github_app.github_app_id = Some(12345);
+        cli.github_app.github_app_private_key_file = Some("/run/secrets/github-app.pem".into());
+        cli.github_app.github_app_webhook_secret_file = Some("/run/secrets/github-webhook".into());
         let config = cli.github_app_config().expect("should return Some");
         assert_eq!(config.app_id, 12345);
         assert_eq!(config.private_key_file, "/run/secrets/github-app.pem");
@@ -289,7 +262,7 @@ mod tests {
     #[test]
     fn s3_config_with_bucket_returns_some() {
         let mut cli = base_cli();
-        cli.s3_bucket = Some("my-bucket".into());
+        cli.s3.s3_bucket = Some("my-bucket".into());
         let config = cli.s3_config().expect("should return Some");
         assert_eq!(config.bucket, "my-bucket");
         assert_eq!(config.region, "us-east-1");

--- a/backend/core/src/types/mod.rs
+++ b/backend/core/src/types/mod.rs
@@ -25,7 +25,7 @@ pub use self::cli::{
     DatabaseArgs, EmailArgs, EvalArgs, GitHubAppArgs, LimitsArgs, LoggingArgs, OidcArgs,
     ProtoArgs, RegistrationArgs, S3Args, SecretsArgs, ServerArgs, StorageArgs,
 };
-pub use self::config::{EmailConfig, GitHubAppConfig, OidcConfig, S3Config};
+pub use self::config::{EmailConfig, GitHubAppConfig, OidcConfig, RuntimeConfig, S3Config};
 pub use self::consts::*;
 pub use self::db::{WebDb, WorkerDb};
 pub use self::entity_aliases::*;
@@ -93,7 +93,11 @@ pub struct ServerState {
     /// Dedicated DB pool used by the axum/web layer so HTTP requests are
     /// not starved by the busy proto/scheduler pool under heavy NarPush load.
     pub web_db: WebDb,
-    pub cli: Cli,
+    /// Resolved runtime configuration. Built once at startup from the parsed
+    /// [`Cli`]. Replaces the prior `cli: Cli` field so handlers depend on the
+    /// slice they need (`state.config.<group>.<field>`) instead of the full
+    /// 65-field parser DTO.
+    pub config: Arc<RuntimeConfig>,
     pub log_storage: Arc<dyn LogStorage>,
     pub webhooks: Arc<dyn WebhookClient>,
     pub email: Arc<dyn EmailSender>,

--- a/backend/core/src/types/mod.rs
+++ b/backend/core/src/types/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod build_output_metadata;
 pub mod cached_path_info;
+pub mod cli;
 pub mod config;
 pub mod consts;
 pub mod db;
@@ -20,6 +21,10 @@ mod nix_cache;
 
 pub use self::build_output_metadata::BuildOutputMetadata;
 pub use self::cached_path_info::CachedPathInfo;
+pub use self::cli::{
+    DatabaseArgs, EmailArgs, EvalArgs, GitHubAppArgs, LimitsArgs, LoggingArgs, OidcArgs,
+    ProtoArgs, RegistrationArgs, S3Args, SecretsArgs, ServerArgs, StorageArgs,
+};
 pub use self::config::{EmailConfig, GitHubAppConfig, OidcConfig, S3Config};
 pub use self::consts::*;
 pub use self::db::{WebDb, WorkerDb};
@@ -47,223 +52,37 @@ pub fn now() -> NaiveDateTime {
     chrono::Utc::now().naive_utc()
 }
 
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Clone)]
 #[command(name = "Gradient", display_name = "Gradient", bin_name = "gradient-server", author = "Wavelens", version, about, long_about = None)]
 pub struct Cli {
-    /// Default log level for the whole binary. Per-component overrides:
-    /// `--builder-log-level`, `--cache-log-level`, `--web-log-level`.
-    #[arg(long, env = "GRADIENT_LOG_LEVEL", default_value = "info")]
-    pub log_level: String,
-    /// Log level for the `builder` crate. Defaults to `--log-level`.
-    #[arg(long, env = "GRADIENT_BUILDER_LOG_LEVEL")]
-    pub builder_log_level: Option<String>,
-    /// Log level for the `cache` crate. Defaults to `--log-level`.
-    #[arg(long, env = "GRADIENT_CACHE_LOG_LEVEL")]
-    pub cache_log_level: Option<String>,
-    /// Log level for the `web` crate. Defaults to `--log-level`.
-    #[arg(long, env = "GRADIENT_WEB_LOG_LEVEL")]
-    pub web_log_level: Option<String>,
-    /// Log level for the `proto` crate. Defaults to `--log-level`.
-    #[arg(long, env = "GRADIENT_PROTO_LOG_LEVEL")]
-    pub proto_log_level: Option<String>,
-    #[arg(long, env = "GRADIENT_IP", default_value = "127.0.0.1")]
-    pub ip: String,
-    #[arg(long, env = "GRADIENT_PORT", value_parser = port_in_range, default_value_t = 3000)]
-    pub port: u16,
-    #[arg(
-        long,
-        env = "GRADIENT_SERVE_URL",
-        default_value = "http://127.0.0.1:8000"
-    )]
-    pub serve_url: String,
-    #[arg(long, env = "GRADIENT_DATABASE_URL")]
-    pub database_url: Option<String>,
-    #[arg(long, env = "GRADIENT_DATABASE_URL_FILE")]
-    pub database_url_file: Option<String>,
-    #[arg(long, env = "GRADIENT_MAX_CONCURRENT_EVALUATIONS", value_parser = greater_than_zero::<usize>, default_value = "10")]
-    pub max_concurrent_evaluations: usize,
-    #[arg(long, env = "GRADIENT_MAX_CONCURRENT_BUILDS", value_parser = greater_than_zero::<usize>, default_value = "1000")]
-    pub max_concurrent_builds: usize,
-    #[arg(long, env = "GRADIENT_EVALUATION_TIMEOUT", value_parser = greater_than_zero::<i64>, default_value = "10")]
-    pub evaluation_timeout: i64,
-    #[arg(long, env = "GRADIENT_STORE_PATH")]
-    pub store_path: Option<String>,
-    #[arg(long, env = "GRADIENT_BASE_PATH", default_value = ".")]
-    pub base_path: String,
-    #[arg(long, env = "GRADIENT_ENABLE_REGISTRATION", default_value = "true")]
-    pub enable_registration: bool,
-    #[arg(long, env = "GRADIENT_OIDC_ENABLED", default_value = "false")]
-    pub oidc_enabled: bool,
-    #[arg(long, env = "GRADIENT_OIDC_REQUIRED", default_value = "false")]
-    pub oidc_required: bool,
-    #[arg(long, env = "GRADIENT_OIDC_CLIENT_ID")]
-    pub oidc_client_id: Option<String>,
-    #[arg(long, env = "GRADIENT_OIDC_CLIENT_SECRET_FILE")]
-    pub oidc_client_secret_file: Option<String>,
-    #[arg(long, env = "GRADIENT_OIDC_SCOPES")]
-    pub oidc_scopes: Option<String>,
-    #[arg(long, env = "GRADIENT_OIDC_DISCOVERY_URL")]
-    pub oidc_discovery_url: Option<String>,
-    #[arg(long, env = "GRADIENT_CRYPT_SECRET_FILE")]
-    pub crypt_secret_file: String,
-    #[arg(long, env = "GRADIENT_JWT_SECRET_FILE")]
-    pub jwt_secret_file: String,
-    #[arg(long, env = "GRADIENT_REPORT_ERRORS", default_value = "false")]
-    pub report_errors: bool,
-    #[arg(long, env = "GRADIENT_EMAIL_ENABLED", default_value = "false")]
-    pub email_enabled: bool,
-    #[arg(
-        long,
-        env = "GRADIENT_EMAIL_REQUIRE_VERIFICATION",
-        default_value = "false"
-    )]
-    pub email_require_verification: bool,
-    #[arg(long, env = "GRADIENT_EMAIL_SMTP_HOST")]
-    pub email_smtp_host: Option<String>,
-    #[arg(long, env = "GRADIENT_EMAIL_SMTP_PORT", default_value = "587")]
-    pub email_smtp_port: u16,
-    #[arg(long, env = "GRADIENT_EMAIL_SMTP_USERNAME")]
-    pub email_smtp_username: Option<String>,
-    #[arg(long, env = "GRADIENT_EMAIL_SMTP_PASSWORD_FILE")]
-    pub email_smtp_password_file: Option<String>,
-    #[arg(long, env = "GRADIENT_EMAIL_FROM_ADDRESS")]
-    pub email_from_address: Option<String>,
-    #[arg(long, env = "GRADIENT_EMAIL_FROM_NAME", default_value = "Gradient")]
-    pub email_from_name: String,
-    #[arg(long, env = "GRADIENT_EMAIL_ENABLE_TLS", default_value = "true")]
-    pub email_enable_tls: bool,
-    #[arg(long, env = "GRADIENT_STATE_FILE")]
-    pub state_file: Option<String>,
-    #[arg(long, env = "GRADIENT_DELETE_STATE", default_value = "true")]
-    pub delete_state: bool,
-    #[arg(long, env = "GRADIENT_KEEP_EVALUATIONS", default_value = "0")]
-    pub keep_evaluations: usize,
-    /// Maximum size in bytes of an HTTP request body for most endpoints
-    /// (default 2 MiB). Caps webhook payloads, JSON bodies, etc. so an
-    /// attacker cannot exhaust server memory by sending an unbounded body.
-    /// The direct-build multipart upload endpoint uses
-    /// `--max-direct-build-size` instead.
-    #[arg(
-        long,
-        env = "GRADIENT_MAX_REQUEST_SIZE",
-        value_parser = greater_than_zero::<usize>,
-        default_value_t = 2 * 1024 * 1024,
-    )]
-    pub max_request_size: usize,
-    /// Maximum size in bytes of a `POST /api/v1/builds` multipart upload
-    /// (default 1 GiB). Direct-build uploads carry an entire repository
-    /// snapshot, so the limit is larger than `--max-request-size`.
-    #[arg(
-        long,
-        env = "GRADIENT_MAX_DIRECT_BUILD_SIZE",
-        value_parser = greater_than_zero::<usize>,
-        default_value_t = 1024 * 1024 * 1024,
-    )]
-    pub max_direct_build_size: usize,
-    /// Number of long-lived Nix evaluator worker subprocesses to keep around.
-    /// Each worker hosts one persistent embedded `NixEvaluator`, paying the
-    /// libnix init cost only once. Must be at least `1`: in-process evaluation
-    /// is unsafe because the Nix C API `EvalState` is not thread-safe and the
-    /// embedded Boehm GC conflicts with Tokio's signal handling.
-    #[arg(long, env = "GRADIENT_EVAL_WORKERS", value_parser = greater_than_zero::<usize>, default_value = "1")]
-    pub eval_workers: usize,
-    /// Recycle an eval-worker subprocess after it has served this many
-    /// `list` / `resolve` calls. Nix's Boehm GC never releases memory
-    /// back to the OS, so long-lived workers grow monotonically; this
-    /// cap bounds RSS growth by forcing a respawn. Set to 0 to disable.
-    #[arg(long, env = "GRADIENT_MAX_EVALUATIONS_PER_WORKER", default_value = "1")]
-    pub max_evaluations_per_worker: usize,
-    /// TTL in hours for cached NAR files that have not been fetched recently.
-    /// When expired the NAR is removed from storage and its GC root is deleted.
-    /// Set to 0 to disable (default).
-    #[arg(long, env = "GRADIENT_NAR_TTL_HOURS", default_value_t = 0)]
-    pub nar_ttl_hours: u64,
-    /// Grace period in hours before the GC pass deletes a `derivation` row
-    /// that no longer has any referencing `build` rows. The grace lets rapid
-    /// re-evaluations reuse a freshly-orphaned derivation without
-    /// re-inserting it. Set to 0 to GC immediately.
-    #[arg(
-        long,
-        env = "GRADIENT_KEEP_ORPHAN_DERIVATIONS_HOURS",
-        default_value_t = 24
-    )]
-    pub keep_orphan_derivations_hours: i64,
-
-    // ── S3 / object-storage options ──────────────────────────────────────────
-    /// S3 bucket name. When set, NARs are stored in S3 instead of local disk.
-    #[arg(long, env = "GRADIENT_S3_BUCKET")]
-    pub s3_bucket: Option<String>,
-    /// AWS region for the S3 bucket.
-    #[arg(long, env = "GRADIENT_S3_REGION", default_value = "us-east-1")]
-    pub s3_region: String,
-    /// Custom S3-compatible endpoint URL (MinIO, Cloudflare R2, …).
-    #[arg(long, env = "GRADIENT_S3_ENDPOINT")]
-    pub s3_endpoint: Option<String>,
-    /// AWS access key ID. Falls back to instance credentials when absent.
-    #[arg(long, env = "GRADIENT_S3_ACCESS_KEY_ID")]
-    pub s3_access_key_id: Option<String>,
-    /// File containing the AWS secret access key.
-    #[arg(long, env = "GRADIENT_S3_SECRET_ACCESS_KEY_FILE")]
-    pub s3_secret_access_key_file: Option<String>,
-    /// Key prefix within the S3 bucket (e.g. "gradient/").
-    #[arg(long, env = "GRADIENT_S3_PREFIX", default_value = "")]
-    pub s3_prefix: String,
-    /// Public URL of the Gradient frontend, used to build links in CI status
-    /// reports (e.g. `https://gradient.example.com`). Defaults to `serve_url`.
-    #[arg(
-        long,
-        env = "GRADIENT_FRONTEND_URL",
-        default_value = "http://127.0.0.1:8000"
-    )]
-    pub frontend_url: String,
-
-    // ── GitHub App options ────────────────────────────────────────────────────
-    /// GitHub App ID. Required to enable GitHub App webhook and CI reporting.
-    #[arg(long, env = "GRADIENT_GITHUB_APP_ID")]
-    pub github_app_id: Option<u64>,
-    /// Path to the GitHub App RS256 private key PEM file.
-    #[arg(long, env = "GRADIENT_GITHUB_APP_PRIVATE_KEY_FILE")]
-    pub github_app_private_key_file: Option<String>,
-    /// Path to a file containing the shared secret used to verify incoming
-    /// GitHub App webhook payloads (`X-Hub-Signature-256`). The file's
-    /// contents must match the value configured on the GitHub App's webhook
-    /// settings page.
-    #[arg(long, env = "GRADIENT_GITHUB_APP_WEBHOOK_SECRET_FILE")]
-    pub github_app_webhook_secret_file: Option<String>,
-
-    // ── WebSocket protocol options ────────────────────────────────────────────
-    /// Advertise HTTP/3 (QUIC) support to connecting clients.
-    /// Enabling this does NOT change the backend transport — configure nginx
-    /// with `listen 443 quic` and set the `Alt-Svc` header there.
-    /// This flag is surfaced via `GET /api/v1/config` so clients can choose
-    /// whether to attempt an HTTP/3 upgrade.
-    #[arg(long, env = "GRADIENT_QUIC", default_value = "false")]
-    pub quic: bool,
-
-    /// Maximum number of simultaneous proto WebSocket connections.
-    #[arg(long, env = "GRADIENT_MAX_PROTO_CONNECTIONS", default_value = "256")]
-    pub max_proto_connections: usize,
-
-    /// Accept incoming connections on `/proto` (workers and federated servers).
-    /// Enabled by default — disable to reject all `/proto` connections.
-    #[arg(long, env = "GRADIENT_DISCOVERABLE", default_value = "true")]
-    pub discoverable: bool,
-
-    /// Accept federated connections from other Gradient servers on `/proto`.
-    /// Requires `discoverable` to be enabled.
-    #[arg(long, env = "GRADIENT_FEDERATE_PROTO", default_value = "false")]
-    pub federate_proto: bool,
-
-    /// Expose `GET /api/v1/workers` and worker stats without authentication.
-    /// When `false` (default), only superusers can access those endpoints.
-    #[arg(long, env = "GRADIENT_GLOBAL_STATS_PUBLIC", default_value = "false")]
-    pub global_stats_public: bool,
-
-    /// Whether the server is served over TLS (HTTPS). Controls the `Secure`
-    /// flag on session cookies. Set to `false` for plain HTTP deployments.
-    #[arg(long, env = "GRADIENT_USE_TLS", default_value = "true")]
-    pub use_tls: bool,
+    #[command(flatten)]
+    pub logging: LoggingArgs,
+    #[command(flatten)]
+    pub server: ServerArgs,
+    #[command(flatten)]
+    pub database: DatabaseArgs,
+    #[command(flatten)]
+    pub eval: EvalArgs,
+    #[command(flatten)]
+    pub storage: StorageArgs,
+    #[command(flatten)]
+    pub secrets: SecretsArgs,
+    #[command(flatten)]
+    pub limits: LimitsArgs,
+    #[command(flatten)]
+    pub registration: RegistrationArgs,
+    #[command(flatten)]
+    pub proto: ProtoArgs,
+    #[command(flatten)]
+    pub oidc: OidcArgs,
+    #[command(flatten)]
+    pub email: EmailArgs,
+    #[command(flatten)]
+    pub s3: S3Args,
+    #[command(flatten)]
+    pub github_app: GitHubAppArgs,
 }
+
 
 #[derive(Debug)]
 pub struct ServerState {

--- a/backend/proto/src/handler/auth.rs
+++ b/backend/proto/src/handler/auth.rs
@@ -248,7 +248,7 @@ pub(super) fn negotiate_capabilities(
     GradientCapabilities {
         core: true,
         cache: true,
-        federate: client.federate && state.cli.proto.federate_proto,
+        federate: client.federate && state.config.proto.federate_proto,
         fetch: client.fetch && enabled.enable_fetch,
         eval: client.eval && enabled.enable_eval,
         build: client.build && enabled.enable_build,
@@ -283,7 +283,7 @@ mod tests {
     fn make_state(federate_proto: bool) -> ServerState {
         let db = sea_orm::MockDatabase::new(sea_orm::DatabaseBackend::Postgres).into_connection();
         let mut state = Arc::try_unwrap(test_support::prelude::test_state(db)).unwrap();
-        state.cli.proto.federate_proto = federate_proto;
+        Arc::make_mut(&mut state.config).proto.federate_proto = federate_proto;
         state
     }
 

--- a/backend/proto/src/handler/auth.rs
+++ b/backend/proto/src/handler/auth.rs
@@ -248,7 +248,7 @@ pub(super) fn negotiate_capabilities(
     GradientCapabilities {
         core: true,
         cache: true,
-        federate: client.federate && state.cli.federate_proto,
+        federate: client.federate && state.cli.proto.federate_proto,
         fetch: client.fetch && enabled.enable_fetch,
         eval: client.eval && enabled.enable_eval,
         build: client.build && enabled.enable_build,
@@ -283,7 +283,7 @@ mod tests {
     fn make_state(federate_proto: bool) -> ServerState {
         let db = sea_orm::MockDatabase::new(sea_orm::DatabaseBackend::Postgres).into_connection();
         let mut state = Arc::try_unwrap(test_support::prelude::test_state(db)).unwrap();
-        state.cli.federate_proto = federate_proto;
+        state.cli.proto.federate_proto = federate_proto;
         state
     }
 

--- a/backend/proto/src/handler/session.rs
+++ b/backend/proto/src/handler/session.rs
@@ -71,7 +71,7 @@ impl ProtoSession<Opening> {
         mut self,
         server_initiated: bool,
     ) -> Option<ProtoSession<Authenticated>> {
-        if !server_initiated && !self.state.cli.discoverable {
+        if !server_initiated && !self.state.cli.proto.discoverable {
             send_reject(
                 &mut self.socket,
                 403,

--- a/backend/proto/src/handler/session.rs
+++ b/backend/proto/src/handler/session.rs
@@ -71,7 +71,7 @@ impl ProtoSession<Opening> {
         mut self,
         server_initiated: bool,
     ) -> Option<ProtoSession<Authenticated>> {
-        if !server_initiated && !self.state.cli.proto.discoverable {
+        if !server_initiated && !self.state.config.proto.discoverable {
             send_reject(
                 &mut self.socket,
                 403,

--- a/backend/proto/src/handler/socket.rs
+++ b/backend/proto/src/handler/socket.rs
@@ -261,9 +261,9 @@ async fn send_ssh_key_credential(socket: &mut ProtoSocket, state: &ServerState, 
     match EOrganization::find_by_id(org_id).one(&state.worker_db).await {
         Ok(Some(org)) => {
             match gradient_core::sources::ssh_key::decrypt_ssh_private_key(
-                &state.cli.crypt_secret_file,
+                &state.cli.secrets.crypt_secret_file,
                 org,
-                &state.cli.serve_url,
+                &state.cli.server.serve_url,
             ) {
                 Ok((private_key, _public_key)) => {
                     let _ = send_server_msg(

--- a/backend/proto/src/handler/socket.rs
+++ b/backend/proto/src/handler/socket.rs
@@ -261,9 +261,9 @@ async fn send_ssh_key_credential(socket: &mut ProtoSocket, state: &ServerState, 
     match EOrganization::find_by_id(org_id).one(&state.worker_db).await {
         Ok(Some(org)) => {
             match gradient_core::sources::ssh_key::decrypt_ssh_private_key(
-                &state.cli.secrets.crypt_secret_file,
+                &state.config.secrets.crypt_secret_file,
                 org,
-                &state.cli.server.serve_url,
+                &state.config.server.serve_url,
             ) {
                 Ok((private_key, _public_key)) => {
                     let _ = send_server_msg(

--- a/backend/scheduler/src/ci.rs
+++ b/backend/scheduler/src/ci.rs
@@ -100,7 +100,7 @@ pub async fn report_ci_for_entry_points(
     let details_url = org_name.as_ref().map(|org| {
         format!(
             "{}/organization/{}/log/{}",
-            state.cli.frontend_url, org, evaluation_id
+            state.cli.server.frontend_url, org, evaluation_id
         )
     });
 
@@ -221,7 +221,7 @@ pub async fn report_ci_for_evaluation(
     let details_url = org_name.as_ref().map(|org| {
         format!(
             "{}/organization/{}/log/{}",
-            state.cli.frontend_url, org, evaluation_id
+            state.cli.server.frontend_url, org, evaluation_id
         )
     });
 

--- a/backend/scheduler/src/ci.rs
+++ b/backend/scheduler/src/ci.rs
@@ -100,7 +100,7 @@ pub async fn report_ci_for_entry_points(
     let details_url = org_name.as_ref().map(|org| {
         format!(
             "{}/organization/{}/log/{}",
-            state.cli.server.frontend_url, org, evaluation_id
+            state.config.server.frontend_url, org, evaluation_id
         )
     });
 
@@ -221,7 +221,7 @@ pub async fn report_ci_for_evaluation(
     let details_url = org_name.as_ref().map(|org| {
         format!(
             "{}/organization/{}/log/{}",
-            state.cli.server.frontend_url, org, evaluation_id
+            state.config.server.frontend_url, org, evaluation_id
         )
     });
 

--- a/backend/scheduler/src/dispatch.rs
+++ b/backend/scheduler/src/dispatch.rs
@@ -69,7 +69,7 @@ async fn project_poll_loop(scheduler: Arc<Scheduler>) {
 pub(crate) async fn poll_projects_for_evaluations(scheduler: &Scheduler) -> anyhow::Result<()> {
     let state = &scheduler.state;
     let now = gradient_core::types::now();
-    let threshold = now - chrono::Duration::seconds(state.cli.eval.evaluation_timeout);
+    let threshold = now - chrono::Duration::seconds(state.config.eval.evaluation_timeout);
     let webhook_threshold = now - chrono::Duration::seconds(WEBHOOK_BACKUP_POLL_SECS);
 
     // Webhook delivery is configured via the project's inbound integration: when

--- a/backend/scheduler/src/dispatch.rs
+++ b/backend/scheduler/src/dispatch.rs
@@ -69,7 +69,7 @@ async fn project_poll_loop(scheduler: Arc<Scheduler>) {
 pub(crate) async fn poll_projects_for_evaluations(scheduler: &Scheduler) -> anyhow::Result<()> {
     let state = &scheduler.state;
     let now = gradient_core::types::now();
-    let threshold = now - chrono::Duration::seconds(state.cli.evaluation_timeout);
+    let threshold = now - chrono::Duration::seconds(state.cli.eval.evaluation_timeout);
     let webhook_threshold = now - chrono::Duration::seconds(WEBHOOK_BACKUP_POLL_SECS);
 
     // Webhook delivery is configured via the project's inbound integration: when

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -7,33 +7,34 @@
 use clap::Parser;
 use gradient_core::init_state;
 use gradient_core::types::Cli;
+use gradient_core::types::cli::LoggingArgs;
 use std::sync::Arc;
 use tracing::info;
 use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
 /// Build an `EnvFilter` directive string from the global default plus optional
 /// per-crate overrides. Example output: `info,builder=debug,cache=trace,web=warn`.
-fn build_filter_directive(cli: &Cli) -> String {
-    let mut parts = vec![cli.logging.log_level.clone()];
-    if let Some(lvl) = &cli.logging.builder_log_level {
+fn build_filter_directive(logging: &LoggingArgs) -> String {
+    let mut parts = vec![logging.log_level.clone()];
+    if let Some(lvl) = &logging.builder_log_level {
         parts.push(format!("builder={}", lvl));
     }
-    if let Some(lvl) = &cli.logging.cache_log_level {
+    if let Some(lvl) = &logging.cache_log_level {
         parts.push(format!("cache={}", lvl));
     }
-    if let Some(lvl) = &cli.logging.web_log_level {
+    if let Some(lvl) = &logging.web_log_level {
         parts.push(format!("web={}", lvl));
     }
-    if let Some(lvl) = &cli.logging.proto_log_level {
+    if let Some(lvl) = &logging.proto_log_level {
         parts.push(format!("proto={}", lvl));
     }
     parts.join(",")
 }
 
-fn init_logging(cli: &Cli) {
+fn init_logging(logging: &LoggingArgs) {
     // `RUST_LOG` always wins if set, so operators can still override at runtime.
     // Otherwise we synthesize a directive from the per-component CLI options.
-    let directive = build_filter_directive(cli);
+    let directive = build_filter_directive(logging);
     let env_filter = match EnvFilter::try_from_default_env() {
         Ok(filter) => filter,
         Err(e) => {
@@ -62,24 +63,22 @@ pub fn main() -> std::io::Result<()> {
 
 async fn run() -> std::io::Result<()> {
     let cli = Cli::parse();
+    init_logging(&cli.logging);
     let state = init_state(cli).await;
-
-    // Initialize logging with the configured level
-    init_logging(&state.cli);
 
     info!(
         version = env!("CARGO_PKG_VERSION"),
-        ip = %state.cli.server.ip,
-        port = state.cli.server.port,
-        log_level = %state.cli.logging.log_level,
-        builder_log_level = state.cli.logging.builder_log_level.as_deref().unwrap_or("(default)"),
-        cache_log_level = state.cli.logging.cache_log_level.as_deref().unwrap_or("(default)"),
-        web_log_level = state.cli.logging.web_log_level.as_deref().unwrap_or("(default)"),
-        proto_log_level = state.cli.logging.proto_log_level.as_deref().unwrap_or("(default)"),
+        ip = %state.config.server.ip,
+        port = state.config.server.port,
+        log_level = %state.config.logging.log_level,
+        builder_log_level = state.config.logging.builder_log_level.as_deref().unwrap_or("(default)"),
+        cache_log_level = state.config.logging.cache_log_level.as_deref().unwrap_or("(default)"),
+        web_log_level = state.config.logging.web_log_level.as_deref().unwrap_or("(default)"),
+        proto_log_level = state.config.logging.proto_log_level.as_deref().unwrap_or("(default)"),
         "Starting Gradient server"
     );
 
-    let _guard = if state.cli.registration.report_errors {
+    let _guard = if state.config.registration.report_errors {
         info!("Error reporting enabled - initializing Sentry");
         Some(sentry::init(
             "https://5895e5a5d35f4dbebbcc47d5a722c402@reports.wavelens.io/1",

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -14,17 +14,17 @@ use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberI
 /// Build an `EnvFilter` directive string from the global default plus optional
 /// per-crate overrides. Example output: `info,builder=debug,cache=trace,web=warn`.
 fn build_filter_directive(cli: &Cli) -> String {
-    let mut parts = vec![cli.log_level.clone()];
-    if let Some(lvl) = &cli.builder_log_level {
+    let mut parts = vec![cli.logging.log_level.clone()];
+    if let Some(lvl) = &cli.logging.builder_log_level {
         parts.push(format!("builder={}", lvl));
     }
-    if let Some(lvl) = &cli.cache_log_level {
+    if let Some(lvl) = &cli.logging.cache_log_level {
         parts.push(format!("cache={}", lvl));
     }
-    if let Some(lvl) = &cli.web_log_level {
+    if let Some(lvl) = &cli.logging.web_log_level {
         parts.push(format!("web={}", lvl));
     }
-    if let Some(lvl) = &cli.proto_log_level {
+    if let Some(lvl) = &cli.logging.proto_log_level {
         parts.push(format!("proto={}", lvl));
     }
     parts.join(",")
@@ -69,17 +69,17 @@ async fn run() -> std::io::Result<()> {
 
     info!(
         version = env!("CARGO_PKG_VERSION"),
-        ip = %state.cli.ip,
-        port = state.cli.port,
-        log_level = %state.cli.log_level,
-        builder_log_level = state.cli.builder_log_level.as_deref().unwrap_or("(default)"),
-        cache_log_level = state.cli.cache_log_level.as_deref().unwrap_or("(default)"),
-        web_log_level = state.cli.web_log_level.as_deref().unwrap_or("(default)"),
-        proto_log_level = state.cli.proto_log_level.as_deref().unwrap_or("(default)"),
+        ip = %state.cli.server.ip,
+        port = state.cli.server.port,
+        log_level = %state.cli.logging.log_level,
+        builder_log_level = state.cli.logging.builder_log_level.as_deref().unwrap_or("(default)"),
+        cache_log_level = state.cli.logging.cache_log_level.as_deref().unwrap_or("(default)"),
+        web_log_level = state.cli.logging.web_log_level.as_deref().unwrap_or("(default)"),
+        proto_log_level = state.cli.logging.proto_log_level.as_deref().unwrap_or("(default)"),
         "Starting Gradient server"
     );
 
-    let _guard = if state.cli.report_errors {
+    let _guard = if state.cli.registration.report_errors {
         info!("Error reporting enabled - initializing Sentry");
         Some(sentry::init(
             "https://5895e5a5d35f4dbebbcc47d5a722c402@reports.wavelens.io/1",

--- a/backend/test-support/src/cli.rs
+++ b/backend/test-support/src/cli.rs
@@ -5,6 +5,7 @@
  */
 
 use gradient_core::types::Cli;
+use gradient_core::types::cli::*;
 
 /// Single source of truth for the `Cli` struct in tests.
 /// Update only here when fields are added/removed from `Cli`.
@@ -16,64 +17,49 @@ pub fn test_cli() -> Cli {
 /// Use this in tests that need a real decryptable webhook secret.
 pub fn test_cli_with_crypt(crypt_secret_file: String) -> Cli {
     Cli {
-        log_level: "error".into(),
-        builder_log_level: None,
-        cache_log_level: None,
-        web_log_level: None,
-        proto_log_level: None,
-        ip: "127.0.0.1".into(),
-        port: 3000,
-        serve_url: "http://127.0.0.1:3000".into(),
-        database_url: None,
-        database_url_file: None,
-        max_concurrent_evaluations: 2,
-        max_concurrent_builds: 10,
-        evaluation_timeout: 5,
-        store_path: None,
-        base_path: "/tmp/gradient-test".into(),
-        enable_registration: false,
-        oidc_enabled: false,
-        oidc_required: false,
-        oidc_client_id: None,
-        oidc_client_secret_file: None,
-        oidc_scopes: None,
-        oidc_discovery_url: None,
-        crypt_secret_file,
-        jwt_secret_file: "test-jwt".into(),
-        report_errors: false,
-        email_enabled: false,
-        email_require_verification: false,
-        email_smtp_host: None,
-        email_smtp_port: 587,
-        email_smtp_username: None,
-        email_smtp_password_file: None,
-        email_from_address: None,
-        email_from_name: "Gradient Test".into(),
-        email_enable_tls: false,
-        state_file: None,
-        delete_state: true,
-        keep_evaluations: 30,
-        max_request_size: 2 * 1024 * 1024,
-        max_direct_build_size: 1024 * 1024 * 1024,
-        keep_orphan_derivations_hours: 24,
-        eval_workers: 1,
-        max_evaluations_per_worker: 0,
-        nar_ttl_hours: 0,
-        s3_bucket: None,
-        s3_region: "us-east-1".into(),
-        s3_endpoint: None,
-        s3_access_key_id: None,
-        s3_secret_access_key_file: None,
-        s3_prefix: String::new(),
-        frontend_url: "http://127.0.0.1:8000".into(),
-        github_app_id: None,
-        github_app_private_key_file: None,
-        github_app_webhook_secret_file: None,
-        quic: false,
-        max_proto_connections: 16,
-        discoverable: false,
-        federate_proto: false,
-        global_stats_public: false,
-        use_tls: false,
+        logging: LoggingArgs {
+            log_level: "error".into(),
+            ..Default::default()
+        },
+        server: ServerArgs {
+            serve_url: "http://127.0.0.1:3000".into(),
+            use_tls: false,
+            ..Default::default()
+        },
+        database: DatabaseArgs::default(),
+        eval: EvalArgs {
+            max_concurrent_evaluations: 2,
+            max_concurrent_builds: 10,
+            evaluation_timeout: 5,
+            eval_workers: 1,
+            max_evaluations_per_worker: 0,
+        },
+        storage: StorageArgs {
+            base_path: "/tmp/gradient-test".into(),
+            keep_evaluations: 30,
+            ..Default::default()
+        },
+        secrets: SecretsArgs {
+            crypt_secret_file,
+            jwt_secret_file: "test-jwt".into(),
+        },
+        limits: LimitsArgs::default(),
+        registration: RegistrationArgs {
+            enable_registration: false,
+            report_errors: false,
+        },
+        proto: ProtoArgs {
+            max_proto_connections: 16,
+            discoverable: false,
+            ..Default::default()
+        },
+        oidc: OidcArgs::default(),
+        email: EmailArgs {
+            email_from_name: "Gradient Test".into(),
+            email_enable_tls: false,
+            ..Default::default()
+        },
+        s3: S3Args::default(),
+        github_app: GitHubAppArgs::default(),
     }
 }

--- a/backend/test-support/src/state.rs
+++ b/backend/test-support/src/state.rs
@@ -11,7 +11,7 @@ use crate::log_storage::NoopLogStorage;
 use gradient_core::ci::WebhookClient;
 use gradient_core::storage::EmailSender;
 use gradient_core::storage::NarStore;
-use gradient_core::types::{ServerState, WebDb, WorkerDb};
+use gradient_core::types::{RuntimeConfig, ServerState, WebDb, WorkerDb};
 use sea_orm::{DatabaseBackend, DatabaseConnection, MockDatabase};
 use std::sync::Arc;
 
@@ -22,11 +22,12 @@ use std::sync::Arc;
 /// directly so they can supply their own mock query results.
 pub fn test_state(db: DatabaseConnection) -> Arc<ServerState> {
     let cli = test_cli();
-    let nar_storage = NarStore::local(&cli.storage.base_path).expect("create test NarStore");
+    let config = Arc::new(RuntimeConfig::from_cli(&cli));
+    let nar_storage = NarStore::local(&config.storage.base_path).expect("create test NarStore");
     Arc::new(ServerState {
         web_db: WebDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
         worker_db: WorkerDb::new(db),
-        cli,
+        config,
         log_storage: Arc::new(NoopLogStorage),
         webhooks: Arc::new(RecordingWebhookClient::new()) as Arc<dyn WebhookClient>,
         email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,
@@ -43,12 +44,13 @@ pub fn test_state_recorded(
     crypt_secret_file: String,
 ) -> (Arc<ServerState>, Arc<RecordingWebhookClient>) {
     let cli = test_cli_with_crypt(crypt_secret_file);
-    let nar_storage = NarStore::local(&cli.storage.base_path).expect("create test NarStore");
+    let config = Arc::new(RuntimeConfig::from_cli(&cli));
+    let nar_storage = NarStore::local(&config.storage.base_path).expect("create test NarStore");
     let recorder = Arc::new(RecordingWebhookClient::new());
     let state = Arc::new(ServerState {
         web_db: WebDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
         worker_db: WorkerDb::new(db),
-        cli,
+        config,
         log_storage: Arc::new(NoopLogStorage),
         webhooks: Arc::clone(&recorder) as Arc<dyn WebhookClient>,
         email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,

--- a/backend/test-support/src/state.rs
+++ b/backend/test-support/src/state.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 /// directly so they can supply their own mock query results.
 pub fn test_state(db: DatabaseConnection) -> Arc<ServerState> {
     let cli = test_cli();
-    let nar_storage = NarStore::local(&cli.base_path).expect("create test NarStore");
+    let nar_storage = NarStore::local(&cli.storage.base_path).expect("create test NarStore");
     Arc::new(ServerState {
         web_db: WebDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
         worker_db: WorkerDb::new(db),
@@ -43,7 +43,7 @@ pub fn test_state_recorded(
     crypt_secret_file: String,
 ) -> (Arc<ServerState>, Arc<RecordingWebhookClient>) {
     let cli = test_cli_with_crypt(crypt_secret_file);
-    let nar_storage = NarStore::local(&cli.base_path).expect("create test NarStore");
+    let nar_storage = NarStore::local(&cli.storage.base_path).expect("create test NarStore");
     let recorder = Arc::new(RecordingWebhookClient::new());
     let state = Arc::new(ServerState {
         web_db: WebDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),

--- a/backend/web/src/authorization/jwt.rs
+++ b/backend/web/src/authorization/jwt.rs
@@ -75,7 +75,7 @@ pub fn encode_jwt(
     let iat: usize = now.timestamp() as usize;
 
     let claim = Cliams { iat, exp, id };
-    let secret = load_secret(&state.cli.jwt_secret_file);
+    let secret = load_secret(&state.cli.secrets.jwt_secret_file);
 
     encode(
         &Header::default(),
@@ -120,7 +120,7 @@ pub async fn decode_jwt(
             header: Default::default(),
         }
     } else {
-        let secret = load_secret(&state.cli.jwt_secret_file);
+        let secret = load_secret(&state.cli.secrets.jwt_secret_file);
 
         decode(
             &jwt,
@@ -141,7 +141,7 @@ pub fn encode_download_token(
     let exp = (now + Duration::hours(1)).timestamp() as usize;
     let iat = now.timestamp() as usize;
     let claim = DownloadClaims { iat, exp, build_id };
-    let secret = load_secret(&state.cli.jwt_secret_file);
+    let secret = load_secret(&state.cli.secrets.jwt_secret_file);
     encode(
         &Header::default(),
         &claim,
@@ -154,7 +154,7 @@ pub async fn decode_download_token(
     state: State<Arc<ServerState>>,
     token: String,
 ) -> Result<DownloadClaims, StatusCode> {
-    let secret = load_secret(&state.cli.jwt_secret_file);
+    let secret = load_secret(&state.cli.secrets.jwt_secret_file);
     decode::<DownloadClaims>(
         &token,
         &DecodingKey::from_secret(secret.expose().as_bytes()),

--- a/backend/web/src/authorization/jwt.rs
+++ b/backend/web/src/authorization/jwt.rs
@@ -75,7 +75,7 @@ pub fn encode_jwt(
     let iat: usize = now.timestamp() as usize;
 
     let claim = Cliams { iat, exp, id };
-    let secret = load_secret(&state.cli.secrets.jwt_secret_file);
+    let secret = load_secret(&state.config.secrets.jwt_secret_file);
 
     encode(
         &Header::default(),
@@ -120,7 +120,7 @@ pub async fn decode_jwt(
             header: Default::default(),
         }
     } else {
-        let secret = load_secret(&state.cli.secrets.jwt_secret_file);
+        let secret = load_secret(&state.config.secrets.jwt_secret_file);
 
         decode(
             &jwt,
@@ -141,7 +141,7 @@ pub fn encode_download_token(
     let exp = (now + Duration::hours(1)).timestamp() as usize;
     let iat = now.timestamp() as usize;
     let claim = DownloadClaims { iat, exp, build_id };
-    let secret = load_secret(&state.cli.secrets.jwt_secret_file);
+    let secret = load_secret(&state.config.secrets.jwt_secret_file);
     encode(
         &Header::default(),
         &claim,
@@ -154,7 +154,7 @@ pub async fn decode_download_token(
     state: State<Arc<ServerState>>,
     token: String,
 ) -> Result<DownloadClaims, StatusCode> {
-    let secret = load_secret(&state.cli.secrets.jwt_secret_file);
+    let secret = load_secret(&state.config.secrets.jwt_secret_file);
     decode::<DownloadClaims>(
         &token,
         &DecodingKey::from_secret(secret.expose().as_bytes()),

--- a/backend/web/src/authorization/oidc.rs
+++ b/backend/web/src/authorization/oidc.rs
@@ -114,8 +114,8 @@ pub async fn oidc_login_create(
     state: State<Arc<ServerState>>,
 ) -> Result<OidcAuthRequest> {
     let oidc = state
-        .cli
-        .oidc_config()
+        .config
+        .oidc.clone()
         .context("OIDC is not enabled or not fully configured")?;
 
     let metadata = get_oidc_metadata(&oidc.discovery_url).await?;
@@ -124,7 +124,7 @@ pub async fn oidc_login_create(
         .as_str()
         .context("No authorization_endpoint in OIDC metadata")?;
 
-    let redirect_uri = format!("{}/api/v1/auth/oidc/callback", state.cli.server.serve_url);
+    let redirect_uri = format!("{}/api/v1/auth/oidc/callback", state.config.server.serve_url);
     let scope = oidc
         .scopes
         .as_deref()
@@ -141,7 +141,7 @@ pub async fn oidc_login_create(
         state: csrf_state.clone(),
         nonce: nonce.clone(),
     };
-    let secret = load_secret(&state.cli.secrets.jwt_secret_file);
+    let secret = load_secret(&state.config.secrets.jwt_secret_file);
     let cookie_value = encode(
         &Header::default(),
         &claims,
@@ -174,11 +174,11 @@ pub async fn oidc_login_verify(
     csrf_cookie: String,
 ) -> Result<MUser> {
     let oidc = state
-        .cli
-        .oidc_config()
+        .config
+        .oidc.clone()
         .context("OIDC is not enabled or not fully configured")?;
 
-    let secret = load_secret(&state.cli.secrets.jwt_secret_file);
+    let secret = load_secret(&state.config.secrets.jwt_secret_file);
     let csrf_data = decode::<CsrfClaims>(
         &csrf_cookie,
         &DecodingKey::from_secret(secret.expose().as_bytes()),
@@ -217,7 +217,7 @@ pub async fn oidc_login_verify(
         .build()
         .context("Failed to create HTTP client")?;
 
-    let redirect_uri = format!("{}/api/v1/auth/oidc/callback", state.cli.server.serve_url);
+    let redirect_uri = format!("{}/api/v1/auth/oidc/callback", state.config.server.serve_url);
     let client_secret = load_secret(&oidc.client_secret_file);
 
     let token_response = http_client

--- a/backend/web/src/authorization/oidc.rs
+++ b/backend/web/src/authorization/oidc.rs
@@ -124,7 +124,7 @@ pub async fn oidc_login_create(
         .as_str()
         .context("No authorization_endpoint in OIDC metadata")?;
 
-    let redirect_uri = format!("{}/api/v1/auth/oidc/callback", state.cli.serve_url);
+    let redirect_uri = format!("{}/api/v1/auth/oidc/callback", state.cli.server.serve_url);
     let scope = oidc
         .scopes
         .as_deref()
@@ -141,7 +141,7 @@ pub async fn oidc_login_create(
         state: csrf_state.clone(),
         nonce: nonce.clone(),
     };
-    let secret = load_secret(&state.cli.jwt_secret_file);
+    let secret = load_secret(&state.cli.secrets.jwt_secret_file);
     let cookie_value = encode(
         &Header::default(),
         &claims,
@@ -178,7 +178,7 @@ pub async fn oidc_login_verify(
         .oidc_config()
         .context("OIDC is not enabled or not fully configured")?;
 
-    let secret = load_secret(&state.cli.jwt_secret_file);
+    let secret = load_secret(&state.cli.secrets.jwt_secret_file);
     let csrf_data = decode::<CsrfClaims>(
         &csrf_cookie,
         &DecodingKey::from_secret(secret.expose().as_bytes()),
@@ -217,7 +217,7 @@ pub async fn oidc_login_verify(
         .build()
         .context("Failed to create HTTP client")?;
 
-    let redirect_uri = format!("{}/api/v1/auth/oidc/callback", state.cli.serve_url);
+    let redirect_uri = format!("{}/api/v1/auth/oidc/callback", state.cli.server.serve_url);
     let client_secret = load_secret(&oidc.client_secret_file);
 
     let token_response = http_client

--- a/backend/web/src/endpoints/admin/github_app.rs
+++ b/backend/web/src/endpoints/admin/github_app.rs
@@ -66,9 +66,9 @@ pub async fn request_manifest(
     let host = body.host.unwrap_or_else(default_host);
     validate_host(&host)?;
 
-    let manifest = gradient_core::ci::github_app_manifest::build_manifest(&state.cli.serve_url);
-    let token = gradient_core::ci::manifest_state::issue_state(&state.manifest_state, user.id);
-    let post_url = gradient_core::ci::github_app_manifest::manifest_post_url(&host, &token);
+    let manifest = core::ci::github_app_manifest::build_manifest(&state.cli.server.serve_url);
+    let token = core::ci::manifest_state::issue_state(&state.manifest_state, user.id);
+    let post_url = core::ci::github_app_manifest::manifest_post_url(&host, &token);
 
     Ok(ok_json(ManifestResponse {
             manifest,

--- a/backend/web/src/endpoints/admin/github_app.rs
+++ b/backend/web/src/endpoints/admin/github_app.rs
@@ -66,9 +66,9 @@ pub async fn request_manifest(
     let host = body.host.unwrap_or_else(default_host);
     validate_host(&host)?;
 
-    let manifest = core::ci::github_app_manifest::build_manifest(&state.cli.server.serve_url);
-    let token = core::ci::manifest_state::issue_state(&state.manifest_state, user.id);
-    let post_url = core::ci::github_app_manifest::manifest_post_url(&host, &token);
+    let manifest = gradient_core::ci::github_app_manifest::build_manifest(&state.config.server.serve_url);
+    let token = gradient_core::ci::manifest_state::issue_state(&state.manifest_state, user.id);
+    let post_url = gradient_core::ci::github_app_manifest::manifest_post_url(&host, &token);
 
     Ok(ok_json(ManifestResponse {
             manifest,

--- a/backend/web/src/endpoints/auth.rs
+++ b/backend/web/src/endpoints/auth.rs
@@ -51,7 +51,7 @@ pub async fn post_basic_register(
     state: State<Arc<ServerState>>,
     Json(body): Json<MakeUserRequest>,
 ) -> WebResult<Json<BaseResponse<String>>> {
-    if !state.cli.enable_registration || state.cli.oidc_required {
+    if !state.cli.registration.enable_registration || state.cli.oidc.oidc_required {
         return Err(WebError::registration_disabled());
     }
 
@@ -85,7 +85,7 @@ pub async fn post_basic_register(
     }
 
     let (email_verified, verification_token, verification_expires) =
-        if state.cli.email_enabled && state.cli.email_require_verification {
+        if state.cli.email.email_enabled && state.cli.email.email_require_verification {
             let token = generate_verification_token();
             let expires = gradient_core::types::now() + chrono::Duration::hours(24);
             (false, Some(token), Some(expires))
@@ -112,18 +112,18 @@ pub async fn post_basic_register(
 
     let user = user.insert(&state.web_db).await?;
 
-    if state.cli.email_enabled
-        && state.cli.email_require_verification
+    if state.cli.email.email_enabled
+        && state.cli.email.email_require_verification
         && let Some(ref token) = verification_token
         && let Err(e) = state
             .email
-            .send_verification_email(&body.email, &body.name, token, &state.cli.serve_url)
+            .send_verification_email(&body.email, &body.name, token, &state.cli.server.serve_url)
             .await
     {
         tracing::warn!("Failed to send verification email: {}", e);
     }
 
-    let message = if state.cli.email_enabled && state.cli.email_require_verification {
+    let message = if state.cli.email.email_enabled && state.cli.email.email_require_verification {
         format!(
             "User {} created. Please check your email to verify your account.",
             user.id
@@ -144,7 +144,7 @@ pub async fn post_basic_login(
     state: State<Arc<ServerState>>,
     Json(body): Json<MakeLoginRequest>,
 ) -> WebResult<Response> {
-    if state.cli.oidc_required {
+    if state.cli.oidc.oidc_required {
         return Err(WebError::oauth_required());
     }
 
@@ -162,11 +162,11 @@ pub async fn post_basic_login(
 
     verify_password(body.password, &user_password).map_err(|_| WebError::invalid_credentials())?;
 
-    if state.cli.email_enabled && state.cli.email_require_verification && !user.email_verified {
+    if state.cli.email.email_enabled && state.cli.email.email_require_verification && !user.email_verified {
         return Err(WebError::bad_request("Email not verified. Please check your email and verify your account before logging in."));
     }
 
-    let use_tls = state.cli.use_tls;
+    let use_tls = state.cli.server.use_tls;
     let token = encode_jwt(state.clone(), user.id, body.remember_me)
         .map_err(|_| WebError::failed_to_generate_token())?;
 
@@ -219,7 +219,7 @@ pub async fn get_oauth_authorize(
     headers: axum::http::HeaderMap,
     Query(query): Query<HashMap<String, String>>,
 ) -> WebResult<Response> {
-    if !state.cli.oidc_enabled {
+    if !state.cli.oidc.oidc_enabled {
         return Err(WebError::oauth_disabled());
     }
 
@@ -230,7 +230,7 @@ pub async fn get_oauth_authorize(
     let csrf = read_cookie(&headers, OIDC_CSRF_COOKIE)
         .ok_or_else(|| WebError::unauthorized("Missing OIDC CSRF cookie"))?;
 
-    let use_tls = state.cli.use_tls;
+    let use_tls = state.cli.server.use_tls;
     let user: MUser = oidc_login_verify(
         state.clone(),
         code.to_string(),
@@ -260,11 +260,11 @@ pub async fn get_oauth_authorize(
 pub async fn post_oauth_authorize(
     state: State<Arc<ServerState>>,
 ) -> WebResult<Response> {
-    if !state.cli.oidc_enabled {
+    if !state.cli.oidc.oidc_enabled {
         return Err(WebError::oauth_disabled());
     }
 
-    let use_tls = state.cli.use_tls;
+    let use_tls = state.cli.server.use_tls;
     let req = oidc_login_create(state)
         .await
         .map_err(|e| WebError::Unauthorized(e.to_string()))?;
@@ -286,11 +286,11 @@ pub async fn get_oidc_login(
     state: State<Arc<ServerState>>,
     Query(_query): Query<HashMap<String, String>>,
 ) -> WebResult<Response> {
-    if !state.cli.oidc_enabled {
+    if !state.cli.oidc.oidc_enabled {
         return Err(WebError::oauth_disabled());
     }
 
-    let use_tls = state.cli.use_tls;
+    let use_tls = state.cli.server.use_tls;
     let req = oidc_login_create(state)
         .await
         .map_err(|e| WebError::Unauthorized(e.to_string()))?;
@@ -318,7 +318,7 @@ pub async fn get_oidc_callback(
     let csrf = read_cookie(&headers, OIDC_CSRF_COOKIE)
         .ok_or_else(|| WebError::unauthorized("Missing OIDC CSRF cookie"))?;
 
-    let use_tls = state.cli.use_tls;
+    let use_tls = state.cli.server.use_tls;
     let user: MUser = oidc_login_verify(
         state.clone(),
         code.to_string(),
@@ -347,7 +347,7 @@ pub async fn get_oidc_callback(
 }
 
 pub async fn post_logout(state: State<Arc<ServerState>>) -> WebResult<Response> {
-    let secure = if state.cli.use_tls { "; Secure" } else { "" };
+    let secure = if state.cli.server.use_tls { "; Secure" } else { "" };
     let clear_cookie = format!(
         "jwt_token=; HttpOnly{}; SameSite=Strict; Path=/; Max-Age=0",
         secure
@@ -416,7 +416,7 @@ pub async fn get_verify_email(
     state: State<Arc<ServerState>>,
     Query(query): Query<HashMap<String, String>>,
 ) -> WebResult<Json<BaseResponse<String>>> {
-    if !state.cli.email_enabled || !state.cli.email_require_verification {
+    if !state.cli.email.email_enabled || !state.cli.email.email_require_verification {
         return Err(WebError::BadRequest(
             "Email verification is not enabled".to_string(),
         ));
@@ -458,7 +458,7 @@ pub async fn post_resend_verification(
     state: State<Arc<ServerState>>,
     Json(body): Json<CheckUsernameRequest>,
 ) -> WebResult<Json<BaseResponse<String>>> {
-    if !state.cli.email_enabled || !state.cli.email_require_verification {
+    if !state.cli.email.email_enabled || !state.cli.email.email_require_verification {
         return Err(WebError::BadRequest(
             "Email verification is not enabled".to_string(),
         ));
@@ -491,7 +491,7 @@ pub async fn post_resend_verification(
             &user.email,
             &user.name,
             &verification_token,
-            &state.cli.serve_url,
+            &state.cli.server.serve_url,
         )
         .await
     {

--- a/backend/web/src/endpoints/auth.rs
+++ b/backend/web/src/endpoints/auth.rs
@@ -51,7 +51,7 @@ pub async fn post_basic_register(
     state: State<Arc<ServerState>>,
     Json(body): Json<MakeUserRequest>,
 ) -> WebResult<Json<BaseResponse<String>>> {
-    if !state.cli.registration.enable_registration || state.cli.oidc.oidc_required {
+    if !state.config.registration.enable_registration || state.config.oidc.as_ref().is_some_and(|o| o.required) {
         return Err(WebError::registration_disabled());
     }
 
@@ -85,7 +85,7 @@ pub async fn post_basic_register(
     }
 
     let (email_verified, verification_token, verification_expires) =
-        if state.cli.email.email_enabled && state.cli.email.email_require_verification {
+        if state.config.email.as_ref().is_some_and(|e| e.require_verification) {
             let token = generate_verification_token();
             let expires = gradient_core::types::now() + chrono::Duration::hours(24);
             (false, Some(token), Some(expires))
@@ -112,18 +112,17 @@ pub async fn post_basic_register(
 
     let user = user.insert(&state.web_db).await?;
 
-    if state.cli.email.email_enabled
-        && state.cli.email.email_require_verification
+    if state.config.email.as_ref().is_some_and(|e| e.require_verification)
         && let Some(ref token) = verification_token
         && let Err(e) = state
             .email
-            .send_verification_email(&body.email, &body.name, token, &state.cli.server.serve_url)
+            .send_verification_email(&body.email, &body.name, token, &state.config.server.serve_url)
             .await
     {
         tracing::warn!("Failed to send verification email: {}", e);
     }
 
-    let message = if state.cli.email.email_enabled && state.cli.email.email_require_verification {
+    let message = if state.config.email.as_ref().is_some_and(|e| e.require_verification) {
         format!(
             "User {} created. Please check your email to verify your account.",
             user.id
@@ -144,7 +143,7 @@ pub async fn post_basic_login(
     state: State<Arc<ServerState>>,
     Json(body): Json<MakeLoginRequest>,
 ) -> WebResult<Response> {
-    if state.cli.oidc.oidc_required {
+    if state.config.oidc.as_ref().is_some_and(|o| o.required) {
         return Err(WebError::oauth_required());
     }
 
@@ -162,11 +161,11 @@ pub async fn post_basic_login(
 
     verify_password(body.password, &user_password).map_err(|_| WebError::invalid_credentials())?;
 
-    if state.cli.email.email_enabled && state.cli.email.email_require_verification && !user.email_verified {
+    if state.config.email.as_ref().is_some_and(|e| e.require_verification) && !user.email_verified {
         return Err(WebError::bad_request("Email not verified. Please check your email and verify your account before logging in."));
     }
 
-    let use_tls = state.cli.server.use_tls;
+    let use_tls = state.config.server.use_tls;
     let token = encode_jwt(state.clone(), user.id, body.remember_me)
         .map_err(|_| WebError::failed_to_generate_token())?;
 
@@ -219,7 +218,7 @@ pub async fn get_oauth_authorize(
     headers: axum::http::HeaderMap,
     Query(query): Query<HashMap<String, String>>,
 ) -> WebResult<Response> {
-    if !state.cli.oidc.oidc_enabled {
+    if state.config.oidc.is_none() {
         return Err(WebError::oauth_disabled());
     }
 
@@ -230,7 +229,7 @@ pub async fn get_oauth_authorize(
     let csrf = read_cookie(&headers, OIDC_CSRF_COOKIE)
         .ok_or_else(|| WebError::unauthorized("Missing OIDC CSRF cookie"))?;
 
-    let use_tls = state.cli.server.use_tls;
+    let use_tls = state.config.server.use_tls;
     let user: MUser = oidc_login_verify(
         state.clone(),
         code.to_string(),
@@ -260,11 +259,11 @@ pub async fn get_oauth_authorize(
 pub async fn post_oauth_authorize(
     state: State<Arc<ServerState>>,
 ) -> WebResult<Response> {
-    if !state.cli.oidc.oidc_enabled {
+    if state.config.oidc.is_none() {
         return Err(WebError::oauth_disabled());
     }
 
-    let use_tls = state.cli.server.use_tls;
+    let use_tls = state.config.server.use_tls;
     let req = oidc_login_create(state)
         .await
         .map_err(|e| WebError::Unauthorized(e.to_string()))?;
@@ -286,11 +285,11 @@ pub async fn get_oidc_login(
     state: State<Arc<ServerState>>,
     Query(_query): Query<HashMap<String, String>>,
 ) -> WebResult<Response> {
-    if !state.cli.oidc.oidc_enabled {
+    if state.config.oidc.is_none() {
         return Err(WebError::oauth_disabled());
     }
 
-    let use_tls = state.cli.server.use_tls;
+    let use_tls = state.config.server.use_tls;
     let req = oidc_login_create(state)
         .await
         .map_err(|e| WebError::Unauthorized(e.to_string()))?;
@@ -318,7 +317,7 @@ pub async fn get_oidc_callback(
     let csrf = read_cookie(&headers, OIDC_CSRF_COOKIE)
         .ok_or_else(|| WebError::unauthorized("Missing OIDC CSRF cookie"))?;
 
-    let use_tls = state.cli.server.use_tls;
+    let use_tls = state.config.server.use_tls;
     let user: MUser = oidc_login_verify(
         state.clone(),
         code.to_string(),
@@ -347,7 +346,7 @@ pub async fn get_oidc_callback(
 }
 
 pub async fn post_logout(state: State<Arc<ServerState>>) -> WebResult<Response> {
-    let secure = if state.cli.server.use_tls { "; Secure" } else { "" };
+    let secure = if state.config.server.use_tls { "; Secure" } else { "" };
     let clear_cookie = format!(
         "jwt_token=; HttpOnly{}; SameSite=Strict; Path=/; Max-Age=0",
         secure
@@ -416,7 +415,7 @@ pub async fn get_verify_email(
     state: State<Arc<ServerState>>,
     Query(query): Query<HashMap<String, String>>,
 ) -> WebResult<Json<BaseResponse<String>>> {
-    if !state.cli.email.email_enabled || !state.cli.email.email_require_verification {
+    if !state.config.email.as_ref().is_some_and(|e| e.require_verification) {
         return Err(WebError::BadRequest(
             "Email verification is not enabled".to_string(),
         ));
@@ -458,7 +457,7 @@ pub async fn post_resend_verification(
     state: State<Arc<ServerState>>,
     Json(body): Json<CheckUsernameRequest>,
 ) -> WebResult<Json<BaseResponse<String>>> {
-    if !state.cli.email.email_enabled || !state.cli.email.email_require_verification {
+    if !state.config.email.as_ref().is_some_and(|e| e.require_verification) {
         return Err(WebError::BadRequest(
             "Email verification is not enabled".to_string(),
         ));
@@ -491,7 +490,7 @@ pub async fn post_resend_verification(
             &user.email,
             &user.name,
             &verification_token,
-            &state.cli.server.serve_url,
+            &state.config.server.serve_url,
         )
         .await
     {

--- a/backend/web/src/endpoints/builds/direct.rs
+++ b/backend/web/src/endpoints/builds/direct.rs
@@ -88,7 +88,10 @@ pub async fn post_direct_build(
         .await?
         .or_not_found("Organization")?;
 
-    let temp_dir = format!("{}/uploads/{}", state.cli.base_path, Uuid::new_v4());
+    // We'll create the DirectBuild record after the evaluation
+
+    // Create temporary directory for files
+    let temp_dir = format!("{}/uploads/{}", state.cli.storage.base_path, Uuid::new_v4());
     fs::create_dir_all(&temp_dir).await.map_err(|e| {
         WebError::internal(format!("Failed to create temp directory: {}", e))
     })?;

--- a/backend/web/src/endpoints/builds/direct.rs
+++ b/backend/web/src/endpoints/builds/direct.rs
@@ -91,7 +91,7 @@ pub async fn post_direct_build(
     // We'll create the DirectBuild record after the evaluation
 
     // Create temporary directory for files
-    let temp_dir = format!("{}/uploads/{}", state.cli.storage.base_path, Uuid::new_v4());
+    let temp_dir = format!("{}/uploads/{}", state.config.storage.base_path, Uuid::new_v4());
     fs::create_dir_all(&temp_dir).await.map_err(|e| {
         WebError::internal(format!("Failed to create temp directory: {}", e))
     })?;

--- a/backend/web/src/endpoints/caches/helpers.rs
+++ b/backend/web/src/endpoints/caches/helpers.rs
@@ -195,7 +195,7 @@ async fn get_nar_by_hash_inner(
         let deriver = cached_path_row.deriver.clone();
         let ca = cached_path_row.ca.clone();
 
-        let sig_url = gradient_core::sources::cache_key_host(&state.cli.serve_url);
+        let sig_url = core::sources::cache_key_host(&state.cli.server.serve_url);
 
         let sig = format!("{}-{}:{}", sig_url, cache.name, signature);
 
@@ -266,7 +266,7 @@ async fn get_nar_by_cached_path(
             .signature
             .or_not_found("Signature not yet computed")?;
 
-        let sig_url = gradient_core::sources::cache_key_host(&state.cli.serve_url);
+        let sig_url = core::sources::cache_key_host(&state.cli.server.serve_url);
         let sig = format!("{}-{}:{}", sig_url, cache.name, signature);
 
         let file_hash = cached_path_row

--- a/backend/web/src/endpoints/caches/helpers.rs
+++ b/backend/web/src/endpoints/caches/helpers.rs
@@ -195,7 +195,7 @@ async fn get_nar_by_hash_inner(
         let deriver = cached_path_row.deriver.clone();
         let ca = cached_path_row.ca.clone();
 
-        let sig_url = core::sources::cache_key_host(&state.cli.server.serve_url);
+        let sig_url = gradient_core::sources::cache_key_host(&state.config.server.serve_url);
 
         let sig = format!("{}-{}:{}", sig_url, cache.name, signature);
 
@@ -266,7 +266,7 @@ async fn get_nar_by_cached_path(
             .signature
             .or_not_found("Signature not yet computed")?;
 
-        let sig_url = core::sources::cache_key_host(&state.cli.server.serve_url);
+        let sig_url = gradient_core::sources::cache_key_host(&state.config.server.serve_url);
         let sig = format!("{}-{}:{}", sig_url, cache.name, signature);
 
         let file_hash = cached_path_row

--- a/backend/web/src/endpoints/caches/keys.rs
+++ b/backend/web/src/endpoints/caches/keys.rs
@@ -62,9 +62,9 @@ pub async fn get_cache_key(
     let cache = load_cache_for_owner(&state, user.id, cache).await?;
 
     let cache_key = format_cache_key(
-        &state.cli.secrets.crypt_secret_file,
+        &state.config.secrets.crypt_secret_file,
         cache,
-        state.cli.server.serve_url.clone(),
+        state.config.server.serve_url.clone(),
     )
     .map_err(|e| {
         tracing::error!("Failed to generate cache key: {}", e);
@@ -82,9 +82,9 @@ pub async fn get_cache_public_key(
     let cache = load_cache_readable(&state, &maybe_user, cache).await?;
 
     let public_key = format_cache_public_key(
-        &state.cli.secrets.crypt_secret_file,
+        &state.config.secrets.crypt_secret_file,
         cache,
-        state.cli.server.serve_url.clone(),
+        state.config.server.serve_url.clone(),
     )
     .map_err(|e| {
         tracing::error!("Failed to derive public key: {}", e);

--- a/backend/web/src/endpoints/caches/keys.rs
+++ b/backend/web/src/endpoints/caches/keys.rs
@@ -62,9 +62,9 @@ pub async fn get_cache_key(
     let cache = load_cache_for_owner(&state, user.id, cache).await?;
 
     let cache_key = format_cache_key(
-        &state.cli.crypt_secret_file,
+        &state.cli.secrets.crypt_secret_file,
         cache,
-        state.cli.serve_url.clone(),
+        state.cli.server.serve_url.clone(),
     )
     .map_err(|e| {
         tracing::error!("Failed to generate cache key: {}", e);
@@ -82,9 +82,9 @@ pub async fn get_cache_public_key(
     let cache = load_cache_readable(&state, &maybe_user, cache).await?;
 
     let public_key = format_cache_public_key(
-        &state.cli.crypt_secret_file,
+        &state.cli.secrets.crypt_secret_file,
         cache,
-        state.cli.serve_url.clone(),
+        state.cli.server.serve_url.clone(),
     )
     .map_err(|e| {
         tracing::error!("Failed to derive public key: {}", e);

--- a/backend/web/src/endpoints/caches/management.rs
+++ b/backend/web/src/endpoints/caches/management.rs
@@ -162,7 +162,7 @@ pub async fn put(
         return Err(WebError::already_exists("Cache Name"));
     }
 
-    let (private_key, public_key) = generate_signing_key(&state.cli.secrets.crypt_secret_file)
+    let (private_key, public_key) = generate_signing_key(&state.config.secrets.crypt_secret_file)
         .map_err(|e| {
             tracing::error!("Failed to generate signing key: {}", e);
             WebError::internal("Failed to generate signing key")
@@ -230,9 +230,9 @@ pub async fn get_cache(
     }
 
     let public_key = format_cache_public_key(
-        &state.cli.secrets.crypt_secret_file,
+        &state.config.secrets.crypt_secret_file,
         cache.clone(),
-        state.cli.server.serve_url.clone(),
+        state.config.server.serve_url.clone(),
     )
     .map_err(|e| {
         tracing::error!("Failed to derive public key: {}", e);

--- a/backend/web/src/endpoints/caches/management.rs
+++ b/backend/web/src/endpoints/caches/management.rs
@@ -162,7 +162,7 @@ pub async fn put(
         return Err(WebError::already_exists("Cache Name"));
     }
 
-    let (private_key, public_key) = generate_signing_key(&state.cli.crypt_secret_file)
+    let (private_key, public_key) = generate_signing_key(&state.cli.secrets.crypt_secret_file)
         .map_err(|e| {
             tracing::error!("Failed to generate signing key: {}", e);
             WebError::internal("Failed to generate signing key")
@@ -230,9 +230,9 @@ pub async fn get_cache(
     }
 
     let public_key = format_cache_public_key(
-        &state.cli.crypt_secret_file,
+        &state.cli.secrets.crypt_secret_file,
         cache.clone(),
-        state.cli.serve_url.clone(),
+        state.cli.server.serve_url.clone(),
     )
     .map_err(|e| {
         tracing::error!("Failed to derive public key: {}", e);

--- a/backend/web/src/endpoints/caches/narinfo.rs
+++ b/backend/web/src/endpoints/caches/narinfo.rs
@@ -52,7 +52,7 @@ pub async fn gradient_cache_info(
     let body = format!(
         "GradientVersion: {}\nGradientUrl: {}\n",
         env!("CARGO_PKG_VERSION"),
-        state.cli.server.serve_url,
+        state.config.server.serve_url,
     );
 
     text_response("text/x-gradient-cache-info", body)

--- a/backend/web/src/endpoints/caches/narinfo.rs
+++ b/backend/web/src/endpoints/caches/narinfo.rs
@@ -52,7 +52,7 @@ pub async fn gradient_cache_info(
     let body = format!(
         "GradientVersion: {}\nGradientUrl: {}\n",
         env!("CARGO_PKG_VERSION"),
-        state.cli.serve_url,
+        state.cli.server.serve_url,
     );
 
     text_response("text/x-gradient-cache-info", body)

--- a/backend/web/src/endpoints/forge_hooks/mod.rs
+++ b/backend/web/src/endpoints/forge_hooks/mod.rs
@@ -155,7 +155,7 @@ pub async fn forge_webhook(
     })?;
 
     let plaintext_secret =
-        decrypt_webhook_secret(&state.cli.crypt_secret_file, encrypted_secret).map_err(|e| {
+        decrypt_webhook_secret(&state.cli.secrets.crypt_secret_file, encrypted_secret).map_err(|e| {
             warn!(error = %e, integration_id = %integration.id, "Failed to decrypt integration secret");
             WebError::InternalServerError("internal error".into())
         })?;

--- a/backend/web/src/endpoints/forge_hooks/mod.rs
+++ b/backend/web/src/endpoints/forge_hooks/mod.rs
@@ -49,7 +49,7 @@ pub async fn github_app_webhook(
     headers: HeaderMap,
     body: Bytes,
 ) -> WebResult<Json<BaseResponse<WebhookResponse>>> {
-    let Some(github_app) = state.cli.github_app_config() else {
+    let Some(github_app) = state.config.github_app.clone() else {
         warn!(
             "GitHub App webhook received but GitHub App is not fully configured \
              (requires GRADIENT_GITHUB_APP_ID, GRADIENT_GITHUB_APP_PRIVATE_KEY_FILE, \
@@ -155,7 +155,7 @@ pub async fn forge_webhook(
     })?;
 
     let plaintext_secret =
-        decrypt_webhook_secret(&state.cli.secrets.crypt_secret_file, encrypted_secret).map_err(|e| {
+        decrypt_webhook_secret(&state.config.secrets.crypt_secret_file, encrypted_secret).map_err(|e| {
             warn!(error = %e, integration_id = %integration.id, "Failed to decrypt integration secret");
             WebError::InternalServerError("internal error".into())
         })?;

--- a/backend/web/src/endpoints/mod.rs
+++ b/backend/web/src/endpoints/mod.rs
@@ -125,12 +125,12 @@ pub async fn get_config(
         error: false,
         message: ServerConfig {
             version: env!("CARGO_PKG_VERSION").to_string(),
-            oidc_enabled: state.cli.oidc_enabled,
-            oidc_required: state.cli.oidc_required,
-            registration_enabled: state.cli.enable_registration && !state.cli.oidc_required,
-            email_verification_enabled: state.cli.email_enabled
-                && state.cli.email_require_verification,
-            quic: state.cli.quic,
+            oidc_enabled: state.cli.oidc.oidc_enabled,
+            oidc_required: state.cli.oidc.oidc_required,
+            registration_enabled: state.cli.registration.enable_registration && !state.cli.oidc.oidc_required,
+            email_verification_enabled: state.cli.email.email_enabled
+                && state.cli.email.email_require_verification,
+            quic: state.cli.proto.quic,
         },
     };
 

--- a/backend/web/src/endpoints/mod.rs
+++ b/backend/web/src/endpoints/mod.rs
@@ -125,12 +125,12 @@ pub async fn get_config(
         error: false,
         message: ServerConfig {
             version: env!("CARGO_PKG_VERSION").to_string(),
-            oidc_enabled: state.cli.oidc.oidc_enabled,
-            oidc_required: state.cli.oidc.oidc_required,
-            registration_enabled: state.cli.registration.enable_registration && !state.cli.oidc.oidc_required,
-            email_verification_enabled: state.cli.email.email_enabled
-                && state.cli.email.email_require_verification,
-            quic: state.cli.proto.quic,
+            oidc_enabled: state.config.oidc.is_some(),
+            oidc_required: state.config.oidc.as_ref().is_some_and(|o| o.required),
+            registration_enabled: state.config.registration.enable_registration && !state.config.oidc.as_ref().is_some_and(|o| o.required),
+            email_verification_enabled: state.config.email.is_some()
+                && state.config.email.as_ref().is_some_and(|e| e.require_verification),
+            quic: state.config.proto.quic,
         },
     };
 

--- a/backend/web/src/endpoints/orgs/integrations.rs
+++ b/backend/web/src/endpoints/orgs/integrations.rs
@@ -202,7 +202,7 @@ pub async fn put_integration(
 
     let encrypted_secret = match body.secret.as_deref() {
         Some(s) if !s.is_empty() => Some(
-            encrypt_webhook_secret(&state.cli.secrets.crypt_secret_file, s).map_err(|e| {
+            encrypt_webhook_secret(&state.config.secrets.crypt_secret_file, s).map_err(|e| {
                 WebError::internal(format!("Failed to encrypt secret: {}", e))
             })?,
         ),
@@ -211,7 +211,7 @@ pub async fn put_integration(
 
     let encrypted_token = match body.access_token.as_deref() {
         Some(t) if !t.is_empty() => Some(
-            encrypt_webhook_secret(&state.cli.secrets.crypt_secret_file, t).map_err(|e| {
+            encrypt_webhook_secret(&state.config.secrets.crypt_secret_file, t).map_err(|e| {
                 WebError::internal(format!("Failed to encrypt token: {}", e))
             })?,
         ),
@@ -327,7 +327,7 @@ pub async fn patch_integration(
             None
         } else {
             Some(
-                encrypt_webhook_secret(&state.cli.secrets.crypt_secret_file, &secret).map_err(|e| {
+                encrypt_webhook_secret(&state.config.secrets.crypt_secret_file, &secret).map_err(|e| {
                     WebError::internal(format!("Failed to encrypt secret: {}", e))
                 })?,
             )
@@ -339,7 +339,7 @@ pub async fn patch_integration(
             None
         } else {
             Some(
-                encrypt_webhook_secret(&state.cli.secrets.crypt_secret_file, &token).map_err(|e| {
+                encrypt_webhook_secret(&state.config.secrets.crypt_secret_file, &token).map_err(|e| {
                     WebError::internal(format!("Failed to encrypt token: {}", e))
                 })?,
             )

--- a/backend/web/src/endpoints/orgs/integrations.rs
+++ b/backend/web/src/endpoints/orgs/integrations.rs
@@ -202,7 +202,7 @@ pub async fn put_integration(
 
     let encrypted_secret = match body.secret.as_deref() {
         Some(s) if !s.is_empty() => Some(
-            encrypt_webhook_secret(&state.cli.crypt_secret_file, s).map_err(|e| {
+            encrypt_webhook_secret(&state.cli.secrets.crypt_secret_file, s).map_err(|e| {
                 WebError::internal(format!("Failed to encrypt secret: {}", e))
             })?,
         ),
@@ -211,7 +211,7 @@ pub async fn put_integration(
 
     let encrypted_token = match body.access_token.as_deref() {
         Some(t) if !t.is_empty() => Some(
-            encrypt_webhook_secret(&state.cli.crypt_secret_file, t).map_err(|e| {
+            encrypt_webhook_secret(&state.cli.secrets.crypt_secret_file, t).map_err(|e| {
                 WebError::internal(format!("Failed to encrypt token: {}", e))
             })?,
         ),
@@ -327,7 +327,7 @@ pub async fn patch_integration(
             None
         } else {
             Some(
-                encrypt_webhook_secret(&state.cli.crypt_secret_file, &secret).map_err(|e| {
+                encrypt_webhook_secret(&state.cli.secrets.crypt_secret_file, &secret).map_err(|e| {
                     WebError::internal(format!("Failed to encrypt secret: {}", e))
                 })?,
             )
@@ -339,7 +339,7 @@ pub async fn patch_integration(
             None
         } else {
             Some(
-                encrypt_webhook_secret(&state.cli.crypt_secret_file, &token).map_err(|e| {
+                encrypt_webhook_secret(&state.cli.secrets.crypt_secret_file, &token).map_err(|e| {
                     WebError::internal(format!("Failed to encrypt token: {}", e))
                 })?,
             )

--- a/backend/web/src/endpoints/orgs/management.rs
+++ b/backend/web/src/endpoints/orgs/management.rs
@@ -233,7 +233,7 @@ pub async fn put(
     }
 
     let (private_key, public_key) =
-        generate_ssh_key(&state.cli.secrets.crypt_secret_file).map_err(|e| {
+        generate_ssh_key(&state.config.secrets.crypt_secret_file).map_err(|e| {
             tracing::error!("Failed to generate SSH key: {}", e);
             WebError::failed_ssh_key_generation()
         })?;
@@ -330,7 +330,7 @@ pub async fn get_organization(
             created_by: org.created_by,
             created_at: org.created_at,
             github_installation_id: org.github_installation_id,
-            github_app_available: state.cli.github_app_config().is_some(),
+            github_app_available: state.config.github_app.clone().is_some(),
             role,
         }))
 }

--- a/backend/web/src/endpoints/orgs/management.rs
+++ b/backend/web/src/endpoints/orgs/management.rs
@@ -233,7 +233,7 @@ pub async fn put(
     }
 
     let (private_key, public_key) =
-        generate_ssh_key(&state.cli.crypt_secret_file).map_err(|e| {
+        generate_ssh_key(&state.cli.secrets.crypt_secret_file).map_err(|e| {
             tracing::error!("Failed to generate SSH key: {}", e);
             WebError::failed_ssh_key_generation()
         })?;

--- a/backend/web/src/endpoints/orgs/mod.rs
+++ b/backend/web/src/endpoints/orgs/mod.rs
@@ -123,7 +123,7 @@ mod tests {
     use gradient_core::ci::WebhookClient;
     use gradient_core::storage::{EmailSender, NarStore};
     use gradient_core::types::consts::{BASE_ROLE_ADMIN_ID, BASE_ROLE_VIEW_ID};
-    use gradient_core::types::{WebDb, WorkerDb};
+    use gradient_core::types::{RuntimeConfig, WebDb, WorkerDb};
     use sea_orm::{DatabaseBackend, MockDatabase};
     use test_support::cli::test_cli;
     use test_support::fakes::email::InMemoryEmailSender;
@@ -165,11 +165,12 @@ mod tests {
 
     fn make_state(db: sea_orm::DatabaseConnection) -> Arc<ServerState> {
         let cli = test_cli();
-        let nar_storage = NarStore::local(&cli.storage.base_path).expect("nar store");
+        let config = Arc::new(RuntimeConfig::from_cli(&cli));
+        let nar_storage = NarStore::local(&config.storage.base_path).expect("nar store");
         Arc::new(ServerState {
             web_db: WebDb::new(db),
             worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
-            cli,
+            config,
             log_storage: Arc::new(NoopLogStorage),
             webhooks: Arc::new(RecordingWebhookClient::new()) as Arc<dyn WebhookClient>,
             email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,

--- a/backend/web/src/endpoints/orgs/mod.rs
+++ b/backend/web/src/endpoints/orgs/mod.rs
@@ -165,7 +165,7 @@ mod tests {
 
     fn make_state(db: sea_orm::DatabaseConnection) -> Arc<ServerState> {
         let cli = test_cli();
-        let nar_storage = NarStore::local(&cli.base_path).expect("nar store");
+        let nar_storage = NarStore::local(&cli.storage.base_path).expect("nar store");
         Arc::new(ServerState {
             web_db: WebDb::new(db),
             worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),

--- a/backend/web/src/endpoints/orgs/ssh.rs
+++ b/backend/web/src/endpoints/orgs/ssh.rs
@@ -22,7 +22,7 @@ pub async fn get_organization_ssh(
 ) -> WebResult<Json<BaseResponse<String>>> {
     let organization = load_org_member(&state, user.id, organization).await?;
 
-    Ok(ok_json(format_public_key(organization, &state.cli.server.serve_url)))
+    Ok(ok_json(format_public_key(organization, &state.config.server.serve_url)))
 }
 
 pub async fn post_organization_ssh(
@@ -33,7 +33,7 @@ pub async fn post_organization_ssh(
     let organization = load_unmanaged_org(&state, user.id, organization).await?;
 
     let (private_key, public_key) =
-        generate_ssh_key(&state.cli.secrets.crypt_secret_file).map_err(|e| {
+        generate_ssh_key(&state.config.secrets.crypt_secret_file).map_err(|e| {
             tracing::error!("Failed to generate SSH key: {}", e);
             WebError::failed_ssh_key_generation()
         })?;
@@ -46,7 +46,7 @@ pub async fn post_organization_ssh(
 
     let res = BaseResponse {
         error: false,
-        message: format_public_key(organization, &state.cli.server.serve_url),
+        message: format_public_key(organization, &state.config.server.serve_url),
     };
 
     Ok(Json(res))

--- a/backend/web/src/endpoints/orgs/ssh.rs
+++ b/backend/web/src/endpoints/orgs/ssh.rs
@@ -22,7 +22,7 @@ pub async fn get_organization_ssh(
 ) -> WebResult<Json<BaseResponse<String>>> {
     let organization = load_org_member(&state, user.id, organization).await?;
 
-    Ok(ok_json(format_public_key(organization, &state.cli.serve_url)))
+    Ok(ok_json(format_public_key(organization, &state.cli.server.serve_url)))
 }
 
 pub async fn post_organization_ssh(
@@ -33,7 +33,7 @@ pub async fn post_organization_ssh(
     let organization = load_unmanaged_org(&state, user.id, organization).await?;
 
     let (private_key, public_key) =
-        generate_ssh_key(&state.cli.crypt_secret_file).map_err(|e| {
+        generate_ssh_key(&state.cli.secrets.crypt_secret_file).map_err(|e| {
             tracing::error!("Failed to generate SSH key: {}", e);
             WebError::failed_ssh_key_generation()
         })?;
@@ -46,7 +46,7 @@ pub async fn post_organization_ssh(
 
     let res = BaseResponse {
         error: false,
-        message: format_public_key(organization, &state.cli.serve_url),
+        message: format_public_key(organization, &state.cli.server.serve_url),
     };
 
     Ok(Json(res))

--- a/backend/web/src/endpoints/projects/management.rs
+++ b/backend/web/src/endpoints/projects/management.rs
@@ -366,7 +366,7 @@ impl<'a> ProjectPatcher<'a> {
                 "keep_evaluations must be at least 1".to_string(),
             ));
         }
-        let global_max = self.state.cli.keep_evaluations as i32;
+        let global_max = self.state.cli.storage.keep_evaluations as i32;
         if global_max > 0 && keep > global_max {
             return Err(WebError::bad_request(format!(
                 "keep_evaluations cannot exceed the server maximum of {}",

--- a/backend/web/src/endpoints/projects/management.rs
+++ b/backend/web/src/endpoints/projects/management.rs
@@ -366,7 +366,7 @@ impl<'a> ProjectPatcher<'a> {
                 "keep_evaluations must be at least 1".to_string(),
             ));
         }
-        let global_max = self.state.cli.storage.keep_evaluations as i32;
+        let global_max = self.state.config.storage.keep_evaluations as i32;
         if global_max > 0 && keep > global_max {
             return Err(WebError::bad_request(format!(
                 "keep_evaluations cannot exceed the server maximum of {}",

--- a/backend/web/src/endpoints/projects/mod.rs
+++ b/backend/web/src/endpoints/projects/mod.rs
@@ -193,6 +193,7 @@ mod tests {
     use gradient_core::ci::WebhookClient;
     use gradient_core::storage::{EmailSender, NarStore};
     use gradient_core::types::consts::{BASE_ROLE_ADMIN_ID, BASE_ROLE_VIEW_ID, BASE_ROLE_WRITE_ID};
+    use gradient_core::types::{RuntimeConfig, WebDb, WorkerDb};
     use sea_orm::{DatabaseBackend, MockDatabase};
     use test_support::cli::test_cli;
     use test_support::fakes::email::InMemoryEmailSender;
@@ -254,11 +255,12 @@ mod tests {
 
     fn make_state(db: sea_orm::DatabaseConnection) -> Arc<ServerState> {
         let cli = test_cli();
-        let nar_storage = NarStore::local(&cli.storage.base_path).expect("nar store");
+        let config = Arc::new(RuntimeConfig::from_cli(&cli));
+        let nar_storage = NarStore::local(&config.storage.base_path).expect("nar store");
         Arc::new(ServerState {
             web_db: WebDb::new(db),
             worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
-            cli,
+            config,
             log_storage: Arc::new(NoopLogStorage),
             webhooks: Arc::new(RecordingWebhookClient::new()) as Arc<dyn WebhookClient>,
             email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,

--- a/backend/web/src/endpoints/projects/mod.rs
+++ b/backend/web/src/endpoints/projects/mod.rs
@@ -254,7 +254,7 @@ mod tests {
 
     fn make_state(db: sea_orm::DatabaseConnection) -> Arc<ServerState> {
         let cli = test_cli();
-        let nar_storage = NarStore::local(&cli.base_path).expect("nar store");
+        let nar_storage = NarStore::local(&cli.storage.base_path).expect("nar store");
         Arc::new(ServerState {
             web_db: WebDb::new(db),
             worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),

--- a/backend/web/src/endpoints/webhooks.rs
+++ b/backend/web/src/endpoints/webhooks.rs
@@ -142,7 +142,7 @@ pub async fn put(
         ));
     }
 
-    let encrypted_secret = encrypt_webhook_secret(&state.cli.crypt_secret_file, &body.secret)
+    let encrypted_secret = encrypt_webhook_secret(&state.cli.secrets.crypt_secret_file, &body.secret)
         .map_err(|e| WebError::internal(format!("Failed to encrypt secret: {}", e)))?;
 
     let webhook = AWebhook {
@@ -200,7 +200,7 @@ pub async fn patch_webhook(
     }
     if let Some(secret) = body.secret {
         let encrypted =
-            encrypt_webhook_secret(&state.cli.crypt_secret_file, &secret).map_err(|e| {
+            encrypt_webhook_secret(&state.cli.secrets.crypt_secret_file, &secret).map_err(|e| {
                 WebError::internal(format!("Failed to encrypt secret: {}", e))
             })?;
         active_webhook.secret = Set(encrypted);
@@ -252,7 +252,7 @@ pub async fn post_webhook_test(
     });
 
     let body_str = serde_json::to_string(&payload).unwrap_or_default();
-    let plaintext_secret = decrypt_webhook_secret(&state.cli.crypt_secret_file, &webhook.secret)
+    let plaintext_secret = decrypt_webhook_secret(&state.cli.secrets.crypt_secret_file, &webhook.secret)
         .map_err(|e| {
             WebError::internal(format!("Failed to decrypt webhook secret: {}", e))
         })?;

--- a/backend/web/src/endpoints/webhooks.rs
+++ b/backend/web/src/endpoints/webhooks.rs
@@ -142,7 +142,7 @@ pub async fn put(
         ));
     }
 
-    let encrypted_secret = encrypt_webhook_secret(&state.cli.secrets.crypt_secret_file, &body.secret)
+    let encrypted_secret = encrypt_webhook_secret(&state.config.secrets.crypt_secret_file, &body.secret)
         .map_err(|e| WebError::internal(format!("Failed to encrypt secret: {}", e)))?;
 
     let webhook = AWebhook {
@@ -200,7 +200,7 @@ pub async fn patch_webhook(
     }
     if let Some(secret) = body.secret {
         let encrypted =
-            encrypt_webhook_secret(&state.cli.secrets.crypt_secret_file, &secret).map_err(|e| {
+            encrypt_webhook_secret(&state.config.secrets.crypt_secret_file, &secret).map_err(|e| {
                 WebError::internal(format!("Failed to encrypt secret: {}", e))
             })?;
         active_webhook.secret = Set(encrypted);
@@ -252,7 +252,7 @@ pub async fn post_webhook_test(
     });
 
     let body_str = serde_json::to_string(&payload).unwrap_or_default();
-    let plaintext_secret = decrypt_webhook_secret(&state.cli.secrets.crypt_secret_file, &webhook.secret)
+    let plaintext_secret = decrypt_webhook_secret(&state.config.secrets.crypt_secret_file, &webhook.secret)
         .map_err(|e| {
             WebError::internal(format!("Failed to decrypt webhook secret: {}", e))
         })?;

--- a/backend/web/src/endpoints/workers.rs
+++ b/backend/web/src/endpoints/workers.rs
@@ -18,7 +18,7 @@ pub async fn get_workers(
     Extension(user): Extension<MUser>,
     Extension(scheduler): Extension<Arc<Scheduler>>,
 ) -> WebResult<Json<BaseResponse<Vec<WorkerInfo>>>> {
-    if !state.cli.proto.global_stats_public && !user.superuser {
+    if !state.config.proto.global_stats_public && !user.superuser {
         return Err(WebError::Forbidden(
             "workers endpoint requires superuser".into(),
         ));

--- a/backend/web/src/endpoints/workers.rs
+++ b/backend/web/src/endpoints/workers.rs
@@ -18,7 +18,7 @@ pub async fn get_workers(
     Extension(user): Extension<MUser>,
     Extension(scheduler): Extension<Arc<Scheduler>>,
 ) -> WebResult<Json<BaseResponse<Vec<WorkerInfo>>>> {
-    if !state.cli.global_stats_public && !user.superuser {
+    if !state.cli.proto.global_stats_public && !user.superuser {
         return Err(WebError::Forbidden(
             "workers endpoint requires superuser".into(),
         ));

--- a/backend/web/src/lib.rs
+++ b/backend/web/src/lib.rs
@@ -96,11 +96,12 @@ fn rl_per_ms(
 pub fn create_router(state: Arc<ServerState>) -> Router {
     let serve_url: http::HeaderValue = state
         .cli
+        .server
         .serve_url
         .clone()
         .try_into()
         .expect("invalid serve_url");
-    let debug_url: http::HeaderValue = format!("http://{}:8000", state.cli.ip.clone())
+    let debug_url: http::HeaderValue = format!("http://{}:8000", state.cli.server.ip.clone())
         .try_into()
         .expect("invalid debug_url");
 
@@ -227,7 +228,7 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
         .route(
             "/builds",
             post(builds::post_direct_build)
-                .layer(DefaultBodyLimit::max(state.cli.max_direct_build_size)),
+                .layer(DefaultBodyLimit::max(state.cli.limits.max_direct_build_size)),
         )
         .route(
             "/builds/direct/recent",
@@ -419,7 +420,7 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
     // Default tier covers everything left under /api/v1 (the bulk authenticated
     // surface) plus the proto WS upgrade.
     let api = api.route_layer(GovernorLayer::new(rl_per_ms(200, 150)));
-    let api = api.layer(DefaultBodyLimit::max(state.cli.max_request_size));
+    let api = api.layer(DefaultBodyLimit::max(state.cli.limits.max_request_size));
 
     let mut app = Router::new()
         .nest("/api/v1", api)
@@ -451,7 +452,7 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
 }
 
 pub async fn serve_web(state: Arc<ServerState>) -> std::io::Result<()> {
-    let server_url = format!("{}:{}", state.cli.ip.clone(), state.cli.port.clone());
+    let server_url = format!("{}:{}", state.cli.server.ip.clone(), state.cli.server.port.clone());
     let app = create_router(Arc::clone(&state));
 
     let listener = tokio::net::TcpListener::bind(&server_url)

--- a/backend/web/src/lib.rs
+++ b/backend/web/src/lib.rs
@@ -95,13 +95,13 @@ fn rl_per_ms(
 /// `axum_test::TestServer` without binding a real TCP port.
 pub fn create_router(state: Arc<ServerState>) -> Router {
     let serve_url: http::HeaderValue = state
-        .cli
+        .config
         .server
         .serve_url
         .clone()
         .try_into()
         .expect("invalid serve_url");
-    let debug_url: http::HeaderValue = format!("http://{}:8000", state.cli.server.ip.clone())
+    let debug_url: http::HeaderValue = format!("http://{}:8000", state.config.server.ip.clone())
         .try_into()
         .expect("invalid debug_url");
 
@@ -228,7 +228,7 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
         .route(
             "/builds",
             post(builds::post_direct_build)
-                .layer(DefaultBodyLimit::max(state.cli.limits.max_direct_build_size)),
+                .layer(DefaultBodyLimit::max(state.config.limits.max_direct_build_size)),
         )
         .route(
             "/builds/direct/recent",
@@ -420,7 +420,7 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
     // Default tier covers everything left under /api/v1 (the bulk authenticated
     // surface) plus the proto WS upgrade.
     let api = api.route_layer(GovernorLayer::new(rl_per_ms(200, 150)));
-    let api = api.layer(DefaultBodyLimit::max(state.cli.limits.max_request_size));
+    let api = api.layer(DefaultBodyLimit::max(state.config.limits.max_request_size));
 
     let mut app = Router::new()
         .nest("/api/v1", api)
@@ -452,7 +452,7 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
 }
 
 pub async fn serve_web(state: Arc<ServerState>) -> std::io::Result<()> {
-    let server_url = format!("{}:{}", state.cli.server.ip.clone(), state.cli.server.port.clone());
+    let server_url = format!("{}:{}", state.config.server.ip.clone(), state.config.server.port.clone());
     let app = create_router(Arc::clone(&state));
 
     let listener = tokio::net::TcpListener::bind(&server_url)

--- a/backend/web/tests/auth_middleware.rs
+++ b/backend/web/tests/auth_middleware.rs
@@ -12,7 +12,7 @@
 
 use axum_test::TestServer;
 use gradient_core::storage::{EmailSender, NarStore};
-use gradient_core::types::{ServerState, WebDb, WorkerDb};
+use gradient_core::types::{RuntimeConfig, ServerState, WebDb, WorkerDb};
 use sea_orm::{DatabaseBackend, MockDatabase};
 use serde_json::Value;
 use std::sync::Arc;
@@ -32,13 +32,14 @@ fn server() -> TestServer {
     std::fs::write(&jwt_path, "test-jwt-secret").expect("write jwt secret file");
 
     let mut cli = test_cli();
-    cli.jwt_secret_file = jwt_path.to_string_lossy().into_owned();
+    cli.secrets.jwt_secret_file = jwt_path.to_string_lossy().into_owned();
 
-    let nar_storage = NarStore::local(&cli.base_path).expect("create test NarStore");
+    let config = Arc::new(RuntimeConfig::from_cli(&cli));
+    let nar_storage = NarStore::local(&config.storage.base_path).expect("create test NarStore");
     let state = Arc::new(ServerState {
         web_db: WebDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
         worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
-        cli,
+        config,
         log_storage: Arc::new(NoopLogStorage),
         webhooks: Arc::new(RecordingWebhookClient::new())
             as Arc<dyn gradient_core::ci::WebhookClient>,

--- a/backend/web/tests/body_size_limit.rs
+++ b/backend/web/tests/body_size_limit.rs
@@ -33,9 +33,9 @@ fn make_state_with_limits(
     max_direct_build_size: usize,
 ) -> Arc<ServerState> {
     let mut cli = test_cli();
-    cli.max_request_size = max_request_size;
-    cli.max_direct_build_size = max_direct_build_size;
-    let nar_storage = NarStore::local(&cli.base_path).expect("create test NarStore");
+    cli.limits.max_request_size = max_request_size;
+    cli.limits.max_direct_build_size = max_direct_build_size;
+    let nar_storage = NarStore::local(&cli.storage.base_path).expect("create test NarStore");
     Arc::new(ServerState {
         web_db: WebDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
         worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),

--- a/backend/web/tests/body_size_limit.rs
+++ b/backend/web/tests/body_size_limit.rs
@@ -39,7 +39,7 @@ fn make_state_with_limits(
     Arc::new(ServerState {
         web_db: WebDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
         worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
-        cli,
+        config: std::sync::Arc::new(gradient_core::types::RuntimeConfig::from_cli(&cli)),
         log_storage: Arc::new(NoopLogStorage),
         webhooks: Arc::new(RecordingWebhookClient::new()) as Arc<dyn WebhookClient>,
         email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,

--- a/backend/web/tests/builds_download.rs
+++ b/backend/web/tests/builds_download.rs
@@ -246,7 +246,7 @@ fn listing_returns_products_from_db() {
         let state = Arc::new(ServerState {
             web_db: WebDb::new(db),
             worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
-            cli,
+            config: std::sync::Arc::new(gradient_core::types::RuntimeConfig::from_cli(&cli)),
             log_storage: Arc::new(NoopLogStorage),
             webhooks: Arc::new(RecordingWebhookClient::new()) as Arc<dyn WebhookClient>,
             email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,
@@ -317,7 +317,7 @@ fn download_streams_file_from_nar() {
         let state = Arc::new(ServerState {
             web_db: WebDb::new(db),
             worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
-            cli,
+            config: std::sync::Arc::new(gradient_core::types::RuntimeConfig::from_cli(&cli)),
             log_storage: Arc::new(NoopLogStorage),
             webhooks: Arc::new(RecordingWebhookClient::new()) as Arc<dyn WebhookClient>,
             email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,

--- a/backend/web/tests/builds_download.rs
+++ b/backend/web/tests/builds_download.rs
@@ -240,7 +240,7 @@ fn listing_returns_products_from_db() {
     rt.block_on(async {
         // Set up state — nar_storage is not needed for listing.
         let cli = test_cli();
-        let nar_storage = NarStore::local(&cli.base_path).expect("create test NarStore");
+        let nar_storage = NarStore::local(&cli.storage.base_path).expect("create test NarStore");
 
         let db = mock_db_for_downloads();
         let state = Arc::new(ServerState {
@@ -292,7 +292,7 @@ fn download_streams_file_from_nar() {
 
         // Set up state with nar_storage populated.
         let cli = test_cli();
-        let nar_storage = NarStore::local(&cli.base_path).expect("create test NarStore");
+        let nar_storage = NarStore::local(&cli.storage.base_path).expect("create test NarStore");
         nar_storage
             .put(FIXTURE_HASH, compressed)
             .await

--- a/backend/web/tests/forge_hooks.rs
+++ b/backend/web/tests/forge_hooks.rs
@@ -70,11 +70,11 @@ fn make_state(
     };
     if let Some(ref p) = gh_secret_path {
         // All three fields must be present for `github_app_config()` to return Some.
-        cli.github_app_id = Some(1234);
-        cli.github_app_private_key_file = Some("/dev/null".into());
-        cli.github_app_webhook_secret_file = Some(p.clone());
+        cli.github_app.github_app_id = Some(1234);
+        cli.github_app.github_app_private_key_file = Some("/dev/null".into());
+        cli.github_app.github_app_webhook_secret_file = Some(p.clone());
     }
-    let nar_storage = NarStore::local(&cli.base_path).expect("create test NarStore");
+    let nar_storage = NarStore::local(&cli.storage.base_path).expect("create test NarStore");
     Arc::new(ServerState {
         web_db: WebDb::new(db),
         worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),

--- a/backend/web/tests/forge_hooks.rs
+++ b/backend/web/tests/forge_hooks.rs
@@ -78,7 +78,7 @@ fn make_state(
     Arc::new(ServerState {
         web_db: WebDb::new(db),
         worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
-        cli,
+        config: std::sync::Arc::new(gradient_core::types::RuntimeConfig::from_cli(&cli)),
         log_storage: Arc::new(NoopLogStorage),
         webhooks: Arc::new(RecordingWebhookClient::new()) as Arc<dyn WebhookClient>,
         email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,

--- a/backend/web/tests/narinfo.rs
+++ b/backend/web/tests/narinfo.rs
@@ -168,7 +168,7 @@ async fn narinfo_served_from_db_inner() {
         .into_connection();
 
     let cli = test_cli();
-    let nar_storage = NarStore::local(&cli.base_path).expect("create test NarStore");
+    let nar_storage = NarStore::local(&cli.storage.base_path).expect("create test NarStore");
     let state = Arc::new(ServerState {
         web_db: WebDb::new(db),
         worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),

--- a/backend/web/tests/narinfo.rs
+++ b/backend/web/tests/narinfo.rs
@@ -172,7 +172,7 @@ async fn narinfo_served_from_db_inner() {
     let state = Arc::new(ServerState {
         web_db: WebDb::new(db),
         worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
-        cli,
+        config: std::sync::Arc::new(gradient_core::types::RuntimeConfig::from_cli(&cli)),
         log_storage: Arc::new(NoopLogStorage),
         webhooks: Arc::new(RecordingWebhookClient::new()) as Arc<dyn WebhookClient>,
         email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,

--- a/backend/web/tests/rate_limit.rs
+++ b/backend/web/tests/rate_limit.rs
@@ -25,7 +25,7 @@ use web::create_router;
 
 fn make_state() -> Arc<ServerState> {
     let cli = test_cli();
-    let nar_storage = NarStore::local(&cli.base_path).expect("create test NarStore");
+    let nar_storage = NarStore::local(&cli.storage.base_path).expect("create test NarStore");
     Arc::new(ServerState {
         web_db: WebDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
         worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),

--- a/backend/web/tests/rate_limit.rs
+++ b/backend/web/tests/rate_limit.rs
@@ -29,7 +29,7 @@ fn make_state() -> Arc<ServerState> {
     Arc::new(ServerState {
         web_db: WebDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
         worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
-        cli,
+        config: std::sync::Arc::new(gradient_core::types::RuntimeConfig::from_cli(&cli)),
         log_storage: Arc::new(NoopLogStorage),
         webhooks: Arc::new(RecordingWebhookClient::new()) as Arc<dyn WebhookClient>,
         email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,


### PR DESCRIPTION
Closes #65.

## Summary

The 65-field `Cli` god struct on `core::types::mod` made every handler transitively depend on every feature flag, and forced tests to construct all 65 fields to obtain a `ServerState`. This PR decomposes it into typed groups and removes `cli` from `ServerState` entirely.

- **`Cli` is now a parse-only DTO** of 13 `clap::Args` clusters attached via `#[command(flatten)]`: `LoggingArgs`, `ServerArgs`, `DatabaseArgs`, `EvalArgs`, `StorageArgs`, `SecretsArgs`, `LimitsArgs`, `RegistrationArgs`, `ProtoArgs`, `OidcArgs`, `EmailArgs`, `S3Args`, `GitHubAppArgs`. Field names, env vars, defaults, and `--help` output are preserved verbatim — only the Rust access path moves from `cli.foo` to `cli.<group>.foo`.
- **`RuntimeConfig` replaces `cli: Cli` on `ServerState`.** Built once at startup via `RuntimeConfig::from_cli`. Optional features (`oidc`, `email`, `s3`, `github_app`) appear as `Option<FooConfig>` resolved from the parser DTO; the `Some` variant guarantees the feature is fully usable.
- **`OidcConfig::required` and `EmailConfig::require_verification`** now live with their feature configs instead of dangling on the parser DTO.
- **All ~30 handlers migrated** from `state.cli.X` to `state.config.<group>.<field>`. Each `*Args` struct derives `Default` so test fixtures use `..Default::default()` instead of restating every field.

## Behavioral change

Registration paths previously gated on `email_enabled && email_require_verification`. They now gate on `email.is_some_and(|e| e.require_verification)` — i.e. email-required verification only kicks in when SMTP is fully configured. Previously a partially-configured email setup would gate registration on an email that could never actually be sent.

## Compatibility

- No CLI flag, env var, or default value changed. `cargo run -- --help` produces the same output (verified).
- No docs/Nix module changes required — operator-facing surface is unchanged.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --tests --workspace` — all 800+ tests pass
- [x] `cargo run --bin gradient-server -- --help` — flags, env vars, and defaults unchanged
- [x] `cargo clippy --workspace --tests` — no new warnings introduced by this PR
- [x] `rg 'state\.cli\b' backend/` returns nothing