### PR TITLE
refactor: derive num_enum primitives on db-backed enums (#80)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -985,6 +985,7 @@ dependencies = [
  "migration",
  "mockall",
  "nix-bindings",
+ "num_enum",
  "object_store",
  "password-auth",
  "rand 0.10.1",
@@ -1518,6 +1519,7 @@ name = "entity"
 version = "1.1.1"
 dependencies = [
  "chrono",
+ "num_enum",
  "sea-orm",
  "serde",
  "serde_json",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -105,6 +105,9 @@ tempfile      = { version = "3.27", default-features = false }
 url           = { version = "2.5", default-features = false }
 webpki-roots  = { version = "1.0", default-features = false }
 
+# Enum primitive conversions
+num_enum = { version = "0.7", default-features = false }
+
 # Test utilities
 mockall = { version = "0.14", default-features = false }
 

--- a/backend/core/Cargo.toml
+++ b/backend/core/Cargo.toml
@@ -39,6 +39,7 @@ hex                   = { workspace = true }
 hmac                  = { workspace = true }
 libc                  = { workspace = true }
 nix-bindings          = { workspace = true }
+num_enum              = { workspace = true }
 object_store          = { workspace = true }
 rand                  = { workspace = true }
 reqwest               = { workspace = true }

--- a/backend/core/src/ci/apply.rs
+++ b/backend/core/src/ci/apply.rs
@@ -62,7 +62,8 @@ pub async fn apply_trigger<C: ConnectionTrait>(
     // currently-running commit AND for the concurrency policy below.
     let active_codes: Vec<i32> = EvaluationStatus::ACTIVE
         .iter()
-        .map(|s| s.num_value())
+        .copied()
+        .map(i32::from)
         .collect();
     let in_flight = EEvaluation::find()
         .filter(CEvaluation::Project.eq(project.id))
@@ -78,35 +79,30 @@ pub async fn apply_trigger<C: ConnectionTrait>(
     //   - last_evaluation's commit matches (covers terminal-then-poll-again).
     // Time triggers and manual fires bypass this check.
     if dedup_applies {
-        if let Some(running) = &in_flight {
-            if let Some(running_commit) = ECommit::find_by_id(running.commit).one(db).await? {
-                if running_commit.hash == input.commit_hash {
+        if let Some(running) = &in_flight
+            && let Some(running_commit) = ECommit::find_by_id(running.commit).one(db).await?
+                && running_commit.hash == input.commit_hash {
                     return Ok(ApplyOutcome::SkippedSameCommit);
                 }
-            }
-        }
 
-        if let Some(prev) = project.last_evaluation {
-            if let Some(prev_eval) = EEvaluation::find_by_id(prev).one(db).await? {
-                if let Some(prev_commit) = ECommit::find_by_id(prev_eval.commit).one(db).await? {
-                    if prev_commit.hash == input.commit_hash {
+        if let Some(prev) = project.last_evaluation
+            && let Some(prev_eval) = EEvaluation::find_by_id(prev).one(db).await?
+                && let Some(prev_commit) = ECommit::find_by_id(prev_eval.commit).one(db).await?
+                    && prev_commit.hash == input.commit_hash {
                         return Ok(ApplyOutcome::SkippedSameCommit);
                     }
-                }
-            }
-        }
     }
 
     // ── Concurrency policy ────────────────────────────────────────────────
-    let concurrency = ConcurrencyPolicy::from_i16(project.concurrency)
-        .unwrap_or(ConcurrencyPolicy::SoftAbort);
+    let concurrency =
+        ConcurrencyPolicy::try_from(project.concurrency).unwrap_or(ConcurrencyPolicy::SoftAbort);
 
     let mut aborted_evaluation: Option<EvaluationId> = None;
     let mut aborted_builds: Vec<BuildId> = Vec::new();
     let concurrent_flag = matches!(concurrency, ConcurrencyPolicy::All);
 
-    if !concurrent_flag {
-        if let Some(running) = in_flight {
+    if !concurrent_flag
+        && let Some(running) = in_flight {
             match concurrency {
                 ConcurrencyPolicy::Skip => return Ok(ApplyOutcome::SkippedConcurrency),
                 ConcurrencyPolicy::HardAbort => {
@@ -121,7 +117,6 @@ pub async fn apply_trigger<C: ConnectionTrait>(
                 ConcurrencyPolicy::All => unreachable!("filtered above"),
             }
         }
-    }
 
     let eval = match trigger_evaluation(
         db,

--- a/backend/core/src/ci/integration_lookup.rs
+++ b/backend/core/src/ci/integration_lookup.rs
@@ -15,6 +15,7 @@ use super::reporter::{
 };
 use super::webhook::decrypt_webhook_secret;
 use crate::types::*;
+use num_enum::{IntoPrimitive, TryFromPrimitive};
 use sea_orm::EntityTrait;
 use std::fs;
 use std::sync::Arc;
@@ -22,21 +23,15 @@ use tracing::warn;
 
 /// Numeric encoding of `integration.kind`.
 #[repr(i16)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
 pub enum IntegrationKind {
     Inbound = 0,
     Outbound = 1,
 }
 
-impl IntegrationKind {
-    pub fn as_i16(self) -> i16 {
-        self as i16
-    }
-}
-
 /// Numeric encoding of `integration.forge_type`.
 #[repr(i16)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
 pub enum ForgeType {
     Gitea = 0,
     Forgejo = 1,
@@ -45,20 +40,6 @@ pub enum ForgeType {
 }
 
 impl ForgeType {
-    pub fn as_i16(self) -> i16 {
-        self as i16
-    }
-
-    pub fn from_i16(v: i16) -> Option<Self> {
-        match v {
-            0 => Some(Self::Gitea),
-            1 => Some(Self::Forgejo),
-            2 => Some(Self::GitLab),
-            3 => Some(Self::GitHub),
-            _ => None,
-        }
-    }
-
     pub fn from_path_segment(s: &str) -> Option<Self> {
         match s {
             "gitea" => Some(Self::Gitea),
@@ -110,7 +91,7 @@ pub async fn resolve_outbound_reporter_for_project(
     let outbound_id = outbound_id.unwrap();
 
     let integration = match EIntegration::find_by_id(outbound_id)
-        .filter(CIntegration::Kind.eq(IntegrationKind::Outbound.as_i16()))
+        .filter(CIntegration::Kind.eq(i16::from(IntegrationKind::Outbound)))
         .one(&state.worker_db)
         .await
     {
@@ -122,9 +103,9 @@ pub async fn resolve_outbound_reporter_for_project(
         }
     };
 
-    let forge = match ForgeType::from_i16(integration.forge_type) {
-        Some(f) => f,
-        None => return Arc::new(NoopCiReporter),
+    let forge = match ForgeType::try_from(integration.forge_type) {
+        Ok(f) => f,
+        Err(_) => return Arc::new(NoopCiReporter),
     };
 
     // Decrypt access token if present.

--- a/backend/core/src/ci/trigger.rs
+++ b/backend/core/src/ci/trigger.rs
@@ -203,7 +203,7 @@ pub async fn trigger_restart_builds<C: ConnectionTrait>(
         std::collections::HashMap::with_capacity(prev_builds.len());
 
     for prev_build in &prev_builds {
-        let new_status = restart_build_status(prev_build.status.clone());
+        let new_status = restart_build_status(prev_build.status);
         let new_build_id = BuildId::now_v7();
         let abuild = ABuild {
             id: Set(new_build_id),
@@ -400,7 +400,7 @@ mod tests {
         for status in active_statuses {
             let project = make_project();
             let db = MockDatabase::new(DatabaseBackend::Postgres)
-                .append_query_results([vec![make_eval(EvaluationId::now_v7(), status.clone())]])
+                .append_query_results([vec![make_eval(EvaluationId::now_v7(), status)]])
                 .into_connection();
             let result = trigger_evaluation(&db, &project, vec![0u8; 20], None, None, None, false).await;
             assert!(
@@ -435,7 +435,7 @@ mod tests {
             BuildStatus::DependencyFailed,
         ] {
             assert_eq!(
-                restart_build_status(s.clone()),
+                restart_build_status(s),
                 BuildStatus::Queued,
                 "{s:?} should be re-queued"
             );

--- a/backend/core/src/db/gc.rs
+++ b/backend/core/src/db/gc.rs
@@ -207,15 +207,14 @@ pub async fn gc_orphan_derivations(state: Arc<ServerState>, grace_hours: i64) ->
         }
     }
 
-    if !to_delete.is_empty() {
-        if let Err(e) = ECachedPath::delete_many()
+    if !to_delete.is_empty()
+        && let Err(e) = ECachedPath::delete_many()
             .filter(CCachedPath::Hash.is_in(to_delete.clone()))
             .exec(&state.worker_db)
             .await
         {
             warn!(error = %e, "GC: failed to delete cached_path rows for orphan hashes");
         }
-    }
 
     for drv_id in drv_ids {
         if let Some(d) = EDerivation::find_by_id(drv_id)

--- a/backend/core/src/db/status.rs
+++ b/backend/core/src/db/status.rs
@@ -30,7 +30,7 @@ pub async fn update_build_status(
         return build;
     }
 
-    match BuildStateMachine::validate(build.status.clone(), status.clone()) {
+    match BuildStateMachine::validate(build.status, status) {
         Ok(_) => {}
         Err(e) => {
             // Loud: a rejected transition usually means the build is stuck
@@ -54,7 +54,7 @@ pub async fn update_build_status(
 
     let mut active_build: ABuild = build.clone().into_active_model();
 
-    let webhook_status = status.clone();
+    let webhook_status = status;
     let now = crate::types::now();
     // When transitioning out of `Building` into a terminal state, record the
     // elapsed wall-clock time. `build.updated_at` is the timestamp of the
@@ -126,7 +126,7 @@ pub async fn update_evaluation_status(
     // The state machine validates the transition locally. The filtered update_many
     // below also guards atomically in the DB, so concurrent aborts cannot be
     // clobbered by an in-flight evaluator.
-    match EvalStateMachine::validate(evaluation.status.clone(), status.clone()) {
+    match EvalStateMachine::validate(evaluation.status, status) {
         Ok(_) => {}
         Err(e) => {
             warn!(evaluation_id = %evaluation.id, error = %e, "Skipping invalid evaluation status transition");
@@ -136,13 +136,13 @@ pub async fn update_evaluation_status(
 
     debug!(evaluation_id = %evaluation.id, status = ?status, "Updating evaluation status");
 
-    let webhook_status = status.clone();
+    let webhook_status = status;
     let now = crate::types::now();
 
     let mut update = EEvaluation::update_many()
         .col_expr(
             CEvaluation::Status,
-            sea_orm::sea_query::Expr::value(status.clone()),
+            sea_orm::sea_query::Expr::value(status),
         )
         .col_expr(CEvaluation::UpdatedAt, sea_orm::sea_query::Expr::value(now));
 

--- a/backend/core/src/state/mod.rs
+++ b/backend/core/src/state/mod.rs
@@ -552,6 +552,6 @@ mod tests {
         }"#;
         let cfg: StateConfiguration = serde_json::from_str(json).unwrap();
         assert_eq!(cfg.projects["web"].concurrency, ConcurrencyPolicy::HardAbort);
-        assert_eq!(cfg.projects["web"].concurrency.as_i16(), 0);
+        assert_eq!(i16::from(cfg.projects["web"].concurrency), 0);
     }
 }

--- a/backend/core/src/state/provisioning.rs
+++ b/backend/core/src/state/provisioning.rs
@@ -106,7 +106,7 @@ async fn resolve_integration_id(
     }
     let row = integration::Entity::find()
         .filter(integration::Column::Organization.eq(org_id))
-        .filter(integration::Column::Kind.eq(kind.as_i16()))
+        .filter(integration::Column::Kind.eq(i16::from(kind)))
         .filter(integration::Column::Name.eq(name))
         .one(db)
         .await?
@@ -363,7 +363,7 @@ impl<'a> StateApplicator<'a> {
                 proj.evaluation_wildcard = Set(state_project.evaluation_wildcard.clone());
                 proj.force_evaluation = Set(state_project.force_evaluation);
                 proj.created_by = Set(created_by_id);
-                proj.concurrency = Set(state_project.concurrency.as_i16());
+                proj.concurrency = Set(i16::from(state_project.concurrency));
                 proj.sign_cache = Set(state_project.sign_cache);
                 proj.managed = Set(true);
                 proj.update(self.db).await?;
@@ -389,7 +389,7 @@ impl<'a> StateApplicator<'a> {
                     created_at: Set(now),
                     managed: Set(true),
                     keep_evaluations: Set(0),
-                    concurrency: Set(state_project.concurrency.as_i16()),
+                    concurrency: Set(i16::from(state_project.concurrency)),
                     sign_cache: Set(state_project.sign_cache),
                 };
                 let inserted = proj.insert(self.db).await?;
@@ -814,7 +814,7 @@ impl<'a> StateApplicator<'a> {
 
             let existing = integration::Entity::find()
                 .filter(integration::Column::Organization.eq(org_id))
-                .filter(integration::Column::Kind.eq(kind.as_i16()))
+                .filter(integration::Column::Kind.eq(i16::from(kind)))
                 .filter(integration::Column::Name.eq(&state_int.name))
                 .one(self.db)
                 .await?;
@@ -827,7 +827,7 @@ impl<'a> StateApplicator<'a> {
             if let Some(existing) = existing {
                 let mut active: integration::ActiveModel = existing.into();
                 active.display_name = Set(display_name);
-                active.forge_type = Set(forge.as_i16());
+                active.forge_type = Set(i16::from(forge));
                 active.endpoint_url = Set(endpoint);
                 active.secret = Set(encrypted_secret);
                 active.access_token = Set(encrypted_token);
@@ -840,8 +840,8 @@ impl<'a> StateApplicator<'a> {
                     organization: Set(org_id),
                     name: Set(state_int.name.clone()),
                     display_name: Set(display_name),
-                    kind: Set(kind.as_i16()),
-                    forge_type: Set(forge.as_i16()),
+                    kind: Set(i16::from(kind)),
+                    forge_type: Set(i16::from(forge)),
                     secret: Set(encrypted_secret),
                     endpoint_url: Set(endpoint),
                     access_token: Set(encrypted_token),
@@ -1032,7 +1032,7 @@ async fn apply_project_triggers<C: ConnectionTrait>(
         AProjectTrigger {
             id: Set(ProjectTriggerId::now_v7()),
             project: Set(project.id),
-            trigger_type: Set(cfg.trigger_type().as_i16()),
+            trigger_type: Set(i16::from(cfg.trigger_type())),
             config: Set(cfg.to_db_json()),
             active: Set(*active),
             last_fired_at: Set(None),
@@ -1138,7 +1138,7 @@ fn build_trigger_config(
 fn trigger_key(cfg: &TriggerConfig) -> String {
     let json = cfg.to_db_json();
     let canonical = serde_json::to_string(&json).unwrap_or_default();
-    format!("{}|{}", cfg.trigger_type().as_i16(), canonical)
+    format!("{}|{}", i16::from(cfg.trigger_type()), canonical)
 }
 
 // ── Pure helpers ──────────────────────────────────────────────────────────────

--- a/backend/core/src/state_machine/build.rs
+++ b/backend/core/src/state_machine/build.rs
@@ -63,7 +63,7 @@ impl BuildStateMachine {
             return Err(InvalidBuildTransition { from, to });
         }
 
-        match (from.clone(), to.clone()) {
+        match (from, to) {
             // Normal progression (still enforced for non-terminal states so
             // we don't accidentally skip Queued / Building in the UI).
             (BuildStatus::Created, BuildStatus::Queued) => Ok(to),
@@ -137,7 +137,7 @@ mod tests {
             BuildStatus::Building,
         ] {
             assert!(
-                BuildStateMachine::validate(from.clone(), BuildStatus::Aborted).is_ok(),
+                BuildStateMachine::validate(from, BuildStatus::Aborted).is_ok(),
                 "{from:?} → Aborted should be valid"
             );
         }
@@ -151,7 +151,7 @@ mod tests {
             BuildStatus::Building,
         ] {
             assert!(
-                BuildStateMachine::validate(from.clone(), BuildStatus::DependencyFailed).is_ok(),
+                BuildStateMachine::validate(from, BuildStatus::DependencyFailed).is_ok(),
                 "{from:?} → DependencyFailed should be valid"
             );
         }
@@ -174,7 +174,7 @@ mod tests {
                 BuildStatus::Building,
             ] {
                 assert!(
-                    BuildStateMachine::validate(from.clone(), to.clone()).is_err(),
+                    BuildStateMachine::validate(*from, to).is_err(),
                     "{from:?} → {to:?} should be rejected"
                 );
             }
@@ -189,7 +189,7 @@ mod tests {
             BuildStatus::Building,
             BuildStatus::Completed,
         ] {
-            assert!(BuildStateMachine::validate(s.clone(), s).is_ok());
+            assert!(BuildStateMachine::validate(s, s).is_ok());
         }
     }
 
@@ -220,7 +220,7 @@ mod tests {
         for from in &from_states {
             for to in &terminal_states {
                 assert!(
-                    BuildStateMachine::validate(from.clone(), to.clone()).is_ok(),
+                    BuildStateMachine::validate(*from, *to).is_ok(),
                     "{from:?} → {to:?} should be valid (terminal shortcut)"
                 );
             }

--- a/backend/core/src/state_machine/eval.rs
+++ b/backend/core/src/state_machine/eval.rs
@@ -59,7 +59,7 @@ impl EvalStateMachine {
             return Err(InvalidEvalTransition { from, to });
         }
 
-        match (from.clone(), to.clone()) {
+        match (from, to) {
             // Normal progression through evaluation phases
             (EvaluationStatus::Queued, EvaluationStatus::Fetching) => Ok(to),
             (EvaluationStatus::Queued, EvaluationStatus::EvaluatingFlake) => Ok(to),
@@ -115,7 +115,7 @@ mod tests {
         ];
         for (from, to) in chain {
             assert!(
-                EvalStateMachine::validate(from.clone(), to.clone()).is_ok(),
+                EvalStateMachine::validate(from, to).is_ok(),
                 "{from:?} → {to:?} failed"
             );
         }
@@ -145,7 +145,7 @@ mod tests {
         ];
         for from in nonterminals {
             assert!(
-                EvalStateMachine::validate(from.clone(), EvaluationStatus::Failed).is_ok(),
+                EvalStateMachine::validate(from, EvaluationStatus::Failed).is_ok(),
                 "{from:?} → Failed failed"
             );
         }
@@ -163,7 +163,7 @@ mod tests {
         ];
         for from in nonterminals {
             assert!(
-                EvalStateMachine::validate(from.clone(), EvaluationStatus::Aborted).is_ok(),
+                EvalStateMachine::validate(from, EvaluationStatus::Aborted).is_ok(),
                 "{from:?} → Aborted failed"
             );
         }
@@ -182,7 +182,7 @@ mod tests {
                 EvaluationStatus::Fetching,
             ] {
                 assert!(
-                    EvalStateMachine::validate(from.clone(), to.clone()).is_err(),
+                    EvalStateMachine::validate(from, to).is_err(),
                     "{from:?} → {to:?} should be rejected"
                 );
             }
@@ -205,7 +205,7 @@ mod tests {
             EvaluationStatus::Building,
             EvaluationStatus::Fetching,
         ] {
-            assert!(EvalStateMachine::validate(s.clone(), s).is_ok());
+            assert!(EvalStateMachine::validate(s, s).is_ok());
         }
     }
 

--- a/backend/core/src/types/triggers.rs
+++ b/backend/core/src/types/triggers.rs
@@ -10,67 +10,32 @@
 //! `sec min hour dom mon dow` — not the five-field POSIX form.
 
 use crate::types::ids::IntegrationId;
+use num_enum::{IntoPrimitive, TryFromPrimitive};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[repr(i16)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, IntoPrimitive, TryFromPrimitive,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum TriggerType {
-    Polling,
-    ReporterPush,
-    ReporterPullRequest,
-    Time,
+    Polling = 0,
+    ReporterPush = 1,
+    ReporterPullRequest = 2,
+    Time = 3,
 }
 
-impl TriggerType {
-    pub const fn as_i16(self) -> i16 {
-        match self {
-            Self::Polling => 0,
-            Self::ReporterPush => 1,
-            Self::ReporterPullRequest => 2,
-            Self::Time => 3,
-        }
-    }
-
-    pub fn from_i16(v: i16) -> Option<Self> {
-        Some(match v {
-            0 => Self::Polling,
-            1 => Self::ReporterPush,
-            2 => Self::ReporterPullRequest,
-            3 => Self::Time,
-            _ => return None,
-        })
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[repr(i16)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, IntoPrimitive, TryFromPrimitive,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum ConcurrencyPolicy {
-    HardAbort,
-    SoftAbort,
-    All,
-    Skip,
-}
-
-impl ConcurrencyPolicy {
-    pub const fn as_i16(self) -> i16 {
-        match self {
-            Self::HardAbort => 0,
-            Self::SoftAbort => 1,
-            Self::All => 2,
-            Self::Skip => 3,
-        }
-    }
-
-    pub fn from_i16(v: i16) -> Option<Self> {
-        Some(match v {
-            0 => Self::HardAbort,
-            1 => Self::SoftAbort,
-            2 => Self::All,
-            3 => Self::Skip,
-            _ => return None,
-        })
-    }
+    HardAbort = 0,
+    SoftAbort = 1,
+    All = 2,
+    Skip = 3,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -130,7 +95,8 @@ impl TriggerConfig {
 
     /// Parse a row's `(trigger_type, config_json)` pair into a typed config.
     pub fn parse_row(trigger_type: i16, config: &serde_json::Value) -> Result<Self, TriggerConfigError> {
-        let tag = TriggerType::from_i16(trigger_type).ok_or(TriggerConfigError::TypeMismatch(trigger_type))?;
+        let tag = TriggerType::try_from(trigger_type)
+            .map_err(|_| TriggerConfigError::TypeMismatch(trigger_type))?;
         let mut value = config.clone();
         if let serde_json::Value::Object(ref mut m) = value {
             m.insert(
@@ -232,9 +198,10 @@ mod tests {
             (ConcurrencyPolicy::All, 2),
             (ConcurrencyPolicy::Skip, 3),
         ] {
-            assert_eq!(p.as_i16(), n);
-            assert_eq!(ConcurrencyPolicy::from_i16(n), Some(p));
+            assert_eq!(i16::from(p), n);
+            assert_eq!(ConcurrencyPolicy::try_from(n), Ok(p));
         }
+        assert!(ConcurrencyPolicy::try_from(99).is_err());
     }
 
     #[test]
@@ -245,9 +212,10 @@ mod tests {
             (TriggerType::ReporterPullRequest, 2),
             (TriggerType::Time, 3),
         ] {
-            assert_eq!(t.as_i16(), n);
-            assert_eq!(TriggerType::from_i16(n), Some(t));
+            assert_eq!(i16::from(t), n);
+            assert_eq!(TriggerType::try_from(n), Ok(t));
         }
+        assert!(TriggerType::try_from(99).is_err());
     }
 
     #[test]

--- a/backend/entity/Cargo.toml
+++ b/backend/entity/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 
 [dependencies]
 chrono     = { workspace = true }
+num_enum   = { workspace = true }
 sea-orm    = { workspace = true }
 serde      = { workspace = true }
 serde_json = { workspace = true }

--- a/backend/entity/src/build.rs
+++ b/backend/entity/src/build.rs
@@ -5,49 +5,50 @@
  */
 
 use chrono::NaiveDateTime;
+use num_enum::{IntoPrimitive, TryFromPrimitive};
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::ids::{BuildId, DerivationId, EvaluationId};
 
-#[derive(Debug, Clone, PartialEq, Eq, DeriveActiveEnum, EnumIter, Deserialize, Serialize)]
+#[repr(i32)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    DeriveActiveEnum,
+    EnumIter,
+    Deserialize,
+    Serialize,
+    IntoPrimitive,
+    TryFromPrimitive,
+)]
 #[sea_orm(rs_type = "i32", db_type = "Integer")]
 pub enum BuildStatus {
     #[sea_orm(num_value = 0)]
-    Created,
+    Created = 0,
     #[sea_orm(num_value = 1)]
-    Queued,
+    Queued = 1,
     #[sea_orm(num_value = 2)]
-    Building,
+    Building = 2,
     #[sea_orm(num_value = 3)]
-    Completed,
+    Completed = 3,
     #[sea_orm(num_value = 4)]
-    Failed,
+    Failed = 4,
     #[sea_orm(num_value = 5)]
-    Aborted,
+    Aborted = 5,
     #[sea_orm(num_value = 6)]
-    DependencyFailed,
+    DependencyFailed = 6,
     /// The derivation was already present in the Nix store at evaluation
     /// time; no actual work was performed in this evaluation. Distinct from
     /// `Completed` (which means "we ran the build and it succeeded").
     #[sea_orm(num_value = 7)]
-    Substituted,
+    Substituted = 7,
 }
 
 impl BuildStatus {
-    pub const fn num_value(&self) -> i32 {
-        match self {
-            Self::Created => 0,
-            Self::Queued => 1,
-            Self::Building => 2,
-            Self::Completed => 3,
-            Self::Failed => 4,
-            Self::Aborted => 5,
-            Self::DependencyFailed => 6,
-            Self::Substituted => 7,
-        }
-    }
-
     /// Maps internal-only states onto their API-facing equivalents.
     /// `Created` is a transient pre-queue state the scheduler flips to
     /// `Queued` almost immediately, so it is collapsed to `Queued` for clients.
@@ -129,7 +130,7 @@ mod tests {
             BuildStatus::DependencyFailed,
             BuildStatus::Substituted,
         ] {
-            assert_eq!(status.clone().for_api(), status);
+            assert_eq!(status.for_api(), status);
         }
     }
 }

--- a/backend/entity/src/evaluation.rs
+++ b/backend/entity/src/evaluation.rs
@@ -5,32 +5,46 @@
  */
 
 use chrono::NaiveDateTime;
+use num_enum::{IntoPrimitive, TryFromPrimitive};
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::ids::{CommitId, EvaluationId, ProjectId, ProjectTriggerId};
 
-#[derive(Debug, Clone, PartialEq, Eq, DeriveActiveEnum, EnumIter, Deserialize, Serialize)]
+#[repr(i32)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    DeriveActiveEnum,
+    EnumIter,
+    Deserialize,
+    Serialize,
+    IntoPrimitive,
+    TryFromPrimitive,
+)]
 #[sea_orm(rs_type = "i32", db_type = "Integer")]
 pub enum EvaluationStatus {
     #[sea_orm(num_value = 0)]
-    Queued,
+    Queued = 0,
     #[sea_orm(num_value = 1)]
-    EvaluatingFlake,
+    EvaluatingFlake = 1,
     #[sea_orm(num_value = 2)]
-    EvaluatingDerivation,
+    EvaluatingDerivation = 2,
     #[sea_orm(num_value = 3)]
-    Building,
+    Building = 3,
     #[sea_orm(num_value = 4)]
-    Waiting,
+    Waiting = 4,
     #[sea_orm(num_value = 5)]
-    Completed,
+    Completed = 5,
     #[sea_orm(num_value = 6)]
-    Failed,
+    Failed = 6,
     #[sea_orm(num_value = 7)]
-    Aborted,
+    Aborted = 7,
     #[sea_orm(num_value = 8)]
-    Fetching,
+    Fetching = 8,
 }
 
 impl EvaluationStatus {
@@ -54,20 +68,6 @@ impl EvaluationStatus {
         Self::Building,
         Self::Waiting,
     ];
-
-    pub const fn num_value(&self) -> i32 {
-        match self {
-            Self::Queued => 0,
-            Self::EvaluatingFlake => 1,
-            Self::EvaluatingDerivation => 2,
-            Self::Building => 3,
-            Self::Waiting => 4,
-            Self::Completed => 5,
-            Self::Failed => 6,
-            Self::Aborted => 7,
-            Self::Fetching => 8,
-        }
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Deserialize, Serialize)]

--- a/backend/scheduler/src/build.rs
+++ b/backend/scheduler/src/build.rs
@@ -196,7 +196,7 @@ impl<'a> BuildStateHandler<'a> {
             else {
                 continue;
             };
-            update_build_status(Arc::clone(self.state), reloaded, leader.status.clone()).await;
+            update_build_status(Arc::clone(self.state), reloaded, leader.status).await;
 
             if matches!(
                 leader.status,

--- a/backend/scheduler/src/dispatch.rs
+++ b/backend/scheduler/src/dispatch.rs
@@ -490,9 +490,9 @@ pub(crate) async fn dispatch_ready_builds(scheduler: &Scheduler) -> anyhow::Resu
                   WHERE dd.derivation = b.derivation) DESC,
                 b.updated_at ASC
         "#,
-            queued = BuildStatus::Queued.num_value(),
-            completed = BuildStatus::Completed.num_value(),
-            substituted = BuildStatus::Substituted.num_value(),
+            queued = i32::from(BuildStatus::Queued),
+            completed = i32::from(BuildStatus::Completed),
+            substituted = i32::from(BuildStatus::Substituted),
         ),
     );
 

--- a/backend/scheduler/src/trigger_dispatch.rs
+++ b/backend/scheduler/src/trigger_dispatch.rs
@@ -83,8 +83,8 @@ pub(crate) async fn dispatch_once(scheduler: &Scheduler) -> anyhow::Result<()> {
         .filter(ept::Column::Active.eq(true))
         .filter(
             Condition::any()
-                .add(ept::Column::TriggerType.eq(TriggerType::Polling.as_i16()))
-                .add(ept::Column::TriggerType.eq(TriggerType::Time.as_i16())),
+                .add(ept::Column::TriggerType.eq(i16::from(TriggerType::Polling)))
+                .add(ept::Column::TriggerType.eq(i16::from(TriggerType::Time))),
         )
         .all(&state.worker_db)
         .await?;

--- a/backend/web/src/endpoints/evals/query.rs
+++ b/backend/web/src/endpoints/evals/query.rs
@@ -179,7 +179,7 @@ pub async fn get_evaluation_builds(
             Some(BuildItem {
                 id: b.id,
                 name: drv.derivation_path.clone(),
-                status: format!("{:?}", b.status.clone().for_api()),
+                status: format!("{:?}", b.status.for_api()),
                 has_artefacts: *has_artefacts_map.get(&b.derivation).unwrap_or(&false),
                 updated_at: b.updated_at,
                 build_time_ms: b.build_time_ms,

--- a/backend/web/src/endpoints/forge_hooks/mod.rs
+++ b/backend/web/src/endpoints/forge_hooks/mod.rs
@@ -281,7 +281,7 @@ pub async fn forge_webhook(
 
     let integration = EIntegration::find()
         .filter(CIntegration::Organization.eq(org.id))
-        .filter(CIntegration::Kind.eq(IntegrationKind::Inbound.as_i16()))
+        .filter(CIntegration::Kind.eq(i16::from(IntegrationKind::Inbound)))
         .filter(CIntegration::Name.eq(integration_name.as_str()))
         .one(&state.web_db)
         .await

--- a/backend/web/src/endpoints/forge_hooks/trigger.rs
+++ b/backend/web/src/endpoints/forge_hooks/trigger.rs
@@ -129,8 +129,10 @@ pub(super) async fn resolve_github_integration_id(
 
     EIntegration::find()
         .filter(CIntegration::Organization.eq(org.id))
-        .filter(CIntegration::Kind.eq(IntegrationKind::Inbound.as_i16()))
-        .filter(CIntegration::ForgeType.eq(gradient_core::ci::ForgeType::GitHub.as_i16()))
+        .filter(CIntegration::Kind.eq(i16::from(IntegrationKind::Inbound)))
+        .filter(CIntegration::ForgeType.eq(i16::from(
+            gradient_core::ci::ForgeType::GitHub,
+        )))
         .one(&state.web_db)
         .await
         .ok()
@@ -394,12 +396,12 @@ async fn load_active_triggers_for_integration(
 ) -> Result<Vec<ept::Model>, sea_orm::DbErr> {
     let stmt = Statement::from_sql_and_values(
         DbBackend::Postgres,
-        &format!(
+        format!(
             "SELECT * FROM project_trigger \
              WHERE active = true \
                AND trigger_type = {} \
                AND (config->>'integration_id')::uuid = $1",
-            trigger_type.as_i16(),
+            i16::from(trigger_type),
         ),
         [Value::Uuid(Some(Box::new(integration_id.into_inner())))],
     );

--- a/backend/web/src/endpoints/orgs/integrations.rs
+++ b/backend/web/src/endpoints/orgs/integrations.rs
@@ -126,12 +126,12 @@ fn kind_to_str(k: i16) -> &'static str {
 }
 
 fn forge_to_str(f: i16) -> &'static str {
-    match ForgeType::from_i16(f) {
-        Some(ForgeType::Gitea) => "gitea",
-        Some(ForgeType::Forgejo) => "forgejo",
-        Some(ForgeType::GitLab) => "gitlab",
-        Some(ForgeType::GitHub) => "github",
-        None => "unknown",
+    match ForgeType::try_from(f) {
+        Ok(ForgeType::Gitea) => "gitea",
+        Ok(ForgeType::Forgejo) => "forgejo",
+        Ok(ForgeType::GitLab) => "gitlab",
+        Ok(ForgeType::GitHub) => "github",
+        Err(_) => "unknown",
     }
 }
 
@@ -198,7 +198,7 @@ pub async fn put_integration(
     // Name must be unique within (organization, kind).
     let existing = EIntegration::find()
         .filter(CIntegration::Organization.eq(org.id))
-        .filter(CIntegration::Kind.eq(kind.as_i16()))
+        .filter(CIntegration::Kind.eq(i16::from(kind)))
         .filter(CIntegration::Name.eq(body.name.as_str()))
         .one(&state.web_db)
         .await?;
@@ -240,8 +240,8 @@ pub async fn put_integration(
         organization: Set(org.id),
         name: Set(body.name),
         display_name: Set(display_name),
-        kind: Set(kind.as_i16()),
-        forge_type: Set(forge.as_i16()),
+        kind: Set(i16::from(kind)),
+        forge_type: Set(i16::from(forge)),
         secret: Set(encrypted_secret),
         endpoint_url: Set(endpoint_url),
         access_token: Set(encrypted_token),
@@ -331,7 +331,7 @@ pub async fn patch_integration(
                  enable the App on the organization instead of switching forge_type to github.",
             ));
         }
-        active.forge_type = Set(parsed.as_i16());
+        active.forge_type = Set(i16::from(parsed));
     }
 
     if let Some(url) = body.endpoint_url {

--- a/backend/web/src/endpoints/projects/evaluations.rs
+++ b/backend/web/src/endpoints/projects/evaluations.rs
@@ -61,7 +61,9 @@ pub(super) async fn evaluations_to_summaries(
             .await?
             .into_iter()
             .filter_map(|t| {
-                TriggerType::from_i16(t.trigger_type).map(|tt| (t.id, tt))
+                TriggerType::try_from(t.trigger_type)
+                    .ok()
+                    .map(|tt| (t.id, tt))
             })
             .collect()
     };
@@ -156,7 +158,7 @@ pub(super) async fn evaluations_to_summaries(
         out.push(EvaluationSummary {
             id: evaluation.id,
             commit: commit_hash,
-            status: evaluation.status.clone(),
+            status: evaluation.status,
             trigger,
             total_builds,
             failed_builds,
@@ -463,11 +465,11 @@ impl EntryPointRelatedData {
                 build_id: build.id,
                 derivation_path: drv.derivation_path.clone(),
                 eval: ep.eval.clone(),
-                build_status: build.status.clone().for_api(),
+                build_status: build.status.for_api(),
                 has_artefacts: *self.has_products.get(&build.derivation).unwrap_or(&false),
                 architecture: drv.architecture.clone(),
                 evaluation_id: evaluation.id,
-                evaluation_status: evaluation.status.clone(),
+                evaluation_status: evaluation.status,
                 created_at: ep.created_at,
             });
         }

--- a/backend/web/src/endpoints/projects/integrations.rs
+++ b/backend/web/src/endpoints/projects/integrations.rs
@@ -53,7 +53,7 @@ async fn validate_integration(
         .await?
         .or_not_found("Integration")?;
 
-    if row.kind != expected_kind.as_i16() {
+    if row.kind != i16::from(expected_kind) {
         return Err(WebError::bad_request(format!(
             "Integration {} is not {}.",
             integration_id,

--- a/backend/web/src/endpoints/projects/management.rs
+++ b/backend/web/src/endpoints/projects/management.rs
@@ -147,7 +147,7 @@ pub async fn get(
                 last_evaluation_status,
                 force_evaluation: p.force_evaluation,
                 keep_evaluations: p.keep_evaluations,
-                concurrency: ConcurrencyPolicy::from_i16(p.concurrency)
+                concurrency: ConcurrencyPolicy::try_from(p.concurrency)
                     .unwrap_or(ConcurrencyPolicy::SoftAbort),
                 created_by: p.created_by,
                 created_at: p.created_at,
@@ -234,7 +234,9 @@ pub async fn put(
         created_at: Set(gradient_core::types::now()),
         managed: Set(false),
         keep_evaluations: Set(30),
-        concurrency: Set(body.concurrency.unwrap_or(ConcurrencyPolicy::SoftAbort).as_i16()),
+        concurrency: Set(i16::from(
+            body.concurrency.unwrap_or(ConcurrencyPolicy::SoftAbort),
+        )),
         sign_cache: Set(body.sign_cache.unwrap_or(true)),
     };
 
@@ -245,7 +247,7 @@ pub async fn put(
     AProjectTrigger {
         id: Set(ProjectTriggerId::now_v7()),
         project: Set(project.id),
-        trigger_type: Set(TriggerType::Polling.as_i16()),
+        trigger_type: Set(i16::from(TriggerType::Polling)),
         config: Set(default_cfg.to_db_json()),
         active: Set(true),
         last_fired_at: Set(None),
@@ -309,7 +311,7 @@ pub async fn get_project(
         created_at: project.created_at,
         managed: project.managed,
         keep_evaluations: project.keep_evaluations,
-        concurrency: ConcurrencyPolicy::from_i16(project.concurrency)
+        concurrency: ConcurrencyPolicy::try_from(project.concurrency)
             .unwrap_or(ConcurrencyPolicy::SoftAbort),
         sign_cache: project.sign_cache,
         can_edit,
@@ -446,7 +448,7 @@ impl<'a> ProjectPatcher<'a> {
     }
 
     fn apply_concurrency(&mut self, concurrency: ConcurrencyPolicy) -> WebResult<()> {
-        self.aproject.concurrency = Set(concurrency.as_i16());
+        self.aproject.concurrency = Set(i16::from(concurrency));
         Ok(())
     }
 

--- a/backend/web/src/endpoints/projects/triggers.rs
+++ b/backend/web/src/endpoints/projects/triggers.rs
@@ -49,7 +49,7 @@ impl From<MProjectTrigger> for TriggerOut {
         Self {
             id: m.id,
             project: m.project,
-            trigger_type: TriggerType::from_i16(m.trigger_type).unwrap_or(TriggerType::Polling),
+            trigger_type: TriggerType::try_from(m.trigger_type).unwrap_or(TriggerType::Polling),
             config: m.config,
             active: m.active,
             last_fired_at: m.last_fired_at,
@@ -134,7 +134,7 @@ pub async fn create(
     let row = AProjectTrigger {
         id: Set(ProjectTriggerId::now_v7()),
         project: Set(proj.id),
-        trigger_type: Set(trigger_type.as_i16()),
+        trigger_type: Set(i16::from(trigger_type)),
         config: Set(config_json),
         active: Set(body.active),
         last_fired_at: Set(None),
@@ -206,7 +206,7 @@ pub async fn update(
     let mut active: AProjectTrigger = row.into();
     if let Some(cfg) = body.config {
         let tt = cfg.trigger_type();
-        active.trigger_type = Set(tt.as_i16());
+        active.trigger_type = Set(i16::from(tt));
         active.config = Set(cfg.to_db_json());
     }
     if let Some(a) = body.active {
@@ -280,8 +280,8 @@ pub async fn fire_now(
         return Err(WebError::bad_request("trigger is inactive"));
     }
 
-    let trigger_type = TriggerType::from_i16(row.trigger_type)
-        .ok_or_else(|| WebError::internal("invalid trigger_type in row"))?;
+    let trigger_type = TriggerType::try_from(row.trigger_type)
+        .map_err(|_| WebError::internal("invalid trigger_type in row"))?;
 
     let branch_for_fire: Option<String> = TriggerConfig::parse_row(row.trigger_type, &row.config)
         .ok()

--- a/backend/web/tests/forge_hooks.rs
+++ b/backend/web/tests/forge_hooks.rs
@@ -255,7 +255,7 @@ fn trigger_row(cfg: TriggerConfig) -> entity::project_trigger::Model {
     entity::project_trigger::Model {
         id: trigger_id(),
         project: project_id(),
-        trigger_type: cfg.trigger_type().as_i16(),
+        trigger_type: i16::from(cfg.trigger_type()),
         config: cfg.to_db_json(),
         active: true,
         last_fired_at: None,

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -1289,3 +1289,16 @@ Tests (`cargo test -p scheduler --tests ci::tests`):
 - `pending_ci_spawns_task_when_eval_has_project` — when the evaluation
   has a project, the helper registers a task on the shutdown tracker so
   `cancel_and_drain` covers the in-flight report on shutdown.
+
+## Enum primitive conversions via `num_enum` (#80)
+
+`BuildStatus`, `EvaluationStatus`, `IntegrationKind`, `ForgeType`,
+`TriggerType`, and `ConcurrencyPolicy` derive
+`num_enum::IntoPrimitive`/`TryFromPrimitive` instead of hand-rolled
+`as_i16`/`from_i16`/`num_value` helpers. Database rows still use the
+explicit discriminants — moving them in source would silently break the
+on-disk encoding.
+
+The `concurrency_round_trip` and `trigger_type_round_trip` tests in
+`core/src/types/triggers.rs` cover the integer ↔ enum mapping and assert
+that out-of-range values produce an error rather than panicking.


### PR DESCRIPTION
## Summary
- Replace hand-rolled `as_i16` / `from_i16` / `num_value` helpers on `BuildStatus`, `EvaluationStatus`, `IntegrationKind`, `ForgeType`, `TriggerType`, and `ConcurrencyPolicy` with `num_enum::IntoPrimitive` / `TryFromPrimitive` derives.
- Pin explicit discriminants (`Variant = 0`) on every variant so reordering can never silently shift the on-disk encoding.
- Migrate ~50 callsites across `core`, `entity`, `scheduler`, and `web` to `i16::from(x)` / `i32::from(x)` / `Self::try_from(v)`. Adding `Copy` to the entity status enums also lets clippy strip a number of redundant `clone()` calls.

Closes #80.

## Test plan
- [x] `cargo test --tests --workspace` (all green)
- [x] `cargo clippy --workspace --tests` (no new warnings)
- [x] Round-trip tests in `core/src/types/triggers.rs` extended to assert that out-of-range values produce an error rather than panicking.