### PR TITLE
backend: collapse WebError to status-mapped variants with stable error_code

### DIFF
--- a/backend/web/src/access.rs
+++ b/backend/web/src/access.rs
@@ -486,7 +486,7 @@ mod tests {
             let err = load_org(&state, Caller::User(&user), "test-org".into(), admin_required())
                 .await
                 .expect_err("view-only must be rejected");
-            assert!(matches!(err, WebError::Forbidden(_)));
+            assert!(matches!(err, WebError::Forbidden(..)));
         });
     }
 
@@ -502,7 +502,7 @@ mod tests {
             let err = load_org(&state, Caller::User(&user), "test-org".into(), admin_required())
                 .await
                 .expect_err("managed must be rejected");
-            assert!(matches!(err, WebError::Forbidden(_)));
+            assert!(matches!(err, WebError::Forbidden(..)));
         });
     }
 
@@ -518,7 +518,7 @@ mod tests {
             let err = load_org(&state, Caller::User(&user), "test-org".into(), admin_required())
                 .await
                 .expect_err("non-member must be rejected");
-            assert!(matches!(err, WebError::NotFound(_)));
+            assert!(matches!(err, WebError::NotFound(..)));
         });
     }
 
@@ -556,7 +556,7 @@ mod tests {
             let err = load_org(&state, Caller::User(&user), "test-org".into(), access)
                 .await
                 .expect_err("view-only must be rejected");
-            assert!(matches!(err, WebError::Forbidden(_)));
+            assert!(matches!(err, WebError::Forbidden(..)));
         });
     }
 
@@ -608,7 +608,7 @@ mod tests {
             )
             .await
             .expect_err("anon must not see private org");
-            assert!(matches!(err, WebError::NotFound(_)));
+            assert!(matches!(err, WebError::NotFound(..)));
         });
     }
 
@@ -661,7 +661,7 @@ mod tests {
             )
             .await
             .expect_err("view-only must be rejected");
-            assert!(matches!(err, WebError::Forbidden(_)));
+            assert!(matches!(err, WebError::Forbidden(..)));
         });
     }
 
@@ -688,7 +688,7 @@ mod tests {
             )
             .await
             .expect_err("managed must be rejected");
-            assert!(matches!(err, WebError::Forbidden(_)));
+            assert!(matches!(err, WebError::Forbidden(..)));
         });
     }
 
@@ -714,7 +714,7 @@ mod tests {
             .await
             .expect_err("missing must be rejected");
             match err {
-                WebError::NotFound(msg) => assert!(msg.contains("Project"), "got {}", msg),
+                WebError::NotFound(_, msg) => assert!(msg.contains("Project"), "got {}", msg),
                 other => panic!("expected NotFound, got {:?}", other),
             }
         });

--- a/backend/web/src/endpoints/admin/github_app.rs
+++ b/backend/web/src/endpoints/admin/github_app.rs
@@ -43,13 +43,13 @@ fn default_host() -> String {
 
 pub fn validate_host(host: &str) -> Result<(), WebError> {
     if host.is_empty() {
-        return Err(WebError::BadRequest("host must not be empty".into()));
+        return Err(WebError::bad_request("host must not be empty".into()));
     }
     let ok = host
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-');
     if !ok {
-        return Err(WebError::BadRequest(
+        return Err(WebError::bad_request(
             "host must contain only alphanumerics, '.' and '-'".into(),
         ));
     }
@@ -96,7 +96,7 @@ pub async fn callback(
     let Some(user_id) =
         gradient_core::ci::manifest_state::validate_and_consume(&state.manifest_state, &q.state)
     else {
-        return Err(WebError::BadRequest(
+        return Err(WebError::bad_request(
             "manifest state invalid or expired".into(),
         ));
     };
@@ -120,7 +120,7 @@ pub async fn credentials(
     require_superuser(&user)?;
 
     let creds = gradient_core::ci::manifest_state::take_credentials(&state.pending_credentials, user.id)
-        .ok_or_else(|| WebError::NotFound("Pending credentials".into()))?;
+        .ok_or_else(|| WebError::not_found_msg("Pending credentials".into()))?;
 
     Ok(ok_json(creds))
 }

--- a/backend/web/src/endpoints/auth.rs
+++ b/backend/web/src/endpoints/auth.rs
@@ -237,7 +237,7 @@ pub async fn get_oauth_authorize(
         csrf,
     )
     .await
-    .map_err(|e| WebError::Unauthorized(e.to_string()))?;
+    .map_err(|e| WebError::unauthorized(e.to_string()))?;
 
     let token =
         encode_jwt(state, user.id, false).map_err(|_| WebError::failed_to_generate_token())?;
@@ -266,7 +266,7 @@ pub async fn post_oauth_authorize(
     let use_tls = state.config.server.use_tls;
     let req = oidc_login_create(state)
         .await
-        .map_err(|e| WebError::Unauthorized(e.to_string()))?;
+        .map_err(|e| WebError::unauthorized(e.to_string()))?;
 
     let res = BaseResponse {
         error: false,
@@ -292,7 +292,7 @@ pub async fn get_oidc_login(
     let use_tls = state.config.server.use_tls;
     let req = oidc_login_create(state)
         .await
-        .map_err(|e| WebError::Unauthorized(e.to_string()))?;
+        .map_err(|e| WebError::unauthorized(e.to_string()))?;
 
     Response::builder()
         .status(StatusCode::FOUND)
@@ -325,7 +325,7 @@ pub async fn get_oidc_callback(
         csrf,
     )
     .await
-    .map_err(|e| WebError::Unauthorized(e.to_string()))?;
+    .map_err(|e| WebError::unauthorized(e.to_string()))?;
 
     let token =
         encode_jwt(state, user.id, false).map_err(|_| WebError::failed_to_generate_token())?;
@@ -416,7 +416,7 @@ pub async fn get_verify_email(
     Query(query): Query<HashMap<String, String>>,
 ) -> WebResult<Json<BaseResponse<String>>> {
     if !state.config.email.as_ref().is_some_and(|e| e.require_verification) {
-        return Err(WebError::BadRequest(
+        return Err(WebError::bad_request(
             "Email verification is not enabled".to_string(),
         ));
     }
@@ -434,7 +434,7 @@ pub async fn get_verify_email(
     if let Some(expires) = user.email_verification_token_expires
         && gradient_core::types::now() > expires
     {
-        return Err(WebError::BadRequest(
+        return Err(WebError::bad_request(
             "Verification token has expired".to_string(),
         ));
     }
@@ -458,7 +458,7 @@ pub async fn post_resend_verification(
     Json(body): Json<CheckUsernameRequest>,
 ) -> WebResult<Json<BaseResponse<String>>> {
     if !state.config.email.as_ref().is_some_and(|e| e.require_verification) {
-        return Err(WebError::BadRequest(
+        return Err(WebError::bad_request(
             "Email verification is not enabled".to_string(),
         ));
     }
@@ -470,7 +470,7 @@ pub async fn post_resend_verification(
         .or_not_found("User")?;
 
     if user.email_verified {
-        return Err(WebError::BadRequest(
+        return Err(WebError::bad_request(
             "Email is already verified".to_string(),
         ));
     }

--- a/backend/web/src/endpoints/builds/downloads.rs
+++ b/backend/web/src/endpoints/builds/downloads.rs
@@ -138,7 +138,7 @@ async fn find_and_serve_file(
             }
             Err(e) => {
                 tracing::error!(%build_id, %filename, hash, error = %e, "Failed to fetch NAR");
-                return Err(WebError::InternalServerError(
+                return Err(WebError::internal(
                     "Failed to fetch NAR".to_string(),
                 ));
             }
@@ -189,7 +189,7 @@ async fn find_and_serve_file(
             }
             Err(e) => {
                 tracing::error!(%build_id, %filename, %rel, error = %e, "Failed to extract path from NAR");
-                return Err(WebError::InternalServerError(
+                return Err(WebError::internal(
                     "Failed to extract path from NAR".to_string(),
                 ));
             }

--- a/backend/web/src/endpoints/caches/helpers.rs
+++ b/backend/web/src/endpoints/caches/helpers.rs
@@ -87,7 +87,7 @@ async fn require_cache_auth(
     let maybe_user = try_authenticate_basic(state, headers).await;
     match maybe_user {
         Some(user) if user_can_access_cache(state, cache, &user).await => Ok(()),
-        _ => Err(WebError::Unauthorized(
+        _ => Err(WebError::unauthorized(
             "Authentication required to access this cache".to_string(),
         )),
     }

--- a/backend/web/src/endpoints/caches/nar.rs
+++ b/backend/web/src/endpoints/caches/nar.rs
@@ -23,7 +23,7 @@ pub async fn nar(
     Path((cache, path)): Path<(String, String)>,
 ) -> WebResult<Response> {
     let path_hash =
-        get_hash_from_url(path.clone()).map_err(|e| WebError::BadRequest(e.to_string()))?;
+        get_hash_from_url(path.clone()).map_err(|e| WebError::bad_request(e.to_string()))?;
 
     if !(path.ends_with(".nar") || path.contains(".nar.")) {
         return Err(WebError::not_found("Path"));

--- a/backend/web/src/endpoints/caches/narinfo.rs
+++ b/backend/web/src/endpoints/caches/narinfo.rs
@@ -64,7 +64,7 @@ pub async fn path(
     Path((cache, path)): Path<(String, String)>,
 ) -> WebResult<Response<String>> {
     let path_hash =
-        get_hash_from_url(path.clone()).map_err(|e| WebError::BadRequest(e.to_string()))?;
+        get_hash_from_url(path.clone()).map_err(|e| WebError::bad_request(e.to_string()))?;
 
     if !path.ends_with(".narinfo") {
         return Err(WebError::not_found("Path"));

--- a/backend/web/src/endpoints/caches/upstreams.rs
+++ b/backend/web/src/endpoints/caches/upstreams.rs
@@ -122,7 +122,7 @@ pub async fn put_cache_upstream(
         } => {
             let upstream = load_cache_for_user(&state, user.id, cache_name).await?;
             if upstream.id == cache.id {
-                return Err(WebError::BadRequest(
+                return Err(WebError::bad_request(
                     "A cache cannot be its own upstream".to_string(),
                 ));
             }

--- a/backend/web/src/endpoints/forge_hooks/mod.rs
+++ b/backend/web/src/endpoints/forge_hooks/mod.rs
@@ -55,7 +55,7 @@ pub async fn github_app_webhook(
              (requires GRADIENT_GITHUB_APP_ID, GRADIENT_GITHUB_APP_PRIVATE_KEY_FILE, \
              and GRADIENT_GITHUB_APP_WEBHOOK_SECRET_FILE)"
         );
-        return Err(WebError::ServiceUnavailable(
+        return Err(WebError::service_unavailable(
             "github app integration not configured".into(),
         ));
     };
@@ -68,7 +68,7 @@ pub async fn github_app_webhook(
 
     if !verify_github_signature(secret.expose(), sig_header, &body) {
         warn!("GitHub App webhook: invalid signature");
-        return Err(WebError::Unauthorized("invalid webhook signature".into()));
+        return Err(WebError::unauthorized("invalid webhook signature".into()));
     }
 
     let event = headers
@@ -82,7 +82,7 @@ pub async fn github_app_webhook(
     let response = match event.as_str() {
         "push" => {
             let Some(parsed) = ParsedPushEvent::from_github(&body) else {
-                return Err(WebError::BadRequest("malformed webhook payload".into()));
+                return Err(WebError::bad_request("malformed webhook payload".into()));
             };
             let urls = parsed.repository_urls.clone();
             let outcome = parsed.trigger(&state).await;
@@ -118,10 +118,10 @@ pub async fn forge_webhook(
 ) -> WebResult<Json<BaseResponse<WebhookResponse>>> {
     let Some(forge_type) = ForgeType::from_path_segment(&forge) else {
         warn!(forge = %forge, "Unknown forge path segment");
-        return Err(WebError::NotFound("integration not found".into()));
+        return Err(WebError::not_found_msg("integration not found".into()));
     };
     if matches!(forge_type, ForgeType::GitHub) {
-        return Err(WebError::BadRequest("unsupported forge".into()));
+        return Err(WebError::bad_request("unsupported forge".into()));
     }
 
     let org = EOrganization::find()
@@ -130,9 +130,9 @@ pub async fn forge_webhook(
         .await
         .map_err(|e| {
             warn!(error = %e, org = %org_name, "DB error looking up organization for forge webhook");
-            WebError::InternalServerError("internal error".into())
+            WebError::internal("internal error".into())
         })?
-        .ok_or_else(|| WebError::NotFound("integration not found".into()))?;
+        .ok_or_else(|| WebError::not_found_msg("integration not found".into()))?;
 
     let integration = EIntegration::find()
         .filter(CIntegration::Organization.eq(org.id))
@@ -142,27 +142,27 @@ pub async fn forge_webhook(
         .await
         .map_err(|e| {
             warn!(error = %e, "DB error looking up integration for forge webhook");
-            WebError::InternalServerError("internal error".into())
+            WebError::internal("internal error".into())
         })?
         .ok_or_else(|| {
             warn!(org = %org_name, %forge, integration = %integration_name, "Integration not found");
-            WebError::NotFound("integration not found".into())
+            WebError::not_found_msg("integration not found".into())
         })?;
 
     let encrypted_secret = integration.secret.as_ref().ok_or_else(|| {
         warn!(integration_id = %integration.id, "Integration has no secret configured");
-        WebError::NotFound("integration not found".into())
+        WebError::not_found_msg("integration not found".into())
     })?;
 
     let plaintext_secret =
         decrypt_webhook_secret(&state.config.secrets.crypt_secret_file, encrypted_secret).map_err(|e| {
             warn!(error = %e, integration_id = %integration.id, "Failed to decrypt integration secret");
-            WebError::InternalServerError("internal error".into())
+            WebError::internal("internal error".into())
         })?;
 
     if !verify_forge_signature(forge_type, plaintext_secret.expose(), &headers, &body) {
         warn!(org = %org_name, forge = %forge, integration = %integration_name, "Forge webhook: invalid signature");
-        return Err(WebError::Unauthorized("invalid webhook signature".into()));
+        return Err(WebError::unauthorized("invalid webhook signature".into()));
     }
 
     let parsed = match forge_type {
@@ -171,7 +171,7 @@ pub async fn forge_webhook(
         ForgeType::GitHub => unreachable!("checked above"),
     };
     let Some(parsed) = parsed else {
-        return Err(WebError::BadRequest("malformed webhook payload".into()));
+        return Err(WebError::bad_request("malformed webhook payload".into()));
     };
 
     let urls = parsed.repository_urls.clone();

--- a/backend/web/src/endpoints/mod.rs
+++ b/backend/web/src/endpoints/mod.rs
@@ -42,7 +42,7 @@ pub fn content_type_for_filename(filename: &str) -> &'static str {
 }
 
 pub async fn handle_404() -> crate::error::WebError {
-    crate::error::WebError::NotFound("Not Found".to_string())
+    crate::error::WebError::not_found_msg("Not Found".to_string())
 }
 
 pub async fn get_health() -> WebResult<Json<BaseResponse<String>>> {

--- a/backend/web/src/endpoints/orgs/integrations.rs
+++ b/backend/web/src/endpoints/orgs/integrations.rs
@@ -188,7 +188,7 @@ pub async fn put_integration(
     let kind = parse_kind(&body.kind)?;
     let forge = parse_forge(&body.forge_type)?;
     if matches!(forge, ForgeType::GitHub) {
-        return Err(WebError::BadRequest(
+        return Err(WebError::bad_request(
             "GitHub integrations are managed through the server-wide GitHub App; \
              enable the App on the organization instead of creating an integration row."
                 .into(),
@@ -318,7 +318,7 @@ pub async fn patch_integration(
     if let Some(display_name) = body.display_name {
         let trimmed = display_name.trim().to_string();
         if trimmed.is_empty() {
-            return Err(WebError::BadRequest(
+            return Err(WebError::bad_request(
                 "display_name cannot be empty".to_string(),
             ));
         }
@@ -328,7 +328,7 @@ pub async fn patch_integration(
     if let Some(forge) = body.forge_type {
         let parsed = parse_forge(&forge)?;
         if matches!(parsed, ForgeType::GitHub) {
-            return Err(WebError::BadRequest(
+            return Err(WebError::bad_request(
                 "GitHub integrations are managed through the server-wide GitHub App; \
                  enable the App on the organization instead of switching forge_type to github."
                     .into(),

--- a/backend/web/src/endpoints/orgs/settings.rs
+++ b/backend/web/src/endpoints/orgs/settings.rs
@@ -44,7 +44,7 @@ async fn load_subscribable_cache(
         .or_not_found("Cache")?;
 
     if !cache.public && cache.created_by != user_id {
-        return Err(WebError::Forbidden(
+        return Err(WebError::forbidden(
             "You don't have permission to subscribe to this cache. The cache is private and you are not the owner.".to_string(),
         ));
     }

--- a/backend/web/src/endpoints/orgs/workers.rs
+++ b/backend/web/src/endpoints/orgs/workers.rs
@@ -118,7 +118,7 @@ pub async fn post_org_worker(
     let worker_uuid = Uuid::parse_str(&body.worker_id)
         .ok()
         .filter(|u| u.get_version() == Some(uuid::Version::Random))
-        .ok_or_else(|| WebError::BadRequest("worker_id must be a valid UUID v4".into()))?;
+        .ok_or_else(|| WebError::bad_request("worker_id must be a valid UUID v4".into()))?;
     let worker_id_str = worker_uuid.to_string();
 
     // Resolve token: use caller-supplied one (after validation) or generate a new one.
@@ -127,9 +127,9 @@ pub async fn post_org_worker(
         // Must be exactly 64 chars of valid standard base64 (openssl rand -base64 48 output).
         let decoded = base64::engine::general_purpose::STANDARD
             .decode(&t)
-            .map_err(|_| WebError::BadRequest("token is not valid base64".into()))?;
+            .map_err(|_| WebError::bad_request("token is not valid base64".into()))?;
         if decoded.len() != 48 {
-            return Err(WebError::BadRequest(
+            return Err(WebError::bad_request(
                 "token must be 48 raw bytes encoded as base64 (openssl rand -base64 48)".into(),
             ));
         }

--- a/backend/web/src/endpoints/projects/evaluations.rs
+++ b/backend/web/src/endpoints/projects/evaluations.rs
@@ -184,7 +184,7 @@ pub async fn post_project_evaluate(
         .map_err(|e| anyhow::anyhow!(e))?;
 
     if commit_hash.is_empty() {
-        return Err(WebError::InternalServerError(
+        return Err(WebError::internal(
             "Failed to fetch repository state".to_string(),
         ));
     }
@@ -553,7 +553,7 @@ async fn serve_hydra_artifact(
             Err(ExtractError::NotFound) => continue,
             Err(e) => {
                 tracing::error!(output_path = %output_root, %rel, error = %e, "Failed to extract path from NAR");
-                return Err(WebError::InternalServerError(
+                return Err(WebError::internal(
                     "Failed to extract path from NAR".to_string(),
                 ));
             }

--- a/backend/web/src/endpoints/projects/management.rs
+++ b/backend/web/src/endpoints/projects/management.rs
@@ -169,7 +169,7 @@ pub async fn put(
 
     body.repository
         .parse::<RepositoryUrl>()
-        .map_err(|e| WebError::BadRequest(e.to_string()))?;
+        .map_err(|e| WebError::bad_request(e.to_string()))?;
 
     let organization = load_org(
         &state.0,
@@ -199,7 +199,7 @@ pub async fn put(
         .evaluation_wildcard
         .trim()
         .parse::<Wildcard>()
-        .map_err(|e| WebError::BadRequest(e.to_string()))?
+        .map_err(|e| WebError::bad_request(e.to_string()))?
         .to_string();
 
     let project = AProject {
@@ -357,7 +357,7 @@ impl<'a> ProjectPatcher<'a> {
     fn apply_repository(&mut self, repository: String) -> WebResult<()> {
         repository
             .parse::<RepositoryUrl>()
-            .map_err(|e| WebError::BadRequest(e.to_string()))?;
+            .map_err(|e| WebError::bad_request(e.to_string()))?;
         self.aproject.repository = Set(repository);
         Ok(())
     }
@@ -366,7 +366,7 @@ impl<'a> ProjectPatcher<'a> {
         let evaluation_wildcard = evaluation_wildcard
             .trim()
             .parse::<Wildcard>()
-            .map_err(|e| WebError::BadRequest(e.to_string()))?
+            .map_err(|e| WebError::bad_request(e.to_string()))?
             .to_string();
         self.aproject.evaluation_wildcard = Set(evaluation_wildcard);
         Ok(())
@@ -374,7 +374,7 @@ impl<'a> ProjectPatcher<'a> {
 
     fn apply_keep_evaluations(&mut self, keep: i32) -> WebResult<()> {
         if keep < 1 {
-            return Err(WebError::BadRequest(
+            return Err(WebError::bad_request(
                 "keep_evaluations must be at least 1".to_string(),
             ));
         }
@@ -466,7 +466,7 @@ pub async fn post_project_check_repository(
 
         Ok(Json(res))
     } else {
-        Err(WebError::InternalServerError(
+        Err(WebError::internal(
             "Failed to check repository".to_string(),
         ))
     }
@@ -492,13 +492,13 @@ pub async fn post_project_transfer(
     let is_admin = has_permission(&state, user.id, organization.id, Permission::EditProject).await?;
     let is_owner = project.created_by == user.id;
     if !is_admin && !is_owner {
-        return Err(WebError::Forbidden(
+        return Err(WebError::forbidden(
             "Only the project owner or an organization admin can transfer ownership.".to_string(),
         ));
     }
 
     if project.managed {
-        return Err(WebError::Forbidden(
+        return Err(WebError::forbidden(
             "Cannot transfer ownership of a state-managed project.".to_string(),
         ));
     }
@@ -515,7 +515,7 @@ pub async fn post_project_transfer(
     .await?;
 
     if new_organization.id == organization.id {
-        return Err(WebError::BadRequest(
+        return Err(WebError::bad_request(
             "Project is already in this organization.".to_string(),
         ));
     }

--- a/backend/web/src/endpoints/user.rs
+++ b/backend/web/src/endpoints/user.rs
@@ -197,7 +197,7 @@ pub async fn delete_keys(
         .or_not_found("API-Key")?;
 
     if api_key.managed {
-        return Err(WebError::Forbidden(
+        return Err(WebError::forbidden(
             "Cannot delete a state-managed API key.".to_string(),
         ));
     }

--- a/backend/web/src/endpoints/webhooks.rs
+++ b/backend/web/src/endpoints/webhooks.rs
@@ -97,18 +97,18 @@ pub async fn put(
     let organization = load_org(&state, Caller::User(&user), organization, webhook_org_access()).await?;
 
     if body.name.is_empty() {
-        return Err(WebError::BadRequest(
+        return Err(WebError::bad_request(
             "Webhook name cannot be empty.".to_string(),
         ));
     }
     if body.url.is_empty() {
-        return Err(WebError::BadRequest(
+        return Err(WebError::bad_request(
             "Webhook URL cannot be empty.".to_string(),
         ));
     }
     validate_webhook_url(&body.url).map_err(WebError::BadRequest)?;
     if body.secret.is_empty() {
-        return Err(WebError::BadRequest(
+        return Err(WebError::bad_request(
             "Webhook secret cannot be empty.".to_string(),
         ));
     }

--- a/backend/web/src/endpoints/workers.rs
+++ b/backend/web/src/endpoints/workers.rs
@@ -19,7 +19,7 @@ pub async fn get_workers(
     Extension(scheduler): Extension<Arc<Scheduler>>,
 ) -> WebResult<Json<BaseResponse<Vec<WorkerInfo>>>> {
     if !state.config.proto.global_stats_public && !user.superuser {
-        return Err(WebError::Forbidden(
+        return Err(WebError::forbidden(
             "workers endpoint requires superuser".into(),
         ));
     }

--- a/backend/web/src/error.rs
+++ b/backend/web/src/error.rs
@@ -4,230 +4,337 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+//! Web-layer error type.
+//!
+//! `WebError` collapses every failure mode the HTTP layer can produce into one
+//! variant per HTTP status, plus a single `Internal` variant for chained
+//! source errors. Each non-internal variant carries a stable [`ErrorCode`]
+//! slug that is emitted in the JSON response body so clients can
+//! programmatically branch on failures without parsing English prose.
+//!
+//! Construct errors through the `bad_request`, `not_found`, … helper
+//! constructors (which set sensible default codes) or pass an explicit
+//! [`ErrorCode`] for finer-grained semantics.
+
 use anyhow::Error as AnyhowError;
 use axum::Json;
 use axum::extract::rejection::JsonRejection;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use gradient_core::types::BaseResponse;
 use sea_orm::DbErr;
+use serde::Serialize;
 use std::fmt;
+use thiserror::Error;
 
-#[derive(Debug)]
-pub enum WebError {
-    BadRequest(String),
-    Unauthorized(String),
-    Forbidden(String),
-    NotFound(String),
-    Conflict(String),
-    UnprocessableEntity(String),
-    InternalServerError(String),
-    ServiceUnavailable(String),
-    Database(DbErr),
-    Validation(String),
-    Authentication(String),
-    InputValidation(gradient_core::types::input::InputError),
-    JsonParsing(JsonRejection),
-    Internal(AnyhowError),
+/// Stable, machine-readable error slug returned in the JSON body alongside
+/// the HTTP status. Codes are intentionally `&'static str` so they cost
+/// nothing and can be exhaustively listed in API docs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(transparent)]
+pub struct ErrorCode(pub &'static str);
+
+impl ErrorCode {
+    // 400 Bad Request
+    pub const BAD_REQUEST: Self = Self("bad_request");
+    pub const VALIDATION: Self = Self("validation");
+    pub const INPUT_VALIDATION: Self = Self("input_validation");
+    pub const JSON_PARSING: Self = Self("json_parsing");
+    pub const INVALID_NAME: Self = Self("invalid_name");
+    pub const INVALID_EMAIL: Self = Self("invalid_email");
+    pub const INVALID_PASSWORD: Self = Self("invalid_password");
+    pub const INVALID_USERNAME: Self = Self("invalid_username");
+    pub const INVALID_OAUTH_CODE: Self = Self("invalid_oauth_code");
+    pub const OAUTH_DISABLED: Self = Self("oauth_disabled");
+    pub const REGISTRATION_DISABLED: Self = Self("registration_disabled");
+
+    // 401 Unauthorized
+    pub const UNAUTHORIZED: Self = Self("unauthorized");
+    pub const AUTHENTICATION: Self = Self("authentication");
+    pub const INVALID_CREDENTIALS: Self = Self("invalid_credentials");
+    pub const OAUTH_REQUIRED: Self = Self("oauth_required");
+
+    // 403 Forbidden
+    pub const FORBIDDEN: Self = Self("forbidden");
+    pub const SUPERUSER_REQUIRED: Self = Self("superuser_required");
+
+    // 404 Not Found
+    pub const NOT_FOUND: Self = Self("not_found");
+
+    // 409 Conflict
+    pub const CONFLICT: Self = Self("conflict");
+    pub const ALREADY_EXISTS: Self = Self("already_exists");
+
+    // 422 Unprocessable Entity
+    pub const UNPROCESSABLE_ENTITY: Self = Self("unprocessable_entity");
+
+    // 500 Internal Server Error
+    pub const INTERNAL: Self = Self("internal");
+    pub const DATABASE: Self = Self("database");
+    pub const DATA_INCONSISTENCY: Self = Self("data_inconsistency");
+    pub const TOKEN_GENERATION_FAILED: Self = Self("token_generation_failed");
+    pub const USER_UPDATE_FAILED: Self = Self("user_update_failed");
+    pub const SSH_KEY_GENERATION_FAILED: Self = Self("ssh_key_generation_failed");
+
+    // 503 Service Unavailable
+    pub const SERVICE_UNAVAILABLE: Self = Self("service_unavailable");
+
+    #[inline]
+    pub const fn as_str(&self) -> &'static str {
+        self.0
+    }
 }
 
-impl fmt::Display for WebError {
+impl fmt::Display for ErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.0)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum WebError {
+    #[error("Bad Request [{0}]: {1}")]
+    BadRequest(ErrorCode, String),
+    #[error("Unauthorized [{0}]: {1}")]
+    Unauthorized(ErrorCode, String),
+    #[error("Forbidden [{0}]: {1}")]
+    Forbidden(ErrorCode, String),
+    #[error("Not Found [{0}]: {1}")]
+    NotFound(ErrorCode, String),
+    #[error("Conflict [{0}]: {1}")]
+    Conflict(ErrorCode, String),
+    #[error("Unprocessable Entity [{0}]: {1}")]
+    UnprocessableEntity(ErrorCode, String),
+    #[error("Service Unavailable [{0}]: {1}")]
+    ServiceUnavailable(ErrorCode, String),
+    #[error(transparent)]
+    Internal(#[from] AnyhowError),
+}
+
+pub type WebResult<T> = Result<T, WebError>;
+
+/// JSON response body emitted for every `WebError`. Adds a stable `code`
+/// alongside the existing `error`/`message` fields so clients can branch
+/// without parsing prose.
+#[derive(Serialize)]
+struct ErrorResponseBody<'a> {
+    error: bool,
+    code: ErrorCode,
+    message: &'a str,
+}
+
+impl WebError {
+    /// HTTP status this error maps to.
+    pub fn status(&self) -> StatusCode {
         match self {
-            WebError::BadRequest(msg) => write!(f, "Bad Request: {}", msg),
-            WebError::Unauthorized(msg) => write!(f, "Unauthorized: {}", msg),
-            WebError::Forbidden(msg) => write!(f, "Forbidden: {}", msg),
-            WebError::NotFound(msg) => write!(f, "Not Found: {}", msg),
-            WebError::Conflict(msg) => write!(f, "Conflict: {}", msg),
-            WebError::UnprocessableEntity(msg) => write!(f, "Unprocessable Entity: {}", msg),
-            WebError::InternalServerError(msg) => write!(f, "Internal Server Error: {}", msg),
-            WebError::ServiceUnavailable(msg) => write!(f, "Service Unavailable: {}", msg),
-            WebError::Database(err) => write!(f, "Database error: {}", err),
-            WebError::Validation(msg) => write!(f, "Validation error: {}", msg),
-            WebError::Authentication(msg) => write!(f, "Authentication error: {}", msg),
-            WebError::InputValidation(err) => write!(f, "Input validation error: {}", err),
-            WebError::JsonParsing(err) => write!(f, "JSON parsing error: {}", err),
-            WebError::Internal(err) => write!(f, "Internal error: {}", err),
+            Self::BadRequest(..) => StatusCode::BAD_REQUEST,
+            Self::Unauthorized(..) => StatusCode::UNAUTHORIZED,
+            Self::Forbidden(..) => StatusCode::FORBIDDEN,
+            Self::NotFound(..) => StatusCode::NOT_FOUND,
+            Self::Conflict(..) => StatusCode::CONFLICT,
+            Self::UnprocessableEntity(..) => StatusCode::UNPROCESSABLE_ENTITY,
+            Self::ServiceUnavailable(..) => StatusCode::SERVICE_UNAVAILABLE,
+            Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+
+    /// Stable error slug returned in the JSON body.
+    pub fn code(&self) -> ErrorCode {
+        match self {
+            Self::BadRequest(c, _)
+            | Self::Unauthorized(c, _)
+            | Self::Forbidden(c, _)
+            | Self::NotFound(c, _)
+            | Self::Conflict(c, _)
+            | Self::UnprocessableEntity(c, _)
+            | Self::ServiceUnavailable(c, _) => *c,
+            Self::Internal(_) => ErrorCode::INTERNAL,
         }
     }
 }
 
-impl std::error::Error for WebError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            WebError::Database(err) => Some(err),
-            WebError::InputValidation(err) => Some(err),
-            WebError::JsonParsing(err) => Some(err),
-            WebError::Internal(err) => Some(err.as_ref()),
-            _ => None,
-        }
-    }
-}
+// ── Conversions ─────────────────────────────────────────────────────────
 
-// Manual From implementations to avoid naming conflicts with core crate
 impl From<DbErr> for WebError {
     fn from(err: DbErr) -> Self {
-        WebError::Database(err)
+        Self::Internal(AnyhowError::new(err))
     }
 }
 
 impl From<gradient_core::types::input::InputError> for WebError {
     fn from(err: gradient_core::types::input::InputError) -> Self {
-        WebError::InputValidation(err)
+        Self::BadRequest(ErrorCode::INPUT_VALIDATION, err.to_string())
     }
 }
 
 impl From<JsonRejection> for WebError {
     fn from(err: JsonRejection) -> Self {
-        WebError::JsonParsing(err)
-    }
-}
-
-impl From<AnyhowError> for WebError {
-    fn from(err: AnyhowError) -> Self {
-        WebError::Internal(err)
+        Self::BadRequest(ErrorCode::JSON_PARSING, format!("Invalid JSON: {}", err))
     }
 }
 
 impl IntoResponse for WebError {
     fn into_response(self) -> Response {
-        let (status, error_message) = match self {
-            WebError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg),
-            WebError::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, msg),
-            WebError::Forbidden(msg) => (StatusCode::FORBIDDEN, msg),
-            WebError::NotFound(msg) => (StatusCode::NOT_FOUND, msg),
-            WebError::Conflict(msg) => (StatusCode::CONFLICT, msg),
-            WebError::UnprocessableEntity(msg) => (StatusCode::UNPROCESSABLE_ENTITY, msg),
-            WebError::InternalServerError(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
-            WebError::ServiceUnavailable(msg) => (StatusCode::SERVICE_UNAVAILABLE, msg),
-            WebError::Database(err) => {
-                tracing::error!("Database error: {}", err);
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "Database error".to_string(),
-                )
+        let status = self.status();
+        let code = self.code();
+
+        let message: String = match &self {
+            Self::Internal(err) => {
+                tracing::error!("Internal error: {:#}", err);
+                "Internal server error".to_string()
             }
-            WebError::Validation(msg) => (StatusCode::BAD_REQUEST, msg),
-            WebError::Authentication(msg) => (StatusCode::UNAUTHORIZED, msg),
-            WebError::InputValidation(err) => (StatusCode::BAD_REQUEST, err.to_string()),
-            WebError::JsonParsing(err) => {
-                (StatusCode::BAD_REQUEST, format!("Invalid JSON: {}", err))
-            }
-            WebError::Internal(err) => {
-                tracing::error!("Internal error: {}", err);
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "Internal server error".to_string(),
-                )
-            }
+            Self::BadRequest(_, m)
+            | Self::Unauthorized(_, m)
+            | Self::Forbidden(_, m)
+            | Self::NotFound(_, m)
+            | Self::Conflict(_, m)
+            | Self::UnprocessableEntity(_, m)
+            | Self::ServiceUnavailable(_, m) => m.clone(),
         };
 
-        let body = Json(BaseResponse {
+        let body = Json(ErrorResponseBody {
             error: true,
-            message: error_message,
+            code,
+            message: &message,
         });
 
         (status, body).into_response()
     }
 }
 
-pub type WebResult<T> = Result<T, WebError>;
+// ── Constructors ────────────────────────────────────────────────────────
 
-// Helper functions for common error scenarios
 impl WebError {
-    // ── Generic Into<String> constructors so callers can drop `.to_string()` ──
-
     pub fn bad_request(msg: impl Into<String>) -> Self {
-        WebError::BadRequest(msg.into())
+        Self::BadRequest(ErrorCode::BAD_REQUEST, msg.into())
+    }
+
+    pub fn bad_request_with(code: ErrorCode, msg: impl Into<String>) -> Self {
+        Self::BadRequest(code, msg.into())
     }
 
     pub fn unauthorized(msg: impl Into<String>) -> Self {
-        WebError::Unauthorized(msg.into())
+        Self::Unauthorized(ErrorCode::UNAUTHORIZED, msg.into())
+    }
+
+    pub fn unauthorized_with(code: ErrorCode, msg: impl Into<String>) -> Self {
+        Self::Unauthorized(code, msg.into())
     }
 
     pub fn forbidden(msg: impl Into<String>) -> Self {
-        WebError::Forbidden(msg.into())
+        Self::Forbidden(ErrorCode::FORBIDDEN, msg.into())
+    }
+
+    pub fn forbidden_with(code: ErrorCode, msg: impl Into<String>) -> Self {
+        Self::Forbidden(code, msg.into())
     }
 
     pub fn conflict(msg: impl Into<String>) -> Self {
-        WebError::Conflict(msg.into())
+        Self::Conflict(ErrorCode::CONFLICT, msg.into())
     }
 
     pub fn unprocessable_entity(msg: impl Into<String>) -> Self {
-        WebError::UnprocessableEntity(msg.into())
+        Self::UnprocessableEntity(ErrorCode::UNPROCESSABLE_ENTITY, msg.into())
     }
 
     pub fn internal(msg: impl Into<String>) -> Self {
-        WebError::InternalServerError(msg.into())
+        Self::Internal(AnyhowError::msg(msg.into()))
     }
 
     pub fn service_unavailable(msg: impl Into<String>) -> Self {
-        WebError::ServiceUnavailable(msg.into())
+        Self::ServiceUnavailable(ErrorCode::SERVICE_UNAVAILABLE, msg.into())
     }
 
-    // ── Domain-specific constructors ────────────────────────────────────────
+    // ── Domain-specific constructors ────────────────────────────────────
 
     pub fn invalid_name(name: &str) -> Self {
-        WebError::BadRequest(format!("Invalid {}", name))
+        Self::BadRequest(ErrorCode::INVALID_NAME, format!("Invalid {}", name))
     }
 
     pub fn already_exists(resource: &str) -> Self {
-        WebError::Conflict(format!("{} already exists", resource))
+        Self::Conflict(ErrorCode::ALREADY_EXISTS, format!("{} already exists", resource))
     }
 
     pub fn not_found(resource: &str) -> Self {
-        WebError::NotFound(format!("{} not found", resource))
+        Self::NotFound(ErrorCode::NOT_FOUND, format!("{} not found", resource))
+    }
+
+    /// Like [`not_found`] but takes a fully-formed message instead of
+    /// appending " not found".
+    pub fn not_found_msg(msg: impl Into<String>) -> Self {
+        Self::NotFound(ErrorCode::NOT_FOUND, msg.into())
     }
 
     /// Internal-server-error for "<resource> data inconsistency" — a
     /// referential-integrity violation discovered at request time
     /// (e.g. a build row with no derivation row).
     pub fn data_inconsistency(resource: &str) -> Self {
-        WebError::InternalServerError(format!("{} data inconsistency", resource))
+        Self::Internal(AnyhowError::msg(format!(
+            "[{}] {} data inconsistency",
+            ErrorCode::DATA_INCONSISTENCY,
+            resource
+        )))
     }
 
     pub fn invalid_credentials() -> Self {
-        WebError::Unauthorized("Invalid credentials".to_string())
+        Self::Unauthorized(ErrorCode::INVALID_CREDENTIALS, "Invalid credentials".to_string())
     }
 
     pub fn oauth_disabled() -> Self {
-        WebError::BadRequest("OAuth login is disabled".to_string())
+        Self::BadRequest(ErrorCode::OAUTH_DISABLED, "OAuth login is disabled".to_string())
     }
 
     pub fn oauth_required() -> Self {
-        WebError::Unauthorized("Please login via OAuth".to_string())
+        Self::Unauthorized(ErrorCode::OAUTH_REQUIRED, "Please login via OAuth".to_string())
     }
 
     pub fn registration_disabled() -> Self {
-        WebError::BadRequest("Registration is disabled".to_string())
+        Self::BadRequest(
+            ErrorCode::REGISTRATION_DISABLED,
+            "Registration is disabled".to_string(),
+        )
     }
 
     pub fn invalid_email() -> Self {
-        WebError::BadRequest("Invalid Email".to_string())
+        Self::BadRequest(ErrorCode::INVALID_EMAIL, "Invalid Email".to_string())
     }
 
     pub fn failed_to_generate_token() -> Self {
-        WebError::InternalServerError("Failed to generate token".to_string())
+        Self::Internal(AnyhowError::msg(format!(
+            "[{}] Failed to generate token",
+            ErrorCode::TOKEN_GENERATION_FAILED
+        )))
     }
 
     pub fn failed_to_update_user() -> Self {
-        WebError::InternalServerError("Failed to update user".to_string())
+        Self::Internal(AnyhowError::msg(format!(
+            "[{}] Failed to update user",
+            ErrorCode::USER_UPDATE_FAILED
+        )))
     }
 
     pub fn invalid_oauth_code() -> Self {
-        WebError::BadRequest("Invalid OAuth Code".to_string())
+        Self::BadRequest(ErrorCode::INVALID_OAUTH_CODE, "Invalid OAuth Code".to_string())
     }
 
     pub fn failed_ssh_key_generation() -> Self {
-        WebError::InternalServerError("Failed to generate SSH key".to_string())
+        Self::Internal(AnyhowError::msg(format!(
+            "[{}] Failed to generate SSH key",
+            ErrorCode::SSH_KEY_GENERATION_FAILED
+        )))
     }
 
     pub fn invalid_password(reason: String) -> Self {
-        WebError::BadRequest(format!("Invalid password: {}", reason))
+        Self::BadRequest(
+            ErrorCode::INVALID_PASSWORD,
+            format!("Invalid password: {}", reason),
+        )
     }
 
     pub fn invalid_username(reason: String) -> Self {
-        WebError::BadRequest(format!("Invalid username: {}", reason))
+        Self::BadRequest(
+            ErrorCode::INVALID_USERNAME,
+            format!("Invalid username: {}", reason),
+        )
     }
 }
 
@@ -237,6 +344,9 @@ pub fn require_superuser(user: &gradient_core::types::MUser) -> Result<(), WebEr
     if user.superuser {
         Ok(())
     } else {
-        Err(WebError::Forbidden("superuser required".into()))
+        Err(WebError::Forbidden(
+            ErrorCode::SUPERUSER_REQUIRED,
+            "superuser required".into(),
+        ))
     }
 }

--- a/backend/web/src/helpers.rs
+++ b/backend/web/src/helpers.rs
@@ -54,7 +54,7 @@ mod tests {
     fn or_not_found_maps_none_to_not_found() {
         let r: WebResult<i32> = Option::<i32>::None.or_not_found("Thing");
         match r.unwrap_err() {
-            WebError::NotFound(msg) => assert_eq!(msg, "Thing not found"),
+            WebError::NotFound(_, msg) => assert_eq!(msg, "Thing not found"),
             other => panic!("expected NotFound, got {other:?}"),
         }
     }

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -3699,6 +3699,67 @@ components:
         message:
           description: Response payload — type varies by endpoint
 
+    ErrorResponse:
+      type: object
+      description: |
+        Returned for every non-2xx response. Carries a stable, machine-readable
+        `code` slug alongside the human-readable `message`, so clients can
+        branch programmatically without parsing English prose.
+      required: [error, code, message]
+      properties:
+        error:
+          type: boolean
+          enum: [true]
+        code:
+          $ref: '#/components/schemas/ErrorCode'
+        message:
+          type: string
+          description: Human-readable error description (English, may change)
+
+    ErrorCode:
+      type: string
+      description: |
+        Stable slug identifying the error category. New codes may be added
+        over time; clients SHOULD treat unknown codes as their underlying
+        HTTP status.
+      enum:
+        # 400 Bad Request
+        - bad_request
+        - validation
+        - input_validation
+        - json_parsing
+        - invalid_name
+        - invalid_email
+        - invalid_password
+        - invalid_username
+        - invalid_oauth_code
+        - oauth_disabled
+        - registration_disabled
+        # 401 Unauthorized
+        - unauthorized
+        - authentication
+        - invalid_credentials
+        - oauth_required
+        # 403 Forbidden
+        - forbidden
+        - superuser_required
+        # 404 Not Found
+        - not_found
+        # 409 Conflict
+        - conflict
+        - already_exists
+        # 422 Unprocessable Entity
+        - unprocessable_entity
+        # 500 Internal Server Error
+        - internal
+        - database
+        - data_inconsistency
+        - token_generation_failed
+        - user_update_failed
+        - ssh_key_generation_failed
+        # 503 Service Unavailable
+        - service_unavailable
+
     StringResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'


### PR DESCRIPTION
## Summary
- Refactor `backend/web/src/error.rs` to use `thiserror`, collapsing 14 overlapping variants into one variant per HTTP status (8 total) plus a single `Internal` for chained sources.
- Add a stable `ErrorCode` slug carried by each variant and serialised as a new `code` field in the JSON error body, so clients can branch programmatically instead of parsing English prose.
- Fold `DbErr` into `Internal` (with `tracing::error!` on response); funnel `JsonRejection` and `InputError` into `BadRequest` with their own codes.
- Migrate direct variant construction at call sites (~15 files under `backend/web/src/endpoints`) to the existing `bad_request`/`not_found`/… helpers.

Closes #62.

## Test plan
- [x] `cargo build -p web` succeeds
- [x] `cargo test --tests --workspace` passes
- [x] Verify error responses include `code`, `error`, `message` fields
- [x] Update `docs/gradient-api.yaml` and `docs/src` to reflect the new `code` field (follow-up)