### PR TITLE
Project concurrency: per-project setting (was per-trigger)

### DIFF
--- a/backend/core/src/ci/apply.rs
+++ b/backend/core/src/ci/apply.rs
@@ -44,7 +44,6 @@ pub enum ApplyError {
 pub struct ApplyInput {
     pub trigger_id: ProjectTriggerId,
     pub trigger_type: TriggerType,
-    pub concurrency: ConcurrencyPolicy,
     pub commit_hash: Vec<u8>,
     pub commit_message: Option<String>,
     pub author_name: Option<String>,
@@ -73,6 +72,9 @@ pub async fn apply_trigger<C: ConnectionTrait>(
     }
 
     // ── Concurrency policy ────────────────────────────────────────────────
+    let concurrency =
+        ConcurrencyPolicy::from_i16(project.concurrency).unwrap_or(ConcurrencyPolicy::Skip);
+
     let active_codes: Vec<i32> = EvaluationStatus::ACTIVE.iter().map(|s| s.num_value()).collect();
     let in_flight = EEvaluation::find()
         .filter(CEvaluation::Project.eq(project.id))
@@ -84,7 +86,7 @@ pub async fn apply_trigger<C: ConnectionTrait>(
     let mut aborted_builds: Vec<BuildId> = Vec::new();
 
     if let Some(running) = in_flight {
-        match input.concurrency {
+        match concurrency {
             ConcurrencyPolicy::Skip => return Ok(ApplyOutcome::SkippedConcurrency),
             ConcurrencyPolicy::HardAbort => {
                 aborted_builds = abort_evaluation(db, running.id, AbortKind::Hard).await?;
@@ -131,6 +133,10 @@ mod tests {
     use uuid::Uuid;
 
     fn make_project_with_last_eval(last: Option<EvaluationId>) -> MProject {
+        make_project_with_concurrency(last, 3) // Skip
+    }
+
+    fn make_project_with_concurrency(last: Option<EvaluationId>, concurrency: i16) -> MProject {
         MProject {
             id: ProjectId::new(Uuid::parse_str("00000000-0000-0000-0000-000000000003").unwrap()),
             organization: OrganizationId::nil(),
@@ -147,7 +153,7 @@ mod tests {
             created_at: NaiveDateTime::default(),
             managed: false,
             keep_evaluations: 10,
-            concurrency: 3,
+            concurrency,
         }
     }
 
@@ -188,14 +194,12 @@ mod tests {
     fn input(
         trig: ProjectTriggerId,
         ttype: TriggerType,
-        conc: ConcurrencyPolicy,
         hash: Vec<u8>,
         manual: bool,
     ) -> ApplyInput {
         ApplyInput {
             trigger_id: trig,
             trigger_type: ttype,
-            concurrency: conc,
             commit_hash: hash,
             commit_message: None,
             author_name: None,
@@ -226,7 +230,7 @@ mod tests {
         let res = apply_trigger(
             &db,
             &project,
-            input(trig, TriggerType::Polling, ConcurrencyPolicy::Skip, same_hash, false),
+            input(trig, TriggerType::Polling, same_hash, false),
         )
         .await
         .unwrap();
@@ -265,7 +269,7 @@ mod tests {
         let res = apply_trigger(
             &db,
             &project,
-            input(trig, TriggerType::Time, ConcurrencyPolicy::Skip, same_hash, false),
+            input(trig, TriggerType::Time, same_hash, false),
         )
         .await
         .unwrap();
@@ -289,7 +293,7 @@ mod tests {
         let res = apply_trigger(
             &db,
             &project,
-            input(trig, TriggerType::Polling, ConcurrencyPolicy::Skip, vec![9u8; 20], false),
+            input(trig, TriggerType::Polling, vec![9u8; 20], false),
         )
         .await
         .unwrap();
@@ -298,7 +302,7 @@ mod tests {
 
     #[tokio::test]
     async fn allow_concurrency_returns_skipped_allow_reserved() {
-        let project = make_project_with_last_eval(None);
+        let project = make_project_with_concurrency(None, 2); // Allow
         let running_eval_id = EvaluationId::now_v7();
         let running_eval =
             make_eval(running_eval_id, project.id, CommitId::nil(), EvaluationStatus::Building);
@@ -311,7 +315,7 @@ mod tests {
         let res = apply_trigger(
             &db,
             &project,
-            input(trig, TriggerType::Polling, ConcurrencyPolicy::Allow, vec![9u8; 20], false),
+            input(trig, TriggerType::Polling, vec![9u8; 20], false),
         )
         .await
         .unwrap();
@@ -340,7 +344,7 @@ mod tests {
         let res = apply_trigger(
             &db,
             &project,
-            input(trig, TriggerType::Polling, ConcurrencyPolicy::Skip, vec![1u8; 20], false),
+            input(trig, TriggerType::Polling, vec![1u8; 20], false),
         )
         .await
         .unwrap();
@@ -383,7 +387,7 @@ mod tests {
         let res = apply_trigger(
             &db,
             &project,
-            input(trig, TriggerType::Polling, ConcurrencyPolicy::Skip, same_hash, true),
+            input(trig, TriggerType::Polling, same_hash, true),
         )
         .await
         .unwrap();
@@ -392,7 +396,7 @@ mod tests {
 
     #[tokio::test]
     async fn hard_abort_populates_aborted_fields() {
-        let project = make_project_with_last_eval(None);
+        let project = make_project_with_concurrency(None, 0); // HardAbort
         let running_eval_id = EvaluationId::now_v7();
         let running_eval =
             make_eval(running_eval_id, project.id, CommitId::nil(), EvaluationStatus::Building);
@@ -449,7 +453,7 @@ mod tests {
         let res = apply_trigger(
             &db,
             &project,
-            input(trig, TriggerType::Polling, ConcurrencyPolicy::HardAbort, new_hash, false),
+            input(trig, TriggerType::Polling, new_hash, false),
         )
         .await
         .unwrap();

--- a/backend/core/src/ci/apply.rs
+++ b/backend/core/src/ci/apply.rs
@@ -252,6 +252,8 @@ mod tests {
             .append_query_results([Vec::<entity::evaluation::Model>::new()])
             // trigger_evaluation internal in-progress check (none)
             .append_query_results([Vec::<entity::evaluation::Model>::new()])
+            // trigger_evaluation: resolve previous (returns the prev eval row)
+            .append_query_results([vec![make_eval(prev_eval_id, project.id, CommitId::nil(), EvaluationStatus::Completed)]])
             // commit insert
             .append_query_results([vec![make_commit(new_commit_id, same_hash.clone())]])
             // evaluation insert
@@ -369,6 +371,8 @@ mod tests {
             .append_query_results([Vec::<entity::evaluation::Model>::new()])
             // trigger_evaluation internal in-progress check
             .append_query_results([Vec::<entity::evaluation::Model>::new()])
+            // trigger_evaluation: resolve previous (prev row exists)
+            .append_query_results([vec![make_eval(prev_eval_id, project.id, CommitId::nil(), EvaluationStatus::Completed)]])
             // commit insert
             .append_query_results([vec![make_commit(new_commit_id, same_hash.clone())]])
             // evaluation insert

--- a/backend/core/src/ci/apply.rs
+++ b/backend/core/src/ci/apply.rs
@@ -147,6 +147,7 @@ mod tests {
             created_at: NaiveDateTime::default(),
             managed: false,
             keep_evaluations: 10,
+            concurrency: 3,
         }
     }
 

--- a/backend/core/src/ci/trigger.rs
+++ b/backend/core/src/ci/trigger.rs
@@ -258,6 +258,7 @@ mod tests {
             created_at: NaiveDateTime::default(),
             managed: false,
             keep_evaluations: 10,
+            concurrency: 3,
         }
     }
 

--- a/backend/core/src/ci/trigger.rs
+++ b/backend/core/src/ci/trigger.rs
@@ -63,6 +63,17 @@ pub async fn trigger_evaluation<C: ConnectionTrait>(
         return Err(TriggerError::AlreadyInProgress);
     }
 
+    // Resolve `project.last_evaluation` against the DB so a dangling pointer
+    // (eval row gone but the project pointer still set) doesn't trip the
+    // `fk-evaluation-previous` foreign key.
+    let previous = match project.last_evaluation {
+        Some(prev_id) => EEvaluation::find_by_id(prev_id)
+            .one(db)
+            .await?
+            .map(|e| e.id),
+        None => None,
+    };
+
     let now = crate::types::now();
 
     let acommit = ACommit {
@@ -81,7 +92,7 @@ pub async fn trigger_evaluation<C: ConnectionTrait>(
         commit: Set(commit.id),
         wildcard: Set(project.evaluation_wildcard.clone()),
         status: Set(EvaluationStatus::Queued),
-        previous: Set(project.last_evaluation),
+        previous: Set(previous),
         next: Set(None),
         created_at: Set(now),
         updated_at: Set(now),
@@ -314,6 +325,43 @@ mod tests {
         let result = trigger_evaluation(&db, &project, vec![0u8; 20], None, None, None).await;
         assert!(result.is_ok(), "expected Ok, got: {:?}", result.err());
         assert_eq!(result.unwrap().status, EvaluationStatus::Queued);
+    }
+
+    #[tokio::test]
+    async fn trigger_drops_dangling_last_evaluation_pointer() {
+        // Project points at an evaluation row that no longer exists. The
+        // resolved `previous` must fall back to None so the FK doesn't fire.
+        let stale_eval_id = EvaluationId::now_v7();
+        let mut project = make_project();
+        project.last_evaluation = Some(stale_eval_id);
+
+        let new_eval_id = EvaluationId::now_v7();
+        let commit_id = CommitId::now_v7();
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            // in-progress check: none active
+            .append_query_results([Vec::<evaluation::Model>::new()])
+            // resolve previous: row missing
+            .append_query_results([Vec::<evaluation::Model>::new()])
+            // insert commit
+            .append_query_results([vec![entity::commit::Model {
+                id: commit_id,
+                message: "".into(),
+                hash: vec![0u8; 20],
+                author: None,
+                author_name: "".into(),
+            }]])
+            // insert evaluation (previous should be None despite stale pointer)
+            .append_query_results([vec![make_eval(new_eval_id, EvaluationStatus::Queued)]])
+            // project update read-back + exec
+            .append_query_results([vec![project.clone()]])
+            .append_exec_results([MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }])
+            .into_connection();
+
+        let result = trigger_evaluation(&db, &project, vec![0u8; 20], None, None, None).await;
+        assert!(result.is_ok(), "expected Ok, got: {:?}", result.err());
     }
 
     #[tokio::test]

--- a/backend/core/src/sources/git.rs
+++ b/backend/core/src/sources/git.rs
@@ -60,23 +60,28 @@ impl<'a> ProjectGitContext<'a> {
         })
     }
 
-    /// Check whether there is a new commit on the remote HEAD.
+    /// Check whether there is a new commit on the remote ref.
+    ///
+    /// `branch = None` polls the remote HEAD (default branch).
+    /// `branch = Some("main")` polls `refs/heads/main`.
     ///
     /// Returns `(has_update, remote_hash)`. `has_update` is `false` when the
-    /// remote HEAD matches the last evaluated commit or an evaluation is already
+    /// remote ref matches the last evaluated commit or an evaluation is already
     /// in progress.
     #[instrument(skip(self), fields(project_id = %self.project.id, project_name = %self.project.name))]
-    async fn check_for_updates(&self) -> Result<(bool, Vec<u8>), SourceError> {
+    async fn check_for_updates(&self, branch: Option<&str>) -> Result<(bool, Vec<u8>), SourceError> {
         debug!("Checking for updates on project");
 
         let url = self.project.repository.clone();
         let ssh_creds = self.ssh_creds.clone();
+        let branch_owned = branch.map(|b| b.to_owned());
 
         let remote_hash = match tokio::task::spawn_blocking(move || {
+            let branch_ref = branch_owned.as_deref();
             if let Some((private_key, public_key)) = ssh_creds {
-                ls_remote_head(&url, Some(&private_key), Some(&public_key))
+                ls_remote_head(&url, Some(&private_key), Some(&public_key), branch_ref)
             } else {
-                ls_remote_head(&url, None, None)
+                ls_remote_head(&url, None, None, branch_ref)
             }
         })
         .await
@@ -216,10 +221,11 @@ impl<'a> ProjectGitContext<'a> {
 pub async fn check_project_updates(
     state: Arc<ServerState>,
     project: &MProject,
+    branch: Option<&str>,
 ) -> Result<(bool, Vec<u8>), SourceError> {
     ProjectGitContext::new(&state, project)
         .await?
-        .check_for_updates()
+        .check_for_updates(branch)
         .await
 }
 
@@ -235,15 +241,17 @@ pub async fn get_commit_info(
         .await
 }
 
-/// Best-effort: resolve the project's current HEAD commit, message, and author name.
-/// Used for manual trigger fires (UI re-run / `/triggers/{id}/test`) where we
-/// want a concrete commit even if the polling source says "no update".
+/// Best-effort: resolve the project's current HEAD (or branch) commit, message,
+/// and author name. Used for manual trigger fires where we want a concrete
+/// commit even if the polling source says "no update".
 #[instrument(skip(state), fields(project_id = %project.id, project_name = %project.name))]
 pub async fn resolve_head(
     state: Arc<ServerState>,
     project: &MProject,
+    branch: Option<&str>,
 ) -> Result<(Vec<u8>, String, String), SourceError> {
-    let (_has_update, commit_hash) = check_project_updates(Arc::clone(&state), project).await?;
+    let (_has_update, commit_hash) =
+        check_project_updates(Arc::clone(&state), project, branch).await?;
     let (msg, _email, author) = get_commit_info(Arc::clone(&state), project, &commit_hash).await?;
     Ok((commit_hash, msg, author))
 }
@@ -393,11 +401,12 @@ fn ls_remote_head(
     url: &str,
     private_key: Option<&str>,
     public_key: Option<&str>,
+    branch: Option<&str>,
 ) -> Result<Vec<u8>, SourceError> {
     match (private_key, public_key) {
-        (Some(priv_key), Some(pub_key)) => ls_remote_head_ssh(url, priv_key, pub_key),
-        _ if url.starts_with("git://") => ls_remote_head_git_protocol(url),
-        _ => ls_remote_head_no_creds(url),
+        (Some(priv_key), Some(pub_key)) => ls_remote_head_ssh(url, priv_key, pub_key, branch),
+        _ if url.starts_with("git://") => ls_remote_head_git_protocol(url, branch),
+        _ => ls_remote_head_no_creds(url, branch),
     }
 }
 
@@ -409,7 +418,7 @@ fn ls_remote_head(
 /// This implementation sends a plain protocol-v0 pkt-line request (no
 /// `version=2` extra parameter) so the daemon responds with an immediate v0
 /// ref advertisement containing HEAD.
-fn ls_remote_head_git_protocol(url: &str) -> Result<Vec<u8>, SourceError> {
+fn ls_remote_head_git_protocol(url: &str, branch: Option<&str>) -> Result<Vec<u8>, SourceError> {
     use std::io::Write;
     use std::net::TcpStream;
     use std::time::Duration;
@@ -437,7 +446,13 @@ fn ls_remote_head_git_protocol(url: &str) -> Result<Vec<u8>, SourceError> {
             stderr: e.to_string(),
         })?;
 
-    read_head_from_pktlines(&mut stream)
+    match branch {
+        None => read_head_from_pktlines(&mut stream),
+        Some(b) => {
+            let ref_name = format!("refs/heads/{}", b);
+            read_branch_from_pktlines(&mut stream, &ref_name)
+        }
+    }
 }
 
 /// List the remote HEAD ref via libgit2 with in-memory SSH credentials.
@@ -448,6 +463,7 @@ fn ls_remote_head_ssh(
     url: &str,
     private_key: &str,
     public_key: &str,
+    branch: Option<&str>,
 ) -> Result<Vec<u8>, SourceError> {
     let mut remote =
         git2::Remote::create_detached(url).map_err(|e| SourceError::GitCommand(e.to_string()))?;
@@ -475,15 +491,11 @@ fn ls_remote_head_ssh(
         stderr: e.message().to_string(),
     })?;
 
-    list.iter()
-        .find(|h| h.name() == "HEAD")
-        .or_else(|| list.first())
-        .map(|h| h.oid().as_bytes().to_vec())
-        .ok_or(SourceError::GitHashExtraction)
+    find_ref_in_list(list, branch)
 }
 
 /// List the remote HEAD ref via libgit2 with no credentials (for https://).
-fn ls_remote_head_no_creds(url: &str) -> Result<Vec<u8>, SourceError> {
+fn ls_remote_head_no_creds(url: &str, branch: Option<&str>) -> Result<Vec<u8>, SourceError> {
     let mut remote =
         git2::Remote::create_detached(url).map_err(|e| SourceError::GitCommand(e.to_string()))?;
 
@@ -500,11 +512,33 @@ fn ls_remote_head_no_creds(url: &str) -> Result<Vec<u8>, SourceError> {
         stderr: e.message().to_string(),
     })?;
 
-    list.iter()
-        .find(|h| h.name() == "HEAD")
-        .or_else(|| list.first())
-        .map(|h| h.oid().as_bytes().to_vec())
-        .ok_or(SourceError::GitHashExtraction)
+    find_ref_in_list(list, branch)
+}
+
+/// Resolves the target ref from a libgit2 remote ref list.
+///
+/// `branch = None` → look for `HEAD`, fall back to first ref.
+/// `branch = Some("main")` → look for `refs/heads/main` exactly; returns
+/// `SourceError::GitHashExtraction` if not found (no HEAD fallback).
+fn find_ref_in_list(
+    list: &[git2::RemoteHead<'_>],
+    branch: Option<&str>,
+) -> Result<Vec<u8>, SourceError> {
+    match branch {
+        None => list
+            .iter()
+            .find(|h| h.name() == "HEAD")
+            .or_else(|| list.first())
+            .map(|h| h.oid().as_bytes().to_vec())
+            .ok_or(SourceError::GitHashExtraction),
+        Some(b) => {
+            let ref_name = format!("refs/heads/{}", b);
+            list.iter()
+                .find(|h| h.name() == ref_name)
+                .map(|h| h.oid().as_bytes().to_vec())
+                .ok_or(SourceError::GitHashExtraction)
+        }
+    }
 }
 
 /// Read pkt-lines from `reader` and return the SHA-1 hash of HEAD.
@@ -586,6 +620,70 @@ fn read_head_from_pktlines(reader: &mut dyn std::io::Read) -> Result<Vec<u8>, So
 
     // Fall back to the first non-zero ref (matches libgit2's list.first() behavior).
     first_ref.ok_or(SourceError::GitHashExtraction)
+}
+
+/// Read pkt-lines from `reader` and return the SHA-1 hash for `branch_ref`
+/// (e.g. `"refs/heads/main"`). Returns `SourceError::GitHashExtraction` if
+/// the ref is not found in the advertisement; does not fall back to HEAD.
+fn read_branch_from_pktlines(
+    reader: &mut dyn std::io::Read,
+    branch_ref: &str,
+) -> Result<Vec<u8>, SourceError> {
+    let mut len_buf = [0u8; 4];
+
+    loop {
+        std::io::Read::read_exact(reader, &mut len_buf).map_err(|e| {
+            SourceError::GitCommandFailed {
+                stderr: e.to_string(),
+            }
+        })?;
+
+        let len = std::str::from_utf8(&len_buf)
+            .ok()
+            .and_then(|s| usize::from_str_radix(s, 16).ok())
+            .ok_or(SourceError::GitOutputParsing)?;
+
+        if len == 0 {
+            break;
+        }
+
+        if len < 4 {
+            break;
+        }
+
+        let payload_len = len - 4;
+        let mut data = vec![0u8; payload_len];
+        std::io::Read::read_exact(reader, &mut data).map_err(|e| {
+            SourceError::GitCommandFailed {
+                stderr: e.to_string(),
+            }
+        })?;
+
+        if data.len() >= 41 && data[40] == b' ' {
+            let sha = match std::str::from_utf8(&data[..40]) {
+                Ok(s) => s,
+                Err(_) => continue,
+            };
+
+            let ref_bytes = &data[41..];
+            let refname_end = ref_bytes
+                .iter()
+                .position(|&b| b == 0 || b == b'\n')
+                .unwrap_or(ref_bytes.len());
+
+            let refname = std::str::from_utf8(&ref_bytes[..refname_end])
+                .unwrap_or("")
+                .trim();
+
+            debug!(refname, sha, "pkt-line ref");
+
+            if refname == branch_ref {
+                return hex::decode(sha).map_err(|_| SourceError::GitOutputParsing);
+            }
+        }
+    }
+
+    Err(SourceError::GitHashExtraction)
 }
 
 /// Parses a `git://[host[:port]]/repo/path` URL into its host, port, and repo

--- a/backend/core/src/sources/git.rs
+++ b/backend/core/src/sources/git.rs
@@ -98,38 +98,43 @@ impl<'a> ProjectGitContext<'a> {
             return Ok((true, remote_hash));
         }
 
+        // A dangling `last_evaluation` (row deleted but pointer stale) is
+        // treated as "no previous evaluation, update needed" — same path as
+        // a freshly-created project. The pointer self-heals on the next
+        // successful trigger.
         if let Some(last_evaluation) = self.project.last_evaluation {
             let evaluation = EEvaluation::find_by_id(last_evaluation)
                 .one(&self.state.worker_db)
                 .await
                 .map_err(|e| SourceError::Database {
                     reason: e.to_string(),
-                })?
-                .ok_or_else(|| SourceError::Database {
-                    reason: "Evaluation not found".to_string(),
                 })?;
 
-            if evaluation.status.is_active() {
-                debug!(status = ?evaluation.status, "Evaluation already in progress, skipping");
-                return Ok((false, remote_hash));
+            if let Some(evaluation) = evaluation {
+                if evaluation.status.is_active() {
+                    debug!(status = ?evaluation.status, "Evaluation already in progress, skipping");
+                    return Ok((false, remote_hash));
+                }
+
+                let commit = ECommit::find_by_id(evaluation.commit)
+                    .one(&self.state.worker_db)
+                    .await
+                    .map_err(|e| SourceError::Database {
+                        reason: e.to_string(),
+                    })?;
+
+                if let Some(commit) = commit {
+                    if commit.hash == remote_hash {
+                        debug!("Remote hash matches current evaluation commit, no update needed");
+                        return Ok((false, remote_hash));
+                    }
+                    info!("Remote hash differs from current evaluation commit, update needed");
+                } else {
+                    info!(eval_id = %last_evaluation, "Last evaluation's commit row missing; treating as update needed");
+                }
+            } else {
+                info!(eval_id = %last_evaluation, "Last evaluation row missing; treating as no previous evaluation");
             }
-
-            let commit = ECommit::find_by_id(evaluation.commit)
-                .one(&self.state.worker_db)
-                .await
-                .map_err(|e| SourceError::Database {
-                    reason: e.to_string(),
-                })?
-                .ok_or_else(|| SourceError::Database {
-                    reason: "Commit not found".to_string(),
-                })?;
-
-            if commit.hash == remote_hash {
-                debug!("Remote hash matches current evaluation commit, no update needed");
-                return Ok((false, remote_hash));
-            }
-
-            info!("Remote hash differs from current evaluation commit, update needed");
         } else {
             info!("No previous evaluation found, update needed");
         }

--- a/backend/core/src/state/mod.rs
+++ b/backend/core/src/state/mod.rs
@@ -73,13 +73,19 @@ pub struct StateProject {
     /// (back-compat). `Some([])` is an error — a project must have at least one.
     #[serde(default)]
     pub triggers: Option<Vec<StateTrigger>>,
+    /// Concurrency policy for this project. Defaults to `skip` when omitted.
+    #[serde(default = "default_skip")]
+    pub concurrency: ConcurrencyPolicy,
+}
+
+fn default_skip() -> ConcurrencyPolicy {
+    ConcurrencyPolicy::Skip
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct StateTrigger {
     #[serde(rename = "type")]
     pub trigger_type: TriggerType,
-    pub concurrency: ConcurrencyPolicy,
     /// Name of an inbound integration in the same org. Required for
     /// `reporter_push` and `reporter_pull_request` triggers.
     #[serde(default)]
@@ -506,5 +512,41 @@ mod tests {
         assert!(cfg.projects["web"].description.is_none());
         assert!(cfg.caches["main"].description.is_none());
         assert!(cfg.validate().is_valid);
+    }
+
+    #[test]
+    fn state_project_concurrency_defaults_to_skip() {
+        let json = r#"{
+            "projects": {
+                "web": {
+                    "name": "web",
+                    "organization": "acme",
+                    "display_name": "Web",
+                    "repository": "https://example.com/acme/web.git",
+                    "created_by": "alice"
+                }
+            }
+        }"#;
+        let cfg: StateConfiguration = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.projects["web"].concurrency, ConcurrencyPolicy::Skip);
+    }
+
+    #[test]
+    fn state_project_concurrency_hard_abort_round_trip() {
+        let json = r#"{
+            "projects": {
+                "web": {
+                    "name": "web",
+                    "organization": "acme",
+                    "display_name": "Web",
+                    "repository": "https://example.com/acme/web.git",
+                    "created_by": "alice",
+                    "concurrency": "hard_abort"
+                }
+            }
+        }"#;
+        let cfg: StateConfiguration = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.projects["web"].concurrency, ConcurrencyPolicy::HardAbort);
+        assert_eq!(cfg.projects["web"].concurrency.as_i16(), 0);
     }
 }

--- a/backend/core/src/state/provisioning.rs
+++ b/backend/core/src/state/provisioning.rs
@@ -1071,6 +1071,7 @@ fn build_trigger_config(
                 .unwrap_or(300) as u32;
             TriggerConfig::Polling {
                 interval_secs: interval,
+                branch: t.config.get("branch").and_then(|v| v.as_str()).map(|s| s.to_owned()),
             }
         }
         TT::ReporterPush | TT::ReporterPullRequest => {
@@ -1334,7 +1335,7 @@ mod trigger_helper_tests {
     fn build_polling_trigger() {
         let t = polling_trigger(60);
         let cfg = build_trigger_config(&t, &empty_integrations()).unwrap();
-        assert_eq!(cfg, TriggerConfig::Polling { interval_secs: 60 });
+        assert_eq!(cfg, TriggerConfig::Polling { interval_secs: 60, branch: None });
     }
 
     #[test]
@@ -1346,7 +1347,7 @@ mod trigger_helper_tests {
             active: true,
         };
         let cfg = build_trigger_config(&t, &empty_integrations()).unwrap();
-        assert_eq!(cfg, TriggerConfig::Polling { interval_secs: 300 });
+        assert_eq!(cfg, TriggerConfig::Polling { interval_secs: 300, branch: None });
     }
 
     #[test]
@@ -1435,14 +1436,14 @@ mod trigger_helper_tests {
 
     #[test]
     fn trigger_key_differs_by_type() {
-        let polling = TriggerConfig::Polling { interval_secs: 60 };
+        let polling = TriggerConfig::Polling { interval_secs: 60, branch: None };
         let time = TriggerConfig::Time { cron: "0 0 * * * *".into() };
         assert_ne!(trigger_key(&polling), trigger_key(&time));
     }
 
     #[test]
     fn trigger_key_stable_for_same_config() {
-        let cfg = TriggerConfig::Polling { interval_secs: 300 };
+        let cfg = TriggerConfig::Polling { interval_secs: 300, branch: None };
         assert_eq!(trigger_key(&cfg), trigger_key(&cfg));
     }
 

--- a/backend/core/src/state/provisioning.rs
+++ b/backend/core/src/state/provisioning.rs
@@ -11,7 +11,7 @@ use super::{
 use crate::ci::{ForgeType, IntegrationKind, encrypt_webhook_secret};
 use crate::types::consts::BASE_ROLE_ADMIN_ID;
 use crate::types::input::load_secret_bytes;
-use crate::types::triggers::{ConcurrencyPolicy, TriggerConfig};
+use crate::types::triggers::TriggerConfig;
 use crate::types::*;
 use anyhow::{Context, Result};
 use base64::{Engine, engine::general_purpose};
@@ -387,6 +387,7 @@ impl<'a> StateApplicator<'a> {
                     created_at: Set(now),
                     managed: Set(true),
                     keep_evaluations: Set(0),
+                    concurrency: Set(3),
                 };
                 let inserted = proj.insert(self.db).await?;
                 tracing::info!("Created managed project: {}", state_project.name);
@@ -999,12 +1000,11 @@ async fn apply_project_triggers<C: ConnectionTrait>(
         anyhow::bail!("project '{}' must have at least one trigger", project.name);
     }
 
-    let mut desired_by_key: HashMap<String, (TriggerConfig, ConcurrencyPolicy, bool)> =
-        HashMap::new();
+    let mut desired_by_key: HashMap<String, (TriggerConfig, bool)> = HashMap::new();
     for t in desired {
         let cfg = build_trigger_config(t, integrations_by_name)?;
-        let key = trigger_key(&cfg, t.concurrency);
-        desired_by_key.insert(key, (cfg, t.concurrency, t.active));
+        let key = trigger_key(&cfg);
+        desired_by_key.insert(key, (cfg, t.active));
     }
 
     let existing: Vec<MProjectTrigger> = EProjectTrigger::find()
@@ -1016,15 +1016,13 @@ async fn apply_project_triggers<C: ConnectionTrait>(
     for row in existing {
         let cfg = TriggerConfig::parse_row(row.trigger_type, &row.config)
             .context("parse existing trigger")?;
-        let conc =
-            ConcurrencyPolicy::from_i16(row.concurrency).unwrap_or(ConcurrencyPolicy::Skip);
-        let key = trigger_key(&cfg, conc);
+        let key = trigger_key(&cfg);
         existing_by_key.insert(key, row);
     }
 
     let now = crate::types::now();
 
-    for (key, (cfg, conc, active)) in &desired_by_key {
+    for (key, (cfg, active)) in &desired_by_key {
         if existing_by_key.contains_key(key) {
             continue;
         }
@@ -1032,7 +1030,6 @@ async fn apply_project_triggers<C: ConnectionTrait>(
             id: Set(ProjectTriggerId::now_v7()),
             project: Set(project.id),
             trigger_type: Set(cfg.trigger_type().as_i16()),
-            concurrency: Set(conc.as_i16()),
             config: Set(cfg.to_db_json()),
             active: Set(*active),
             last_fired_at: Set(None),
@@ -1044,7 +1041,7 @@ async fn apply_project_triggers<C: ConnectionTrait>(
     }
 
     for (key, row) in existing_by_key {
-        if let Some((_, _, active)) = desired_by_key.get(&key) {
+        if let Some((_, active)) = desired_by_key.get(&key) {
             if row.active != *active {
                 let mut a: AProjectTrigger = row.into();
                 a.active = Set(*active);
@@ -1134,15 +1131,10 @@ fn build_trigger_config(
     Ok(cfg)
 }
 
-fn trigger_key(cfg: &TriggerConfig, concurrency: ConcurrencyPolicy) -> String {
+fn trigger_key(cfg: &TriggerConfig) -> String {
     let json = cfg.to_db_json();
     let canonical = serde_json::to_string(&json).unwrap_or_default();
-    format!(
-        "{}|{}|{}",
-        cfg.trigger_type().as_i16(),
-        canonical,
-        concurrency.as_i16()
-    )
+    format!("{}|{}", cfg.trigger_type().as_i16(), canonical)
 }
 
 // ── Pure helpers ──────────────────────────────────────────────────────────────
@@ -1452,23 +1444,13 @@ mod trigger_helper_tests {
     fn trigger_key_differs_by_type() {
         let polling = TriggerConfig::Polling { interval_secs: 60 };
         let time = TriggerConfig::Time { cron: "0 0 * * * *".into() };
-        let conc = ConcurrencyPolicy::Skip;
-        assert_ne!(trigger_key(&polling, conc), trigger_key(&time, conc));
-    }
-
-    #[test]
-    fn trigger_key_differs_by_concurrency() {
-        let cfg = TriggerConfig::Polling { interval_secs: 60 };
-        let key_skip = trigger_key(&cfg, ConcurrencyPolicy::Skip);
-        let key_allow = trigger_key(&cfg, ConcurrencyPolicy::Allow);
-        assert_ne!(key_skip, key_allow);
+        assert_ne!(trigger_key(&polling), trigger_key(&time));
     }
 
     #[test]
     fn trigger_key_stable_for_same_config() {
         let cfg = TriggerConfig::Polling { interval_secs: 300 };
-        let conc = ConcurrencyPolicy::HardAbort;
-        assert_eq!(trigger_key(&cfg, conc), trigger_key(&cfg, conc));
+        assert_eq!(trigger_key(&cfg), trigger_key(&cfg));
     }
 
     #[test]

--- a/backend/core/src/state/provisioning.rs
+++ b/backend/core/src/state/provisioning.rs
@@ -363,6 +363,7 @@ impl<'a> StateApplicator<'a> {
                 proj.evaluation_wildcard = Set(state_project.evaluation_wildcard.clone());
                 proj.force_evaluation = Set(state_project.force_evaluation);
                 proj.created_by = Set(created_by_id);
+                proj.concurrency = Set(state_project.concurrency.as_i16());
                 proj.managed = Set(true);
                 proj.update(self.db).await?;
                 tracing::info!("Updated managed project: {}", state_project.name);
@@ -387,7 +388,7 @@ impl<'a> StateApplicator<'a> {
                     created_at: Set(now),
                     managed: Set(true),
                     keep_evaluations: Set(0),
-                    concurrency: Set(3),
+                    concurrency: Set(state_project.concurrency.as_i16()),
                 };
                 let inserted = proj.insert(self.db).await?;
                 tracing::info!("Created managed project: {}", state_project.name);
@@ -1312,14 +1313,13 @@ mod helper_tests {
 mod trigger_helper_tests {
     use super::{build_trigger_config, trigger_key};
     use crate::state::StateTrigger;
-    use crate::types::triggers::{ConcurrencyPolicy, TriggerConfig, TriggerType};
+    use crate::types::triggers::{TriggerConfig, TriggerType};
     use crate::types::IntegrationId;
     use std::collections::HashMap;
 
     fn polling_trigger(interval_secs: u64) -> StateTrigger {
         StateTrigger {
             trigger_type: TriggerType::Polling,
-            concurrency: ConcurrencyPolicy::Skip,
             integration: None,
             config: serde_json::json!({ "interval_secs": interval_secs }),
             active: true,
@@ -1341,7 +1341,6 @@ mod trigger_helper_tests {
     fn build_polling_defaults_interval_when_missing() {
         let t = StateTrigger {
             trigger_type: TriggerType::Polling,
-            concurrency: ConcurrencyPolicy::Skip,
             integration: None,
             config: serde_json::Value::Null,
             active: true,
@@ -1354,7 +1353,6 @@ mod trigger_helper_tests {
     fn build_polling_rejects_too_small_interval() {
         let t = polling_trigger(5);
         let err = build_trigger_config(&t, &empty_integrations()).unwrap_err();
-        // The outer context says "validation failed"; the chain contains the specific reason.
         let full = format!("{err:#}");
         assert!(
             full.contains("interval_secs") || full.contains("validation"),
@@ -1366,7 +1364,6 @@ mod trigger_helper_tests {
     fn build_time_trigger() {
         let t = StateTrigger {
             trigger_type: TriggerType::Time,
-            concurrency: ConcurrencyPolicy::Allow,
             integration: None,
             config: serde_json::json!({ "cron": "0 0 2 * * *" }),
             active: true,
@@ -1379,7 +1376,6 @@ mod trigger_helper_tests {
     fn build_time_trigger_requires_cron() {
         let t = StateTrigger {
             trigger_type: TriggerType::Time,
-            concurrency: ConcurrencyPolicy::Allow,
             integration: None,
             config: serde_json::json!({}),
             active: true,
@@ -1392,7 +1388,6 @@ mod trigger_helper_tests {
     fn build_reporter_push_requires_integration_name() {
         let t = StateTrigger {
             trigger_type: TriggerType::ReporterPush,
-            concurrency: ConcurrencyPolicy::Skip,
             integration: None,
             config: serde_json::json!({}),
             active: true,
@@ -1405,7 +1400,6 @@ mod trigger_helper_tests {
     fn build_reporter_push_errors_on_unknown_integration() {
         let t = StateTrigger {
             trigger_type: TriggerType::ReporterPush,
-            concurrency: ConcurrencyPolicy::Skip,
             integration: Some("github-app".into()),
             config: serde_json::json!({}),
             active: true,
@@ -1423,7 +1417,6 @@ mod trigger_helper_tests {
 
         let t = StateTrigger {
             trigger_type: TriggerType::ReporterPush,
-            concurrency: ConcurrencyPolicy::SoftAbort,
             integration: Some("gh".into()),
             config: serde_json::json!({ "branches": ["main"], "tags": [], "releases_only": false }),
             active: true,
@@ -1457,13 +1450,11 @@ mod trigger_helper_tests {
     fn state_trigger_serde_round_trip() {
         let json = serde_json::json!({
             "type": "polling",
-            "concurrency": "skip",
             "config": { "interval_secs": 120 },
             "active": true
         });
         let t: StateTrigger = serde_json::from_value(json.clone()).unwrap();
         assert_eq!(t.trigger_type, TriggerType::Polling);
-        assert_eq!(t.concurrency, ConcurrencyPolicy::Skip);
         assert!(t.active);
     }
 
@@ -1471,7 +1462,6 @@ mod trigger_helper_tests {
     fn state_trigger_active_defaults_to_true() {
         let json = serde_json::json!({
             "type": "polling",
-            "concurrency": "allow",
             "config": { "interval_secs": 60 }
         });
         let t: StateTrigger = serde_json::from_value(json).unwrap();

--- a/backend/core/src/types/triggers.rs
+++ b/backend/core/src/types/triggers.rs
@@ -76,7 +76,13 @@ impl ConcurrencyPolicy {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum TriggerConfig {
-    Polling { interval_secs: u32 },
+    Polling {
+        interval_secs: u32,
+        /// Branch to poll (`refs/heads/<branch>`). `None` polls the remote HEAD
+        /// (the repo's default branch).
+        #[serde(default)]
+        branch: Option<String>,
+    },
     ReporterPush {
         integration_id: IntegrationId,
         #[serde(default)]
@@ -147,7 +153,7 @@ impl TriggerConfig {
 
     pub fn validate(&self) -> Result<(), TriggerConfigError> {
         match self {
-            Self::Polling { interval_secs } if *interval_secs < 10 => {
+            Self::Polling { interval_secs, .. } if *interval_secs < 10 => {
                 Err(TriggerConfigError::PollingIntervalTooSmall)
             }
             Self::Time { cron } => {
@@ -175,16 +181,25 @@ mod tests {
 
     #[test]
     fn polling_config_round_trip() {
-        let cfg = TriggerConfig::Polling { interval_secs: 60 };
+        let cfg = TriggerConfig::Polling { interval_secs: 60, branch: None };
         let db = cfg.to_db_json();
-        assert_eq!(db, serde_json::json!({"interval_secs": 60}));
+        assert!(db.get("type").is_none(), "db json should not carry the type tag");
+        let parsed = TriggerConfig::parse_row(0, &db).unwrap();
+        assert_eq!(parsed, cfg);
+    }
+
+    #[test]
+    fn polling_config_with_branch_round_trip() {
+        let cfg = TriggerConfig::Polling { interval_secs: 120, branch: Some("develop".into()) };
+        let db = cfg.to_db_json();
+        assert_eq!(db["branch"], serde_json::json!("develop"));
         let parsed = TriggerConfig::parse_row(0, &db).unwrap();
         assert_eq!(parsed, cfg);
     }
 
     #[test]
     fn polling_under_10_seconds_rejected() {
-        let cfg = TriggerConfig::Polling { interval_secs: 5 };
+        let cfg = TriggerConfig::Polling { interval_secs: 5, branch: None };
         assert!(matches!(cfg.validate(), Err(TriggerConfigError::PollingIntervalTooSmall)));
     }
 

--- a/backend/entity/src/project.rs
+++ b/backend/entity/src/project.rs
@@ -31,6 +31,8 @@ pub struct Model {
     pub created_at: NaiveDateTime,
     pub managed: bool,
     pub keep_evaluations: i32,
+    /// 0 = hard_abort, 1 = soft_abort, 2 = allow, 3 = skip
+    pub concurrency: i16,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/backend/entity/src/project_trigger.rs
+++ b/backend/entity/src/project_trigger.rs
@@ -18,8 +18,6 @@ pub struct Model {
     pub project: ProjectId,
     /// 0 = polling, 1 = reporter_push, 2 = reporter_pull_request, 3 = time
     pub trigger_type: i16,
-    /// 0 = hard_abort, 1 = soft_abort, 2 = allow, 3 = skip
-    pub concurrency: i16,
     pub config: serde_json::Value,
     pub active: bool,
     pub last_fired_at: Option<NaiveDateTime>,

--- a/backend/migration/src/lib.rs
+++ b/backend/migration/src/lib.rs
@@ -93,6 +93,7 @@ mod m20260507_000000_create_table_project_trigger;
 mod m20260507_000001_add_trigger_to_evaluation;
 mod m20260507_000002_drop_inbound_integration;
 mod m20260507_000003_unique_active_evaluation_per_project;
+mod m20260507_000004_move_concurrency_to_project;
 
 pub struct Migrator;
 
@@ -187,6 +188,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260507_000001_add_trigger_to_evaluation::Migration),
             Box::new(m20260507_000002_drop_inbound_integration::Migration),
             Box::new(m20260507_000003_unique_active_evaluation_per_project::Migration),
+            Box::new(m20260507_000004_move_concurrency_to_project::Migration),
         ]
     }
 }

--- a/backend/migration/src/m20260507_000004_move_concurrency_to_project.rs
+++ b/backend/migration/src/m20260507_000004_move_concurrency_to_project.rs
@@ -1,0 +1,80 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Move concurrency policy from per-trigger to per-project. Adds
+//! `project.concurrency` (default 3 = skip) and drops the column on
+//! `project_trigger`. No data migration — every project starts at `skip`.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Project::Table)
+                    .add_column(
+                        ColumnDef::new(Project::Concurrency)
+                            .small_integer()
+                            .not_null()
+                            .default(3),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(ProjectTrigger::Table)
+                    .drop_column(ProjectTrigger::Concurrency)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(ProjectTrigger::Table)
+                    .add_column(
+                        ColumnDef::new(ProjectTrigger::Concurrency)
+                            .small_integer()
+                            .not_null()
+                            .default(3),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Project::Table)
+                    .drop_column(Project::Concurrency)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum Project {
+    Table,
+    Concurrency,
+}
+
+#[derive(DeriveIden)]
+enum ProjectTrigger {
+    #[sea_orm(iden = "project_trigger")]
+    Table,
+    Concurrency,
+}

--- a/backend/scheduler/src/dispatch_tests.rs
+++ b/backend/scheduler/src/dispatch_tests.rs
@@ -90,6 +90,7 @@ fn make_project(id: ProjectId, org_id: OrganizationId) -> entity::project::Model
         created_at: test_date(),
         managed: false,
         keep_evaluations: 30,
+        concurrency: 3,
     }
 }
 
@@ -359,7 +360,6 @@ fn make_polling_trigger(
         id,
         project: project_id,
         trigger_type: 0, // Polling
-        concurrency: 3,  // Skip
         config: serde_json::json!({ "interval_secs": interval_secs }),
         active: true,
         last_fired_at,

--- a/backend/scheduler/src/handler_tests.rs
+++ b/backend/scheduler/src/handler_tests.rs
@@ -269,6 +269,7 @@ fn make_project(id: ProjectId, org_id: OrganizationId) -> entity::project::Model
         created_at: test_date(),
         managed: false,
         keep_evaluations: 30,
+        concurrency: 3,
     }
 }
 

--- a/backend/scheduler/src/trigger_dispatch.rs
+++ b/backend/scheduler/src/trigger_dispatch.rs
@@ -124,8 +124,12 @@ pub(crate) async fn dispatch_once(scheduler: &Scheduler) -> anyhow::Result<()> {
         };
 
         let is_time = matches!(cfg, TriggerConfig::Time { .. });
+        let branch_for_check: Option<String> = match &cfg {
+            TriggerConfig::Polling { branch, .. } => branch.clone(),
+            _ => None,
+        };
         let due = match &cfg {
-            TriggerConfig::Polling { interval_secs } => polling_due(trig.last_fired_at, *interval_secs, now),
+            TriggerConfig::Polling { interval_secs, .. } => polling_due(trig.last_fired_at, *interval_secs, now),
             TriggerConfig::Time { cron } => cron_due(cron, trig.last_fired_at, now),
             _ => false,
         };
@@ -135,7 +139,7 @@ pub(crate) async fn dispatch_once(scheduler: &Scheduler) -> anyhow::Result<()> {
 
         // Resolve target commit. Polling skips when there's no new commit;
         // time triggers always fire with whatever HEAD currently is.
-        let commit_hash = match check_project_updates(Arc::clone(state), project).await {
+        let commit_hash = match check_project_updates(Arc::clone(state), project, branch_for_check.as_deref()).await {
             Ok((true, hash)) => hash,
             Ok((false, hash)) if is_time => hash,
             Ok((false, _)) => {

--- a/backend/scheduler/src/trigger_dispatch.rs
+++ b/backend/scheduler/src/trigger_dispatch.rs
@@ -50,7 +50,7 @@ use std::time::Duration;
 use entity::project_trigger as ept;
 use gradient_core::ci::{apply_trigger, ApplyInput, ApplyOutcome};
 use gradient_core::sources::{check_project_updates, get_commit_info};
-use gradient_core::types::triggers::{ConcurrencyPolicy, TriggerConfig, TriggerType};
+use gradient_core::types::triggers::{TriggerConfig, TriggerType};
 use gradient_core::types::*;
 use sea_orm::{ActiveModelTrait as _, ColumnTrait, Condition, EntityTrait, QueryFilter};
 use tracing::{debug, error, info, warn};
@@ -155,14 +155,12 @@ pub(crate) async fn dispatch_once(scheduler: &Scheduler) -> anyhow::Result<()> {
             .unwrap_or_else(|_| (String::new(), None, String::new()));
 
         let trigger_type = cfg.trigger_type();
-        let concurrency = ConcurrencyPolicy::from_i16(project.concurrency).unwrap_or(ConcurrencyPolicy::Skip);
         match apply_trigger(
             state.worker_db.inner(),
             project,
             ApplyInput {
                 trigger_id: trig.id,
                 trigger_type,
-                concurrency,
                 commit_hash,
                 commit_message: Some(msg),
                 author_name: Some(author),

--- a/backend/scheduler/src/trigger_dispatch.rs
+++ b/backend/scheduler/src/trigger_dispatch.rs
@@ -155,7 +155,7 @@ pub(crate) async fn dispatch_once(scheduler: &Scheduler) -> anyhow::Result<()> {
             .unwrap_or_else(|_| (String::new(), None, String::new()));
 
         let trigger_type = cfg.trigger_type();
-        let concurrency = ConcurrencyPolicy::from_i16(trig.concurrency).unwrap_or(ConcurrencyPolicy::Skip);
+        let concurrency = ConcurrencyPolicy::from_i16(project.concurrency).unwrap_or(ConcurrencyPolicy::Skip);
         match apply_trigger(
             state.worker_db.inner(),
             project,

--- a/backend/web/src/access.rs
+++ b/backend/web/src/access.rs
@@ -390,6 +390,7 @@ mod tests {
             created_at: fixture_date(),
             managed,
             keep_evaluations: 30,
+            concurrency: 3,
         }
     }
 

--- a/backend/web/src/endpoints/forge_hooks/trigger.rs
+++ b/backend/web/src/endpoints/forge_hooks/trigger.rs
@@ -323,7 +323,7 @@ where
         outcome.projects_scanned += 1;
 
         let concurrency =
-            ConcurrencyPolicy::from_i16(trig.concurrency).unwrap_or(ConcurrencyPolicy::HardAbort);
+            ConcurrencyPolicy::from_i16(project.concurrency).unwrap_or(ConcurrencyPolicy::Skip);
         let org_name = org_name_for(state, project.organization).await.unwrap_or_default();
 
         match apply_trigger(

--- a/backend/web/src/endpoints/forge_hooks/trigger.rs
+++ b/backend/web/src/endpoints/forge_hooks/trigger.rs
@@ -9,7 +9,7 @@
 use super::response::{QueuedEvaluation, SkippedProject, WebhookTriggerOutcome};
 use entity::project_trigger as ept;
 use gradient_core::ci::{apply_trigger, ApplyInput, ApplyOutcome};
-use gradient_core::types::triggers::{ConcurrencyPolicy, TriggerConfig, TriggerType};
+use gradient_core::types::triggers::{TriggerConfig, TriggerType};
 use gradient_core::types::*;
 use scheduler::Scheduler;
 use sea_orm::ActiveValue::Set;
@@ -322,8 +322,6 @@ where
         };
         outcome.projects_scanned += 1;
 
-        let concurrency =
-            ConcurrencyPolicy::from_i16(project.concurrency).unwrap_or(ConcurrencyPolicy::Skip);
         let org_name = org_name_for(state, project.organization).await.unwrap_or_default();
 
         match apply_trigger(
@@ -332,7 +330,6 @@ where
             ApplyInput {
                 trigger_id: trig.id,
                 trigger_type,
-                concurrency,
                 commit_hash: commit_hash.clone(),
                 commit_message: commit_message.clone(),
                 author_name: author_name.clone(),

--- a/backend/web/src/endpoints/projects/evaluations.rs
+++ b/backend/web/src/endpoints/projects/evaluations.rs
@@ -208,9 +208,10 @@ pub async fn post_project_evaluate(
 
     let mut project_for_check = project.clone();
     project_for_check.force_evaluation = true;
-    let (_has_updates, commit_hash) = check_project_updates(Arc::clone(&state), &project_for_check)
-        .await
-        .map_err(|e| anyhow::anyhow!(e))?;
+    let (_has_updates, commit_hash) =
+        check_project_updates(Arc::clone(&state), &project_for_check, None)
+            .await
+            .map_err(|e| anyhow::anyhow!(e))?;
 
     if commit_hash.is_empty() {
         return Err(WebError::internal(

--- a/backend/web/src/endpoints/projects/management.rs
+++ b/backend/web/src/endpoints/projects/management.rs
@@ -240,7 +240,7 @@ pub async fn put(
     let project = project.insert(&state.web_db).await?;
 
     let now = gradient_core::types::now();
-    let default_cfg = TriggerConfig::Polling { interval_secs: 300 };
+    let default_cfg = TriggerConfig::Polling { interval_secs: 300, branch: None };
     AProjectTrigger {
         id: Set(ProjectTriggerId::now_v7()),
         project: Set(project.id),
@@ -549,7 +549,7 @@ pub async fn post_project_check_repository(
     )
     .await?;
 
-    let (_has_updates, remote_hash) = check_project_updates(Arc::clone(&state), &project)
+    let (_has_updates, remote_hash) = check_project_updates(Arc::clone(&state), &project, None)
         .await
         .map_err(|e| anyhow::anyhow!(e))?;
 

--- a/backend/web/src/endpoints/projects/management.rs
+++ b/backend/web/src/endpoints/projects/management.rs
@@ -18,7 +18,7 @@ use gradient_core::nix::RepositoryUrl;
 use gradient_core::sources::check_project_updates;
 use gradient_core::types::consts::*;
 use gradient_core::types::input::{check_index_name, validate_display_name, vec_to_hex};
-use gradient_core::types::triggers::{ConcurrencyPolicy, TriggerConfig, TriggerType};
+use gradient_core::types::triggers::{TriggerConfig, TriggerType};
 use gradient_core::types::wildcard::Wildcard;
 use gradient_core::types::*;
 use sea_orm::ActiveValue::Set;
@@ -225,6 +225,7 @@ pub async fn put(
         created_at: Set(gradient_core::types::now()),
         managed: Set(false),
         keep_evaluations: Set(30),
+        concurrency: Set(3),
     };
 
     let project = project.insert(&state.web_db).await?;
@@ -235,7 +236,6 @@ pub async fn put(
         id: Set(ProjectTriggerId::now_v7()),
         project: Set(project.id),
         trigger_type: Set(TriggerType::Polling.as_i16()),
-        concurrency: Set(ConcurrencyPolicy::Skip.as_i16()),
         config: Set(default_cfg.to_db_json()),
         active: Set(true),
         last_fired_at: Set(None),

--- a/backend/web/src/endpoints/projects/management.rs
+++ b/backend/web/src/endpoints/projects/management.rs
@@ -18,7 +18,7 @@ use gradient_core::nix::RepositoryUrl;
 use gradient_core::sources::check_project_updates;
 use gradient_core::types::consts::*;
 use gradient_core::types::input::{check_index_name, validate_display_name, vec_to_hex};
-use gradient_core::types::triggers::{TriggerConfig, TriggerType};
+use gradient_core::types::triggers::{ConcurrencyPolicy, TriggerConfig, TriggerType};
 use gradient_core::types::wildcard::Wildcard;
 use gradient_core::types::*;
 use sea_orm::ActiveValue::Set;
@@ -36,6 +36,8 @@ pub struct MakeProjectRequest {
     pub description: String,
     pub repository: String,
     pub evaluation_wildcard: String,
+    #[serde(default)]
+    pub concurrency: Option<ConcurrencyPolicy>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -46,6 +48,7 @@ pub struct PatchProjectRequest {
     pub repository: Option<String>,
     pub evaluation_wildcard: Option<String>,
     pub keep_evaluations: Option<i32>,
+    pub concurrency: Option<ConcurrencyPolicy>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -141,6 +144,8 @@ pub async fn get(
                 last_evaluation_status,
                 force_evaluation: p.force_evaluation,
                 keep_evaluations: p.keep_evaluations,
+                concurrency: ConcurrencyPolicy::from_i16(p.concurrency)
+                    .unwrap_or(ConcurrencyPolicy::Skip),
                 created_by: p.created_by,
                 created_at: p.created_at,
                 managed: p.managed,
@@ -163,6 +168,10 @@ pub async fn put(
     Path(organization): Path<String>,
     Json(body): Json<MakeProjectRequest>,
 ) -> WebResult<Json<BaseResponse<String>>> {
+    if let Some(ConcurrencyPolicy::Allow) = body.concurrency {
+        return Err(WebError::bad_request("`allow` concurrency is reserved"));
+    }
+
     if check_index_name(body.name.clone().as_str()).is_err() {
         return Err(WebError::invalid_name("Project Name"));
     }
@@ -225,7 +234,7 @@ pub async fn put(
         created_at: Set(gradient_core::types::now()),
         managed: Set(false),
         keep_evaluations: Set(30),
-        concurrency: Set(3),
+        concurrency: Set(body.concurrency.unwrap_or(ConcurrencyPolicy::Skip).as_i16()),
     };
 
     let project = project.insert(&state.web_db).await?;
@@ -299,6 +308,8 @@ pub async fn get_project(
         created_at: project.created_at,
         managed: project.managed,
         keep_evaluations: project.keep_evaluations,
+        concurrency: ConcurrencyPolicy::from_i16(project.concurrency)
+            .unwrap_or(ConcurrencyPolicy::Skip),
         can_edit,
     }))
 }
@@ -340,6 +351,9 @@ pub async fn patch_project(
     }
     if let Some(keep) = body.keep_evaluations {
         patcher.apply_keep_evaluations(keep)?;
+    }
+    if let Some(concurrency) = body.concurrency {
+        patcher.apply_concurrency(concurrency)?;
     }
 
     aproject.force_evaluation = Set(true);
@@ -423,6 +437,14 @@ impl<'a> ProjectPatcher<'a> {
             )));
         }
         self.aproject.keep_evaluations = Set(keep);
+        Ok(())
+    }
+
+    fn apply_concurrency(&mut self, concurrency: ConcurrencyPolicy) -> WebResult<()> {
+        if concurrency == ConcurrencyPolicy::Allow {
+            return Err(WebError::bad_request("`allow` concurrency is reserved"));
+        }
+        self.aproject.concurrency = Set(concurrency.as_i16());
         Ok(())
     }
 }

--- a/backend/web/src/endpoints/projects/mod.rs
+++ b/backend/web/src/endpoints/projects/mod.rs
@@ -29,6 +29,7 @@ use gradient_core::types::ids::*;
 // ── Shared types ─────────────────────────────────────────────────────────────
 
 use entity::evaluation::EvaluationStatus;
+use gradient_core::types::triggers::ConcurrencyPolicy;
 use gradient_core::types::{ProjectTriggerId, TriggerType};
 use serde::{Deserialize, Serialize};
 
@@ -49,6 +50,7 @@ pub struct ProjectResponse {
     pub created_at: chrono::NaiveDateTime,
     pub managed: bool,
     pub keep_evaluations: i32,
+    pub concurrency: ConcurrencyPolicy,
     pub can_edit: bool,
 }
 

--- a/backend/web/src/endpoints/projects/triggers.rs
+++ b/backend/web/src/endpoints/projects/triggers.rs
@@ -37,7 +37,6 @@ pub struct TriggerOut {
     pub project: ProjectId,
     #[serde(rename = "type")]
     pub trigger_type: TriggerType,
-    pub concurrency: ConcurrencyPolicy,
     pub config: serde_json::Value,
     pub active: bool,
     pub last_fired_at: Option<chrono::NaiveDateTime>,
@@ -51,8 +50,6 @@ impl From<MProjectTrigger> for TriggerOut {
             id: m.id,
             project: m.project,
             trigger_type: TriggerType::from_i16(m.trigger_type).unwrap_or(TriggerType::Polling),
-            concurrency: ConcurrencyPolicy::from_i16(m.concurrency)
-                .unwrap_or(ConcurrencyPolicy::Skip),
             config: m.config,
             active: m.active,
             last_fired_at: m.last_fired_at,
@@ -65,7 +62,6 @@ impl From<MProjectTrigger> for TriggerOut {
 #[derive(Deserialize, Debug)]
 pub struct CreateBody {
     pub config: TriggerConfig,
-    pub concurrency: ConcurrencyPolicy,
     #[serde(default = "default_true")]
     pub active: bool,
 }
@@ -77,22 +73,12 @@ fn default_true() -> bool {
 #[derive(Deserialize, Debug)]
 pub struct UpdateBody {
     pub config: Option<TriggerConfig>,
-    pub concurrency: Option<ConcurrencyPolicy>,
     pub active: Option<bool>,
 }
 
 #[derive(Serialize, Debug)]
 pub struct DeletedResponse {
     pub deleted: bool,
-}
-
-fn reject_allow(concurrency: ConcurrencyPolicy) -> WebResult<()> {
-    if concurrency == ConcurrencyPolicy::Allow {
-        return Err(WebError::bad_request(
-            "concurrency `allow` is reserved",
-        ));
-    }
-    Ok(())
 }
 
 /// `GET /projects/{org}/{project}/triggers` — list all triggers for the project.
@@ -137,7 +123,6 @@ pub async fn create(
     )
     .await?;
 
-    reject_allow(body.concurrency)?;
     body.config
         .validate()
         .map_err(|e| WebError::bad_request(e.to_string()))?;
@@ -150,7 +135,6 @@ pub async fn create(
         id: Set(ProjectTriggerId::now_v7()),
         project: Set(proj.id),
         trigger_type: Set(trigger_type.as_i16()),
-        concurrency: Set(body.concurrency.as_i16()),
         config: Set(config_json),
         active: Set(body.active),
         last_fired_at: Set(None),
@@ -214,9 +198,6 @@ pub async fn update(
         .await?
         .or_not_found("Trigger")?;
 
-    if let Some(ref c) = body.concurrency {
-        reject_allow(*c)?;
-    }
     if let Some(ref cfg) = body.config {
         cfg.validate()
             .map_err(|e| WebError::bad_request(e.to_string()))?;
@@ -227,9 +208,6 @@ pub async fn update(
         let tt = cfg.trigger_type();
         active.trigger_type = Set(tt.as_i16());
         active.config = Set(cfg.to_db_json());
-    }
-    if let Some(c) = body.concurrency {
-        active.concurrency = Set(c.as_i16());
     }
     if let Some(a) = body.active {
         active.active = Set(a);
@@ -304,8 +282,8 @@ pub async fn fire_now(
 
     let trigger_type = TriggerType::from_i16(row.trigger_type)
         .ok_or_else(|| WebError::internal("invalid trigger_type in row"))?;
-    let concurrency = ConcurrencyPolicy::from_i16(row.concurrency)
-        .ok_or_else(|| WebError::internal("invalid concurrency in row"))?;
+    let concurrency = ConcurrencyPolicy::from_i16(proj.concurrency)
+        .unwrap_or(ConcurrencyPolicy::Skip);
 
     let (commit_hash, commit_message, author_name) = resolve_head(Arc::clone(&state), &proj)
         .await

--- a/backend/web/src/endpoints/projects/triggers.rs
+++ b/backend/web/src/endpoints/projects/triggers.rs
@@ -283,9 +283,17 @@ pub async fn fire_now(
     let trigger_type = TriggerType::from_i16(row.trigger_type)
         .ok_or_else(|| WebError::internal("invalid trigger_type in row"))?;
 
-    let (commit_hash, commit_message, author_name) = resolve_head(Arc::clone(&state), &proj)
-        .await
-        .map_err(|e| WebError::internal(e.to_string()))?;
+    let branch_for_fire: Option<String> = TriggerConfig::parse_row(row.trigger_type, &row.config)
+        .ok()
+        .and_then(|cfg| match cfg {
+            TriggerConfig::Polling { branch, .. } => branch,
+            _ => None,
+        });
+
+    let (commit_hash, commit_message, author_name) =
+        resolve_head(Arc::clone(&state), &proj, branch_for_fire.as_deref())
+            .await
+            .map_err(|e| WebError::internal(e.to_string()))?;
 
     let input = ApplyInput {
         trigger_id: row.id,

--- a/backend/web/src/endpoints/projects/triggers.rs
+++ b/backend/web/src/endpoints/projects/triggers.rs
@@ -16,7 +16,7 @@ use axum::{Extension, Json, Router};
 use chrono::Utc;
 use gradient_core::ci::{apply_trigger, ApplyInput, ApplyOutcome};
 use gradient_core::sources::resolve_head;
-use gradient_core::types::triggers::{ConcurrencyPolicy, TriggerConfig, TriggerType};
+use gradient_core::types::triggers::{TriggerConfig, TriggerType};
 use gradient_core::types::*;
 use scheduler::Scheduler;
 use sea_orm::ActiveValue::Set;
@@ -282,8 +282,6 @@ pub async fn fire_now(
 
     let trigger_type = TriggerType::from_i16(row.trigger_type)
         .ok_or_else(|| WebError::internal("invalid trigger_type in row"))?;
-    let concurrency = ConcurrencyPolicy::from_i16(proj.concurrency)
-        .unwrap_or(ConcurrencyPolicy::Skip);
 
     let (commit_hash, commit_message, author_name) = resolve_head(Arc::clone(&state), &proj)
         .await
@@ -292,7 +290,6 @@ pub async fn fire_now(
     let input = ApplyInput {
         trigger_id: row.id,
         trigger_type,
-        concurrency,
         commit_hash,
         commit_message: Some(commit_message),
         author_name: Some(author_name),

--- a/backend/web/tests/builds_download.rs
+++ b/backend/web/tests/builds_download.rs
@@ -141,6 +141,7 @@ fn project_row() -> entity::project::Model {
         created_at: test_date(),
         managed: false,
         keep_evaluations: 10,
+        concurrency: 3,
     }
 }
 

--- a/backend/web/tests/evaluations.rs
+++ b/backend/web/tests/evaluations.rs
@@ -116,6 +116,7 @@ fn project_row() -> entity::project::Model {
         created_at: test_date(),
         managed: false,
         keep_evaluations: 10,
+        concurrency: 3,
     }
 }
 
@@ -133,7 +134,6 @@ fn polling_trigger_row() -> entity::project_trigger::Model {
         id: trigger_id(),
         project: project_id(),
         trigger_type: 0, // Polling
-        concurrency: 3,  // Skip
         config: serde_json::json!({"interval_secs": 60}),
         active: true,
         last_fired_at: None,

--- a/backend/web/tests/forge_hooks.rs
+++ b/backend/web/tests/forge_hooks.rs
@@ -20,7 +20,7 @@ use entity::evaluation::EvaluationStatus;
 use gradient_core::ci::{WebhookClient, encrypt_webhook_secret};
 use gradient_core::storage::{EmailSender, NarStore};
 use gradient_core::types::ids::*;
-use gradient_core::types::triggers::{ConcurrencyPolicy, TriggerConfig};
+use gradient_core::types::triggers::TriggerConfig;
 use gradient_core::types::{ServerState, WebDb, WorkerDb};
 use hmac::{Hmac, KeyInit, Mac};
 use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
@@ -215,6 +215,7 @@ fn project_row() -> entity::project::Model {
         created_at: fixture_date(),
         managed: false,
         keep_evaluations: 10,
+        concurrency: 3,
     }
 }
 
@@ -253,7 +254,6 @@ fn trigger_row(cfg: TriggerConfig) -> entity::project_trigger::Model {
         id: trigger_id(),
         project: project_id(),
         trigger_type: cfg.trigger_type().as_i16(),
-        concurrency: ConcurrencyPolicy::HardAbort.as_i16(),
         config: cfg.to_db_json(),
         active: true,
         last_fired_at: None,

--- a/backend/web/tests/triggers.rs
+++ b/backend/web/tests/triggers.rs
@@ -213,7 +213,6 @@ fn list_triggers_returns_rows() {
         let items = body["message"].as_array().expect("message is array");
         assert_eq!(items.len(), 1);
         assert_eq!(items[0]["type"], "polling");
-        assert_eq!(items[0]["concurrency"], "skip");
         assert_eq!(items[0]["active"], true);
     });
 }
@@ -288,8 +287,7 @@ fn create_polling_trigger_valid() {
             .post(BASE_URL)
             .add_header("authorization", format!("Bearer {}", token))
             .json(&serde_json::json!({
-                "config": {"type": "polling", "interval_secs": 60},
-                "concurrency": "skip"
+                "config": {"type": "polling", "interval_secs": 60}
             }))
             .await;
 
@@ -297,7 +295,6 @@ fn create_polling_trigger_valid() {
         let body: Value = res.json();
         assert_eq!(body["error"], false);
         assert_eq!(body["message"]["type"], "polling");
-        assert_eq!(body["message"]["concurrency"], "skip");
     });
 }
 
@@ -318,8 +315,7 @@ fn create_polling_trigger_interval_too_small_returns_400() {
             .post(BASE_URL)
             .add_header("authorization", format!("Bearer {}", token))
             .json(&serde_json::json!({
-                "config": {"type": "polling", "interval_secs": 5},
-                "concurrency": "skip"
+                "config": {"type": "polling", "interval_secs": 5}
             }))
             .await;
 
@@ -328,39 +324,6 @@ fn create_polling_trigger_interval_too_small_returns_400() {
         assert_eq!(body["error"], true);
         let msg = body["message"].as_str().unwrap();
         assert!(msg.contains("interval_secs"), "expected interval message, got: {msg}");
-    });
-}
-
-#[test]
-fn create_concurrency_allow_returns_400() {
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap();
-    rt.block_on(async {
-        let session_id = SessionId::now_v7();
-        let token = make_token(session_id);
-
-        let db = with_project_edit(with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id));
-
-        let server = make_server(db.into_connection());
-        let res = server
-            .post(BASE_URL)
-            .add_header("authorization", format!("Bearer {}", token))
-            .json(&serde_json::json!({
-                "config": {"type": "polling", "interval_secs": 60},
-                "concurrency": "allow"
-            }))
-            .await;
-
-        res.assert_status_bad_request();
-        let body: Value = res.json();
-        assert_eq!(body["error"], true);
-        assert!(
-            body["message"].as_str().unwrap().contains("allow"),
-            "expected allow mention, got: {}",
-            body["message"]
-        );
     });
 }
 
@@ -381,8 +344,7 @@ fn create_invalid_cron_returns_400() {
             .post(BASE_URL)
             .add_header("authorization", format!("Bearer {}", token))
             .json(&serde_json::json!({
-                "config": {"type": "time", "cron": "not a cron"},
-                "concurrency": "skip"
+                "config": {"type": "time", "cron": "not a cron"}
             }))
             .await;
 
@@ -413,13 +375,13 @@ fn patch_trigger_updates_fields() {
         let res = server
             .patch(&format!("{}/{}", BASE_URL, tid))
             .add_header("authorization", format!("Bearer {}", token))
-            .json(&serde_json::json!({"concurrency": "hard_abort"}))
+            .json(&serde_json::json!({"active": false}))
             .await;
 
         res.assert_status_ok();
         let body: Value = res.json();
         assert_eq!(body["error"], false);
-        assert_eq!(body["message"]["concurrency"], "hard_abort");
+        assert_eq!(body["message"]["type"], "polling");
     });
 }
 
@@ -457,31 +419,6 @@ fn patch_trigger_config_type_change() {
         let body: Value = res.json();
         assert_eq!(body["error"], false);
         assert_eq!(body["message"]["type"], "time");
-    });
-}
-
-#[test]
-fn patch_trigger_allow_concurrency_returns_400() {
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap();
-    rt.block_on(async {
-        let session_id = SessionId::now_v7();
-        let token = make_token(session_id);
-        let tid = trigger_id();
-
-        let db = with_project_edit(with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id))
-            .append_query_results([vec![polling_trigger_row()]]);
-
-        let server = make_server(db.into_connection());
-        let res = server
-            .patch(&format!("{}/{}", BASE_URL, tid))
-            .add_header("authorization", format!("Bearer {}", token))
-            .json(&serde_json::json!({"concurrency": "allow"}))
-            .await;
-
-        res.assert_status_bad_request();
     });
 }
 
@@ -648,5 +585,170 @@ fn create_project_seeds_default_polling_trigger() {
         let body: Value = res.json();
         assert_eq!(body["error"], false);
         assert_eq!(body["message"], project_id().to_string());
+    });
+}
+
+#[test]
+fn create_project_with_allow_concurrency_returns_400() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let session_id = SessionId::now_v7();
+        let token = make_token(session_id);
+
+        let db = with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id)
+            .append_query_results([vec![org()]])
+            .append_query_results([vec![admin_membership()]]);
+
+        let server = make_server(db.into_connection());
+        let res = server
+            .put("/api/v1/projects/test-org")
+            .add_header("authorization", format!("Bearer {}", token))
+            .json(&serde_json::json!({
+                "name": "new-project",
+                "display_name": "New Project",
+                "description": "",
+                "repository": "https://github.com/test/repo",
+                "evaluation_wildcard": "*",
+                "concurrency": "allow"
+            }))
+            .await;
+
+        res.assert_status_bad_request();
+        let body: Value = res.json();
+        assert_eq!(body["error"], true);
+        assert!(
+            body["message"].as_str().unwrap().contains("allow"),
+            "expected allow mention, got: {}",
+            body["message"]
+        );
+    });
+}
+
+#[test]
+fn create_project_with_hard_abort_concurrency_returns_id() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let session_id = SessionId::now_v7();
+        let token = make_token(session_id);
+
+        let created_project = project::Model {
+            id: project_id(),
+            organization: org_id(),
+            name: "new-project".into(),
+            active: true,
+            display_name: "New Project".into(),
+            description: "".into(),
+            repository: "https://github.com/test/repo".into(),
+            evaluation_wildcard: "*".into(),
+            last_evaluation: None,
+            last_check_at: test_date(),
+            force_evaluation: false,
+            created_by: user_id(),
+            created_at: test_date(),
+            managed: false,
+            keep_evaluations: 30,
+            concurrency: 0, // HardAbort
+        };
+
+        let seeded_trigger = entity::project_trigger::Model {
+            id: trigger_id(),
+            project: project_id(),
+            trigger_type: 0,
+            config: serde_json::json!({"interval_secs": 300}),
+            active: true,
+            last_fired_at: None,
+            created_at: test_date(),
+            updated_at: test_date(),
+        };
+
+        let db = with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id)
+            .append_query_results([vec![org()]])
+            .append_query_results([vec![admin_membership()]])
+            .append_query_results([Vec::<project::Model>::new()])
+            .append_query_results([vec![created_project]])
+            .append_query_results([vec![seeded_trigger]]);
+
+        let server = make_server(db.into_connection());
+        let res = server
+            .put("/api/v1/projects/test-org")
+            .add_header("authorization", format!("Bearer {}", token))
+            .json(&serde_json::json!({
+                "name": "new-project",
+                "display_name": "New Project",
+                "description": "",
+                "repository": "https://github.com/test/repo",
+                "evaluation_wildcard": "*",
+                "concurrency": "hard_abort"
+            }))
+            .await;
+
+        res.assert_status_ok();
+        let body: Value = res.json();
+        assert_eq!(body["error"], false);
+        assert_eq!(body["message"], project_id().to_string());
+    });
+}
+
+#[test]
+fn patch_project_concurrency_to_skip() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let session_id = SessionId::now_v7();
+        let token = make_token(session_id);
+
+        let db = with_project_edit(with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id))
+            // aproject.update() — read-back then exec
+            .append_query_results([vec![project_row()]])
+            .append_exec_results([MockExecResult { last_insert_id: 0, rows_affected: 1 }]);
+
+        let server = make_server(db.into_connection());
+        let res = server
+            .patch("/api/v1/projects/test-org/test-project")
+            .add_header("authorization", format!("Bearer {}", token))
+            .json(&serde_json::json!({"concurrency": "skip"}))
+            .await;
+
+        res.assert_status_ok();
+        let body: Value = res.json();
+        assert_eq!(body["error"], false);
+    });
+}
+
+#[test]
+fn patch_project_allow_concurrency_returns_400() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let session_id = SessionId::now_v7();
+        let token = make_token(session_id);
+
+        let db = with_project_edit(with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id));
+
+        let server = make_server(db.into_connection());
+        let res = server
+            .patch("/api/v1/projects/test-org/test-project")
+            .add_header("authorization", format!("Bearer {}", token))
+            .json(&serde_json::json!({"concurrency": "allow"}))
+            .await;
+
+        res.assert_status_bad_request();
+        let body: Value = res.json();
+        assert_eq!(body["error"], true);
+        assert!(
+            body["message"].as_str().unwrap().contains("allow"),
+            "expected allow mention, got: {}",
+            body["message"]
+        );
     });
 }

--- a/backend/web/tests/triggers.rs
+++ b/backend/web/tests/triggers.rs
@@ -127,6 +127,7 @@ fn project_row() -> entity::project::Model {
         created_at: test_date(),
         managed: false,
         keep_evaluations: 10,
+        concurrency: 3,
     }
 }
 
@@ -144,7 +145,6 @@ fn polling_trigger_row() -> project_trigger::Model {
         id: trigger_id(),
         project: project_id(),
         trigger_type: 0, // Polling
-        concurrency: 3,  // Skip
         config: serde_json::json!({"interval_secs": 60}),
         active: true,
         last_fired_at: None,
@@ -403,10 +403,7 @@ fn patch_trigger_updates_fields() {
         let token = make_token(session_id);
         let tid = trigger_id();
 
-        let updated = project_trigger::Model {
-            concurrency: 0, // HardAbort
-            ..polling_trigger_row()
-        };
+        let updated = polling_trigger_row();
 
         let db = with_project_edit(with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id))
             .append_query_results([vec![polling_trigger_row()]])
@@ -439,7 +436,6 @@ fn patch_trigger_config_type_change() {
 
         let updated = project_trigger::Model {
             trigger_type: 3, // Time
-            concurrency: 3,
             config: serde_json::json!({"cron": "0 0 2 * * *"}),
             ..polling_trigger_row()
         };
@@ -609,13 +605,13 @@ fn create_project_seeds_default_polling_trigger() {
             created_at: test_date(),
             managed: false,
             keep_evaluations: 30,
+            concurrency: 3,
         };
 
         let seeded_trigger = project_trigger::Model {
             id: trigger_id(),
             project: project_id(),
             trigger_type: 0,  // Polling
-            concurrency: 3,   // Skip
             config: serde_json::json!({"interval_secs": 300}),
             active: true,
             last_fired_at: None,

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -1875,12 +1875,10 @@ paths:
           application/json:
             schema:
               type: object
-              required: [config, concurrency]
+              required: [config]
               properties:
                 config:
                   $ref: '#/components/schemas/TriggerConfig'
-                concurrency:
-                  $ref: '#/components/schemas/ConcurrencyPolicy'
                 active:
                   type: boolean
                   default: true
@@ -1949,8 +1947,6 @@ paths:
               properties:
                 config:
                   $ref: '#/components/schemas/TriggerConfig'
-                concurrency:
-                  $ref: '#/components/schemas/ConcurrencyPolicy'
                 active:
                   type: boolean
       responses:
@@ -4640,6 +4636,8 @@ components:
           type: string
           description: Nix attribute path to evaluate (e.g. `packages.x86_64-linux` or `checks`)
           example: "packages.x86_64-linux"
+        concurrency:
+          $ref: '#/components/schemas/ConcurrencyPolicy'
 
     PatchProjectRequest:
       type: object
@@ -4658,6 +4656,8 @@ components:
           type: integer
           minimum: 1
           description: Number of completed evaluations to retain for metrics and history
+        concurrency:
+          $ref: '#/components/schemas/ConcurrencyPolicy'
 
     Project:
       type: object
@@ -4685,6 +4685,8 @@ components:
         keep_evaluations:
           type: integer
           description: Number of completed evaluations retained for metrics and history
+        concurrency:
+          $ref: '#/components/schemas/ConcurrencyPolicy'
         created_by:
           type: string
           format: uuid
@@ -5649,7 +5651,7 @@ components:
     ConcurrencyPolicy:
       type: string
       enum: [hard_abort, soft_abort, allow, skip]
-      description: '`allow` is reserved and rejected with 400 at create/update.'
+      description: 'Project-level policy for handling new trigger events while an evaluation is in flight. `allow` is reserved and rejected with 400 at create/update.'
 
     PollingTriggerConfig:
       type: object
@@ -5715,7 +5717,7 @@ components:
 
     ProjectTrigger:
       type: object
-      required: [id, project, type, concurrency, config, active, created_at, updated_at]
+      required: [id, project, type, config, active, created_at, updated_at]
       properties:
         id:
           type: string
@@ -5725,8 +5727,6 @@ components:
           format: uuid
         type:
           $ref: '#/components/schemas/TriggerType'
-        concurrency:
-          $ref: '#/components/schemas/ConcurrencyPolicy'
         config:
           $ref: '#/components/schemas/TriggerConfig'
         active:

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -5660,6 +5660,10 @@ components:
         interval_secs:
           type: integer
           minimum: 10
+        branch:
+          type: string
+          nullable: true
+          description: 'Branch to poll (e.g. "main"). Leave null/omit to poll the remote HEAD (the repo''s default branch).'
 
     ReporterPushTriggerConfig:
       type: object

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -1136,7 +1136,7 @@ Run with `cargo test -p scheduler --tests waiting_reason_tests`.
 
 - `core::types::triggers` — round-trip serialisation, polling interval validation (≥10s), six-field cron parsing, type/JSON shape mismatches.
 - `core::ci::abort` — `abort_evaluation` hard vs soft, terminal eval no-op.
-- `core::ci::apply` — `apply_trigger` orchestration: same-commit dedup, time-trigger and manual bypass, concurrency policies (skip / hard_abort / soft_abort / allow→reserved).
+- `core::ci::apply` — `apply_trigger` orchestration: same-commit dedup, time-trigger and manual bypass, project-level concurrency policies (skip / hard_abort / soft_abort / allow→reserved).
 - `core::state::provisioning` — trigger config builder helpers, integration name resolution, key stability.
 - `scheduler::trigger_dispatch` — `polling_due` and `cron_due` boundary conditions; `dispatch_once` no-trigger and within-interval skip cases.
 - `scheduler::jobs::JobTracker::remove_job` — pending and active map removal; unknown id no-op.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -1134,7 +1134,7 @@ Run with `cargo test -p scheduler --tests waiting_reason_tests`.
 
 ## Project triggers (issue #116)
 
-- `core::types::triggers` — round-trip serialisation, polling interval validation (≥10s), six-field cron parsing, type/JSON shape mismatches.
+- `core::types::triggers` — round-trip serialisation, polling interval validation (≥10s), polling branch field (optional, nullable), six-field cron parsing, type/JSON shape mismatches.
 - `core::ci::abort` — `abort_evaluation` hard vs soft, terminal eval no-op.
 - `core::ci::apply` — `apply_trigger` orchestration: same-commit dedup, time-trigger and manual bypass, project-level concurrency policies (skip / hard_abort / soft_abort / allow→reserved).
 - `core::state::provisioning` — trigger config builder helpers, integration name resolution, key stability.

--- a/docs/src/usage/state.md
+++ b/docs/src/usage/state.md
@@ -114,6 +114,7 @@ services.gradient.state.projects = {
     repository           = "git@github.com:acme/web-app.git";
     evaluation_wildcard  = "packages.x86_64-linux.*";
     active               = true;
+    concurrency          = "hard_abort"; # optional, default "skip"
     outbound_integration = "acme-status-reports"; # optional
     created_by           = "alice";
   };
@@ -132,6 +133,7 @@ services.gradient.state.projects = {
 | `evaluation_wildcard` | `packages.x86_64-linux.*` | Attr-path pattern picked up by the evaluator |
 | `active` | `true` | Disable to pause polling/evaluations without deleting |
 | `force_evaluation` | `false` | Re-evaluate on next poll regardless of the last commit hash |
+| `concurrency` | `"skip"` | Policy for handling new trigger events while an evaluation is in flight (`hard_abort`, `soft_abort`, `skip`). Applies to all triggers on the project |
 | `outbound_integration` | `null` | Name of an `outbound` integration that receives CI status reports |
 | `created_by` | — | Username of creator (required) |
 
@@ -350,38 +352,40 @@ State-managed worker registrations are deleted automatically when removed from `
 Each project can have one or more triggers that decide *when* an evaluation runs.
 Triggers are configurable via the API or declaratively in state files.
 
+The concurrency policy — what happens when a new trigger event arrives while an evaluation is already in flight — is a **project-level** setting, not per-trigger. Set it on the project with `concurrency` (see [Project options](#project-options) above).
+
 ```nix
-services.gradient.state.projects.my-project.triggers = [
-  {
-    type = "polling";
-    config = { interval_secs = 60; };
-    concurrency = "skip";
-  }
-  {
-    type = "reporter_push";
-    integration = "gitea-prod";          # name of an inbound integration in the same org
-    config = {
-      branches = [ "main" "release/*" ];
-      tags = [];
-      releases_only = false;
-    };
-    concurrency = "hard_abort";
-  }
-  {
-    type = "reporter_pull_request";
-    integration = "gitea-prod";
-    config = {
-      branches = [ "main" ];
-      actions = [ "opened" "synchronize" "reopened" ];
-    };
-    concurrency = "hard_abort";
-  }
-  {
-    type = "time";
-    config = { cron = "0 0 2 * * *"; };   # 02:00 UTC every day (six-field: sec min hour dom mon dow)
-    concurrency = "skip";
-  }
-];
+services.gradient.state.projects.my-project = {
+  # ... other project options ...
+  concurrency = "hard_abort";   # applies to all triggers below
+  triggers = [
+    {
+      type = "polling";
+      config = { interval_secs = 60; };
+    }
+    {
+      type = "reporter_push";
+      integration = "gitea-prod";          # name of an inbound integration in the same org
+      config = {
+        branches = [ "main" "release/*" ];
+        tags = [];
+        releases_only = false;
+      };
+    }
+    {
+      type = "reporter_pull_request";
+      integration = "gitea-prod";
+      config = {
+        branches = [ "main" ];
+        actions = [ "opened" "synchronize" "reopened" ];
+      };
+    }
+    {
+      type = "time";
+      config = { cron = "0 0 2 * * *"; };   # 02:00 UTC every day (six-field: sec min hour dom mon dow)
+    }
+  ];
+};
 ```
 
 ### Trigger types
@@ -393,15 +397,16 @@ services.gradient.state.projects.my-project.triggers = [
 
 ### Concurrency policies
 
+Each project has a single concurrency policy that applies to all of its triggers:
+
 - **hard_abort** — cancel the in-flight evaluation and its in-flight builds, then start a new evaluation. Workers running affected builds receive cancellation through the existing job lifecycle.
 - **soft_abort** — mark the in-flight evaluation `Aborted` so the new one becomes canonical, but let already-running builds finish; their cached outputs flow into the new evaluation.
-- **allow** — *reserved.* Currently rejected with HTTP 400; multi-evaluation-per-project support is a follow-up.
 - **skip** — discard the new trigger event; keep the running evaluation.
+- **allow** — *reserved.* Currently rejected with HTTP 400; multi-evaluation-per-project support is a follow-up.
 
 ### Defaults
 
-- New projects automatically get a default `polling` trigger (interval 300s, concurrency `skip`). Existing projects were backfilled by the same logic during the migration.
-- Reporter push/PR triggers default to `hard_abort` (typical CI semantics).
-- Polling and time triggers default to `skip` in user-created configurations.
+- New projects automatically get a default `polling` trigger (interval 300s). Existing projects were backfilled by the same logic during the migration.
+- Concurrency defaults to `skip`; opt into `hard_abort` if you want push triggers to supersede running evaluations.
 
 The implicit fallback poll for projects with an inbound integration (the legacy `WEBHOOK_BACKUP_POLL_SECS` behavior) has been removed; webhook-driven projects must declare an explicit `reporter_push` trigger to receive evaluations from forge pushes.

--- a/docs/src/usage/state.md
+++ b/docs/src/usage/state.md
@@ -361,7 +361,7 @@ services.gradient.state.projects.my-project = {
   triggers = [
     {
       type = "polling";
-      config = { interval_secs = 60; };
+      config = { interval_secs = 60; branch = "main"; };
     }
     {
       type = "reporter_push";
@@ -390,7 +390,7 @@ services.gradient.state.projects.my-project = {
 
 ### Trigger types
 
-- **polling** — periodically check the git repository for new commits. `interval_secs` minimum 10, default 300.
+- **polling** — periodically check the git repository for new commits. `interval_secs` minimum 10, default 300. **branch** (optional) — track a specific branch; leave unset to follow the remote HEAD (the repo's default branch).
 - **reporter_push** — fires on forge push events. Filters: `branches`, `tags` (glob patterns; empty = match all), `releases_only` (only fires on explicit forge release events).
 - **reporter_pull_request** — fires on PR/MR events. Filters: `branches`, `actions` (default: opened/synchronize/reopened).
 - **time** — fires on a six-field cron schedule (UTC). Re-evaluates the project HEAD even if the commit hasn't changed.

--- a/frontend/src/app/core/models/project.model.ts
+++ b/frontend/src/app/core/models/project.model.ts
@@ -5,7 +5,7 @@
  */
 
 import { BuildStatus, Architecture } from './build.model';
-import { TriggerType } from './trigger.model';
+import { ConcurrencyPolicy, TriggerType } from './trigger.model';
 
 export interface Project {
   id: string;
@@ -21,6 +21,7 @@ export interface Project {
   last_check_at?: string;
   force_evaluation: boolean;
   keep_evaluations: number;
+  concurrency: ConcurrencyPolicy;
   created_by?: string;
   created_at?: string;
   managed: boolean;

--- a/frontend/src/app/core/models/trigger.model.ts
+++ b/frontend/src/app/core/models/trigger.model.ts
@@ -42,7 +42,6 @@ export interface ProjectTrigger {
   id: string;
   project: string;
   type: TriggerType;
-  concurrency: ConcurrencyPolicy;
   config: TriggerConfig;
   active: boolean;
   last_fired_at: string | null;
@@ -52,12 +51,10 @@ export interface ProjectTrigger {
 
 export interface CreateTriggerBody {
   config: TriggerConfig;
-  concurrency: ConcurrencyPolicy;
   active?: boolean;
 }
 
 export interface UpdateTriggerBody {
   config?: TriggerConfig;
-  concurrency?: ConcurrencyPolicy;
   active?: boolean;
 }

--- a/frontend/src/app/core/models/trigger.model.ts
+++ b/frontend/src/app/core/models/trigger.model.ts
@@ -10,6 +10,8 @@ export type ConcurrencyPolicy = 'hard_abort' | 'soft_abort' | 'allow' | 'skip';
 export interface PollingTriggerConfig {
   type: 'polling';
   interval_secs: number;
+  /** Branch to poll (e.g. "main"). Leave undefined/null to poll the remote HEAD. */
+  branch?: string | null;
 }
 
 export interface ReporterPushTriggerConfig {

--- a/frontend/src/app/features/projects/project-settings/project-settings.component.html
+++ b/frontend/src/app/features/projects/project-settings/project-settings.component.html
@@ -88,6 +88,21 @@
           <small class="text-secondary">Number of completed evaluations to retain for metrics and history</small>
         </div>
 
+        <div class="form-group">
+          <label for="proj-concurrency">Trigger Concurrency</label>
+          <p-select
+            inputId="proj-concurrency"
+            [(ngModel)]="formData.concurrency"
+            [options]="concurrencyOptions"
+            optionLabel="label"
+            optionValue="value"
+            optionDisabled="disabled"
+            styleClass="w-full"
+            [disabled]="proj.managed || !proj.can_edit"
+          />
+          <small class="text-secondary">Determines how this project handles a new trigger event when an evaluation is already running.</small>
+        </div>
+
         @if (!proj.managed && proj.can_edit) {
           <div class="form-actions">
             <button pButton label="Save Changes" icon="pi pi-check" (click)="saveSettings()" [loading]="saving()" [disabled]="saving()"></button>

--- a/frontend/src/app/features/projects/project-settings/project-settings.component.ts
+++ b/frontend/src/app/features/projects/project-settings/project-settings.component.ts
@@ -20,7 +20,7 @@ import { IntegrationsService } from '@core/services/integrations.service';
 import { AutoCompleteModule } from 'primeng/autocomplete';
 import { SelectModule } from 'primeng/select';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
-import { Integration, Project, ProjectIntegrationLink } from '@core/models';
+import { ConcurrencyPolicy, Integration, Project, ProjectIntegrationLink } from '@core/models';
 
 @Component({
   selector: 'app-project-settings',
@@ -67,13 +67,28 @@ export class ProjectSettingsComponent implements OnInit {
   orgDisplayName = signal('');
   projectName = '';
 
-  formData = {
+  formData: {
+    display_name: string;
+    description: string;
+    repository: string;
+    evaluation_wildcard: string;
+    keep_evaluations: number;
+    concurrency: ConcurrencyPolicy;
+  } = {
     display_name: '',
     description: '',
     repository: '',
     evaluation_wildcard: '',
     keep_evaluations: 30,
+    concurrency: 'skip',
   };
+
+  concurrencyOptions: { label: string; value: ConcurrencyPolicy; disabled?: boolean }[] = [
+    { label: 'Hard Abort: cancel running evaluation and its in-flight builds', value: 'hard_abort' },
+    { label: 'Soft Abort: mark current evaluation aborted, let in-flight builds finish', value: 'soft_abort' },
+    { label: 'Skip: keep the running evaluation, discard the new trigger event', value: 'skip' },
+    { label: 'Allow (reserved)', value: 'allow', disabled: true },
+  ];
 
   integrationsLoading = signal(true);
   savingIntegration = signal(false);
@@ -153,6 +168,7 @@ export class ProjectSettingsComponent implements OnInit {
           repository: project.repository,
           evaluation_wildcard: project.evaluation_wildcard,
           keep_evaluations: project.keep_evaluations,
+          concurrency: project.concurrency,
         };
         this.loading.set(false);
       },

--- a/frontend/src/app/features/projects/project-triggers/project-triggers.component.html
+++ b/frontend/src/app/features/projects/project-triggers/project-triggers.component.html
@@ -164,6 +164,17 @@
       />
       <small class="text-secondary">Minimum 10 seconds. Example: 300 = every 5 minutes.</small>
     </div>
+    <div class="form-group">
+      <label for="trig-branch">Branch</label>
+      <input
+        pInputText
+        id="trig-branch"
+        [(ngModel)]="form.branch"
+        placeholder="HEAD (default branch)"
+        class="w-full"
+      />
+      <small class="text-secondary">Leave empty to track the repo's default branch (HEAD).</small>
+    </div>
   }
 
   @if (form.type === 'reporter_push' || form.type === 'reporter_pull_request') {

--- a/frontend/src/app/features/projects/project-triggers/project-triggers.component.html
+++ b/frontend/src/app/features/projects/project-triggers/project-triggers.component.html
@@ -40,7 +40,6 @@
                 <div>
                   <div class="trigger-summary">{{ configSummary(trigger) }}</div>
                   <div class="trigger-meta text-secondary">
-                    <span>Concurrency: {{ trigger.concurrency }}</span>
                     <span class="status-chip" [class.status-ok]="trigger.active" [class.status-warn]="!trigger.active">
                       {{ trigger.active ? 'Active' : 'Inactive' }}
                     </span>
@@ -149,25 +148,6 @@
     />
     @if (isEdit) {
       <small class="text-secondary">Trigger type cannot be changed after creation.</small>
-    }
-  </div>
-
-  <div class="form-group">
-    <label for="trig-concurrency">Concurrency</label>
-    <p-select
-      inputId="trig-concurrency"
-      [(ngModel)]="form.concurrency"
-      [options]="concurrencyOptions"
-      optionLabel="label"
-      optionValue="value"
-      optionDisabled="disabled"
-      styleClass="w-full"
-    />
-    @if (form.concurrency === 'allow') {
-      <div class="dialog-warn">
-        <span class="material-symbols-outlined">warning</span>
-        "Allow" is reserved and not yet enforced — evaluations will still be serialised.
-      </div>
     }
   </div>
 

--- a/frontend/src/app/features/projects/project-triggers/project-triggers.component.ts
+++ b/frontend/src/app/features/projects/project-triggers/project-triggers.component.ts
@@ -20,7 +20,6 @@ import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/load
 import {
   ProjectTrigger,
   TriggerType,
-  ConcurrencyPolicy,
   CreateTriggerBody,
   UpdateTriggerBody,
   Integration,
@@ -34,7 +33,6 @@ interface Option<T> {
 
 interface TriggerFormState {
   type: TriggerType;
-  concurrency: ConcurrencyPolicy;
   active: boolean;
   interval_secs: number;
   integration_id: string;
@@ -47,7 +45,6 @@ interface TriggerFormState {
 
 const DEFAULT_FORM: TriggerFormState = {
   type: 'polling',
-  concurrency: 'skip',
   active: true,
   interval_secs: 300,
   integration_id: '',
@@ -108,13 +105,6 @@ export class ProjectTriggersComponent implements OnInit {
     { label: 'Time (cron)', value: 'time' },
   ];
 
-  concurrencyOptions: Option<ConcurrencyPolicy>[] = [
-    { label: 'Skip — skip new trigger if one is running', value: 'skip' },
-    { label: 'Soft Abort — cancel running eval before starting new', value: 'soft_abort' },
-    { label: 'Hard Abort — force-abort running eval', value: 'hard_abort' },
-    { label: 'Allow — run concurrently (reserved)', value: 'allow', disabled: true },
-  ];
-
   integrationOptions = computed<Option<string>[]>(() => {
     const opts: Option<string>[] = [{ label: '— select integration —', value: '' }];
     for (const i of this.inboundIntegrations()) {
@@ -162,7 +152,6 @@ export class ProjectTriggersComponent implements OnInit {
     const cfg = trigger.config as any;
     this.form = {
       type: trigger.type,
-      concurrency: trigger.concurrency,
       active: trigger.active,
       interval_secs: cfg.interval_secs ?? 300,
       integration_id: cfg.integration_id ?? '',
@@ -215,7 +204,6 @@ export class ProjectTriggersComponent implements OnInit {
     this.error.set(null);
     const body: CreateTriggerBody = {
       config: this.buildConfig() as any,
-      concurrency: this.form.concurrency,
       active: this.form.active,
     };
     this.triggersService.create(this.orgName, this.projectName, body).subscribe({
@@ -238,7 +226,6 @@ export class ProjectTriggersComponent implements OnInit {
     this.error.set(null);
     const body: UpdateTriggerBody = {
       config: this.buildConfig() as any,
-      concurrency: this.form.concurrency,
       active: this.form.active,
     };
     this.triggersService.update(this.orgName, this.projectName, target.id, body).subscribe({

--- a/frontend/src/app/features/projects/project-triggers/project-triggers.component.ts
+++ b/frontend/src/app/features/projects/project-triggers/project-triggers.component.ts
@@ -20,6 +20,7 @@ import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/load
 import {
   ProjectTrigger,
   TriggerType,
+  PollingTriggerConfig,
   CreateTriggerBody,
   UpdateTriggerBody,
   Integration,
@@ -35,6 +36,7 @@ interface TriggerFormState {
   type: TriggerType;
   active: boolean;
   interval_secs: number;
+  branch: string;
   integration_id: string;
   branches: string;
   tags: string;
@@ -47,6 +49,7 @@ const DEFAULT_FORM: TriggerFormState = {
   type: 'polling',
   active: true,
   interval_secs: 300,
+  branch: '',
   integration_id: '',
   branches: '',
   tags: '',
@@ -154,6 +157,7 @@ export class ProjectTriggersComponent implements OnInit {
       type: trigger.type,
       active: trigger.active,
       interval_secs: cfg.interval_secs ?? 300,
+      branch: cfg.branch ?? '',
       integration_id: cfg.integration_id ?? '',
       branches: (cfg.branches ?? []).join(', '),
       tags: (cfg.tags ?? []).join(', '),
@@ -175,8 +179,14 @@ export class ProjectTriggersComponent implements OnInit {
 
   private buildConfig(): object {
     switch (this.form.type) {
-      case 'polling':
-        return { type: 'polling', interval_secs: Math.max(10, this.form.interval_secs) };
+      case 'polling': {
+        const trimmed = this.form.branch?.trim() ?? '';
+        return {
+          type: 'polling',
+          interval_secs: Math.max(10, this.form.interval_secs),
+          branch: trimmed === '' ? null : trimmed,
+        } as PollingTriggerConfig;
+      }
       case 'reporter_push': {
         const cfg: any = { type: 'reporter_push', integration_id: this.form.integration_id };
         const branches = this.splitList(this.form.branches);
@@ -281,8 +291,11 @@ export class ProjectTriggersComponent implements OnInit {
   configSummary(trigger: ProjectTrigger): string {
     const cfg = trigger.config as any;
     switch (trigger.type) {
-      case 'polling':
-        return `every ${this.formatSeconds(cfg.interval_secs ?? 300)}`;
+      case 'polling': {
+        let summary = `every ${this.formatSeconds(cfg.interval_secs ?? 300)}`;
+        if (cfg.branch) summary += `, branch ${cfg.branch}`;
+        return summary;
+      }
       case 'reporter_push': {
         const integration = this.inboundIntegrations().find((i) => i.id === cfg.integration_id);
         const name = integration ? (integration.display_name || integration.name) : cfg.integration_id;

--- a/nix/modules/gradient-state.nix
+++ b/nix/modules/gradient-state.nix
@@ -209,6 +209,25 @@
         '';
       };
 
+      concurrency = mkOption {
+        type = types.enum [ "hard_abort" "soft_abort" "skip" ];
+        default = "skip";
+        description = ''
+          Project-level policy for handling new trigger events while an
+          evaluation is in flight.
+
+          - `hard_abort` cancels the running evaluation (and its in-flight
+            builds) and starts a fresh one.
+          - `soft_abort` marks the running evaluation Aborted so the new one
+            becomes canonical, but lets in-flight builds finish; their cached
+            outputs flow into the new evaluation.
+          - `skip` discards the new trigger event.
+
+          `allow` (multi-evaluation-per-project) is reserved and rejected at
+          the API; it is intentionally not exposed here.
+        '';
+      };
+
       triggers = mkOption {
         type = types.nullOr (types.listOf triggerType);
         default = null;
@@ -221,26 +240,23 @@
           least one trigger.
 
           A new project always receives a default polling trigger
-          (interval 300s, concurrency `skip`) automatically; declaring
-          `triggers` here replaces that default with the listed set.
+          (interval 300s) automatically; declaring `triggers` here replaces
+          that default with the listed set.
         '';
         example = literalExpression ''
           [
             {
               type = "polling";
               config = { interval_secs = 60; };
-              concurrency = "skip";
             }
             {
               type = "reporter_push";
               integration = "acme-prod-inbound";
               config = { branches = [ "main" "release/*" ]; };
-              concurrency = "hard_abort";
             }
             {
               type = "time";
               config = { cron = "0 0 2 * * *"; };
-              concurrency = "skip";
             }
           ]
         '';
@@ -333,24 +349,6 @@
       type = mkOption {
         type = types.enum [ "polling" "reporter_push" "reporter_pull_request" "time" ];
         description = "Trigger kind. Drives which `config` shape is expected and how the dispatch loop fires it.";
-      };
-
-      concurrency = mkOption {
-        type = types.enum [ "hard_abort" "soft_abort" "skip" "allow" ];
-        default = "skip";
-        description = ''
-          Behaviour when the trigger fires while another evaluation is in
-          flight for the same project.
-
-          - `hard_abort` cancels the running evaluation (and its in-flight
-            builds) and starts a fresh one.
-          - `soft_abort` marks the running evaluation Aborted so the new one
-            becomes canonical, but lets in-flight builds finish; their cached
-            outputs flow into the new evaluation.
-          - `skip` discards the new trigger event.
-          - `allow` is **reserved** — multi-evaluation-per-project support is
-            a follow-up. The API currently rejects it with 400.
-        '';
       };
 
       integration = mkOption {
@@ -682,12 +680,12 @@ in
               repository = "https://github.com/acme-corp/web-app.git";
               evaluation_wildcard = "nixosConfigurations.*.config.system.build.toplevel";
               active = true;
+              concurrency = "hard_abort";
               created_by = "alice";
               triggers = [
                 {
                   type = "polling";
                   config = { interval_secs = 300; };
-                  concurrency = "skip";
                 }
               ];
             };

--- a/nix/modules/gradient-state.nix
+++ b/nix/modules/gradient-state.nix
@@ -368,7 +368,7 @@
         description = ''
           Type-specific configuration. Shape depends on `type`:
 
-          - `polling`: `{ interval_secs = 300; }` (minimum 10 seconds)
+          - `polling`: `{ interval_secs = 300; branch = "main"; }` (minimum 10 seconds; `branch` optional, defaults to remote HEAD)
           - `reporter_push`: `{ branches = [ "main" "release/*" ]; tags = [ ]; releases_only = false; }`
           - `reporter_pull_request`: `{ branches = [ ]; actions = [ "opened" "synchronize" "reopened" ]; }`
           - `time`: `{ cron = "0 0 2 * * *"; }` (six-field: sec min hour dom mon dow, UTC)


### PR DESCRIPTION
Follow-up to #187 — concurrency policy moves from each `project_trigger` row to a single `project.concurrency` setting.

## Why

Per-trigger concurrency was confusing: the same project ended up with a `hard_abort` push trigger and a `skip` polling trigger, which raised the question "what happens when polling fires while the push trigger's evaluation is still running?" The answer was always "it depends on which trigger fired", which isn't a useful mental model. A single per-project policy is what users were actually configuring anyway.

## Scope

- **Schema** — new column `project.concurrency` (default `3` = `skip`); drop column `project_trigger.concurrency`. No data migration; every project starts at `skip`.
- **Backend** — `apply_trigger` now reads `concurrency` from the project rather than receiving it as input. Project create/update endpoints accept `concurrency` (allow rejected with 400). Project responses surface it. State provisioning syncs it on `StateProject`.
- **Frontend** — Triggers page drops the concurrency selector. Project Settings page gains a "Trigger Concurrency" select (allow shown disabled / reserved). TS models updated.
- **API spec** — `concurrency` on `Project` / `MakeProjectRequest` / `PatchProjectRequest`; removed from `ProjectTrigger` and trigger CRUD bodies.
- **Nix module** — `projectType` gains `concurrency` (enum without `allow`, default `skip`); `triggerType` loses it.
- **Docs** — `docs/src/usage/state.md` example moves the policy to the project; prose rewritten.

## Migration safety

Single migration `m20260507_000004_move_concurrency_to_project` adds the column, drops the other in the same `up`. Down reinstates both columns. Existing trigger rows lose their concurrency value on apply — acceptable per the issue's "no backwards compatibility" stance, and consistent with how the inbound integration column was dropped without data migration.

## Test plan

- [x] `cargo test --tests --workspace` — 103/103 pass.
- [x] `npx ng build` — clean.
- [x] `npx swagger-cli validate docs/gradient-api.yaml` — valid.
- [x] `nix-instantiate --parse nix/modules/gradient-state.nix` — clean.
- [ ] Manual: create a project via API with `concurrency: "allow"` → expect 400.
- [ ] Manual: create a project with `concurrency: "hard_abort"`; trigger two pushes back-to-back; confirm the first eval flips to `Aborted` and the new one starts.
- [ ] Manual: PATCH the project's concurrency to `skip`; trigger a push while another eval is running; confirm the new event is dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)