### PR TITLE
backend: core: dedupe transitive-dependents graph walks (#108)

### DIFF
--- a/backend/cache/src/cacher/invalidate.rs
+++ b/backend/cache/src/cacher/invalidate.rs
@@ -5,13 +5,13 @@
  */
 
 use anyhow::{Context, Result};
+use gradient_core::db::collect_transitive_dependents;
 use gradient_core::sources::get_hash_from_path;
 use gradient_core::types::*;
 use sea_orm::ActiveValue::Set;
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, Condition, EntityTrait, IntoActiveModel, QueryFilter,
 };
-use std::collections::HashSet;
 use std::sync::Arc;
 use tracing::{info, warn};
 use uuid::Uuid;
@@ -91,30 +91,13 @@ pub async fn invalidate_cache_for_path(state: Arc<ServerState>, path: String) ->
     Ok(())
 }
 
-/// Walks reverse `derivation_dependency` edges starting at `derivation_id` and removes
-/// all `cache_derivation` rows touching the visited derivations across every cache.
+/// Removes all `cache_derivation` rows touching `derivation_id` and any of its
+/// transitive dependents across every cache.
 async fn revoke_cache_derivation_closure(
     state: &Arc<ServerState>,
     derivation_id: Uuid,
 ) -> Result<()> {
-    let mut visited: HashSet<Uuid> = HashSet::new();
-    let mut frontier = vec![derivation_id];
-    visited.insert(derivation_id);
-
-    while !frontier.is_empty() {
-        let edges = EDerivationDependency::find()
-            .filter(CDerivationDependency::Dependency.is_in(frontier.clone()))
-            .all(&state.worker_db)
-            .await
-            .context("Failed to walk reverse derivation_dependency")?;
-        frontier.clear();
-        for edge in edges {
-            if visited.insert(edge.derivation) {
-                frontier.push(edge.derivation);
-            }
-        }
-    }
-
+    let visited = collect_transitive_dependents(&state.worker_db, derivation_id).await?;
     let drv_ids: Vec<Uuid> = visited.into_iter().collect();
     let cache_rows = ECacheDerivation::find()
         .filter(CCacheDerivation::Derivation.is_in(drv_ids))

--- a/backend/core/src/db/dependency_graph.rs
+++ b/backend/core/src/db/dependency_graph.rs
@@ -1,0 +1,117 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Shared graph walks over the `derivation_dependency` table.
+//!
+//! The `derivation_dependency` row `(derivation, dependency)` means
+//! "`derivation` depends on `dependency`". A *reverse* walk from a starting
+//! derivation therefore yields its transitive **dependents** — every derivation
+//! that (directly or indirectly) needs the start node to be available.
+//!
+//! Two callers historically reimplemented the same BFS with subtly different
+//! shapes (cache invalidation closure revocation, build-failure cascade); this
+//! module hosts the single canonical version.
+
+use anyhow::{Context, Result};
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
+use std::collections::HashSet;
+use uuid::Uuid;
+
+use crate::types::*;
+
+/// Returns the set of all transitive dependents of `start`, **including** `start`
+/// itself. Walks reverse `derivation_dependency` edges in BFS layers, batching
+/// each layer into a single `IS IN` query.
+///
+/// Empty input (caller passes `start` only) ⇒ result contains exactly `{start}`.
+pub async fn collect_transitive_dependents<C: ConnectionTrait>(
+    db: &C,
+    start: Uuid,
+) -> Result<HashSet<Uuid>> {
+    let mut visited: HashSet<Uuid> = HashSet::new();
+    visited.insert(start);
+    let mut frontier: Vec<Uuid> = vec![start];
+
+    while !frontier.is_empty() {
+        let edges = EDerivationDependency::find()
+            .filter(CDerivationDependency::Dependency.is_in(frontier.clone()))
+            .all(db)
+            .await
+            .context("walk derivation_dependency reverse edges")?;
+        frontier.clear();
+        for edge in edges {
+            if visited.insert(edge.derivation) {
+                frontier.push(edge.derivation);
+            }
+        }
+    }
+
+    Ok(visited)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sea_orm::{DatabaseBackend, MockDatabase};
+
+    fn dep_edge(derivation: Uuid, dependency: Uuid) -> MDerivationDependency {
+        entity::derivation_dependency::Model {
+            id: Uuid::new_v4(),
+            derivation,
+            dependency,
+        }
+    }
+
+    #[tokio::test]
+    async fn no_dependents_returns_only_start() {
+        let start = Uuid::new_v4();
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([Vec::<MDerivationDependency>::new()])
+            .into_connection();
+
+        let visited = collect_transitive_dependents(&db, start).await.unwrap();
+        assert_eq!(visited.len(), 1);
+        assert!(visited.contains(&start));
+    }
+
+    #[tokio::test]
+    async fn walks_multiple_layers_breadth_first() {
+        let a = Uuid::new_v4(); // start
+        let b = Uuid::new_v4(); // depends on a
+        let c = Uuid::new_v4(); // depends on b
+        let d = Uuid::new_v4(); // depends on a (sibling of b)
+
+        // Layer 1: dependents of {a}        → b, d
+        // Layer 2: dependents of {b, d}     → c
+        // Layer 3: dependents of {c}        → ∅
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![dep_edge(b, a), dep_edge(d, a)]])
+            .append_query_results([vec![dep_edge(c, b)]])
+            .append_query_results([Vec::<MDerivationDependency>::new()])
+            .into_connection();
+
+        let visited = collect_transitive_dependents(&db, a).await.unwrap();
+        assert_eq!(visited.len(), 4);
+        for id in [a, b, c, d] {
+            assert!(visited.contains(&id), "missing {}", id);
+        }
+    }
+
+    #[tokio::test]
+    async fn cycles_terminate() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        // Pathological cycle: b depends on a AND a depends on b. The visited
+        // set must dedupe so the BFS terminates.
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![dep_edge(b, a)]])
+            .append_query_results([vec![dep_edge(a, b)]])
+            .into_connection();
+
+        let visited = collect_transitive_dependents(&db, a).await.unwrap();
+        assert_eq!(visited.len(), 2);
+    }
+}

--- a/backend/core/src/db/mod.rs
+++ b/backend/core/src/db/mod.rs
@@ -5,6 +5,7 @@
  */
 
 pub mod connection;
+pub mod dependency_graph;
 pub mod derivation;
 pub mod drv_output_spec;
 pub mod gc;
@@ -12,6 +13,7 @@ pub mod permission;
 pub mod status;
 
 pub use self::connection::*;
+pub use self::dependency_graph::*;
 pub use self::derivation::*;
 pub use self::drv_output_spec::DrvOutputSpec;
 pub use self::gc::*;

--- a/backend/scheduler/src/build.rs
+++ b/backend/scheduler/src/build.rs
@@ -13,7 +13,9 @@ use anyhow::{Context, Result};
 
 use entity::build::BuildStatus;
 use entity::evaluation::EvaluationStatus;
-use gradient_core::db::{update_build_status, update_evaluation_status};
+use gradient_core::db::{
+    collect_transitive_dependents, update_build_status, update_evaluation_status,
+};
 use gradient_core::types::*;
 use sea_orm::{
     ActiveModelTrait, ActiveValue::Set, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter,
@@ -136,35 +138,26 @@ impl<'a> BuildStateHandler<'a> {
         evaluation_id: Uuid,
         failed_derivation_id: Uuid,
     ) -> Result<()> {
-        // BFS: walk the derivation_dependency graph and mark all transitive
-        // dependents as DependencyFailed.
-        let mut queue = vec![failed_derivation_id];
+        let mut closure =
+            collect_transitive_dependents(&self.state.worker_db, failed_derivation_id).await?;
+        // The failed derivation itself was already marked Failed by the caller;
+        // only its dependents need DependencyFailed.
+        closure.remove(&failed_derivation_id);
+        if closure.is_empty() {
+            return Ok(());
+        }
 
-        while let Some(failed_drv) = queue.pop() {
-            let dependents = EBuild::find()
-                .filter(CBuild::Evaluation.eq(evaluation_id))
-                .filter(CBuild::Status.is_in(vec![BuildStatus::Created, BuildStatus::Queued]))
-                .all(&self.state.worker_db)
-                .await
-                .context("fetch builds for cascade")?;
+        let cascaded_builds = EBuild::find()
+            .filter(CBuild::Evaluation.eq(evaluation_id))
+            .filter(CBuild::Status.is_in(vec![BuildStatus::Created, BuildStatus::Queued]))
+            .filter(CBuild::Derivation.is_in(closure.into_iter().collect::<Vec<_>>()))
+            .all(&self.state.worker_db)
+            .await
+            .context("fetch builds for cascade")?;
 
-            for build in dependents {
-                let dep_edge = EDerivationDependency::find()
-                    .filter(CDerivationDependency::Derivation.eq(build.derivation))
-                    .filter(CDerivationDependency::Dependency.eq(failed_drv))
-                    .one(&self.state.worker_db)
-                    .await?;
-                if dep_edge.is_some() {
-                    let cascaded_drv = build.derivation;
-                    update_build_status(
-                        Arc::clone(self.state),
-                        build,
-                        BuildStatus::DependencyFailed,
-                    )
-                    .await;
-                    queue.push(cascaded_drv);
-                }
-            }
+        for build in cascaded_builds {
+            update_build_status(Arc::clone(self.state), build, BuildStatus::DependencyFailed)
+                .await;
         }
         Ok(())
     }

--- a/backend/scheduler/src/handler_tests.rs
+++ b/backend/scheduler/src/handler_tests.rs
@@ -812,18 +812,17 @@ async fn build_failed_cascades_to_direct_dependent() {
         .append_query_results([vec![build_a]])
         // 2. update buildA → Failed (UPDATE...RETURNING)
         .append_query_results([vec![build_a_failed]])
-        // ── BFS iteration 1: failed_drv = A ──
-        // 3. cascade: find Created/Queued builds → [buildB]
-        .append_query_results([vec![build_b]])
-        // 4. cascade: find dep edge for buildB → found
+        // ── collect_transitive_dependents ──
+        // 3. BFS layer 1: dep edges where Dependency=A → [B→A]
         .append_query_results([vec![dep_edge]])
-        // 5. update buildB → DependencyFailed
+        // 4. BFS layer 2: dep edges where Dependency=B → empty
+        .append_query_results([Vec::<MDerivationDependency>::new()])
+        // 5. cascade: find Created/Queued builds with derivation in {B} → [buildB]
+        .append_query_results([vec![build_b]])
+        // 6. update buildB → DependencyFailed
         .append_query_results([vec![build_b_dep_failed]])
-        // ── BFS iteration 2: failed_drv = B (transitive) ──
-        // 6. find Created/Queued builds → empty (B already DependencyFailed)
-        .append_query_results([Vec::<MBuild>::new()])
-        // ── BFS done ──
-        // 7. check_evaluation_done: find active builds → empty
+        // ── check_evaluation_done ──
+        // 7. find active builds → empty
         .append_query_results([Vec::<MBuild>::new()])
         // 8. find_by_id(eval) → Building
         .append_query_results([vec![make_eval(eval_id, EvaluationStatus::Building)]])
@@ -908,28 +907,25 @@ async fn build_failed_cascade_only_direct_dependents() {
     let build_c = make_build(build_c_id, eval_id, drv_c_id, BuildStatus::Queued);
     // B depends on A; C does NOT depend on A
     let dep_edge_b_a = make_dep_edge(Uuid::new_v4(), drv_b_id, drv_a_id);
+    let _ = drv_c_id; // referenced only for documentation
 
     let db = MockDatabase::new(DatabaseBackend::Postgres)
         // 1. find_by_id(buildA)
         .append_query_results([vec![build_a]])
         // 2. update → Failed
         .append_query_results([vec![build_a_failed]])
-        // ── BFS iteration 1: failed_drv = A ──
-        // 3. cascade: find Created/Queued → [buildB, buildC]
-        .append_query_results([vec![build_b, build_c.clone()]])
-        // 4. cascade for buildB: dep edge B→A found
+        // ── collect_transitive_dependents ──
+        // 3. BFS layer 1: dep edges where Dependency=A → [B→A] (C has no edge to A)
         .append_query_results([vec![dep_edge_b_a]])
-        // 5. update buildB → DependencyFailed
+        // 4. BFS layer 2: dep edges where Dependency=B → empty
+        .append_query_results([Vec::<MDerivationDependency>::new()])
+        // 5. cascade: find Created/Queued with derivation in {B} → [buildB]
+        // (C is excluded by the derivation filter, not by a per-row dep check)
+        .append_query_results([vec![build_b]])
+        // 6. update buildB → DependencyFailed
         .append_query_results([vec![build_b_dep_failed]])
-        // 6. cascade for buildC: NO dep edge C→A
-        .append_query_results([Vec::<MDerivationDependency>::new()])
-        // ── BFS iteration 2: failed_drv = B (transitively cascaded) ──
-        // 7. find Created/Queued → [buildC] (B already DependencyFailed)
-        .append_query_results([vec![build_c.clone()]])
-        // 8. does C depend on B? → no
-        .append_query_results([Vec::<MDerivationDependency>::new()])
-        // ── BFS done ──
-        // 9. check active → buildC is still Queued
+        // ── check_evaluation_done ──
+        // 7. check active → buildC is still Queued
         .append_query_results([vec![build_c]])
         // active not empty → check_evaluation_done returns early
         .into_connection();
@@ -1903,16 +1899,16 @@ async fn webhook_not_fired_for_dep_failed() {
         .append_query_results([vec![build_a]])
         // 2. update buildA → Failed
         .append_query_results([vec![build_a_failed.clone()]])
-        // 3. cascade: find Created/Queued → [buildB]
-        .append_query_results([vec![build_b]])
-        // 4. cascade: dep edge for buildB → found
+        // ── collect_transitive_dependents ──
+        // 3. BFS layer 1: dep edges where Dependency=A → [B→A]
         .append_query_results([vec![dep_edge]])
-        // 5. update buildB → DependencyFailed
+        // 4. BFS layer 2: dep edges where Dependency=B → empty
+        .append_query_results([Vec::<MDerivationDependency>::new()])
+        // 5. cascade: find Created/Queued with derivation in {B} → [buildB]
+        .append_query_results([vec![build_b]])
+        // 6. update buildB → DependencyFailed
         .append_query_results([vec![build_b_dep_failed.clone()]])
-        // ── BFS iteration 2: failed_drv = B ──
-        // 6. find Created/Queued → empty (B already DependencyFailed)
-        .append_query_results([Vec::<MBuild>::new()])
-        // ── BFS done ──
+        // ── check_evaluation_done ──
         // 7. check active → empty
         .append_query_results([Vec::<MBuild>::new()])
         // 8. find_by_id(eval) → Building
@@ -2367,61 +2363,50 @@ async fn build_failed_cascades_transitively_through_graph() {
             drv_c,
             BuildStatus::Failed,
         )]])
-        // ── cascade iteration 1: failed_drv = C ──
-        // 3. find Created/Queued builds
+        // ── collect_transitive_dependents ──
+        // 3. BFS layer 1: dep edges where Dependency=C → [B→C]
+        .append_query_results([vec![make_dep_edge(Uuid::new_v4(), drv_b, drv_c)]])
+        // 4. BFS layer 2: dep edges where Dependency=B → [A→B]
+        .append_query_results([vec![make_dep_edge(Uuid::new_v4(), drv_a, drv_b)]])
+        // 5. BFS layer 3: dep edges where Dependency=A → empty
+        .append_query_results([Vec::<MDerivationDependency>::new()])
+        // 6. cascade: find Created/Queued with derivation in {A, B} → [build_a, build_b]
         .append_query_results([vec![
             make_build(build_a, eval_id, drv_a, BuildStatus::Queued),
             make_build(build_b, eval_id, drv_b, BuildStatus::Queued),
         ]])
-        // 4. does A depend on C? → no
-        .append_query_results([Vec::<MDerivationDependency>::new()])
-        // 5. does B depend on C? → yes
-        .append_query_results([vec![make_dep_edge(Uuid::new_v4(), drv_b, drv_c)]])
-        // 6. update B → DependencyFailed
+        // 7. update first cascaded build → DependencyFailed
+        .append_query_results([vec![make_build(
+            build_a,
+            eval_id,
+            drv_a,
+            BuildStatus::DependencyFailed,
+        )]])
+        // 8. update second cascaded build → DependencyFailed
         .append_query_results([vec![make_build(
             build_b,
             eval_id,
             drv_b,
             BuildStatus::DependencyFailed,
         )]])
-        // ── cascade iteration 2: failed_drv = B (transitively cascaded) ──
-        // 7. find Created/Queued builds (A still Queued, B already DependencyFailed)
-        .append_query_results([vec![make_build(
-            build_a,
-            eval_id,
-            drv_a,
-            BuildStatus::Queued,
-        )]])
-        // 8. does A depend on B? → yes
-        .append_query_results([vec![make_dep_edge(Uuid::new_v4(), drv_a, drv_b)]])
-        // 9. update A → DependencyFailed
-        .append_query_results([vec![make_build(
-            build_a,
-            eval_id,
-            drv_a,
-            BuildStatus::DependencyFailed,
-        )]])
-        // ── cascade iteration 3: failed_drv = A ──
-        // 10. find Created/Queued builds → empty (all cascaded)
-        .append_query_results([Vec::<MBuild>::new()])
         // ── check_evaluation_done ──
-        // 11. find active builds → empty
+        // 9. find active builds → empty
         .append_query_results([Vec::<MBuild>::new()])
-        // 12. find eval
+        // 10. find eval
         .append_query_results([vec![make_eval(eval_id, EvaluationStatus::Building)]])
-        // 13. find failed builds → B and A
+        // 11. find failed builds → B and A
         .append_query_results([vec![
             make_build(build_b, eval_id, drv_b, BuildStatus::DependencyFailed),
             make_build(build_a, eval_id, drv_a, BuildStatus::DependencyFailed),
         ]])
-        // 14. find eval error messages → empty
+        // 12. find eval error messages → empty
         .append_query_results([Vec::<MEvaluationMessage>::new()])
-        // 15. update eval → Failed
+        // 13. update eval → Failed
         .append_exec_results([MockExecResult {
             last_insert_id: 0,
             rows_affected: 1,
         }])
-        // 16. find eval → Failed
+        // 14. find eval → Failed
         .append_query_results([vec![make_eval(eval_id, EvaluationStatus::Failed)]])
         .into_connection();
 

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -925,3 +925,24 @@ Unit tests in `backend/core/src/shutdown.rs`:
   signal is reported as a drain timeout, not silently abandoned.
 - `child_token_cascades_from_parent` — child tokens used for
   per-connection / per-job scopes cancel transitively.
+
+## Shared transitive-dependents walk (`#108`)
+
+`backend/core/src/db/dependency_graph.rs` exposes
+`collect_transitive_dependents`, the single canonical reverse-edge BFS over
+the `derivation_dependency` table. Both the cache-invalidation closure
+revocation in `cache::cacher::invalidate::revoke_cache_derivation_closure`
+and the build-failure cascade in
+`scheduler::build::BuildStateHandler::cascade_dependency_failed` now route
+through it instead of carrying their own copy. The cascade also collapses
+to a single batched `derivation IS IN (...)` builds query, replacing the
+prior per-iteration full re-scan + per-build edge probe.
+
+Unit tests in `backend/core/src/db/dependency_graph.rs`:
+
+- `no_dependents_returns_only_start` — a leaf derivation yields a set
+  containing exactly the starting id.
+- `walks_multiple_layers_breadth_first` — a 3-layer graph is fully
+  visited, including a sibling that depends directly on the start.
+- `cycles_terminate` — a pathological reverse cycle is deduped via the
+  visited set so the BFS terminates.


### PR DESCRIPTION
Closes #108.

## Summary
- Hoist the reverse-edge `derivation_dependency` BFS into
  `core::db::dependency_graph::collect_transitive_dependents`. Both
  `cache::cacher::invalidate::revoke_cache_derivation_closure` and
  `scheduler::build::BuildStateHandler::cascade_dependency_failed` now call
  this single helper instead of carrying their own copy.
- Replace the cascade's per-BFS-iteration full builds re-scan + per-build
  edge probe with a single batched `derivation IS IN (...)` query against
  the precomputed dependent set — fewer round-trips and removes the
  N×N quadratic that the old implementation had.
- Add three unit tests for the helper (leaf, multi-layer BFS, cycle
  termination) and refresh the four `scheduler::handler_tests` mock-DB
  sequences whose query order shifted with the new shape.

## Test plan
- [x] `cargo test --tests --workspace` (all crates green)
- [x] new `core::db::dependency_graph::tests` (3 cases) pass
- [x] scheduler cascade tests pass with the rewritten mock-DB query order