### PR TITLE
backend: graceful shutdown for background tasks (#72)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1233,6 +1233,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-test",
+ "tokio-util",
  "tracing",
  "url",
  "uuid",
@@ -6368,6 +6369,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -61,6 +61,7 @@ sha2             = "0.11"
 thiserror        = "2.0"
 tokio            = { version = "1.50", features = ["rt-multi-thread"] }
 tokio-test       = "0.4"
+tokio-util       = "0.7"
 tracing          = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 uuid             = { version = "1.23", features = ["fast-rng", "macro-diagnostics", "v4"] }

--- a/backend/cache/src/cacher/cleanup.rs
+++ b/backend/cache/src/cacher/cleanup.rs
@@ -303,6 +303,7 @@ mod tests {
             manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             http: gradient_core::http::build_client().expect("http client"),
+            shutdown: gradient_core::shutdown::Shutdown::new(),
         })
     }
 
@@ -382,6 +383,7 @@ mod tests {
             manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             http: gradient_core::http::build_client().expect("http client"),
+            shutdown: gradient_core::shutdown::Shutdown::new(),
         });
 
         cleanup_stale_cached_nars(state).await.unwrap();

--- a/backend/cache/src/cacher/mod.rs
+++ b/backend/cache/src/cacher/mod.rs
@@ -39,9 +39,16 @@ pub async fn cache_loop(state: Arc<ServerState>) {
     // No per-output work anymore — the worker uploads+signs. This loop only
     // runs maintenance. Tick every hour; nothing is latency-sensitive.
     let mut interval = time::interval(Duration::from_secs(3600));
+    let cancel = state.shutdown.token();
 
     loop {
-        interval.tick().await;
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                info!("cache loop shutting down");
+                return;
+            }
+            _ = interval.tick() => {}
+        }
 
         if let Err(e) = cleanup_orphaned_cache_files(Arc::clone(&state)).await {
             error!(error = %e, "Cache cleanup failed");
@@ -83,8 +90,15 @@ pub async fn sign_sweep_loop(state: Arc<ServerState>) {
     };
 
     let mut interval = time::interval(Duration::from_secs(60));
+    let cancel = state.shutdown.token();
     loop {
-        interval.tick().await;
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                info!("sign sweep loop shutting down");
+                return;
+            }
+            _ = interval.tick() => {}
+        }
         if let Err(e) = sign_missing_signatures(Arc::clone(&state)).await {
             error!(error = %e, "Signature sweep failed");
         }

--- a/backend/cache/src/lib.rs
+++ b/backend/cache/src/lib.rs
@@ -10,7 +10,8 @@ use gradient_core::types::ServerState;
 use std::sync::Arc;
 
 pub async fn start_cache(state: Arc<ServerState>) -> std::io::Result<()> {
-    tokio::spawn(cacher::cache_loop(Arc::clone(&state)));
-    tokio::spawn(cacher::sign_sweep_loop(Arc::clone(&state)));
+    let shutdown = state.shutdown.clone();
+    shutdown.spawn(cacher::cache_loop(Arc::clone(&state)));
+    shutdown.spawn(cacher::sign_sweep_loop(Arc::clone(&state)));
     Ok(())
 }

--- a/backend/core/Cargo.toml
+++ b/backend/core/Cargo.toml
@@ -32,6 +32,7 @@ serde            = { workspace = true }
 serde_json       = { workspace = true }
 thiserror        = { workspace = true }
 tokio            = { workspace = true, features = ["process"] }
+tokio-util       = { workspace = true, features = ["rt"] }
 tracing          = { workspace = true }
 sha2             = { workspace = true }
 uuid             = { workspace = true }

--- a/backend/core/src/db/status.rs
+++ b/backend/core/src/db/status.rs
@@ -77,7 +77,7 @@ pub async fn update_build_status(
         Ok(updated_build) => {
             let webhook_state = Arc::clone(&state);
             let webhook_build = updated_build.clone();
-            tokio::spawn(async move {
+            state.shutdown.spawn(async move {
                 crate::ci::fire_build_webhook(webhook_state, webhook_build, webhook_status).await;
             });
 
@@ -92,7 +92,7 @@ pub async fn update_build_status(
             ) {
                 let log_state = Arc::clone(&state);
                 let log_id = updated_build.log_id.unwrap_or(updated_build.id);
-                tokio::spawn(async move {
+                state.shutdown.spawn(async move {
                     if let Err(e) = log_state.log_storage.finalize(log_id).await {
                         error!(error = %e, build_id = %log_id, "Failed to finalize build log");
                     }
@@ -102,7 +102,7 @@ pub async fn update_build_status(
             if let Some(ci_status) = crate::ci::ci_status_for_build(&updated_build.status) {
                 let ci_state = Arc::clone(&state);
                 let ci_build = updated_build.clone();
-                tokio::spawn(async move {
+                state.shutdown.spawn(async move {
                     crate::ci::report_build_ci(ci_state, ci_build, ci_status).await;
                 });
             }
@@ -185,14 +185,14 @@ pub async fn update_evaluation_status(
 
     let webhook_state = Arc::clone(&state);
     let webhook_eval = updated_eval.clone();
-    tokio::spawn(async move {
+    state.shutdown.spawn(async move {
         crate::ci::fire_evaluation_webhook(webhook_state, webhook_eval, webhook_status).await;
     });
 
     if let Some(ci_status) = crate::ci::ci_status_for_evaluation(&updated_eval.status) {
         let ci_state = Arc::clone(&state);
         let ci_eval = updated_eval.clone();
-        tokio::spawn(async move {
+        state.shutdown.spawn(async move {
             crate::ci::report_evaluation_ci(ci_state, ci_eval, ci_status).await;
         });
     }

--- a/backend/core/src/lib.rs
+++ b/backend/core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod hydra;
 pub mod nix;
 pub mod nix_hash;
 pub mod repo;
+pub mod shutdown;
 pub mod sources;
 pub mod state;
 pub mod state_machine;
@@ -20,6 +21,7 @@ pub mod types;
 
 use ci::ReqwestWebhookClient;
 use db::{connect_db, connect_web_db};
+use shutdown::Shutdown;
 use sea_orm::{
     ActiveModelTrait, ActiveValue::Set, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter,
 };
@@ -196,5 +198,6 @@ pub async fn init_state(cli: Cli) -> Arc<ServerState> {
         manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         http,
+        shutdown: Shutdown::new(),
     })
 }

--- a/backend/core/src/shutdown.rs
+++ b/backend/core/src/shutdown.rs
@@ -1,0 +1,176 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Centralized graceful-shutdown primitive.
+//!
+//! `Shutdown` bundles a [`CancellationToken`] (the signal) with a
+//! [`TaskTracker`] (the registry). Long-lived background tasks are spawned
+//! via `spawn` so the process can drain them on SIGTERM/SIGINT instead of
+//! abandoning in-flight cleanups, metric writes, and webhook deliveries.
+//!
+//! # Rules
+//!
+//! - Anything outliving a single request goes through `Shutdown::spawn`,
+//!   never bare `tokio::spawn`.
+//! - Loops that sleep (`interval.tick`, `sleep`) must `select!` on
+//!   `cancelled()` so SIGTERM doesn't have to wait a full poll cycle.
+//! - Per-connection / per-job tasks derive a child token via
+//!   [`Shutdown::child_token`] so cancelling the parent cancels them
+//!   transitively.
+
+use std::future::Future;
+use std::time::Duration;
+
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
+use tracing::{info, warn};
+
+#[derive(Clone, Debug)]
+pub struct Shutdown {
+    token: CancellationToken,
+    tracker: TaskTracker,
+}
+
+impl Default for Shutdown {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Shutdown {
+    pub fn new() -> Self {
+        Self {
+            token: CancellationToken::new(),
+            tracker: TaskTracker::new(),
+        }
+    }
+
+    /// Cancellation token. `cancelled().await` resolves once shutdown is
+    /// requested. Cheap to clone.
+    pub fn token(&self) -> CancellationToken {
+        self.token.clone()
+    }
+
+    /// Future that resolves when shutdown has been requested.
+    pub fn cancelled(&self) -> tokio_util::sync::WaitForCancellationFuture<'_> {
+        self.token.cancelled()
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.token.is_cancelled()
+    }
+
+    /// A child token that is cancelled when the parent token is cancelled,
+    /// or independently. Used for per-connection / per-job scopes that
+    /// should be cancellable on their own without affecting siblings.
+    pub fn child_token(&self) -> CancellationToken {
+        self.token.child_token()
+    }
+
+    /// Register a background task with the tracker. Replaces bare
+    /// `tokio::spawn` for anything outliving a single request.
+    pub fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        self.tracker.spawn(future)
+    }
+
+    /// Trigger shutdown. Idempotent.
+    pub fn cancel(&self) {
+        self.token.cancel();
+    }
+
+    /// Cancel and drain all tracked tasks, bounded by `timeout`. Returns
+    /// `true` if all tasks completed before the deadline.
+    pub async fn cancel_and_drain(&self, timeout: Duration) -> bool {
+        self.cancel();
+        self.tracker.close();
+        match tokio::time::timeout(timeout, self.tracker.wait()).await {
+            Ok(()) => {
+                info!("background tasks drained cleanly");
+                true
+            }
+            Err(_) => {
+                warn!(
+                    pending = self.tracker.len(),
+                    "shutdown drain timed out — some background tasks were abandoned"
+                );
+                false
+            }
+        }
+    }
+
+    /// Number of currently-tracked tasks. Useful for tests / introspection.
+    pub fn pending(&self) -> usize {
+        self.tracker.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn cancel_interrupts_select_loop() {
+        let s = Shutdown::new();
+        let token = s.token();
+        let done = Arc::new(AtomicBool::new(false));
+        let done2 = Arc::clone(&done);
+
+        let handle = s.spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = token.cancelled() => break,
+                    _ = tokio::time::sleep(Duration::from_secs(60)) => {}
+                }
+            }
+            done2.store(true, Ordering::SeqCst);
+        });
+
+        s.cancel_and_drain(Duration::from_secs(1)).await;
+        assert!(done.load(Ordering::SeqCst));
+        assert!(handle.is_finished());
+    }
+
+    #[tokio::test]
+    async fn drain_waits_for_in_flight_work() {
+        let s = Shutdown::new();
+        let done = Arc::new(AtomicBool::new(false));
+        let done2 = Arc::clone(&done);
+        s.spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            done2.store(true, Ordering::SeqCst);
+        });
+        let drained = s.cancel_and_drain(Duration::from_secs(1)).await;
+        assert!(drained);
+        assert!(done.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn drain_timeout_returns_false() {
+        let s = Shutdown::new();
+        s.spawn(async {
+            // Ignores the cancel signal — simulates a misbehaving task.
+            tokio::time::sleep(Duration::from_secs(10)).await;
+        });
+        let drained = s.cancel_and_drain(Duration::from_millis(50)).await;
+        assert!(!drained);
+    }
+
+    #[tokio::test]
+    async fn child_token_cascades_from_parent() {
+        let s = Shutdown::new();
+        let child = s.child_token();
+        assert!(!child.is_cancelled());
+        s.cancel();
+        assert!(child.is_cancelled());
+    }
+}

--- a/backend/core/src/types/mod.rs
+++ b/backend/core/src/types/mod.rs
@@ -36,6 +36,7 @@ pub use self::secret::{SecretBytes, SecretString};
 pub use self::wildcard::*;
 
 use super::ci::webhook::WebhookClient;
+use super::shutdown::Shutdown;
 use super::storage::LogStorage;
 use super::storage::NarStore;
 use super::storage::email::EmailSender;
@@ -110,6 +111,9 @@ pub struct ServerState {
     pub manifest_state: Arc<crate::ci::manifest_state::ManifestStateStore>,
     /// Manifest results awaiting one-shot pickup by the superuser's browser.
     pub pending_credentials: Arc<crate::ci::manifest_state::PendingCredentialsStore>,
+    /// Graceful-shutdown coordination for all long-lived background tasks
+    /// (dispatch loops, outbound, cache loops, webhook deliveries, etc.).
+    pub shutdown: Shutdown,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/backend/proto/src/outbound.rs
+++ b/backend/proto/src/outbound.rs
@@ -27,14 +27,23 @@ use entity::worker_registration::{Column, Entity as EWorkerRegistration};
 use crate::handler::{MAX_PROTO_MESSAGE_SIZE, ProtoSocket, handle_socket};
 use scheduler::Scheduler;
 
-/// Spawn the outbound connection loop as a detached tokio task.
+/// Spawn the outbound connection loop on the shared shutdown tracker so it
+/// drains cleanly on SIGTERM.
 pub fn start_outbound_loop(scheduler: Arc<Scheduler>) {
-    tokio::spawn(async move {
+    let shutdown = scheduler.state.shutdown.clone();
+    let cancel = shutdown.token();
+    shutdown.spawn(async move {
         let mut interval = tokio::time::interval(Duration::from_secs(15));
         let connecting: Arc<Mutex<HashSet<String>>> = Arc::default();
         info!("outbound worker connection loop started");
         loop {
-            interval.tick().await;
+            tokio::select! {
+                _ = cancel.cancelled() => {
+                    info!("outbound worker connection loop shutting down");
+                    return;
+                }
+                _ = interval.tick() => {}
+            }
             connect_to_registered_workers(&scheduler, &connecting).await;
         }
     });
@@ -87,8 +96,9 @@ async fn connect_to_registered_workers(
         let worker_id = reg.worker_id.clone();
         let scheduler = Arc::clone(scheduler);
         let connecting = Arc::clone(connecting);
+        let shutdown = scheduler.state.shutdown.clone();
 
-        tokio::spawn(async move {
+        shutdown.spawn(async move {
             debug!(%worker_id, %url, "connecting outbound to worker");
 
             let config = WebSocketConfig::default()

--- a/backend/scheduler/src/dispatch.rs
+++ b/backend/scheduler/src/dispatch.rs
@@ -38,23 +38,31 @@ use super::Scheduler;
 use super::jobs::{PendingBuildJob, PendingEvalJob};
 use gradient_core::types::proto::{BuildJob, BuildTask, FlakeJob, FlakeTask};
 
-/// Spawns all dispatch loops as detached tokio tasks.
+/// Spawns all dispatch loops on the shared shutdown tracker so they drain on SIGTERM.
 pub fn start_dispatch_loops(scheduler: Arc<Scheduler>) {
+    let shutdown = scheduler.state.shutdown.clone();
     let s1 = Arc::clone(&scheduler);
     let s2 = Arc::clone(&scheduler);
     let s3 = Arc::clone(&scheduler);
-    tokio::spawn(async move { project_poll_loop(s3).await });
-    tokio::spawn(async move { eval_dispatch_loop(s1).await });
-    tokio::spawn(async move { build_dispatch_loop(s2).await });
+    shutdown.spawn(async move { project_poll_loop(s3).await });
+    shutdown.spawn(async move { eval_dispatch_loop(s1).await });
+    shutdown.spawn(async move { build_dispatch_loop(s2).await });
 }
 
 // ── Project polling ──────────────────────────────────────────────────────────
 
 async fn project_poll_loop(scheduler: Arc<Scheduler>) {
     let mut interval = tokio::time::interval(Duration::from_secs(30));
+    let cancel = scheduler.state.shutdown.token();
     info!("project poll loop started");
     loop {
-        interval.tick().await;
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                info!("project poll loop shutting down");
+                return;
+            }
+            _ = interval.tick() => {}
+        }
         if let Err(e) = poll_projects_for_evaluations(&scheduler).await {
             error!(error = %e, "project poll error");
         }
@@ -178,9 +186,16 @@ pub(crate) async fn poll_projects_for_evaluations(scheduler: &Scheduler) -> anyh
 
 async fn eval_dispatch_loop(scheduler: Arc<Scheduler>) {
     let mut interval = tokio::time::interval(Duration::from_secs(5));
+    let cancel = scheduler.state.shutdown.token();
     info!("eval dispatch loop started");
     loop {
-        interval.tick().await;
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                info!("eval dispatch loop shutting down");
+                return;
+            }
+            _ = interval.tick() => {}
+        }
         if let Err(e) = dispatch_queued_evals(&scheduler).await {
             error!(error = %e, "eval dispatch error");
         }
@@ -262,9 +277,16 @@ pub(crate) async fn dispatch_queued_evals(scheduler: &Scheduler) -> anyhow::Resu
 
 async fn build_dispatch_loop(scheduler: Arc<Scheduler>) {
     let mut interval = tokio::time::interval(Duration::from_secs(5));
+    let cancel = scheduler.state.shutdown.token();
     info!("build dispatch loop started");
     loop {
-        interval.tick().await;
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                info!("build dispatch loop shutting down");
+                return;
+            }
+            _ = interval.tick() => {}
+        }
         if let Err(e) = dispatch_ready_builds(&scheduler).await {
             error!(error = %e, "build dispatch error");
         }

--- a/backend/scheduler/src/eval.rs
+++ b/backend/scheduler/src/eval.rs
@@ -349,7 +349,7 @@ impl<'a> EvalResultProcessor<'a> {
             let repo = self.evaluation.repository.clone();
             let commit_id = self.evaluation.commit;
             let evaluation_id = self.evaluation_id;
-            tokio::spawn(async move {
+            self.state.shutdown.spawn(async move {
                 report_ci_for_entry_points(
                     state_clone,
                     project_id,
@@ -367,7 +367,7 @@ impl<'a> EvalResultProcessor<'a> {
         if let Ok(Some(project)) = EProject::find_by_id(project_id).one(&self.state.worker_db).await {
             let gc_state = Arc::clone(self.state);
             let gc_keep = project.keep_evaluations as usize;
-            tokio::spawn(async move {
+            self.state.shutdown.spawn(async move {
                 if let Err(e) =
                     gradient_core::db::gc_project_evaluations(gc_state, project_id, gc_keep).await
                 {

--- a/backend/scheduler/src/job_handlers.rs
+++ b/backend/scheduler/src/job_handlers.rs
@@ -202,7 +202,7 @@ impl Scheduler {
                     let state = Arc::clone(&self.state);
                     let repo = eval.repository.clone();
                     let commit_id = eval.commit;
-                    tokio::spawn(async move {
+                    self.state.shutdown.spawn(async move {
                         ci::report_ci_for_evaluation(
                             state,
                             pid,

--- a/backend/test-support/src/state.rs
+++ b/backend/test-support/src/state.rs
@@ -35,6 +35,7 @@ pub fn test_state(db: DatabaseConnection) -> Arc<ServerState> {
         manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         http: gradient_core::http::build_client().expect("build test HTTP client"),
+        shutdown: gradient_core::shutdown::Shutdown::new(),
     })
 }
 
@@ -59,6 +60,7 @@ pub fn test_state_recorded(
         manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         http: gradient_core::http::build_client().expect("build test HTTP client"),
+        shutdown: gradient_core::shutdown::Shutdown::new(),
     });
     (state, recorder)
 }

--- a/backend/web/Cargo.toml
+++ b/backend/web/Cargo.toml
@@ -25,7 +25,7 @@ sea-orm      = { workspace = true }
 serde        = { workspace = true }
 serde_json   = { workspace = true }
 thiserror    = { workspace = true }
-tokio        = { workspace = true, features = ["process"] }
+tokio        = { workspace = true, features = ["process", "signal"] }
 tracing      = { workspace = true }
 uuid         = { workspace = true }
 sha2         = { workspace = true }

--- a/backend/web/src/access.rs
+++ b/backend/web/src/access.rs
@@ -441,6 +441,7 @@ mod tests {
             manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             http: gradient_core::http::build_client().expect("http client"),
+            shutdown: gradient_core::shutdown::Shutdown::new(),
         })
     }
 

--- a/backend/web/src/endpoints/caches/management.rs
+++ b/backend/web/src/endpoints/caches/management.rs
@@ -300,9 +300,11 @@ pub async fn delete_cache(
     let acache: ACache = cache.into();
     acache.delete(&state.web_db).await?;
 
-    // Spawn background task to delete now-orphaned NAR files.
+    // Spawn background task to delete now-orphaned NAR files. Tracked via
+    // the shared shutdown registry so SIGTERM drains it instead of leaving
+    // orphaned NAR files only partially removed.
     let state_bg = Arc::clone(&state);
-    tokio::spawn(async move {
+    state.shutdown.spawn(async move {
         cleanup_nars_for_orgs(state_bg, subscribing_orgs).await;
     });
 

--- a/backend/web/src/endpoints/caches/nar.rs
+++ b/backend/web/src/endpoints/caches/nar.rs
@@ -111,8 +111,9 @@ pub(crate) async fn resolve_effective_hash_db<C: ConnectionTrait>(
 }
 
 fn spawn_nar_traffic_metric(state: Arc<ServerState>, cache_id: Uuid, bytes_len: i64) {
-    tokio::spawn(async move {
-        super::super::stats::record_nar_traffic(state, cache_id, bytes_len).await;
+    let s = Arc::clone(&state);
+    state.shutdown.spawn(async move {
+        super::super::stats::record_nar_traffic(s, cache_id, bytes_len).await;
     });
 }
 
@@ -121,10 +122,11 @@ fn spawn_nar_traffic_metric(state: Arc<ServerState>, cache_id: Uuid, bytes_len: 
 /// fire-and-forget UPDATE would otherwise contend with foreground HTTP
 /// requests on the web pool.
 fn spawn_cache_derivation_fetch_update(state: Arc<ServerState>, cache_id: Uuid, hash: String) {
-    tokio::spawn(async move {
+    let s = Arc::clone(&state);
+    state.shutdown.spawn(async move {
         use sea_orm::{ConnectionTrait, DatabaseBackend, Statement};
         let now = gradient_core::types::now();
-        let _ = state
+        let _ = s
             .worker_db
             .execute(Statement::from_sql_and_values(
                 DatabaseBackend::Postgres,

--- a/backend/web/src/lib.rs
+++ b/backend/web/src/lib.rs
@@ -463,9 +463,51 @@ pub async fn serve_web(state: Arc<ServerState>) -> std::io::Result<()> {
             tracing::error!("Failed to bind to {}: {}", server_url, e);
             e
         })?;
-    axum::serve(
+
+    let shutdown = state.shutdown.clone();
+    install_signal_handler(shutdown.clone());
+
+    let drain_token = shutdown.token();
+    let serve_result = axum::serve(
         listener,
         app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
     )
-    .await
+    .with_graceful_shutdown(async move { drain_token.cancelled().await })
+    .await;
+
+    // Drain background tasks (dispatch loops, outbound, cache GC, webhook
+    // deliveries, metric writes). Bounded so a misbehaving task can't block
+    // shutdown indefinitely.
+    shutdown
+        .cancel_and_drain(std::time::Duration::from_secs(30))
+        .await;
+
+    serve_result
+}
+
+/// Install a SIGINT/SIGTERM handler that triggers graceful shutdown.
+fn install_signal_handler(shutdown: gradient_core::shutdown::Shutdown) {
+    tokio::spawn(async move {
+        #[cfg(unix)]
+        {
+            use tokio::signal::unix::{SignalKind, signal};
+            let mut sigterm = match signal(SignalKind::terminate()) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::error!(error = %e, "failed to install SIGTERM handler");
+                    return;
+                }
+            };
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => tracing::info!("received SIGINT, shutting down"),
+                _ = sigterm.recv() => tracing::info!("received SIGTERM, shutting down"),
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = tokio::signal::ctrl_c().await;
+            tracing::info!("received Ctrl-C, shutting down");
+        }
+        shutdown.cancel();
+    });
 }

--- a/backend/web/tests/auth_middleware.rs
+++ b/backend/web/tests/auth_middleware.rs
@@ -48,6 +48,7 @@ fn server() -> TestServer {
         manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         http: gradient_core::http::build_client().expect("http client"),
+        shutdown: gradient_core::shutdown::Shutdown::new(),
     });
     TestServer::new(create_router(state))
 }

--- a/backend/web/tests/body_size_limit.rs
+++ b/backend/web/tests/body_size_limit.rs
@@ -47,6 +47,7 @@ fn make_state_with_limits(
         manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         http: gradient_core::http::build_client().expect("http client"),
+        shutdown: gradient_core::shutdown::Shutdown::new(),
     })
 }
 

--- a/backend/web/tests/builds_download.rs
+++ b/backend/web/tests/builds_download.rs
@@ -254,6 +254,7 @@ fn listing_returns_products_from_db() {
             manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             http: gradient_core::http::build_client().expect("http client"),
+            shutdown: gradient_core::shutdown::Shutdown::new(),
         });
 
         let router = create_router(state);
@@ -326,6 +327,7 @@ fn download_streams_file_from_nar() {
             manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             http: gradient_core::http::build_client().expect("http client"),
+            shutdown: gradient_core::shutdown::Shutdown::new(),
         });
 
         let router = create_router(state);

--- a/backend/web/tests/forge_hooks.rs
+++ b/backend/web/tests/forge_hooks.rs
@@ -86,6 +86,7 @@ fn make_state(
         manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         http: gradient_core::http::build_client().expect("http client"),
+        shutdown: gradient_core::shutdown::Shutdown::new(),
     })
 }
 

--- a/backend/web/tests/narinfo.rs
+++ b/backend/web/tests/narinfo.rs
@@ -180,6 +180,7 @@ async fn narinfo_served_from_db_inner() {
         manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         http: gradient_core::http::build_client().expect("http client"),
+        shutdown: gradient_core::shutdown::Shutdown::new(),
     });
 
     let router = create_router(state);

--- a/backend/web/tests/rate_limit.rs
+++ b/backend/web/tests/rate_limit.rs
@@ -37,6 +37,7 @@ fn make_state() -> Arc<ServerState> {
         manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         http: gradient_core::http::build_client().expect("http client"),
+        shutdown: gradient_core::shutdown::Shutdown::new(),
     })
 }
 

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -900,3 +900,28 @@ Unit tests in `backend/core/src/http.rs`:
 - `user_agent_is_prefixed` — the user-agent string is namespaced
   `gradient/...` so server logs can identify outbound calls from
   Gradient processes.
+
+## Graceful shutdown (`#72`)
+
+`backend/core/src/shutdown.rs` introduces a `Shutdown` primitive bundling a
+`tokio_util::sync::CancellationToken` with a `tokio_util::task::TaskTracker`.
+It replaces bare `tokio::spawn` for every long-lived background task —
+dispatch loops, the outbound worker connection loop, the cache GC and
+sign-sweep loops, webhook deliveries, CI reporters, and the fire-and-forget
+metric writes from the NAR cache surface. `serve_web` installs a
+SIGINT/SIGTERM handler that calls `shutdown.cancel()`, hands the token to
+`axum::serve(...).with_graceful_shutdown(...)`, then awaits
+`shutdown.cancel_and_drain(30s)` so in-flight cleanups, metric writes, and
+webhook deliveries finish before the process exits.
+
+Unit tests in `backend/core/src/shutdown.rs`:
+
+- `cancel_interrupts_select_loop` — a task that `select!`s on
+  `cancelled()` against a 60-second sleep returns immediately when the
+  token fires.
+- `drain_waits_for_in_flight_work` — `cancel_and_drain` waits for
+  spawned futures to finish (no abandonment of in-flight work).
+- `drain_timeout_returns_false` — a task that ignores the cancel
+  signal is reported as a drain timeout, not silently abandoned.
+- `child_token_cascades_from_parent` — child tokens used for
+  per-connection / per-job scopes cancel transitively.


### PR DESCRIPTION
Closes #72.

## Summary

- Adds `core::shutdown::Shutdown` — a `CancellationToken` + `TaskTracker` pair that replaces bare `tokio::spawn` for every long-lived background task. Wired into `ServerState`.
- Migrates the long-lived spawn sites: scheduler dispatch loops (project poll / eval / build), `proto::outbound` worker-reconnect loop and per-worker connect tasks, cache GC and signature sweep loops, build/eval webhook deliveries, CI reporters, log-finalize on terminal build, NAR-traffic metric writes, and the post-cache-delete NAR cleanup. All loops now `select!` on `cancelled()` so SIGTERM doesn't have to wait a full poll cycle.
- `serve_web` installs a SIGINT/SIGTERM handler, hands the token to `axum::serve(...).with_graceful_shutdown(...)`, then awaits `shutdown.cancel_and_drain(30s)` so in-flight cleanups, metric writes, and webhook deliveries complete before exit. Bounded so a misbehaving task can't block shutdown indefinitely; pending count is logged on timeout.
- Per-connection / per-job spawns and worker-side per-socket tasks are left in place — they're naturally bounded by the connection lifetime, which is itself owned by a tracked parent loop.

## Test plan

- [x] `cargo test --manifest-path backend/Cargo.toml --workspace --tests` (all suites green)
- [x] New unit tests in `backend/core/src/shutdown.rs`:
  - `cancel_interrupts_select_loop` — token cancel breaks a 60s sleep loop
  - `drain_waits_for_in_flight_work` — drain awaits in-flight futures
  - `drain_timeout_returns_false` — misbehaving task reported, not silently abandoned
  - `child_token_cascades_from_parent` — child tokens cancel transitively
- [ ] Manual SIGTERM smoke test against a running server