### PR TITLE
backend: switch harmonia deps back to nix-community upstream

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -278,7 +278,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -289,7 +289,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -580,7 +580,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.6",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
@@ -1396,6 +1396,7 @@ dependencies = [
  "fiat-crypto",
  "rustc_version",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1658,12 +1659,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
-name = "dyn-clone"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
-
-[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,6 +1678,7 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
+ "pkcs8",
  "signature",
 ]
 
@@ -1704,8 +1700,10 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
+ "serde",
  "sha2 0.10.9",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1801,7 +1799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2299,7 +2297,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap 2.14.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -2308,13 +2306,15 @@ dependencies = [
 
 [[package]]
 name = "harmonia-nar"
-version = "3.0.0"
-source = "git+https://github.com/DerDennisOP/harmonia.git#f723899dc92a2578470ba9d63e6a5eae7ff2b82b"
+version = "3.1.0"
+source = "git+https://github.com/nix-community/harmonia.git#d1fd4bcc8d87bd5740dc3bd861a9bad343eef9a5"
 dependencies = [
  "bstr",
  "bytes",
  "derive_more",
- "futures",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
  "harmonia-utils-io",
  "nix 0.31.2",
  "pin-project-lite",
@@ -2327,14 +2327,15 @@ dependencies = [
 
 [[package]]
 name = "harmonia-protocol"
-version = "3.0.0"
-source = "git+https://github.com/DerDennisOP/harmonia.git#f723899dc92a2578470ba9d63e6a5eae7ff2b82b"
+version = "3.1.0"
+source = "git+https://github.com/nix-community/harmonia.git#d1fd4bcc8d87bd5740dc3bd861a9bad343eef9a5"
 dependencies = [
  "async-stream",
  "bstr",
  "bytes",
  "derive_more",
- "futures",
+ "futures-core",
+ "futures-util",
  "harmonia-nar",
  "harmonia-protocol-derive",
  "harmonia-store-core",
@@ -2345,7 +2346,6 @@ dependencies = [
  "pin-project-lite",
  "serde",
  "serde_json",
- "serde_with",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -2354,8 +2354,8 @@ dependencies = [
 
 [[package]]
 name = "harmonia-protocol-derive"
-version = "3.0.0"
-source = "git+https://github.com/DerDennisOP/harmonia.git#f723899dc92a2578470ba9d63e6a5eae7ff2b82b"
+version = "3.1.0"
+source = "git+https://github.com/nix-community/harmonia.git#d1fd4bcc8d87bd5740dc3bd861a9bad343eef9a5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2365,31 +2365,32 @@ dependencies = [
 [[package]]
 name = "harmonia-store-core"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/DerDennisOP/harmonia.git#f723899dc92a2578470ba9d63e6a5eae7ff2b82b"
+source = "git+https://github.com/nix-community/harmonia.git#d1fd4bcc8d87bd5740dc3bd861a9bad343eef9a5"
 dependencies = [
  "bytes",
  "data-encoding",
  "derive_more",
+ "ed25519-dalek",
+ "getrandom 0.4.2",
  "harmonia-utils-base-encoding",
  "harmonia-utils-hash",
- "num_enum",
- "ring",
  "serde",
  "serde_json",
- "serde_with",
+ "subtle",
  "thiserror 2.0.18",
- "tokio",
  "tracing",
  "zerocopy",
+ "zeroize",
 ]
 
 [[package]]
 name = "harmonia-store-remote"
-version = "3.0.0"
-source = "git+https://github.com/DerDennisOP/harmonia.git#f723899dc92a2578470ba9d63e6a5eae7ff2b82b"
+version = "3.1.0"
+source = "git+https://github.com/nix-community/harmonia.git#d1fd4bcc8d87bd5740dc3bd861a9bad343eef9a5"
 dependencies = [
  "async-stream",
- "futures",
+ "futures-core",
+ "futures-util",
  "harmonia-nar",
  "harmonia-protocol",
  "harmonia-store-core",
@@ -2402,7 +2403,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-base-encoding"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/DerDennisOP/harmonia.git#f723899dc92a2578470ba9d63e6a5eae7ff2b82b"
+source = "git+https://github.com/nix-community/harmonia.git#d1fd4bcc8d87bd5740dc3bd861a9bad343eef9a5"
 dependencies = [
  "data-encoding",
  "derive_more",
@@ -2412,14 +2413,15 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-hash"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/DerDennisOP/harmonia.git#f723899dc92a2578470ba9d63e6a5eae7ff2b82b"
+source = "git+https://github.com/nix-community/harmonia.git#d1fd4bcc8d87bd5740dc3bd861a9bad343eef9a5"
 dependencies = [
  "data-encoding",
  "derive_more",
  "harmonia-utils-base-encoding",
  "md5",
- "ring",
  "serde",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
 ]
@@ -2427,13 +2429,12 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-io"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/DerDennisOP/harmonia.git#f723899dc92a2578470ba9d63e6a5eae7ff2b82b"
+source = "git+https://github.com/nix-community/harmonia.git#d1fd4bcc8d87bd5740dc3bd861a9bad343eef9a5"
 dependencies = [
  "bytes",
- "futures",
+ "futures-util",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -2714,7 +2715,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2866,17 +2867,6 @@ name = "impl-more"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
-]
 
 [[package]]
 name = "indexmap"
@@ -3527,7 +3517,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4475,7 +4465,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4513,7 +4503,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4661,26 +4651,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "ref-cast"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -4884,7 +4854,7 @@ dependencies = [
  "bytecheck 0.8.2",
  "bytes",
  "hashbrown 0.17.0",
- "indexmap 2.14.0",
+ "indexmap",
  "munge",
  "ptr_meta 0.3.1",
  "rancor",
@@ -5000,7 +4970,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5059,7 +5029,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5126,30 +5096,6 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
-]
-
-[[package]]
-name = "schemars"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -5561,37 +5507,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "3.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
-dependencies = [
- "base64",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.14.0",
- "schemars 0.9.0",
- "schemars 1.2.1",
- "serde_core",
- "serde_json",
- "serde_with_macros",
- "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
-dependencies = [
- "darling 0.23.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5600,6 +5515,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -5719,7 +5645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5783,7 +5709,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "memchr",
  "once_cell",
@@ -5875,7 +5801,7 @@ dependencies = [
  "rsa",
  "rust_decimal",
  "serde",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
@@ -6142,7 +6068,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6389,7 +6315,7 @@ version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -6441,7 +6367,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.14.0",
+ "indexmap",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -6594,7 +6520,7 @@ dependencies = [
  "log",
  "native-tls",
  "rand 0.9.4",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
 ]
 
@@ -6929,7 +6855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.14.0",
+ "indexmap",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -6955,7 +6881,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap",
  "semver",
 ]
 
@@ -7078,7 +7004,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7445,7 +7371,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.14.0",
+ "indexmap",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -7476,7 +7402,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -7495,7 +7421,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "semver",
  "serde",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -33,14 +33,13 @@ chrono           = "0.4"
 clap             = "4.6"
 futures              = "0.3"
 tokio-tungstenite    = { version = "0.29", features = ["native-tls"] }
-# { git = "https://github.com/nix-community/harmonia.git", tag = "harmonia-v3.0.0" }
-harmonia-nar           = { git = "https://github.com/DerDennisOP/harmonia.git" }
-harmonia-protocol      = { git = "https://github.com/DerDennisOP/harmonia.git" }
-harmonia-store-core    = { git = "https://github.com/DerDennisOP/harmonia.git" }
-harmonia-store-remote  = { git = "https://github.com/DerDennisOP/harmonia.git" }
-harmonia-utils-base-encoding = { git = "https://github.com/DerDennisOP/harmonia.git" }
-harmonia-utils-hash    = { git = "https://github.com/DerDennisOP/harmonia.git" }
-harmonia-utils-io      = { git = "https://github.com/DerDennisOP/harmonia.git" }
+harmonia-nar           = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-protocol      = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-store-core    = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-store-remote  = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-utils-base-encoding = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-utils-hash    = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-utils-io      = { git = "https://github.com/nix-community/harmonia.git" }
 git2             = "0.20"
 libc             = "0.2"
 hex              = "0.4"
@@ -80,10 +79,10 @@ tracing-subscriber = { workspace = true }
 web              = { workspace = true }
 
 [patch.crates-io]
-harmonia-nar             = { git = "https://github.com/DerDennisOP/harmonia.git" }
-harmonia-protocol        = { git = "https://github.com/DerDennisOP/harmonia.git" }
-harmonia-protocol-derive = { git = "https://github.com/DerDennisOP/harmonia.git" }
-harmonia-store-core      = { git = "https://github.com/DerDennisOP/harmonia.git" }
-harmonia-utils-base-encoding = { git = "https://github.com/DerDennisOP/harmonia.git" }
-harmonia-utils-hash      = { git = "https://github.com/DerDennisOP/harmonia.git" }
-harmonia-utils-io        = { git = "https://github.com/DerDennisOP/harmonia.git" }
+harmonia-nar             = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-protocol        = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-protocol-derive = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-store-core      = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-utils-base-encoding = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-utils-hash      = { git = "https://github.com/nix-community/harmonia.git" }
+harmonia-utils-io        = { git = "https://github.com/nix-community/harmonia.git" }


### PR DESCRIPTION
## Summary
- Point all `harmonia-*` git deps (and `[patch.crates-io]` entries) at `nix-community/harmonia` instead of the `DerDennisOP/harmonia` fork.
- Lockfile bumps the harmonia crates from the fork's `f723899d` to upstream `d1fd4bcc` (v3.1.0).

The fork existed because required patches weren't yet upstream; those changes are now in `nix-community/harmonia`, so the fork is no longer needed.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --tests --workspace` (all suites pass)