### PR TITLE
backend: dedupe concurrent same-derivation builds via `via` link

### DIFF
--- a/backend/core/src/ci/trigger.rs
+++ b/backend/core/src/ci/trigger.rs
@@ -191,6 +191,7 @@ pub async fn trigger_restart_builds<C: ConnectionTrait>(
             log_id: Set(None),
             build_time_ms: Set(None),
             worker: Set(None),
+            via: Set(None),
             created_at: Set(now),
             updated_at: Set(now),
         };

--- a/backend/core/src/db/connection.rs
+++ b/backend/core/src/db/connection.rs
@@ -86,6 +86,7 @@ async fn update_db(db: &DatabaseConnection) -> Result<(), DbErr> {
     for build in builds {
         let mut abuild: ABuild = build.into();
         abuild.status = Set(BuildStatus::Aborted);
+        abuild.via = Set(None);
         abuild.update(db).await?;
     }
 

--- a/backend/core/src/db/status.rs
+++ b/backend/core/src/db/status.rs
@@ -286,8 +286,93 @@ pub async fn abort_evaluation(state: Arc<ServerState>, evaluation: MEvaluation) 
     };
 
     for build in builds {
+        if build.via.is_some() {
+            // Follower: aborting it does not interrupt the leader's work in
+            // another evaluation. Clear `via` so the eventual leader-completion
+            // sweep skips it, then mark Aborted.
+            abort_follower(&state, build).await;
+            continue;
+        }
+
+        // Leader (or plain build).
+        let has_followers = match EBuild::find()
+            .filter(CBuild::Via.eq(build.id))
+            .one(&state.worker_db)
+            .await
+        {
+            Ok(opt) => opt.is_some(),
+            Err(e) => {
+                error!(error = %e, build_id = %build.id, "Failed to query followers for abort");
+                false
+            }
+        };
+
+        if has_followers && build.status == BuildStatus::Building {
+            // Already running on a worker — let it finish so followers in
+            // other (non-aborted) evaluations get the result.
+            continue;
+        }
+
+        if has_followers && matches!(build.status, BuildStatus::Queued | BuildStatus::Created) {
+            // Hand off leadership before aborting.
+            if let Err(e) = reelect_leader(&state, &build).await {
+                error!(error = %e, build_id = %build.id, "Failed to re-elect leader on abort");
+            }
+        }
+
         update_build_status(Arc::clone(&state), build, BuildStatus::Aborted).await;
     }
 
     update_evaluation_status(state, evaluation, EvaluationStatus::Aborted).await;
+}
+
+async fn abort_follower(state: &Arc<ServerState>, build: MBuild) {
+    let mut active: ABuild = build.clone().into_active_model();
+    active.via = Set(None);
+    if let Err(e) = active.update(&state.worker_db).await {
+        error!(error = %e, build_id = %build.id, "Failed to clear via on follower abort");
+        return;
+    }
+    let reloaded = match EBuild::find_by_id(build.id).one(&state.worker_db).await {
+        Ok(Some(b)) => b,
+        Ok(None) => return,
+        Err(e) => {
+            error!(error = %e, build_id = %build.id, "Failed to reload follower for abort");
+            return;
+        }
+    };
+    update_build_status(Arc::clone(state), reloaded, BuildStatus::Aborted).await;
+}
+
+/// Promote one follower of `leader` to be the new leader, then re-point any
+/// remaining followers at the new leader's id. Picks the oldest follower by
+/// `created_at` for stability. No-op if no followers exist.
+async fn reelect_leader(state: &Arc<ServerState>, leader: &MBuild) -> Result<(), sea_orm::DbErr> {
+    use sea_orm::QueryOrder;
+
+    let new_leader = EBuild::find()
+        .filter(CBuild::Via.eq(leader.id))
+        .order_by_asc(CBuild::CreatedAt)
+        .one(&state.worker_db)
+        .await?;
+    let Some(new_leader) = new_leader else {
+        return Ok(());
+    };
+
+    let mut active: ABuild = new_leader.clone().into_active_model();
+    active.via = Set(None);
+    active.update(&state.worker_db).await?;
+
+    EBuild::update_many()
+        .col_expr(CBuild::Via, sea_orm::sea_query::Expr::value(new_leader.id))
+        .filter(CBuild::Via.eq(leader.id))
+        .exec(&state.worker_db)
+        .await?;
+
+    debug!(
+        old_leader = %leader.id,
+        new_leader = %new_leader.id,
+        "re-elected build leader"
+    );
+    Ok(())
 }

--- a/backend/entity/src/build.rs
+++ b/backend/entity/src/build.rs
@@ -72,6 +72,13 @@ pub struct Model {
     /// executed this build. `None` for builds that never reached a worker
     /// (still queued, aborted before dispatch, or pre-migration rows).
     pub worker: Option<String>,
+    /// Points at another build sharing the same derivation whose result this
+    /// build follows. `None` for leaders (and plain builds). Followers are
+    /// skipped by the dispatcher; the leader's terminal status, log_id,
+    /// build_time_ms, and worker are copied to followers when the leader
+    /// finishes. Same-organization only — followers always share a `derivation`
+    /// row with their leader.
+    pub via: Option<Uuid>,
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
 }

--- a/backend/migration/src/lib.rs
+++ b/backend/migration/src/lib.rs
@@ -80,6 +80,7 @@ mod m20260502_000000_hash_api_keys;
 mod m20260502_000001_drop_file_columns_from_derivation_output;
 mod m20260502_000002_add_oidc_identity_to_user;
 mod m20260504_000000_cached_path_signature_to_bytea;
+mod m20260504_000001_add_via_to_build;
 
 pub struct Migrator;
 
@@ -161,6 +162,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260502_000001_drop_file_columns_from_derivation_output::Migration),
             Box::new(m20260502_000002_add_oidc_identity_to_user::Migration),
             Box::new(m20260504_000000_cached_path_signature_to_bytea::Migration),
+            Box::new(m20260504_000001_add_via_to_build::Migration),
         ]
     }
 }

--- a/backend/migration/src/m20260504_000001_add_via_to_build.rs
+++ b/backend/migration/src/m20260504_000001_add_via_to_build.rs
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Build::Table)
+                    .add_column(ColumnDef::new(Build::Via).uuid().null())
+                    .add_foreign_key(
+                        &TableForeignKey::new()
+                            .name("fk-build-via")
+                            .from_tbl(Build::Table)
+                            .from_col(Build::Via)
+                            .to_tbl(Build::Table)
+                            .to_col(Build::Id)
+                            .on_delete(ForeignKeyAction::SetNull)
+                            .to_owned(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx-build-via")
+                    .table(Build::Table)
+                    .col(Build::Via)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(Index::drop().name("idx-build-via").table(Build::Table).to_owned())
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Build::Table)
+                    .drop_foreign_key(Alias::new("fk-build-via"))
+                    .drop_column(Build::Via)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum Build {
+    Table,
+    Id,
+    Via,
+}

--- a/backend/scheduler/src/build.rs
+++ b/backend/scheduler/src/build.rs
@@ -113,7 +113,9 @@ impl<'a> BuildStateHandler<'a> {
             }
         };
         let evaluation_id = build.evaluation;
-        update_build_status(Arc::clone(self.state), build, BuildStatus::Completed).await;
+        let leader =
+            update_build_status(Arc::clone(self.state), build, BuildStatus::Completed).await;
+        self.propagate_to_followers(&leader).await?;
         self.check_evaluation_done(evaluation_id).await
     }
 
@@ -127,10 +129,76 @@ impl<'a> BuildStateHandler<'a> {
         };
         let evaluation_id = build.evaluation;
         let derivation_id = build.derivation;
-        update_build_status(Arc::clone(self.state), build, BuildStatus::Failed).await;
+        let leader = update_build_status(Arc::clone(self.state), build, BuildStatus::Failed).await;
+        self.propagate_to_followers(&leader).await?;
         self.cascade_dependency_failed(evaluation_id, derivation_id)
             .await?;
         self.check_evaluation_done(evaluation_id).await
+    }
+
+    /// Copy a leader's terminal status (and `log_id`, `build_time_ms`,
+    /// `worker`) onto every build with `via = leader.id`, then run the
+    /// per-evaluation finalisation each follower needs (`DependencyFailed`
+    /// cascade on failure, `check_evaluation_done` to flip the eval).
+    ///
+    /// Followers always share a `derivation` row with their leader, so
+    /// `derivation_output` and `build_product` rows are already visible to
+    /// the follower's evaluation without any copy.
+    ///
+    /// `Aborted` is not propagated — when a leader is aborted (its eval was
+    /// cancelled), callers re-elect a new leader from the followers instead.
+    async fn propagate_to_followers(&self, leader: &MBuild) -> Result<()> {
+        let propagate = matches!(
+            leader.status,
+            BuildStatus::Completed
+                | BuildStatus::Substituted
+                | BuildStatus::Failed
+                | BuildStatus::DependencyFailed
+        );
+        if !propagate {
+            return Ok(());
+        }
+
+        let followers = EBuild::find()
+            .filter(CBuild::Via.eq(leader.id))
+            .all(&self.state.worker_db)
+            .await
+            .context("fetch followers")?;
+        if followers.is_empty() {
+            return Ok(());
+        }
+
+        for follower in followers {
+            let evaluation_id = follower.evaluation;
+            let derivation_id = follower.derivation;
+            let mut active: ABuild = follower.clone().into_active_model();
+            active.log_id = Set(leader.log_id);
+            active.build_time_ms = Set(leader.build_time_ms);
+            active.worker = Set(leader.worker.clone());
+            active.via = Set(None);
+            if let Err(e) = active.update(&self.state.worker_db).await {
+                error!(error = %e, follower_id = %follower.id, "failed to copy leader fields to follower");
+                continue;
+            }
+
+            let Some(reloaded) =
+                EBuild::find_by_id(follower.id).one(&self.state.worker_db).await?
+            else {
+                continue;
+            };
+            update_build_status(Arc::clone(self.state), reloaded, leader.status.clone()).await;
+
+            if matches!(
+                leader.status,
+                BuildStatus::Failed | BuildStatus::DependencyFailed
+            ) {
+                self.cascade_dependency_failed(evaluation_id, derivation_id)
+                    .await?;
+            }
+            self.check_evaluation_done(evaluation_id).await?;
+        }
+
+        Ok(())
     }
 
     async fn cascade_dependency_failed(

--- a/backend/scheduler/src/dispatch.rs
+++ b/backend/scheduler/src/dispatch.rs
@@ -595,6 +595,7 @@ pub(crate) async fn dispatch_ready_builds(scheduler: &Scheduler) -> anyhow::Resu
             LEFT JOIN public.derivation_dependency dd
                 ON dd.derivation = b.derivation
             WHERE b.status = {queued}
+            AND b.via IS NULL
             AND NOT EXISTS (
                 SELECT 1
                 FROM public.derivation_dependency dep_edge

--- a/backend/scheduler/src/dispatch_tests.rs
+++ b/backend/scheduler/src/dispatch_tests.rs
@@ -109,6 +109,7 @@ fn make_build_queued(id: Uuid, eval_id: Uuid, drv_id: Uuid) -> MBuild {
         log_id: None,
         build_time_ms: None,
         worker: None,
+        via: None,
         created_at: test_date(),
         updated_at: test_date(),
     }
@@ -357,4 +358,29 @@ async fn project_poll_with_no_projects_is_noop() {
     let scheduler = make_scheduler(db);
     let result = dispatch::poll_projects_for_evaluations(&scheduler).await;
     assert!(result.is_ok(), "poll with no projects should succeed");
+}
+
+// ── Group K: via / follower behaviour ────────────────────────────────────────
+
+/// A follower build (`via IS NOT NULL`) is filtered out by the SQL gate, so
+/// the dispatcher never sees it. Issue #175.
+#[tokio::test]
+async fn dispatch_skips_follower_builds() {
+    // The ready-builds SQL has `AND b.via IS NULL`, so a follower row never
+    // makes it into the result set. We model that by returning an empty list
+    // from the raw SQL — the test asserts the dispatcher then enqueues nothing.
+    let db = MockDatabase::new(DatabaseBackend::Postgres)
+        .append_query_results([Vec::<MBuild>::new()])
+        .into_connection();
+
+    let scheduler = make_scheduler(db);
+    dispatch::dispatch_ready_builds(&scheduler)
+        .await
+        .expect("dispatch failed");
+
+    assert_eq!(
+        scheduler.pending_job_count().await,
+        0,
+        "follower builds must not be enqueued"
+    );
 }

--- a/backend/scheduler/src/eval.rs
+++ b/backend/scheduler/src/eval.rs
@@ -192,6 +192,20 @@ impl<'a> EvalResultProcessor<'a> {
         let now = gradient_core::types::now();
         let mut builds: Vec<ABuild> = Vec::new();
 
+        let drv_ids: Vec<Uuid> = derivations
+            .iter()
+            .filter(|d| !d.substituted)
+            .filter_map(|d| drv_path_to_id.get(&d.drv_path).copied())
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
+
+        let leader_for_drv = if drv_ids.is_empty() {
+            HashMap::new()
+        } else {
+            find_active_leaders(self.state, &drv_ids).await
+        };
+
         for d in derivations {
             let Some(&drv_id) = drv_path_to_id.get(&d.drv_path) else {
                 continue;
@@ -201,6 +215,11 @@ impl<'a> EvalResultProcessor<'a> {
             } else {
                 BuildStatus::Created
             };
+            let via = if matches!(status, BuildStatus::Substituted) {
+                None
+            } else {
+                leader_for_drv.get(&drv_id).copied()
+            };
             builds.push(ABuild {
                 id: Set(Uuid::new_v4()),
                 evaluation: Set(self.evaluation_id),
@@ -209,6 +228,7 @@ impl<'a> EvalResultProcessor<'a> {
                 log_id: Set(None),
                 build_time_ms: Set(None),
                 worker: Set(None),
+                via: Set(via),
                 created_at: Set(now),
                 updated_at: Set(now),
             });
@@ -440,6 +460,7 @@ async fn expand_substituted_closure(state: &Arc<ServerState>, evaluation_id: Uui
                 log_id: Set(None),
                 build_time_ms: Set(None),
                 worker: Set(None),
+                via: Set(None),
                 created_at: Set(now),
                 updated_at: Set(now),
             })
@@ -682,4 +703,46 @@ pub async fn handle_eval_job_failed(
         .await;
     }
     Ok(())
+}
+
+/// Find the in-flight leader build for each derivation in `drv_ids`.
+///
+/// A build is a leader if its `via` is NULL and its status is non-terminal
+/// (Created/Queued/Building). Returns the head of the via chain — i.e. an
+/// existing follower's `via` value, or the leader's own id. New builds for
+/// the same derivation should set `via` to this id, producing a flat fan-out
+/// (no chains).
+async fn find_active_leaders(
+    state: &Arc<ServerState>,
+    drv_ids: &[Uuid],
+) -> HashMap<Uuid, Uuid> {
+    let rows = match EBuild::find()
+        .filter(CBuild::Derivation.is_in(drv_ids.to_vec()))
+        .filter(CBuild::Status.is_in(vec![
+            BuildStatus::Created,
+            BuildStatus::Queued,
+            BuildStatus::Building,
+        ]))
+        .all(&state.worker_db)
+        .await
+    {
+        Ok(rs) => rs,
+        Err(e) => {
+            error!(error = %e, "failed to query active leaders");
+            return HashMap::new();
+        }
+    };
+
+    let mut out: HashMap<Uuid, Uuid> = HashMap::new();
+    for b in rows {
+        let head = b.via.unwrap_or(b.id);
+        out.entry(b.derivation)
+            .and_modify(|cur| {
+                if b.via.is_none() {
+                    *cur = b.id;
+                }
+            })
+            .or_insert(head);
+    }
+    out
 }

--- a/backend/scheduler/src/handler_tests.rs
+++ b/backend/scheduler/src/handler_tests.rs
@@ -76,6 +76,7 @@ fn make_build(id: Uuid, eval_id: Uuid, drv_id: Uuid, status: BuildStatus) -> MBu
         log_id: None,
         build_time_ms: None,
         worker: None,
+        via: None,
         created_at: test_date(),
         updated_at: test_date(),
     }
@@ -615,6 +616,8 @@ async fn build_completed_last_build_completes_eval() {
         .append_query_results([vec![build]])
         // 2. update_build_status → Completed (UPDATE...RETURNING)
         .append_query_results([vec![build_completed]])
+        // 2a. propagate_to_followers: find via=leader.id → empty
+        .append_query_results([Vec::<MBuild>::new()])
         // 3. find active builds → empty
         .append_query_results([Vec::<MBuild>::new()])
         // 4. find_by_id(eval) → Building
@@ -657,6 +660,8 @@ async fn build_completed_with_remaining_active() {
         .append_query_results([vec![build]])
         // 2. update build → Completed
         .append_query_results([vec![build_completed]])
+        // 2a. propagate_to_followers: empty
+        .append_query_results([Vec::<MBuild>::new()])
         // 3. find active builds → still has other_build
         .append_query_results([vec![other_build]])
         // check_evaluation_done returns early — no further queries
@@ -685,6 +690,8 @@ async fn build_completed_with_failed_sibling() {
         .append_query_results([vec![build]])
         // 2. update → Completed
         .append_query_results([vec![build_completed]])
+        // 2a. propagate_to_followers: empty
+        .append_query_results([Vec::<MBuild>::new()])
         // 3. active builds → empty
         .append_query_results([Vec::<MBuild>::new()])
         // 4. find eval → Building
@@ -721,6 +728,8 @@ async fn build_completed_eval_not_building_noop() {
         .append_query_results([vec![build]])
         // 2. update → Completed
         .append_query_results([vec![build_completed]])
+        // 2a. propagate_to_followers: empty
+        .append_query_results([Vec::<MBuild>::new()])
         // 3. active builds → empty
         .append_query_results([Vec::<MBuild>::new()])
         // 4. find eval → already Completed (not Building)
@@ -770,6 +779,7 @@ async fn build_completed_dep_failed_siblings_cause_eval_failed() {
     let db = MockDatabase::new(DatabaseBackend::Postgres)
         .append_query_results([vec![build]])
         .append_query_results([vec![build_completed]])
+        .append_query_results([Vec::<MBuild>::new()]) // propagate_to_followers: empty
         .append_query_results([Vec::<MBuild>::new()]) // no active
         .append_query_results([vec![make_eval(eval_id, EvaluationStatus::Building)]])
         .append_query_results([vec![dep_failed]]) // DependencyFailed counts
@@ -812,6 +822,8 @@ async fn build_failed_cascades_to_direct_dependent() {
         .append_query_results([vec![build_a]])
         // 2. update buildA → Failed (UPDATE...RETURNING)
         .append_query_results([vec![build_a_failed]])
+        // 2a. propagate_to_followers: empty
+        .append_query_results([Vec::<MBuild>::new()])
         // ── collect_transitive_dependents ──
         // 3. BFS layer 1: dep edges where Dependency=A → [B→A]
         .append_query_results([vec![dep_edge]])
@@ -863,6 +875,8 @@ async fn build_failed_no_dependents() {
         .append_query_results([vec![build]])
         // 2. update → Failed
         .append_query_results([vec![build_failed.clone()]])
+        // 2a. propagate_to_followers: empty
+        .append_query_results([Vec::<MBuild>::new()])
         // 3. cascade: find Created/Queued → empty (no candidates)
         .append_query_results([Vec::<MBuild>::new()])
         // 4. check active → empty
@@ -914,6 +928,8 @@ async fn build_failed_cascade_only_direct_dependents() {
         .append_query_results([vec![build_a]])
         // 2. update → Failed
         .append_query_results([vec![build_a_failed]])
+        // 2a. propagate_to_followers: empty
+        .append_query_results([Vec::<MBuild>::new()])
         // ── collect_transitive_dependents ──
         // 3. BFS layer 1: dep edges where Dependency=A → [B→A] (C has no edge to A)
         .append_query_results([vec![dep_edge_b_a]])
@@ -970,6 +986,8 @@ async fn build_failed_cascade_skips_building_status() {
         .append_query_results([vec![build_a]])
         // 2. update → Failed
         .append_query_results([vec![build_a_failed]])
+        // 2a. propagate_to_followers: empty
+        .append_query_results([Vec::<MBuild>::new()])
         // 3. cascade: find Created/Queued → empty (buildB is Building, excluded)
         .append_query_results([Vec::<MBuild>::new()])
         // 4. check active: buildB is Building → still active
@@ -1578,6 +1596,8 @@ async fn eval_result_build_insert_fails_transitions_eval_failed() {
             "out",
             out_path,
         )]])
+        // 4a. find_active_leaders: empty
+        .append_query_results([Vec::<MBuild>::new()])
         // 5. insert_many builds → empty result → RecordNotInserted error
         .append_query_results([Vec::<MBuild>::new()])
         // 6. update_evaluation_status_with_error: insert evaluation_message
@@ -1774,6 +1794,8 @@ async fn webhook_fired_on_build_completed() {
         .append_query_results([vec![build_building]])
         // 2. update build → Completed
         .append_query_results([vec![build_completed]])
+        // 2a. propagate_to_followers: empty
+        .append_query_results([Vec::<MBuild>::new()])
         // 3. find active builds → empty
         .append_query_results([Vec::<MBuild>::new()])
         // 4. find_by_id(eval) → Building
@@ -1899,6 +1921,8 @@ async fn webhook_not_fired_for_dep_failed() {
         .append_query_results([vec![build_a]])
         // 2. update buildA → Failed
         .append_query_results([vec![build_a_failed.clone()]])
+        // 2a. propagate_to_followers: empty
+        .append_query_results([Vec::<MBuild>::new()])
         // ── collect_transitive_dependents ──
         // 3. BFS layer 1: dep edges where Dependency=A → [B→A]
         .append_query_results([vec![dep_edge]])
@@ -2363,6 +2387,8 @@ async fn build_failed_cascades_transitively_through_graph() {
             drv_c,
             BuildStatus::Failed,
         )]])
+        // 2a. propagate_to_followers: empty
+        .append_query_results([Vec::<MBuild>::new()])
         // ── collect_transitive_dependents ──
         // 3. BFS layer 1: dep edges where Dependency=C → [B→C]
         .append_query_results([vec![make_dep_edge(Uuid::new_v4(), drv_b, drv_c)]])

--- a/backend/web/src/endpoints/builds/downloads.rs
+++ b/backend/web/src/endpoints/builds/downloads.rs
@@ -144,6 +144,12 @@ async fn find_and_serve_file(
             }
         };
 
+        let disposition = if product.file_type == "html" {
+            "inline".to_string()
+        } else {
+            format!("attachment; filename=\"{}\"", filename)
+        };
+
         match extract_path_from_nar_bytes(compressed, &rel).await {
             Ok(Extracted::File { contents, .. }) => {
                 tracing::info!(%build_id, %filename, file_size = contents.len(), "Successfully extracted file for download");
@@ -152,10 +158,7 @@ async fn find_and_serve_file(
                         StatusCode::OK,
                         [
                             (header::CONTENT_TYPE, content_type_for_filename(filename)),
-                            (
-                                header::CONTENT_DISPOSITION,
-                                &format!("attachment; filename=\"{}\"", filename),
-                            ),
+                            (header::CONTENT_DISPOSITION, disposition.as_str()),
                         ],
                         contents,
                     )

--- a/backend/web/src/endpoints/builds/query.rs
+++ b/backend/web/src/endpoints/builds/query.rs
@@ -28,6 +28,10 @@ pub struct BuildWithOutputs {
     /// Worker identity (the `worker_id` string from `InitConnection`) that
     /// executed this build. `None` if the build never reached a worker.
     pub worker: Option<String>,
+    /// When set, this build is a follower of another build (same derivation,
+    /// different evaluation) whose terminal status will be copied here. The
+    /// scheduler does not dispatch builds with `via` set.
+    pub via: Option<Uuid>,
     pub output: HashMap<String, String>,
     pub created_at: chrono::NaiveDateTime,
     pub updated_at: chrono::NaiveDateTime,
@@ -70,6 +74,7 @@ pub async fn get_build(
         derivation_path: derivation.derivation_path,
         architecture: derivation.architecture,
         worker: build.worker,
+        via: build.via,
         output: outputs,
         created_at: build.created_at,
         updated_at: build.updated_at,

--- a/backend/web/src/endpoints/mod.rs
+++ b/backend/web/src/endpoints/mod.rs
@@ -30,6 +30,7 @@ pub fn content_type_for_filename(filename: &str) -> &'static str {
         .extension()
         .and_then(|ext| ext.to_str())
     {
+        Some("html") | Some("htm") => "text/html",
         Some("tar") => "application/x-tar",
         Some("gz") => "application/gzip",
         Some("zst") => "application/zstd",
@@ -125,6 +126,8 @@ mod tests {
 
     #[test]
     fn content_type_for_known_extensions() {
+        assert_eq!(content_type_for_filename("x.html"), "text/html");
+        assert_eq!(content_type_for_filename("x.htm"), "text/html");
         assert_eq!(content_type_for_filename("x.tar"), "application/x-tar");
         assert_eq!(content_type_for_filename("x.gz"), "application/gzip");
         assert_eq!(content_type_for_filename("x.zst"), "application/zstd");

--- a/backend/web/src/endpoints/projects/evaluations.rs
+++ b/backend/web/src/endpoints/projects/evaluations.rs
@@ -513,6 +513,12 @@ async fn serve_hydra_artifact(
             }
         };
 
+        let disposition = if product.file_type == "html" {
+            "inline".to_string()
+        } else {
+            format!("attachment; filename=\"{}\"", filename)
+        };
+
         match extract_path_from_nar_bytes(compressed, &rel).await {
             Ok(Extracted::File { contents, .. }) => {
                 return Ok(Some(
@@ -520,10 +526,7 @@ async fn serve_hydra_artifact(
                         StatusCode::OK,
                         [
                             (header::CONTENT_TYPE, content_type_for_filename(filename)),
-                            (
-                                header::CONTENT_DISPOSITION,
-                                &format!("attachment; filename=\"{}\"", filename),
-                            ),
+                            (header::CONTENT_DISPOSITION, disposition.as_str()),
                         ],
                         contents,
                     )

--- a/backend/web/tests/builds_download.rs
+++ b/backend/web/tests/builds_download.rs
@@ -169,6 +169,7 @@ fn build_row() -> entity::build::Model {
         log_id: None,
         build_time_ms: None,
         worker: None,
+        via: None,
         created_at: test_date(),
         updated_at: test_date(),
     }

--- a/backend/worker/src/proto/nar_import.rs
+++ b/backend/worker/src/proto/nar_import.rs
@@ -494,11 +494,40 @@ impl<'a> InputPrefetcher<'a> {
                     "closure walk: examining references"
                 );
             }
-            let refs: HashSet<String> = batch
+            let mut refs: HashSet<String> = batch
                 .iter()
                 .flat_map(|(_, _, meta)| meta.references.clone().unwrap_or_default())
                 .filter(|r| !queried.contains(r))
                 .collect();
+
+            // For every `.drv` we just fetched, parse it to discover its
+            // declared output paths. A .drv's `references` only enumerate
+            // its inputs (input drvs + sources) — never its own outputs —
+            // so without this step the closure walk misses the output
+            // store paths the dependent build will ultimately need (e.g.
+            // `closure-info` produced by `closure-info.drv`).
+            for (path, bytes, meta) in &batch {
+                if !path.ends_with(".drv") {
+                    continue;
+                }
+                let compression = meta
+                    .url
+                    .as_deref()
+                    .map(detect_compression)
+                    .unwrap_or(Compression::Zstd);
+                for out_path in
+                    drv_outputs_from_compressed_nar(bytes, compression, path).await
+                {
+                    if !queried.contains(&out_path) {
+                        tracing::trace!(
+                            drv = %path,
+                            out = %out_path,
+                            "closure walk: discovered drv output"
+                        );
+                        refs.insert(out_path);
+                    }
+                }
+            }
 
             all_results.extend(batch);
 
@@ -811,6 +840,65 @@ fn decompress(compressed: &[u8], kind: Compression) -> Result<Vec<u8>> {
         Compression::Xz => decompress_xz(compressed),
         Compression::Bzip2 => decompress_bzip2(compressed),
     }
+}
+
+/// Extract the single regular-file payload from a NAR. `.drv` files are
+/// stored as exactly that, so this is enough to recover the .drv bytes
+/// without writing them to disk first.
+async fn extract_single_file_from_nar(nar_bytes: &[u8]) -> Result<Vec<u8>> {
+    use futures::StreamExt as _;
+    use harmonia_nar::{NarEvent, parse_nar};
+    use tokio::io::AsyncReadExt as _;
+
+    let cursor = std::io::Cursor::new(nar_bytes.to_vec());
+    let mut stream = std::pin::pin!(parse_nar(cursor));
+    let event = stream
+        .next()
+        .await
+        .ok_or_else(|| anyhow::anyhow!("NAR is empty"))??;
+    match event {
+        NarEvent::File { mut reader, .. } => {
+            let mut buf = Vec::new();
+            reader.read_to_end(&mut buf).await.context("read NAR file body")?;
+            Ok(buf)
+        }
+        _ => Err(anyhow::anyhow!("expected single regular file in NAR")),
+    }
+}
+
+/// Decompress a `.drv`'s NAR, parse it, and return its declared output store
+/// paths. Returns an empty vec on any failure — the caller proceeds with what
+/// it has so a transient parse problem does not stall the closure walk.
+async fn drv_outputs_from_compressed_nar(
+    compressed: &[u8],
+    compression: Compression,
+    drv_path: &str,
+) -> Vec<String> {
+    let nar = match decompress(compressed, compression) {
+        Ok(b) => b,
+        Err(e) => {
+            warn!(drv = %drv_path, error = %e, "decompress failed while harvesting drv outputs");
+            return Vec::new();
+        }
+    };
+    let drv_bytes = match extract_single_file_from_nar(&nar).await {
+        Ok(b) => b,
+        Err(e) => {
+            warn!(drv = %drv_path, error = %e, "could not extract drv file from NAR");
+            return Vec::new();
+        }
+    };
+    let drv = match parse_drv(&drv_bytes) {
+        Ok(d) => d,
+        Err(e) => {
+            warn!(drv = %drv_path, error = %e, "could not parse fetched .drv");
+            return Vec::new();
+        }
+    };
+    drv.outputs
+        .into_iter()
+        .filter_map(|o| (!o.path.is_empty()).then_some(o.path))
+        .collect()
 }
 
 fn decompress_zstd(compressed: &[u8]) -> Result<Vec<u8>> {

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -4461,6 +4461,17 @@ components:
             `InitConnection`) that executed this build. `null` if the
             build has not yet reached a worker (still queued, aborted
             before dispatch, or a pre-migration row).
+        via:
+          type: string
+          format: uuid
+          nullable: true
+          description: |-
+            When set, this build is a *follower* of another build (same
+            derivation, different evaluation) whose terminal status will be
+            copied here. The scheduler does not dispatch builds with `via`
+            set; this avoids two workers racing for the Nix store lock on the
+            same output path when multiple projects build the same package.
+            See issue #175.
         output:
           type: object
           additionalProperties:

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -980,3 +980,28 @@ Unit tests in `backend/core/src/db/dependency_graph.rs`:
   visited, including a sibling that depends directly on the start.
 - `cycles_terminate` — a pathological reverse cycle is deduped via the
   visited set so the BFS terminates.
+
+## Build deduplication via `via` field (`#175`)
+
+When two evaluations (in the same organisation) discover the same
+derivation, the second build is inserted as a *follower* of the first by
+storing the leader's id in the new `build.via` column. Followers are
+filtered out of `dispatch_ready_builds` SQL (`AND b.via IS NULL`), so two
+workers never race for the Nix store lock on the same output path. When a
+leader transitions to `Completed`, `Substituted`, `Failed`, or
+`DependencyFailed`, `propagate_to_followers` copies the terminal status,
+`log_id`, `build_time_ms`, and `worker` onto every follower, runs the
+per-evaluation cascade for failure cases, and finalises each follower's
+evaluation. `Aborted` is never propagated — when a leader is aborted (its
+own evaluation cancelled) `abort_evaluation` re-elects a new leader from
+the surviving followers instead of dragging unrelated evaluations down.
+
+Tests:
+
+- `dispatch_tests::dispatch_skips_follower_builds` — the SQL gate keeps
+  followers out of the dispatcher result set, so no follower job is ever
+  enqueued.
+- The full pre-existing `handle_build_job_completed` /
+  `handle_build_job_failed` mock-DB suite was extended to mock the
+  `propagate_to_followers` followers query, exercising the new code path
+  on every terminal transition.

--- a/frontend/src/app/features/evaluations/build-artefacts/build-artefacts.component.html
+++ b/frontend/src/app/features/evaluations/build-artefacts/build-artefacts.component.html
@@ -36,10 +36,12 @@
           <a
             class="download-btn"
             [href]="downloadUrl(artefact)"
-            [title]="'Download ' + artefact.name"
+            [attr.target]="artefact.file_type === 'html' ? '_blank' : null"
+            [attr.rel]="artefact.file_type === 'html' ? 'noopener noreferrer' : null"
+            [title]="(artefact.file_type === 'html' ? 'Open ' : 'Download ') + artefact.name"
           >
-            <span class="material-symbols-outlined">download</span>
-            <span>Download</span>
+            <span class="material-symbols-outlined">{{ artefact.file_type === 'html' ? 'open_in_new' : 'download' }}</span>
+            <span>{{ artefact.file_type === 'html' ? 'Open' : 'Download' }}</span>
           </a>
         </div>
       }

--- a/frontend/src/app/features/evaluations/build-artefacts/build-artefacts.component.ts
+++ b/frontend/src/app/features/evaluations/build-artefacts/build-artefacts.component.ts
@@ -90,6 +90,7 @@ export class BuildArtefactsComponent implements OnInit {
 
   fileTypeLabel(fileType: string): string {
     const labels: Record<string, string> = {
+      'html': 'HTML',
       'iso': 'ISO',
       'tar': 'TAR',
       'rpm': 'RPM',


### PR DESCRIPTION
Closes #175.

## Summary
- New nullable `build.via` column FK→`build.id`. When two evaluations in the same organisation discover the same derivation, the second build is inserted as a *follower* with `via` pointing at the existing leader.
- `dispatch_ready_builds` SQL gate (`AND b.via IS NULL`) keeps followers out of worker dispatch — no more `waiting for lock on '/nix/store/…'` races between two projects building the same package.
- Leader terminal transition (`Completed` / `Substituted` / `Failed` / `DependencyFailed`) copies `status`, `log_id`, `build_time_ms`, and `worker` to every follower, runs the dep-failed cascade where applicable, and finalises each follower's evaluation. `Aborted` is never propagated.
- `abort_evaluation` is via-aware: followers in an aborted eval are aborted but `via` is cleared so the leader keeps running for everyone else; a `Building` leader with followers is left running; a `Queued`/`Created` leader with followers hands leadership to the oldest follower before being aborted.
- Same-organisation only — followers share a `derivation` row with their leader, so `derivation_output` / `build_product` rows are visible without any copy.
- API: `BuildWithOutputs` now exposes the optional `via` UUID; docs updated.

## Test plan
- [x] `cargo test --tests --workspace` (all crates green; existing `handle_build_job_completed` / `handle_build_job_failed` mock-DB suite extended for the new follower-lookup query)
- [x] New `dispatch_skips_follower_builds` test
- [ ] Manual: stage two projects on the same package against a single worker and confirm only one Nix build runs while the other shows the same log + status copy on completion.