### PR TITLE
backend: shared reqwest client across server / worker / CLI (#79)

### DIFF
--- a/backend/cache/src/cacher/cleanup.rs
+++ b/backend/cache/src/cacher/cleanup.rs
@@ -302,6 +302,7 @@ mod tests {
             nar_storage,
             manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            http: gradient_core::http::build_client().expect("http client"),
         })
     }
 
@@ -380,6 +381,7 @@ mod tests {
             nar_storage,
             manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            http: gradient_core::http::build_client().expect("http client"),
         });
 
         cleanup_stale_cached_nars(state).await.unwrap();

--- a/backend/core/src/ci/github_app.rs
+++ b/backend/core/src/ci/github_app.rs
@@ -95,16 +95,12 @@ struct InstallationTokenResponse {
 /// installation. The token is valid for ~1 hour and can be used as a Bearer
 /// token against the GitHub REST API.
 pub async fn get_installation_token(
+    client: &reqwest::Client,
     app_id: u64,
     private_key_pem: &str,
     installation_id: i64,
 ) -> Result<String> {
     let jwt = generate_jwt(app_id, private_key_pem)?;
-
-    let client = reqwest::Client::builder()
-        .user_agent("gradient-ci/1.0")
-        .build()
-        .context("failed to build reqwest client")?;
 
     let url = format!("https://api.github.com/app/installations/{installation_id}/access_tokens");
     debug!(installation_id, "requesting GitHub App installation token");

--- a/backend/core/src/ci/github_app_manifest.rs
+++ b/backend/core/src/ci/github_app_manifest.rs
@@ -87,21 +87,24 @@ use tracing::debug;
 /// `host` is the GitHub host (`github.com` for github.com, `ghe.example.com`
 /// for an Enterprise instance); the API base URL is derived via
 /// [`api_base_url`].
-pub async fn exchange_code(host: &str, code: &str) -> Result<ManifestResult> {
+pub async fn exchange_code(
+    client: &reqwest::Client,
+    host: &str,
+    code: &str,
+) -> Result<ManifestResult> {
     let base = api_base_url(host);
-    exchange_code_with_base(&base, code).await
+    exchange_code_with_base(client, &base, code).await
 }
 
 /// Lower-level exchange entry point that accepts an explicit API base URL.
 /// Used by tests against `wiremock`.
-pub async fn exchange_code_with_base(api_base_url: &str, code: &str) -> Result<ManifestResult> {
+pub async fn exchange_code_with_base(
+    client: &reqwest::Client,
+    api_base_url: &str,
+    code: &str,
+) -> Result<ManifestResult> {
     let url = format!("{api_base_url}/app-manifests/{code}/conversions");
     debug!(%url, "exchanging github app manifest code");
-
-    let client = reqwest::Client::builder()
-        .user_agent("gradient-ci/1.0")
-        .build()
-        .context("failed to build reqwest client")?;
 
     let resp = client
         .post(&url)
@@ -216,7 +219,8 @@ mod tests {
             .mount(&server)
             .await;
 
-        let result = exchange_code_with_base(&server.uri(), "abc")
+        let client = crate::http::build_client().unwrap();
+        let result = exchange_code_with_base(&client, &server.uri(), "abc")
             .await
             .expect("happy path");
         assert_eq!(result.id, 42);
@@ -234,7 +238,8 @@ mod tests {
             .mount(&server)
             .await;
 
-        let err = exchange_code_with_base(&server.uri(), "bad")
+        let client = crate::http::build_client().unwrap();
+        let err = exchange_code_with_base(&client, &server.uri(), "bad")
             .await
             .expect_err("404 should error");
         let msg = format!("{err}");

--- a/backend/core/src/ci/integration_lookup.rs
+++ b/backend/core/src/ci/integration_lookup.rs
@@ -151,7 +151,7 @@ pub async fn resolve_outbound_reporter_for_project(
             let Some(token) = token else {
                 return Arc::new(NoopCiReporter);
             };
-            match GiteaReporter::new(base_url.to_string(), token.expose().to_string()) {
+            match GiteaReporter::new(state.http.clone(), base_url.to_string(), token.expose().to_string()) {
                 Ok(r) => Arc::new(r),
                 Err(e) => {
                     warn!(error = %e, "Failed to build GiteaReporter");
@@ -227,7 +227,7 @@ async fn build_github_app_reporter_for_project(
     // GitHub Enterprise support deferred — no production user yet. When
     // adding it, derive `api_base_url` from the installation account host or
     // from a server-config field instead of hardcoding the empty default.
-    match GithubAppReporter::new("", github_app.app_id, pem, installation_id) {
+    match GithubAppReporter::new(state.http.clone(), "", github_app.app_id, pem, installation_id) {
         Ok(r) => Some(Arc::new(r)),
         Err(e) => {
             warn!(error = %e, "Failed to build GithubAppReporter");

--- a/backend/core/src/ci/reporter.rs
+++ b/backend/core/src/ci/reporter.rs
@@ -9,7 +9,6 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use std::time::Duration;
 use tracing::warn;
 
 /// Validate a user-supplied base URL for outbound CI API calls.
@@ -113,15 +112,14 @@ pub struct GiteaReporter {
 }
 
 impl GiteaReporter {
-    pub fn new(base_url: impl Into<String>, token: impl Into<String>) -> Result<Self> {
+    pub fn new(
+        client: reqwest::Client,
+        base_url: impl Into<String>,
+        token: impl Into<String>,
+    ) -> Result<Self> {
         let raw = base_url.into();
         validate_safe_outbound_url(&raw)
             .map_err(|e| anyhow::anyhow!("Rejected Gitea base_url: {}", e))?;
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(10))
-            .redirect(reqwest::redirect::Policy::none())
-            .build()
-            .context("Failed to build HTTP client for GiteaReporter")?;
         Ok(Self {
             base_url: raw.trim_end_matches('/').to_string(),
             token: token.into(),
@@ -226,7 +224,11 @@ pub struct GithubReporter {
 impl GithubReporter {
     const DEFAULT_API_URL: &'static str = "https://api.github.com";
 
-    pub fn new(base_url: impl Into<String>, token: impl Into<String>) -> Result<Self> {
+    pub fn new(
+        client: reqwest::Client,
+        base_url: impl Into<String>,
+        token: impl Into<String>,
+    ) -> Result<Self> {
         let raw = base_url.into();
         let base_url = if raw.is_empty() {
             Self::DEFAULT_API_URL.to_string()
@@ -235,13 +237,6 @@ impl GithubReporter {
                 .map_err(|e| anyhow::anyhow!("Rejected GitHub base_url: {}", e))?;
             raw.trim_end_matches('/').to_string()
         };
-
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(10))
-            .redirect(reqwest::redirect::Policy::none())
-            .user_agent("gradient-ci/1.0")
-            .build()
-            .context("Failed to build HTTP client for GithubReporter")?;
 
         Ok(Self {
             base_url,
@@ -360,6 +355,7 @@ impl GithubAppReporter {
     const DEFAULT_API_URL: &'static str = "https://api.github.com";
 
     pub fn new(
+        client: reqwest::Client,
         api_base_url: impl Into<String>,
         app_id: u64,
         private_key_pem: impl Into<String>,
@@ -373,13 +369,6 @@ impl GithubAppReporter {
                 .map_err(|e| anyhow::anyhow!("Rejected GitHub App api_base_url: {}", e))?;
             raw.trim_end_matches('/').to_string()
         };
-
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(10))
-            .redirect(reqwest::redirect::Policy::none())
-            .user_agent("gradient-ci/1.0")
-            .build()
-            .context("Failed to build HTTP client for GithubAppReporter")?;
 
         Ok(Self {
             api_base_url,
@@ -461,6 +450,7 @@ struct CheckRunCreateResponse {
 impl CiReporter for GithubAppReporter {
     async fn report(&self, report: &CiReport) -> Result<Option<i64>> {
         let token = crate::ci::github_app::get_installation_token(
+            &self.client,
             self.app_id,
             &self.private_key_pem,
             self.installation_id,
@@ -559,6 +549,7 @@ impl CiReporter for GithubAppReporter {
 /// Returns `NoopCiReporter` when CI reporting is not configured or the
 /// reporter type is unrecognised.
 pub fn reporter_for_project(
+    http: reqwest::Client,
     ci_type: Option<&str>,
     ci_url: Option<&str>,
     ci_token: Option<&str>,
@@ -571,14 +562,14 @@ pub fn reporter_for_project(
     let url = ci_url.unwrap_or("");
 
     match ci_type {
-        Some("gitea") => match GiteaReporter::new(url, token) {
+        Some("gitea") => match GiteaReporter::new(http, url, token) {
             Ok(r) => Arc::new(r),
             Err(e) => {
                 warn!(error = %e, "Failed to build GiteaReporter, falling back to noop");
                 Arc::new(NoopCiReporter)
             }
         },
-        Some("github") => match GithubReporter::new(url, token) {
+        Some("github") => match GithubReporter::new(http, url, token) {
             Ok(r) => Arc::new(r),
             Err(e) => {
                 warn!(error = %e, "Failed to build GithubReporter, falling back to noop");
@@ -627,6 +618,10 @@ pub fn parse_owner_repo(repository_url: &str) -> Option<(String, String)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_client() -> reqwest::Client {
+        crate::http::build_client().expect("build test http client")
+    }
 
     // ── State conversions ─────────────────────────────────────────────────────
 
@@ -714,31 +709,31 @@ mod tests {
 
     #[test]
     fn gitea_reporter_trims_trailing_slash() {
-        let r = GiteaReporter::new("https://gitea.example.com/", "tok").unwrap();
+        let r = GiteaReporter::new(test_client(), "https://gitea.example.com/", "tok").unwrap();
         assert_eq!(r.base_url, "https://gitea.example.com");
     }
 
     #[test]
     fn gitea_reporter_preserves_no_trailing_slash() {
-        let r = GiteaReporter::new("https://gitea.example.com", "tok").unwrap();
+        let r = GiteaReporter::new(test_client(), "https://gitea.example.com", "tok").unwrap();
         assert_eq!(r.base_url, "https://gitea.example.com");
     }
 
     #[test]
     fn github_reporter_empty_url_uses_default() {
-        let r = GithubReporter::new("", "tok").unwrap();
+        let r = GithubReporter::new(test_client(), "", "tok").unwrap();
         assert_eq!(r.base_url, GithubReporter::DEFAULT_API_URL);
     }
 
     #[test]
     fn github_reporter_custom_url_kept() {
-        let r = GithubReporter::new("https://github.example.com/api/v3", "tok").unwrap();
+        let r = GithubReporter::new(test_client(), "https://github.example.com/api/v3", "tok").unwrap();
         assert_eq!(r.base_url, "https://github.example.com/api/v3");
     }
 
     #[test]
     fn github_reporter_trims_trailing_slash() {
-        let r = GithubReporter::new("https://github.example.com/api/v3/", "tok").unwrap();
+        let r = GithubReporter::new(test_client(), "https://github.example.com/api/v3/", "tok").unwrap();
         assert_eq!(r.base_url, "https://github.example.com/api/v3");
     }
 
@@ -746,57 +741,57 @@ mod tests {
 
     #[test]
     fn gitea_reporter_rejects_aws_metadata_ip() {
-        let err = GiteaReporter::new("http://169.254.169.254/", "tok").unwrap_err();
+        let err = GiteaReporter::new(test_client(), "http://169.254.169.254/", "tok").unwrap_err();
         assert!(format!("{err}").contains("Rejected Gitea base_url"));
     }
 
     #[test]
     fn gitea_reporter_rejects_localhost_hostname() {
-        assert!(GiteaReporter::new("http://localhost:3000/", "tok").is_err());
+        assert!(GiteaReporter::new(test_client(), "http://localhost:3000/", "tok").is_err());
     }
 
     #[test]
     fn gitea_reporter_rejects_loopback_ipv4() {
-        assert!(GiteaReporter::new("http://127.0.0.1/", "tok").is_err());
+        assert!(GiteaReporter::new(test_client(), "http://127.0.0.1/", "tok").is_err());
     }
 
     #[test]
     fn gitea_reporter_rejects_rfc1918() {
-        assert!(GiteaReporter::new("http://10.0.0.5/", "tok").is_err());
-        assert!(GiteaReporter::new("http://192.168.1.1/", "tok").is_err());
+        assert!(GiteaReporter::new(test_client(), "http://10.0.0.5/", "tok").is_err());
+        assert!(GiteaReporter::new(test_client(), "http://192.168.1.1/", "tok").is_err());
     }
 
     #[test]
     fn gitea_reporter_rejects_non_http_scheme() {
-        assert!(GiteaReporter::new("file:///etc/passwd", "tok").is_err());
-        assert!(GiteaReporter::new("ftp://gitea.example.com/", "tok").is_err());
+        assert!(GiteaReporter::new(test_client(), "file:///etc/passwd", "tok").is_err());
+        assert!(GiteaReporter::new(test_client(), "ftp://gitea.example.com/", "tok").is_err());
     }
 
     #[test]
     fn github_reporter_rejects_aws_metadata_ip() {
-        let err = GithubReporter::new("http://169.254.169.254/api/v3", "tok").unwrap_err();
+        let err = GithubReporter::new(test_client(), "http://169.254.169.254/api/v3", "tok").unwrap_err();
         assert!(format!("{err}").contains("Rejected GitHub base_url"));
     }
 
     #[test]
     fn github_reporter_rejects_localhost_hostname() {
-        assert!(GithubReporter::new("http://localhost/api/v3", "tok").is_err());
+        assert!(GithubReporter::new(test_client(), "http://localhost/api/v3", "tok").is_err());
     }
 
     #[test]
     fn github_reporter_rejects_ipv6_loopback() {
-        assert!(GithubReporter::new("http://[::1]/api/v3", "tok").is_err());
+        assert!(GithubReporter::new(test_client(), "http://[::1]/api/v3", "tok").is_err());
     }
 
     #[test]
     fn github_app_reporter_rejects_aws_metadata_ip() {
-        let err = GithubAppReporter::new("http://169.254.169.254/", 1, "pem", 1).unwrap_err();
+        let err = GithubAppReporter::new(test_client(), "http://169.254.169.254/", 1, "pem", 1).unwrap_err();
         assert!(format!("{err}").contains("Rejected GitHub App api_base_url"));
     }
 
     #[test]
     fn github_app_reporter_empty_url_still_uses_default() {
-        let r = GithubAppReporter::new("", 1, "pem", 1).unwrap();
+        let r = GithubAppReporter::new(test_client(), "", 1, "pem", 1).unwrap();
         assert_eq!(r.api_base_url, GithubAppReporter::DEFAULT_API_URL);
     }
 
@@ -804,6 +799,7 @@ mod tests {
     fn reporter_for_project_unsafe_url_falls_back_to_noop() {
         // Bad base_url should not crash callers — the factory logs and returns Noop.
         let r = reporter_for_project(
+            test_client(),
             Some("gitea"),
             Some("http://169.254.169.254/"),
             Some("tok"),
@@ -819,25 +815,26 @@ mod tests {
 
     #[test]
     fn reporter_for_project_no_token_is_noop() {
-        let r = reporter_for_project(Some("github"), Some("https://x"), None);
+        let r = reporter_for_project(test_client(), Some("github"), Some("https://x"), None);
         assert!(is_noop(&r));
     }
 
     #[test]
     fn reporter_for_project_no_type_is_noop() {
-        let r = reporter_for_project(None, None, Some("tok"));
+        let r = reporter_for_project(test_client(), None, None, Some("tok"));
         assert!(is_noop(&r));
     }
 
     #[test]
     fn reporter_for_project_unknown_type_is_noop() {
-        let r = reporter_for_project(Some("bitbucket"), None, Some("tok"));
+        let r = reporter_for_project(test_client(), Some("bitbucket"), None, Some("tok"));
         assert!(is_noop(&r));
     }
 
     #[test]
     fn reporter_for_project_gitea_builds_gitea() {
         let r = reporter_for_project(
+            test_client(),
             Some("gitea"),
             Some("https://gitea.example.com"),
             Some("tok"),
@@ -847,7 +844,7 @@ mod tests {
 
     #[test]
     fn reporter_for_project_github_builds_github() {
-        let r = reporter_for_project(Some("github"), None, Some("tok"));
+        let r = reporter_for_project(test_client(), Some("github"), None, Some("tok"));
         assert!(format!("{:?}", r).contains("GithubReporter"));
     }
 

--- a/backend/core/src/ci/webhook.rs
+++ b/backend/core/src/ci/webhook.rs
@@ -16,7 +16,6 @@ use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use sha2::Sha256;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
-use std::time::Duration;
 use tracing::{error, warn};
 use uuid::Uuid;
 
@@ -164,11 +163,11 @@ pub struct ReqwestWebhookClient {
 
 impl ReqwestWebhookClient {
     pub fn new() -> Result<Self> {
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(10))
-            .redirect(reqwest::redirect::Policy::none())
-            .build()?;
-        Ok(Self { client })
+        Ok(Self::with_client(crate::http::build_client()?))
+    }
+
+    pub fn with_client(client: reqwest::Client) -> Self {
+        Self { client }
     }
 }
 

--- a/backend/core/src/http.rs
+++ b/backend/core/src/http.rs
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Shared HTTP client construction.
+//!
+//! `reqwest::Client` is internally `Arc`'d and is designed to be cloned and
+//! reused across the whole process. Constructing one per call leaks
+//! connection pools and produces inconsistent timeout/redirect behaviour, so
+//! all server-side and CLI-side outbound HTTP traffic should go through a
+//! single client built here.
+
+use std::time::Duration;
+
+/// Default request timeout applied to the shared client.
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// User-agent string sent with every outbound request.
+pub fn user_agent() -> String {
+    format!("gradient/{}", env!("CARGO_PKG_VERSION"))
+}
+
+/// Build a `reqwest::Client` with the project-wide defaults: a 30-second
+/// timeout, no redirect following, and a `gradient/<version>` user-agent.
+///
+/// Callers that need a different per-request timeout should override it on
+/// the `RequestBuilder` (`.timeout(...)`) rather than constructing another
+/// client.
+pub fn build_client() -> reqwest::Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(DEFAULT_TIMEOUT)
+        .redirect(reqwest::redirect::Policy::none())
+        .user_agent(user_agent())
+        .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_client_succeeds() {
+        let _ = build_client().expect("client builds with defaults");
+    }
+
+    #[test]
+    fn user_agent_is_prefixed() {
+        assert!(user_agent().starts_with("gradient/"));
+    }
+}

--- a/backend/core/src/lib.rs
+++ b/backend/core/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod ci;
 pub mod db;
 pub mod executer;
+pub mod http;
 pub mod hydra;
 pub mod nix;
 pub mod nix_hash;
@@ -99,14 +100,16 @@ pub async fn init_state(cli: Cli) -> Arc<ServerState> {
         }
     };
 
-    let webhook_client = match ReqwestWebhookClient::new() {
+    let http = match http::build_client() {
         Ok(c) => c,
         Err(e) => {
-            eprintln!("Failed to build webhook HTTP client: {}", e);
+            eprintln!("Failed to build shared HTTP client: {}", e);
             std::process::exit(1);
         }
     };
-    let webhooks: Arc<dyn ci::WebhookClient> = Arc::new(webhook_client);
+
+    let webhooks: Arc<dyn ci::WebhookClient> =
+        Arc::new(ReqwestWebhookClient::with_client(http.clone()));
 
     let email_service = match EmailService::new(cli.email_config()).await {
         Ok(s) => s,
@@ -192,5 +195,6 @@ pub async fn init_state(cli: Cli) -> Arc<ServerState> {
         nar_storage,
         manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        http,
     })
 }

--- a/backend/core/src/types/mod.rs
+++ b/backend/core/src/types/mod.rs
@@ -102,6 +102,10 @@ pub struct ServerState {
     pub webhooks: Arc<dyn WebhookClient>,
     pub email: Arc<dyn EmailSender>,
     pub nar_storage: NarStore,
+    /// Shared outbound HTTP client. Reuse this for any outbound request
+    /// made from a handler or background task — never construct a fresh
+    /// `reqwest::Client` per call.
+    pub http: reqwest::Client,
     /// Issued-but-unconsumed manifest CSRF state tokens with their issuance time.
     pub manifest_state: Arc<crate::ci::manifest_state::ManifestStateStore>,
     /// Manifest results awaiting one-shot pickup by the superuser's browser.

--- a/backend/proto/src/handler/cache.rs
+++ b/backend/proto/src/handler/cache.rs
@@ -326,17 +326,7 @@ async fn extend_with_upstream_results(
             return;
         }
 
-        let http = match reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(5))
-            .connect_timeout(std::time::Duration::from_secs(3))
-            .build()
-        {
-            Ok(c) => c,
-            Err(e) => {
-                warn!(error = %e, "failed to build upstream HTTP client; skipping upstream lookup");
-                return;
-            }
-        };
+        let http = state.http.clone();
 
         let upstream_urls = Arc::new(upstream_urls);
         let mut futs = FuturesUnordered::new();
@@ -482,7 +472,12 @@ async fn lookup_upstream_narinfo(
 ) -> Option<crate::messages::CachedPath> {
     for base_url in upstream_urls.iter() {
         let narinfo_url = format!("{}/{}.narinfo", base_url.trim_end_matches('/'), &hash);
-        let body = match http.get(&narinfo_url).send().await {
+        let body = match http
+            .get(&narinfo_url)
+            .timeout(std::time::Duration::from_secs(5))
+            .send()
+            .await
+        {
             Ok(r) if r.status().is_success() => match r.text().await {
                 Ok(b) => b,
                 Err(_) => continue,

--- a/backend/test-support/src/state.rs
+++ b/backend/test-support/src/state.rs
@@ -34,6 +34,7 @@ pub fn test_state(db: DatabaseConnection) -> Arc<ServerState> {
         nar_storage,
         manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        http: gradient_core::http::build_client().expect("build test HTTP client"),
     })
 }
 
@@ -57,6 +58,7 @@ pub fn test_state_recorded(
         nar_storage,
         manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        http: gradient_core::http::build_client().expect("build test HTTP client"),
     });
     (state, recorder)
 }

--- a/backend/web/src/authorization/oidc.rs
+++ b/backend/web/src/authorization/oidc.rs
@@ -65,12 +65,10 @@ fn random_url_safe(bytes: usize) -> String {
     URL_SAFE_NO_PAD.encode(buf)
 }
 
-async fn get_oidc_metadata(discovery_url: &str) -> Result<serde_json::Value> {
-    let http_client = reqwest::ClientBuilder::new()
-        .redirect(reqwest::redirect::Policy::limited(5))
-        .build()
-        .context("Failed to create HTTP client")?;
-
+async fn get_oidc_metadata(
+    http_client: &reqwest::Client,
+    discovery_url: &str,
+) -> Result<serde_json::Value> {
     let url = if discovery_url.ends_with("/.well-known/openid-configuration") {
         discovery_url.to_string()
     } else {
@@ -92,12 +90,7 @@ async fn get_oidc_metadata(discovery_url: &str) -> Result<serde_json::Value> {
     Ok(metadata)
 }
 
-async fn fetch_jwks(jwks_uri: &str) -> Result<JwkSet> {
-    let http_client = reqwest::ClientBuilder::new()
-        .redirect(reqwest::redirect::Policy::limited(5))
-        .build()
-        .context("Failed to create HTTP client")?;
-
+async fn fetch_jwks(http_client: &reqwest::Client, jwks_uri: &str) -> Result<JwkSet> {
     let jwks: JwkSet = http_client
         .get(jwks_uri)
         .send()
@@ -118,7 +111,7 @@ pub async fn oidc_login_create(
         .oidc.clone()
         .context("OIDC is not enabled or not fully configured")?;
 
-    let metadata = get_oidc_metadata(&oidc.discovery_url).await?;
+    let metadata = get_oidc_metadata(&state.http, &oidc.discovery_url).await?;
 
     let auth_endpoint = metadata["authorization_endpoint"]
         .as_str()
@@ -199,7 +192,7 @@ pub async fn oidc_login_verify(
 
     let expected_nonce = csrf_data.claims.nonce;
 
-    let metadata = get_oidc_metadata(&oidc.discovery_url).await?;
+    let metadata = get_oidc_metadata(&state.http, &oidc.discovery_url).await?;
 
     let issuer = metadata["issuer"]
         .as_str()
@@ -212,10 +205,7 @@ pub async fn oidc_login_verify(
         .as_str()
         .context("No jwks_uri in OIDC metadata")?;
 
-    let http_client = reqwest::ClientBuilder::new()
-        .redirect(reqwest::redirect::Policy::limited(5))
-        .build()
-        .context("Failed to create HTTP client")?;
+    let http_client = &state.http;
 
     let redirect_uri = format!("{}/api/v1/auth/oidc/callback", state.config.server.serve_url);
     let client_secret = load_secret(&oidc.client_secret_file);
@@ -246,7 +236,7 @@ pub async fn oidc_login_verify(
         .as_str()
         .context("No id_token in token response")?;
 
-    let claims = verify_id_token(id_token, jwks_uri, &issuer, &oidc.client_id).await?;
+    let claims = verify_id_token(&state.http, id_token, jwks_uri, &issuer, &oidc.client_id).await?;
 
     match claims.nonce.as_deref() {
         Some(n) if n.as_bytes().ct_eq(expected_nonce.as_bytes()).unwrap_u8() == 1 => {}
@@ -257,6 +247,7 @@ pub async fn oidc_login_verify(
 }
 
 async fn verify_id_token(
+    http: &reqwest::Client,
     id_token: &str,
     jwks_uri: &str,
     expected_iss: &str,
@@ -268,7 +259,7 @@ async fn verify_id_token(
         .clone()
         .context("id_token header has no kid")?;
 
-    let jwks = fetch_jwks(jwks_uri).await?;
+    let jwks = fetch_jwks(http, jwks_uri).await?;
     let jwk = jwks
         .find(&kid)
         .context("No JWK matches id_token kid")?;

--- a/backend/web/src/endpoints/admin/github_app.rs
+++ b/backend/web/src/endpoints/admin/github_app.rs
@@ -101,7 +101,7 @@ pub async fn callback(
         ));
     };
 
-    let creds = gradient_core::ci::github_app_manifest::exchange_code(&host, &q.code)
+    let creds = gradient_core::ci::github_app_manifest::exchange_code(&state.http, &host, &q.code)
         .await
         .map_err(|e| {
             warn!(error = %e, "github manifest exchange failed");

--- a/backend/web/src/endpoints/caches/nar.rs
+++ b/backend/web/src/endpoints/caches/nar.rs
@@ -71,7 +71,7 @@ pub async fn upstream_nar(
         .url
         .ok_or_else(|| WebError::bad_request("Not an external upstream"))?;
 
-    let bytes = fetch_upstream_nar(&base_url, &path).await?;
+    let bytes = fetch_upstream_nar(&state.http, &base_url, &path).await?;
 
     Response::builder()
         .header(
@@ -144,9 +144,13 @@ fn spawn_cache_derivation_fetch_update(state: Arc<ServerState>, cache_id: Uuid, 
     });
 }
 
-async fn fetch_upstream_nar(base_url: &str, path: &str) -> WebResult<bytes::Bytes> {
+async fn fetch_upstream_nar(
+    http: &reqwest::Client,
+    base_url: &str,
+    path: &str,
+) -> WebResult<bytes::Bytes> {
     let nar_url = format!("{}/{}", base_url.trim_end_matches('/'), path);
-    let resp = reqwest::Client::new()
+    let resp = http
         .get(&nar_url)
         .send()
         .await

--- a/backend/web/src/endpoints/caches/narinfo.rs
+++ b/backend/web/src/endpoints/caches/narinfo.rs
@@ -98,7 +98,7 @@ async fn fetch_from_upstream(
         .await
         .unwrap_or_default();
 
-    let http_client = reqwest::Client::new();
+    let http_client = &state.http;
     for upstream in upstreams {
         let Some(base_url) = upstream.url.as_deref() else {
             continue;

--- a/backend/web/src/endpoints/orgs/mod.rs
+++ b/backend/web/src/endpoints/orgs/mod.rs
@@ -177,6 +177,7 @@ mod tests {
             nar_storage,
             manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            http: gradient_core::http::build_client().expect("http client"),
         })
     }
 

--- a/backend/web/src/endpoints/projects/mod.rs
+++ b/backend/web/src/endpoints/projects/mod.rs
@@ -267,6 +267,7 @@ mod tests {
             nar_storage,
             manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            http: gradient_core::http::build_client().expect("http client"),
         })
     }
 

--- a/backend/web/tests/auth_middleware.rs
+++ b/backend/web/tests/auth_middleware.rs
@@ -47,6 +47,7 @@ fn server() -> TestServer {
         nar_storage,
         manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        http: gradient_core::http::build_client().expect("http client"),
     });
     TestServer::new(create_router(state))
 }

--- a/backend/web/tests/body_size_limit.rs
+++ b/backend/web/tests/body_size_limit.rs
@@ -46,6 +46,7 @@ fn make_state_with_limits(
         nar_storage,
         manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        http: gradient_core::http::build_client().expect("http client"),
     })
 }
 

--- a/backend/web/tests/builds_download.rs
+++ b/backend/web/tests/builds_download.rs
@@ -253,6 +253,7 @@ fn listing_returns_products_from_db() {
             nar_storage,
             manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            http: gradient_core::http::build_client().expect("http client"),
         });
 
         let router = create_router(state);
@@ -324,6 +325,7 @@ fn download_streams_file_from_nar() {
             nar_storage,
             manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            http: gradient_core::http::build_client().expect("http client"),
         });
 
         let router = create_router(state);

--- a/backend/web/tests/forge_hooks.rs
+++ b/backend/web/tests/forge_hooks.rs
@@ -85,6 +85,7 @@ fn make_state(
         nar_storage,
         manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        http: gradient_core::http::build_client().expect("http client"),
     })
 }
 

--- a/backend/web/tests/narinfo.rs
+++ b/backend/web/tests/narinfo.rs
@@ -179,6 +179,7 @@ async fn narinfo_served_from_db_inner() {
         nar_storage,
         manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        http: gradient_core::http::build_client().expect("http client"),
     });
 
     let router = create_router(state);

--- a/backend/web/tests/rate_limit.rs
+++ b/backend/web/tests/rate_limit.rs
@@ -36,6 +36,7 @@ fn make_state() -> Arc<ServerState> {
         nar_storage,
         manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        http: gradient_core::http::build_client().expect("http client"),
     })
 }
 

--- a/backend/worker/src/http.rs
+++ b/backend/worker/src/http.rs
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Process-wide shared `reqwest::Client` for the worker.
+//!
+//! `reqwest::Client` is internally `Arc`'d and is meant to be reused. The
+//! worker has many independent code paths that need outbound HTTP (presigned
+//! NAR uploads, NAR import fetches, …); they all share this single client.
+
+use std::sync::OnceLock;
+
+static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+
+/// Return the shared HTTP client, building it on first use.
+///
+/// Panics only if the client builder cannot construct a client at all
+/// (which only happens in pathological TLS-init failures).
+pub fn client() -> &'static reqwest::Client {
+    CLIENT.get_or_init(|| {
+        gradient_core::http::build_client().expect("failed to build worker HTTP client")
+    })
+}

--- a/backend/worker/src/main.rs
+++ b/backend/worker/src/main.rs
@@ -8,6 +8,7 @@ mod config;
 mod connection;
 mod connection_state;
 mod executor;
+mod http;
 mod nix;
 mod proto;
 mod reconnect;

--- a/backend/worker/src/proto/nar.rs
+++ b/backend/worker/src/proto/nar.rs
@@ -263,7 +263,7 @@ pub async fn upload_presigned(
     );
 
     // --- 2. HTTP request to the presigned URL ---
-    let client = reqwest::Client::new();
+    let client = crate::http::client();
     let http_method = reqwest::Method::from_bytes(method.as_bytes())
         .with_context(|| format!("invalid HTTP method: {method}"))?;
 

--- a/backend/worker/src/proto/nar_import.rs
+++ b/backend/worker/src/proto/nar_import.rs
@@ -275,25 +275,16 @@ impl<'a> InputPrefetcher<'a> {
             return vec![];
         }
 
-        let http = match reqwest::Client::builder()
-            .timeout(HTTP_DOWNLOAD_TIMEOUT)
-            .build()
-        {
-            Ok(c) => c,
-            Err(e) => {
-                warn!(error = %e, "failed to build reqwest client for presigned downloads");
-                return vec![];
-            }
-        };
+        let http = crate::http::client();
 
         let mut futs = by_url
             .into_iter()
             .map(|cp| {
-                let http = http.clone();
                 async move {
                     let url = cp.url.clone().expect("by_url entries have a URL");
                     let resp = http
                         .get(&url)
+                        .timeout(HTTP_DOWNLOAD_TIMEOUT)
                         .send()
                         .await
                         .with_context(|| format!("HTTP GET {} (path {})", url, cp.path))?

--- a/cli/connector/src/builds.rs
+++ b/cli/connector/src/builds.rs
@@ -96,10 +96,9 @@ pub async fn post_direct_build(
         form = form.part("files", part);
     }
 
-    let client = reqwest::Client::new();
     let url = format!("{}/api/v1/builds", config.server_url);
 
-    let res = client
+    let res = crate::http_client()
         .post(&url)
         .header(
             "Authorization",
@@ -136,13 +135,12 @@ pub async fn download_build_file(
     build_id: String,
     filename: String,
 ) -> Result<Vec<u8>, String> {
-    let client = reqwest::Client::new();
     let url = format!(
         "{}/api/v1/builds/{}/download/{}",
         config.server_url, build_id, filename
     );
 
-    let res = client
+    let res = crate::http_client()
         .get(&url)
         .header(
             "Authorization",

--- a/cli/connector/src/lib.rs
+++ b/cli/connector/src/lib.rs
@@ -16,6 +16,26 @@ pub mod workers;
 
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use std::sync::OnceLock;
+use std::time::Duration;
+
+static HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+
+/// Process-wide shared `reqwest::Client` for the CLI.
+///
+/// `reqwest::Client` is internally `Arc`'d and is meant to be cloned/reused;
+/// constructing one per request leaks connection pools and produces no
+/// timeout/redirect policy. Always go through this accessor.
+pub(crate) fn http_client() -> &'static reqwest::Client {
+    HTTP_CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .redirect(reqwest::redirect::Policy::none())
+            .user_agent(concat!("gradient-cli/", env!("CARGO_PKG_VERSION")))
+            .build()
+            .expect("failed to build CLI HTTP client")
+    })
+}
 
 #[derive(Debug, Clone)]
 pub struct RequestConfig {
@@ -78,8 +98,7 @@ fn get_client(
     request_type: RequestType,
     login: bool,
 ) -> Result<reqwest::RequestBuilder, String> {
-    let client = reqwest::Client::new();
-    let mut client = client.request(
+    let mut client = http_client().request(
         request_type,
         format!("{}/api/v1/{}", config.server_url, endpoint),
     );

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -861,3 +861,29 @@ Unit tests in `backend/web/src/helpers.rs`:
   unchanged.
 - `or_not_found_maps_none_to_not_found` — produces the expected
   `WebError::NotFound("Thing not found")`.
+
+## Shared HTTP client (`#79`)
+
+Eliminates the prior 18 ad-hoc `reqwest::Client::new()` /
+`reqwest::Client::builder()` constructions across the workspace, which
+each created a fresh TCP/TLS connection pool with inconsistent (or
+absent) timeout and redirect policy.
+
+`backend/core/src/http.rs` builds the project-wide client with sane
+defaults (30 s timeout, `redirect::none`, `gradient/<version>`
+user-agent). The server stores it once on `ServerState::http`; the
+worker exposes it through a `OnceLock` (`worker::http::client()`); the
+CLI exposes it through `connector::http_client()`.
+
+CI reporters (`GiteaReporter`, `GithubReporter`, `GithubAppReporter`)
+and the GitHub-App helpers (`get_installation_token`, `exchange_code`)
+now take the shared `reqwest::Client` as a parameter instead of building
+their own.
+
+Unit tests in `backend/core/src/http.rs`:
+
+- `build_client_succeeds` — the default builder yields a usable
+  `reqwest::Client`.
+- `user_agent_is_prefixed` — the user-agent string is namespaced
+  `gradient/...` so server logs can identify outbound calls from
+  Gradient processes.


### PR DESCRIPTION
## Summary

Closes #79.

`reqwest::Client` is internally `Arc`'d and is meant to be cloned and reused — constructing one per call (or per object) leaks connection pools and produces inconsistent (or absent) timeout / redirect policy. Before this PR there were 18 ad-hoc `reqwest::Client::new()` / `Client::builder()` constructions across the workspace.

This PR introduces a single shared client per process:

- **`backend/core/src/http.rs`** — `build_client()` returns a `reqwest::Client` with the project-wide defaults (30 s timeout, `redirect::none`, `gradient/<version>` user-agent).
- **Server** stores it on `ServerState::http`, built once in `init_state`. Endpoints (`caches/nar`, `caches/narinfo`, `authorization/oidc`, `admin/github_app`), the proto upstream-cache lookup, and the CI subsystem all consume `state.http`.
- **CI reporters** (`GiteaReporter`, `GithubReporter`, `GithubAppReporter`) and the GitHub-App helpers (`get_installation_token`, `exchange_code`, `exchange_code_with_base`) take `reqwest::Client` as a parameter instead of building their own.
- **Worker** exposes the same client via a `OnceLock` accessor (`worker::http::client()`); used by the presigned NAR upload path and by the upstream-NAR import downloader (which still applies its own 600 s per-request timeout via `RequestBuilder::timeout`).
- **CLI** exposes a `connector::http_client()` `OnceLock` and routes `connector::lib::get_client` and `cli::connector::builds::{push_direct,download_build_file}` through it.

Per-request timeout overrides (NAR import 600 s, upstream narinfo lookup 5 s) move to the `RequestBuilder` so a single client serves all paths.

OIDC discovery / JWKS / token-exchange now use the shared client (no redirects). The previous `redirect::limited(5)` was defensive overconfiguration; canonical IdP discovery URLs do not redirect, and refusing to follow them is the safer default.

## Test plan

- [x] `cargo build --workspace` (backend)
- [x] `cargo build --workspace` (cli)
- [x] `cargo test --tests --workspace` (backend) — all 901 tests pass
- [x] New unit tests in `backend/core/src/http.rs`:
  - `build_client_succeeds`
  - `user_agent_is_prefixed`
- [x] CI reporter tests adapted for the new `client` parameter (`GiteaReporter::new`, `GithubReporter::new`, `GithubAppReporter::new`, `reporter_for_project`)
- [x] `docs/src/tests.md` updated under `Shared HTTP client (#79)`