### PR TITLE
Fire CI pending status when evaluation is queued (#117)

### DIFF
--- a/backend/scheduler/src/ci.rs
+++ b/backend/scheduler/src/ci.rs
@@ -153,8 +153,41 @@ pub async fn report_ci_for_entry_points(
     let _ = entry_points; // signature kept for backwards-compatibility with callers
 }
 
+/// Spawn a best-effort `Pending` top-level CI report for a freshly-queued
+/// evaluation.
+///
+/// Called from every site that creates a `Queued` evaluation via
+/// `apply_trigger` (scheduler trigger dispatch, manual API trigger, forge
+/// webhook fan-out). The report goes out as soon as the evaluation row exists
+/// — before any worker has picked the eval up — so the commit shows a pending
+/// check immediately.
+///
+/// No-op when the evaluation has no project: direct builds and restart flows
+/// don't currently report CI status.
+pub fn spawn_pending_ci_for_eval(state: Arc<ServerState>, eval: &MEvaluation) {
+    let Some(project_id) = eval.project else {
+        return;
+    };
+    let repo = eval.repository.clone();
+    let commit_id = eval.commit;
+    let evaluation_id = eval.id;
+    let s = Arc::clone(&state);
+    state.shutdown.spawn(async move {
+        report_ci_for_evaluation(
+            s,
+            project_id,
+            commit_id,
+            &repo,
+            evaluation_id,
+            CiStatus::Pending,
+        )
+        .await;
+    });
+}
+
 /// Reports a single `"gradient"` top-level CI status for the whole evaluation.
 ///
+/// - **Pending** when the evaluation is queued (before any worker picks it up).
 /// - **Running** when evaluation starts (before nix eval).
 /// - **Failure** if nix eval itself fails.
 /// - **Success / Failure / Error** when all builds finish (reported from builder).
@@ -263,5 +296,73 @@ pub async fn report_ci_for_evaluation(
             error = format!("{e:#}"),
             "CI evaluation status report failed"
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveDateTime;
+    use sea_orm::{DatabaseBackend, MockDatabase};
+    use test_support::prelude::test_state;
+
+    fn make_eval(project: Option<ProjectId>) -> MEvaluation {
+        entity::evaluation::Model {
+            id: EvaluationId::now_v7(),
+            project,
+            repository: "https://example.com/repo".into(),
+            commit: CommitId::now_v7(),
+            wildcard: "*".into(),
+            status: entity::evaluation::EvaluationStatus::Queued,
+            previous: None,
+            next: None,
+            created_at: NaiveDateTime::default(),
+            updated_at: NaiveDateTime::default(),
+            flake_source: None,
+            repo_check_id: None,
+            waiting_reason: None,
+            trigger: None,
+            concurrent: false,
+        }
+    }
+
+    fn empty_state() -> Arc<ServerState> {
+        let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
+        test_state(db)
+    }
+
+    #[tokio::test]
+    async fn pending_ci_skips_when_eval_has_no_project() {
+        let state = empty_state();
+        let eval = make_eval(None);
+
+        spawn_pending_ci_for_eval(Arc::clone(&state), &eval);
+
+        assert_eq!(
+            state.shutdown.pending(),
+            0,
+            "no project ⇒ no spawned task"
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_ci_spawns_task_when_eval_has_project() {
+        let state = empty_state();
+        let eval = make_eval(Some(ProjectId::now_v7()));
+
+        spawn_pending_ci_for_eval(Arc::clone(&state), &eval);
+
+        assert!(
+            state.shutdown.pending() >= 1,
+            "project present ⇒ task tracked on shutdown",
+        );
+
+        // Drain the spawned task so it doesn't outlive the test. With an empty
+        // mock DB the inner report bails on the first missing query and exits
+        // cleanly, so a short timeout is enough.
+        let _ = state
+            .shutdown
+            .cancel_and_drain(std::time::Duration::from_secs(1))
+            .await;
     }
 }

--- a/backend/scheduler/src/trigger_dispatch.rs
+++ b/backend/scheduler/src/trigger_dispatch.rs
@@ -177,6 +177,7 @@ pub(crate) async fn dispatch_once(scheduler: &Scheduler) -> anyhow::Result<()> {
                 if let Some(aborted_id) = aborted_evaluation {
                     scheduler.cancel_evaluation_jobs(aborted_id, &aborted_builds).await;
                 }
+                super::ci::spawn_pending_ci_for_eval(Arc::clone(state), &eval);
                 info!(project = %project.name, trigger_id = %trig.id, evaluation_id = %eval.id, "trigger created evaluation");
             }
             Ok(other) => {

--- a/backend/web/src/endpoints/forge_hooks/trigger.rs
+++ b/backend/web/src/endpoints/forge_hooks/trigger.rs
@@ -342,6 +342,7 @@ where
                 if let Some(aborted_id) = aborted_evaluation {
                     scheduler.cancel_evaluation_jobs(aborted_id, &aborted_builds).await;
                 }
+                scheduler::ci::spawn_pending_ci_for_eval(Arc::clone(state), &eval);
                 info!(
                     project_id = %project.id,
                     evaluation_id = %eval.id,

--- a/backend/web/src/endpoints/projects/triggers.rs
+++ b/backend/web/src/endpoints/projects/triggers.rs
@@ -313,6 +313,7 @@ pub async fn fire_now(
             if let Some(aborted_id) = aborted_evaluation {
                 scheduler.cancel_evaluation_jobs(aborted_id, &aborted_builds).await;
             }
+            scheduler::ci::spawn_pending_ci_for_eval(Arc::clone(&state), &eval);
             serde_json::json!({
                 "outcome": "Created",
                 "evaluation_id": eval.id,

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -1268,3 +1268,24 @@ Tests (`cargo test -p worker executor::build::tests`):
   `file_type`, `subtype`, `name` (basename), and `size` (stat) populated.
   Regression for substituted/external-cached builds whose artefacts never
   reached the `build_product` table.
+
+## CI pending status fires at queue time (#117)
+
+The top-level `gradient` CI status used to first appear on a commit only
+when a worker picked the evaluation up and it transitioned `Queued →
+Fetching`. During the gap between insert and worker pickup the commit
+showed no status, hiding that work had been scheduled. The scheduler now
+spawns a `Pending` report from `scheduler::ci::spawn_pending_ci_for_eval`
+at every site that creates a `Queued` evaluation via `apply_trigger`
+(scheduler trigger dispatch, manual API fire, forge webhook fan-out). The
+existing `Running`-on-`Fetching` transition is preserved and updates the
+same check run id.
+
+Tests (`cargo test -p scheduler --tests ci::tests`):
+
+- `pending_ci_skips_when_eval_has_no_project` — direct builds and other
+  project-less evaluations don't get a CI report; the helper returns
+  without spawning so the shutdown tracker stays empty.
+- `pending_ci_spawns_task_when_eval_has_project` — when the evaluation
+  has a project, the helper registers a task on the shutdown tracker so
+  `cancel_and_drain` covers the in-flight report on shutdown.


### PR DESCRIPTION
## Summary

- Add `scheduler::ci::spawn_pending_ci_for_eval`, called from every site that creates a `Queued` evaluation via `apply_trigger` (scheduler trigger dispatch, manual `/test` API endpoint, forge webhook fan-out).
- The CI `Pending` status now reaches the forge as soon as the evaluation row is inserted, instead of waiting for the `Queued → Fetching` transition that only happens once a worker picks the eval up.
- Existing `Running`-on-`Fetching` transition is preserved and updates the same `check_run` id (no duplicate checks).

Closes #117.

## Test plan

- [x] `cargo test -p scheduler --tests` (new tests: `pending_ci_skips_when_eval_has_no_project`, `pending_ci_spawns_task_when_eval_has_project`)
- [x] `cargo test --tests --workspace` — full suite green
- [x] Existing forge_hooks integration tests still pass — the spawned task uses an empty mock `worker_db` and bails gracefully through `resolve_outbound_reporter_for_project`'s noop fallback
- [x] `cargo clippy -p scheduler -p web --tests` — no new warnings