### PR TITLE
nix: add caddy as a second reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,14 @@ Configure Gradient in your `configuration.nix`:
 ```nix
 {
   services.gradient = {
-    enable            = true;
-    frontend.enable   = true;
-    domain            = "gradient.example.com";
-    jwtSecretFile     = "/run/secrets/gradient-jwt"; # openssl rand -base64 48 > /run/secrets/gradient-jwt
-    cryptSecretFile   = "/run/secrets/gradient-crypt"; # openssl rand -base64 48 > /run/secrets/gradient-crypt
-    configurePostgres = true;
-    configureNginx    = true;
-    reportErrors      = true; # optional: will send crash reports to us
+    enable                    = true;
+    frontend.enable           = true;
+    domain                    = "gradient.example.com";
+    jwtSecretFile             = "/run/secrets/gradient-jwt"; # openssl rand -base64 48 > /run/secrets/gradient-jwt
+    cryptSecretFile           = "/run/secrets/gradient-crypt"; # openssl rand -base64 48 > /run/secrets/gradient-crypt
+    configurePostgres         = true;
+    reverseProxy.nginx.enable = true; # you can also use caddy with: reverseProxy.caddy.enable = true
+    reportErrors              = true; # optional: will send crash reports to us
   };
 
   services.gradient.worker = {

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -9,14 +9,14 @@ services.gradient = {
   enable            = true;
   frontend.enable   = true;
   configurePostgres = true;
-  configureNginx    = true;
+  reverseProxy.nginx.enable = true;
   domain            = "gradient.example.com";
   jwtSecretFile     = "/run/secrets/gradient-jwt";
   cryptSecretFile   = "/run/secrets/gradient-crypt";
 };
 ```
 
-`configurePostgres` creates a local PostgreSQL database and user. `configureNginx` adds a virtual host that proxies `/api/`, `/proto`, and `/cache/` to the backend and serves the frontend SPA.
+`configurePostgres` creates a local PostgreSQL database and user. `reverseProxy` adds a virtual host that proxies `/api/`, `/proto`, and `/cache/` to the backend and serves the frontend SPA (either with `nginx` or `caddy` as a reverse proxy)
 
 ## Secrets
 
@@ -55,6 +55,40 @@ openssl rand -base64 48 > /run/secrets/gradient-crypt
 | `settings.enableRegistration` | `true` | Allow new user self-registration |
 | `settings.deleteState` | `true` | Remove entities no longer in `state` (see below) |
 | `settings.cacheTtlHours` | `336` | TTL in hours for cached NARs not fetched recently (0 = disabled) |
+
+## Reverse Proxies
+
+The Gradient server does not come with a built-in http server for the frontend. 
+Therefore a reverse proxy / webserver is needed for hosting.
+The nixos module provides two preconfigured reverse proxies:
+- `nginx`
+- `caddy`
+
+### Nginx
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `reverseProxy.nginx.enable` | `false` | Whether to enable nginx as the reverse proxy |
+
+### Caddy
+
+!!! note
+    To match the upstream `services.caddy` configuration you have to manage the ACME host certificate yourself.
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `reverseProxy.caddy.enable` | `false` | Whether to enable caddy as the reverse proxy |
+| `reverseProxy.caddy.useACMEHost` | `null` | Passed directly to [`services.caddy.virtualHosts.<name>.useACMEHost`](https://search.nixos.org/options?channel=unstable&query=services.caddy.virtualHosts.&show=option:services.caddy.virtualHosts.%3Cname%3E.useACMEHost) |
+| `reversePorxy.caddy.extraConfig` | `""` | Caddy config options written to [`services.caddy.virtualHosts.<name>.extraConfig`](https://search.nixos.org/options?channel=unstable&query=services.caddy.virtualHosts.&show=option:services.caddy.virtualHosts.%3Cname%3E.extraConfig) after the reverse proxy setup |
+
+### Custom Reverse Proxy
+
+If you want to use your own reverse proxy you have to setup redirects as follows:
+- `https://example.com/api` _(with all subpaths)_ -> `http://${ADDR}:${PORT}/api`
+- `https://example.com/proto` -> `http://${ADDR}:${PORT}/proto` _(must support websockets)_
+- `https://example.com/cache` _(with all subpaths)_ -> `http://${ADDR}:${PORT}/cache`
+All other requests should be handled by a static webserver hosting the files at:
+- `${pkgs.gradient-frontend}/share/gradient-frontend`
 
 ## OIDC
 

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -52,8 +52,8 @@ In your `configuration.nix`:
     jwtSecretFile   = "/var/lib/gradient/jwt-secret";   # random alphanumeric RS256 secret
 
     # Convenience options
-    configurePostgres = true;
-    configureNginx    = true;
+    configurePostgres         = true;
+    reverseProxy.nginx.enable = true;
   };
 }
 ```

--- a/docs/src/quick-start.md
+++ b/docs/src/quick-start.md
@@ -51,14 +51,14 @@ echo "*:$(cat /run/secrets/gradient-worker-token)" > /run/secrets/gradient-worke
 ```nix
 {
   services.gradient = {
-    enable            = true;
-    frontend.enable   = true;
-    domain            = "gradient.example.com";
-    jwtSecretFile     = "/run/secrets/gradient-jwt";
-    cryptSecretFile   = "/run/secrets/gradient-crypt";
-    configurePostgres = true;
-    configureNginx    = true;
-    reportErrors      = true; # optional: will send crash reports to us
+    enable                    = true;
+    frontend.enable           = true;
+    domain                    = "gradient.example.com";
+    jwtSecretFile             = "/run/secrets/gradient-jwt";
+    cryptSecretFile           = "/run/secrets/gradient-crypt";
+    configurePostgres         = true;
+    reverseProxy.nginx.enable = true;
+    reportErrors              = true; # optional: will send crash reports to us
   };
 
   services.gradient.worker = {

--- a/nix/modules/gradient-worker.nix
+++ b/nix/modules/gradient-worker.nix
@@ -34,11 +34,35 @@ in {
       };
     };
 
-    configureNginx = lib.mkEnableOption "Nginx reverse proxy for the worker listener";
+    reverseProxy = {
+      nginx.enable = lib.mkEnableOption "Nginx reverse proxy for the worker listener";
+      caddy = {
+        enable = lib.mkEnableOption "Caddy reverse proxy for the worker listener";
+        useACMEHost = lib.mkOption {
+          description = ''
+            A host of an existing Let’s Encrypt certificate to use.
+
+            This options is directly passed to `services.caddy.virtualHosts.<name>.useACMEHost`
+            and therefore does not create an ACME certificate.
+          '';
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+        };
+        extraConfig = lib.mkOption {
+          description = ''
+            Additional lines of configuration passed to
+            `services.caddy.virtualHosts.<name>.extraConfig` 
+            after the reverse proxy setup.
+          '';
+          type = lib.types.lines;
+          default = "";
+        };
+      };
+    };
     useTls = lib.mkEnableOption "TLS" // { default = true; };
     discoverable = lib.mkEnableOption "accept incoming connections on /proto";
     domain = lib.mkOption {
-      description = "Domain under which the worker's nginx vhost is served. Only used when configureNginx is enabled";
+      description = "Domain under which the worker's nginx vhost is served. Only used when a reverseProxy is enabled";
       type = lib.types.str;
       default = "";
       example = "worker.example.com";
@@ -213,10 +237,16 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    assertions = [{
-      assertion = cfg.capabilities.federate -> cfg.discoverable;
-      message = "services.gradient.worker: capabilities.federate requires discoverable to be enabled";
-    }];
+    assertions = [
+      {
+        assertion = cfg.capabilities.federate -> cfg.discoverable;
+        message = "services.gradient.worker: capabilities.federate requires discoverable to be enabled";
+      }
+      {
+        assertion = !(cfg.reverseProxy.nginx.enable && cfg.reverseProxy.caddy.enable);
+        message = "You can only use one reverse proxy at a time";
+      }
+    ];
 
     systemd = {
       tmpfiles.settings."10-gradient"."/nix/var/nix/gcroots/gradient".d = {
@@ -314,18 +344,29 @@ in {
       ];
     };
 
-    services.nginx = lib.mkIf cfg.configureNginx {
-      enable = true;
-      virtualHosts."${cfg.domain}" = {
-        enableACME = cfg.useTls;
-        forceSSL = cfg.useTls;
-        locations."/proto" = {
-          proxyPass = "http://${cfg.listenAddr}:${toString cfg.port}";
-          proxyWebsockets = true;
+    services = {
+      nginx = lib.mkIf cfg.reverseProxy.nginx.enable {
+        enable = true;
+        virtualHosts."${cfg.domain}" = {
+          enableACME = cfg.useTls;
+          forceSSL = cfg.useTls;
+          locations."/proto" = {
+            proxyPass = "http://${cfg.listenAddr}:${toString cfg.port}";
+            proxyWebsockets = true;
+            extraConfig = ''
+              proxy_connect_timeout 90d;
+              proxy_send_timeout 90d;
+              proxy_read_timeout 90d;
+            '';
+          };
+        };
+      };
+      caddy = lib.mkIf cfg.reverseProxy.caddy.enable {
+        enable = true;
+        virtualHosts."${if cfg.useTls then "" else "http://"}${cfg.domain}" = {
+          useACMEHost = cfg.reverseProxy.caddy.useACMEHost;
           extraConfig = ''
-            proxy_connect_timeout 90d;
-            proxy_send_timeout 90d;
-            proxy_read_timeout 90d;
+            reverse_proxy http://${cfg.listenAddr}:${toString cfg.port}
           '';
         };
       };

--- a/nix/modules/gradient.nix
+++ b/nix/modules/gradient.nix
@@ -48,7 +48,32 @@ in {
   options = {
     services.gradient = {
       enable = lib.mkEnableOption "Gradient";
-      configureNginx = lib.mkEnableOption "Nginx configuration";
+      reverseProxy = {
+        nginx.enable = lib.mkEnableOption "nginx configuration";
+        caddy = {
+          enable = lib.mkEnableOption "caddy configuration";
+          useACMEHost = lib.mkOption {
+            description = ''
+              A host of an existing Let’s Encrypt certificate to use.
+
+              This options is directly passed to `services.caddy.virtualHosts.<name>.useACMEHost`
+              and therefore does not create an ACME certificate.
+            '';
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+          };
+          extraConfig = lib.mkOption {
+            description = ''
+              Additional lines of configuration passed to
+              `services.caddy.virtualHosts.<name>.extraConfig` 
+              after the reverse proxy setup.
+            '';
+            type = lib.types.lines;
+            default = "";
+          };
+        };
+      };
+      configureCaddy = lib.mkEnableOption "Caddy configuration";
       configurePostgres = lib.mkEnableOption "PostgreSQL configuration";
       reportErrors = lib.mkEnableOption "error reporting to Sentry";
       useTls = lib.mkEnableOption "TLS" // { default = true; };
@@ -323,6 +348,10 @@ in {
         assertion = cfg.proto.federate -> cfg.discoverable;
         message = "proto.federate requires discoverable to be enabled";
       }
+      {
+        assertion = !(cfg.reverseProxy.nginx && cfg.reverseProxy.caddy);
+        message = "You can only use one reverse proxy at a time";
+      }
     ];
 
     systemd.services.gradient-server = {
@@ -443,7 +472,7 @@ in {
     };
 
     services = {
-      nginx = lib.mkIf cfg.configureNginx {
+      nginx = lib.mkIf cfg.reverseProxy.nginx.enable {
         enable = true;
         virtualHosts."${cfg.domain}" = {
           enableACME = cfg.useTls;
@@ -457,12 +486,12 @@ in {
             };
 
             "/api/" = {
-              proxyPass = "http://127.0.0.1:${toString config.services.gradient.port}";
+              proxyPass = "http://${config.services.gradient.listenAddr}:${toString config.services.gradient.port}";
               proxyWebsockets = true;
             };
 
             "/proto" = lib.mkIf (cfg.discoverable && cfg.proto.public) {
-              proxyPass = "http://127.0.0.1:${toString config.services.gradient.port}";
+              proxyPass = "http://${config.services.gradient.listenAddr}:${toString config.services.gradient.port}";
               proxyWebsockets = true;
               extraConfig = ''
                 proxy_connect_timeout 90d;
@@ -472,10 +501,35 @@ in {
             };
 
             "/cache/" = {
-              proxyPass = "http://127.0.0.1:${toString config.services.gradient.port}";
+              proxyPass = "http://${config.services.gradient.listenAddr}:${toString config.services.gradient.port}";
               proxyWebsockets = true;
             };
           };
+        };
+      };
+
+      caddy = lib.mkIf cfg.reverseProxy.caddy.enable {
+        enable = true;
+        virtualHosts."${if cfg.useTls then "" else "http://"}${cfg.domain}" = {
+          useACMEHost = cfg.reverseProxy.caddy.useACMEHost;
+          extraConfig = ''
+            @backend {
+              path_regexp api ^/(api|proto|cache)(/.*)?$
+            }
+            reverse_proxy @backend http://${cfg.listenAddr}:${toString cfg.port}
+
+            ${
+              if cfg.frontend.enable then
+                ''
+                  root ${cfg.frontend.package}/share/gradient-frontend
+                  file_server
+                ''
+              else
+                ""
+            }
+
+            ${cfg.reverseProxy.caddy.extraConfig}
+          '';
         };
       };
 

--- a/nix/tests/gradient/api/default.nix
+++ b/nix/tests/gradient/api/default.nix
@@ -15,7 +15,7 @@
         services = {
           gradient = {
             enable = true;
-            configureNginx = true;
+            reverseProxy.nginx.enable = true;
             configurePostgres = true;
             domain = "gradient.local";
             jwtSecretFile = toString (pkgs.writeText "jwtSecret" "b68a8eaa8ebcff23ebaba1bd74ecb8a2eb7ba959570ff8842f148207524c7b8d731d7a1998584105e951599221f9dcd20e41223be17275ca70ab6f7e6ecafa8d4f8905623866edb2b344bd15de52ccece395b3546e2f00644eb2679cf7bdaa156fd75cc5f47c34448cba19d903e68015b1ad3c8e9d04862de0a2c525b6676779012919fa9551c4746f9323ab207aedae86c28ada67c901cae821eef97b69ca4ebe1260de31add34d8265f17d9c547e3bbabe284d9cadcc22063ee625b104592403368090642a41967f8ada5791cb09703d0762a3175d0fe06ec37822e9e41d0a623a6349901749673735fdb94f2c268ac08a24216efb058feced6e785f34185a");

--- a/nix/tests/gradient/building/default.nix
+++ b/nix/tests/gradient/building/default.nix
@@ -34,7 +34,7 @@
         services = {
           gradient = {
             enable = true;
-            configureNginx = true;
+            reverseProxy.nginx.enable = true;
             configurePostgres = true;
             domain = "gradient.local";
             jwtSecretFile = toString (pkgs.writeText "jwtSecret" "b68a8eaa8ebcff23ebaba1bd74ecb8a2eb7ba959570ff8842f148207524c7b8d731d7a1998584105e951599221f9dcd20e41223be17275ca70ab6f7e6ecafa8d4f8905623866edb2b344bd15de52ccece395b3546e2f00644eb2679cf7bdaa156fd75cc5f47c34448cba19d903e68015b1ad3c8e9d04862de0a2c525b6676779012919fa9551c4746f9323ab207aedae86c28ada67c901cae821eef97b69ca4ebe1260de31add34d8265f17d9c547e3bbabe284d9cadcc22063ee625b104592403368090642a41967f8ada5791cb09703d0762a3175d0fe06ec37822e9e41d0a623a6349901749673735fdb94f2c268ac08a24216efb058feced6e785f34185a");

--- a/nix/tests/gradient/cache/default.nix
+++ b/nix/tests/gradient/cache/default.nix
@@ -98,7 +98,7 @@ in {
         services = {
           gradient = {
             enable = true;
-            configureNginx = true;
+            reverseProxy.nginx.enable = true;
             configurePostgres = true;
             domain = "gradient.local";
             proto.public = true;

--- a/nix/tests/gradient/frontend/default.nix
+++ b/nix/tests/gradient/frontend/default.nix
@@ -50,7 +50,7 @@
           gradient = {
             enable = true;
             frontend.enable = true;
-            configureNginx = true;
+            reverseProxy.nginx.enable = true;
             configurePostgres = true;
             domain = "gradient.local";
             jwtSecretFile = toString (pkgs.writeText "jwtSecret" "b68a8eaa8ebcff23ebaba1bd74ecb8a2eb7ba959570ff8842f148207524c7b8d731d7a1998584105e951599221f9dcd20e41223be17275ca70ab6f7e6ecafa8d4f8905623866edb2b344bd15de52ccece395b3546e2f00644eb2679cf7bdaa156fd75cc5f47c34448cba19d903e68015b1ad3c8e9d04862de0a2c525b6676779012919fa9551c4746f9323ab207aedae86c28ada67c901cae821eef97b69ca4ebe1260de31add34d8265f17d9c547e3bbabe284d9cadcc22063ee625b104592403368090642a41967f8ada5791cb09703d0762a3175d0fe06ec37822e9e41d0a623a6349901749673735fdb94f2c268ac08a24216efb058feced6e785f34185a");

--- a/nix/tests/gradient/mail/default.nix
+++ b/nix/tests/gradient/mail/default.nix
@@ -31,7 +31,7 @@
           mailhog.enable = true;
           gradient = {
             enable = true;
-            configureNginx = true;
+            reverseProxy.nginx.enable = true;
             configurePostgres = true;
             domain = "gradient.local";
             jwtSecretFile = toString (pkgs.writeText "jwtSecret" "b68a8eaa8ebcff23ebaba1bd74ecb8a2eb7ba959570ff8842f148207524c7b8d731d7a1998584105e951599221f9dcd20e41223be17275ca70ab6f7e6ecafa8d4f8905623866edb2b344bd15de52ccece395b3546e2f00644eb2679cf7bdaa156fd75cc5f47c34448cba19d903e68015b1ad3c8e9d04862de0a2c525b6676779012919fa9551c4746f9323ab207aedae86c28ada67c901cae821eef97b69ca4ebe1260de31add34d8265f17d9c547e3bbabe284d9cadcc22063ee625b104592403368090642a41967f8ada5791cb09703d0762a3175d0fe06ec37822e9e41d0a623a6349901749673735fdb94f2c268ac08a24216efb058feced6e785f34185a");

--- a/nix/tests/gradient/oidc/default.nix
+++ b/nix/tests/gradient/oidc/default.nix
@@ -30,7 +30,7 @@
         services = {
           gradient = {
             enable = true;
-            configureNginx = true;
+            reverseProxy.nginx.enable = true;
             configurePostgres = true;
             domain = "gradient.local";
             jwtSecretFile = toString (pkgs.writeText "jwtSecret" "b68a8eaa8ebcff23ebaba1bd74ecb8a2eb7ba959570ff8842f148207524c7b8d731d7a1998584105e951599221f9dcd20e41223be17275ca70ab6f7e6ecafa8d4f8905623866edb2b344bd15de52ccece395b3546e2f00644eb2679cf7bdaa156fd75cc5f47c34448cba19d903e68015b1ad3c8e9d04862de0a2c525b6676779012919fa9551c4746f9323ab207aedae86c28ada67c901cae821eef97b69ca4ebe1260de31add34d8265f17d9c547e3bbabe284d9cadcc22063ee625b104592403368090642a41967f8ada5791cb09703d0762a3175d0fe06ec37822e9e41d0a623a6349901749673735fdb94f2c268ac08a24216efb058feced6e785f34185a");

--- a/nix/tests/gradient/remote/default.nix
+++ b/nix/tests/gradient/remote/default.nix
@@ -33,7 +33,7 @@
         services = {
           gradient = {
             enable = true;
-            configureNginx = true;
+            reverseProxy.nginx.enable = true;
             configurePostgres = true;
             domain = "gradient.local";
             jwtSecretFile = toString (pkgs.writeText "jwtSecret" "b68a8eaa8ebcff23ebaba1bd74ecb8a2eb7ba959570ff8842f148207524c7b8d731d7a1998584105e951599221f9dcd20e41223be17275ca70ab6f7e6ecafa8d4f8905623866edb2b344bd15de52ccece395b3546e2f00644eb2679cf7bdaa156fd75cc5f47c34448cba19d903e68015b1ad3c8e9d04862de0a2c525b6676779012919fa9551c4746f9323ab207aedae86c28ada67c901cae821eef97b69ca4ebe1260de31add34d8265f17d9c547e3bbabe284d9cadcc22063ee625b104592403368090642a41967f8ada5791cb09703d0762a3175d0fe06ec37822e9e41d0a623a6349901749673735fdb94f2c268ac08a24216efb058feced6e785f34185a");

--- a/nix/tests/gradient/state/default.nix
+++ b/nix/tests/gradient/state/default.nix
@@ -71,7 +71,7 @@
         services = {
           gradient = {
             enable = true;
-            configureNginx = true;
+            reverseProxy.nginx.enable = true;
             configurePostgres = true;
             domain = "gradient.local";
             jwtSecretFile = toString (pkgs.writeText "jwtSecret" "b68a8eaa8ebcff23ebaba1bd74ecb8a2eb7ba959570ff8842f148207524c7b8d731d7a1998584105e951599221f9dcd20e41223be17275ca70ab6f7e6ecafa8d4f8905623866edb2b344bd15de52ccece395b3546e2f00644eb2679cf7bdaa156fd75cc5f47c34448cba19d903e68015b1ad3c8e9d04862de0a2c525b6676779012919fa9551c4746f9323ab207aedae86c28ada67c901cae821eef97b69ca4ebe1260de31add34d8265f17d9c547e3bbabe284d9cadcc22063ee625b104592403368090642a41967f8ada5791cb09703d0762a3175d0fe06ec37822e9e41d0a623a6349901749673735fdb94f2c268ac08a24216efb058feced6e785f34185a");

--- a/nix/vms/frontend/default.nix
+++ b/nix/vms/frontend/default.nix
@@ -110,7 +110,7 @@
     services = {
       gradient = {
         enable = true;
-        configureNginx = true;
+        reverseProxy.nginx.enable = true;
         configurePostgres = true;
         domain = "gradient.local";
         jwtSecretFile = toString (pkgs.writeText "jwtSecret" "b68a8eaa8ebcff23ebaba1bd74ecb8a2eb7ba959570ff8842f148207524c7b8d731d7a1998584105e951599221f9dcd20e41223be17275ca70ab6f7e6ecafa8d4f8905623866edb2b344bd15de52ccece395b3546e2f00644eb2679cf7bdaa156fd75cc5f47c34448cba19d903e68015b1ad3c8e9d04862de0a2c525b6676779012919fa9551c4746f9323ab207aedae86c28ada67c901cae821eef97b69ca4ebe1260de31add34d8265f17d9c547e3bbabe284d9cadcc22063ee625b104592403368090642a41967f8ada5791cb09703d0762a3175d0fe06ec37822e9e41d0a623a6349901749673735fdb94f2c268ac08a24216efb058feced6e785f34185a");


### PR DESCRIPTION
This PR adds caddy as a reverse proxy option.

To support more reverse proxies in the future this PR changes the `configureNginx` API with a `reverseProxy` api which contains an `enable` option for each reverse proxy and more reverse proxy specific options (e.g. caddy needs a `useACMEHost` option to provide the Let's encrypt host to use).
