### PR TITLE
fix(web): enforce authorization on GET /commits/{commit} (#88)

### DIFF
--- a/backend/web/src/endpoints/commits.rs
+++ b/backend/web/src/endpoints/commits.rs
@@ -4,17 +4,23 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-use crate::error::WebResult;
+use crate::authorization::MaybeUser;
+use crate::error::{WebError, WebResult};
 use crate::helpers::OptionExt;
 use axum::extract::{Path, State};
 use axum::{Extension, Json};
 use gradient_core::types::*;
-use sea_orm::EntityTrait;
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+use std::collections::HashSet;
 use std::sync::Arc;
 
+/// `GET /commits/{commit}` — returns commit metadata when the caller can
+/// reach the commit through an evaluation in an organization they belong to,
+/// or the org is public. Anything else maps to `404` so the endpoint never
+/// confirms or denies the existence of a commit the caller can't see.
 pub async fn get_commit(
     state: State<Arc<ServerState>>,
-    Extension(_user): Extension<MUser>,
+    Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
     Path(commit_id): Path<CommitId>,
 ) -> WebResult<Json<BaseResponse<MCommit>>> {
     let commit = ECommit::find_by_id(commit_id)
@@ -22,12 +28,71 @@ pub async fn get_commit(
         .await?
         .or_not_found("Commit")?;
 
-    // TODO: Check if user has access to the commit
+    let evaluations = EEvaluation::find()
+        .filter(CEvaluation::Commit.eq(commit_id))
+        .all(&state.web_db)
+        .await?;
 
-    let res = BaseResponse {
-        error: false,
-        message: commit,
+    if evaluations.is_empty() {
+        return Err(WebError::not_found("Commit"));
+    }
+
+    let mut org_ids: HashSet<OrganizationId> = HashSet::new();
+
+    let project_ids: Vec<ProjectId> = evaluations.iter().filter_map(|e| e.project).collect();
+    if !project_ids.is_empty() {
+        let projects = EProject::find()
+            .filter(CProject::Id.is_in(project_ids))
+            .all(&state.web_db)
+            .await?;
+        org_ids.extend(projects.into_iter().map(|p| p.organization));
+    }
+
+    let direct_eval_ids: Vec<EvaluationId> = evaluations
+        .iter()
+        .filter(|e| e.project.is_none())
+        .map(|e| e.id)
+        .collect();
+    if !direct_eval_ids.is_empty() {
+        let direct_builds = EDirectBuild::find()
+            .filter(CDirectBuild::Evaluation.is_in(direct_eval_ids))
+            .all(&state.web_db)
+            .await?;
+        org_ids.extend(direct_builds.into_iter().map(|d| d.organization));
+    }
+
+    if org_ids.is_empty() {
+        return Err(WebError::not_found("Commit"));
+    }
+
+    let org_id_vec: Vec<OrganizationId> = org_ids.into_iter().collect();
+
+    let organizations = EOrganization::find()
+        .filter(COrganization::Id.is_in(org_id_vec.clone()))
+        .all(&state.web_db)
+        .await?;
+
+    let any_public = organizations.iter().any(|o| o.public);
+
+    let accessible = if any_public {
+        true
+    } else if let Some(user) = &maybe_user {
+        EOrganizationUser::find()
+            .filter(COrganizationUser::User.eq(user.id))
+            .filter(COrganizationUser::Organization.is_in(org_id_vec))
+            .one(&state.web_db)
+            .await?
+            .is_some()
+    } else {
+        false
     };
 
-    Ok(Json(res))
+    if !accessible {
+        return Err(WebError::not_found("Commit"));
+    }
+
+    Ok(Json(BaseResponse {
+        error: false,
+        message: commit,
+    }))
 }

--- a/backend/web/src/lib.rs
+++ b/backend/web/src/lib.rs
@@ -284,7 +284,6 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
             "/user/settings",
             get(user::get_settings).patch(user::patch_settings),
         )
-        .route("/commits/{commit}", get(commits::get_commit))
         .route(
             "/webhook/{organization}",
             get(webhooks::get).put(webhooks::put),
@@ -373,6 +372,7 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
             "/builds/{build}/download/{filename}",
             get(builds::get_build_download),
         )
+        .route("/commits/{commit}", get(commits::get_commit))
         .route("/caches/{cache}", get(caches::get_cache))
         .route(
             "/caches/{cache}/public-key",

--- a/backend/web/tests/commits_authorization.rs
+++ b/backend/web/tests/commits_authorization.rs
@@ -1,0 +1,375 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Integration tests for `GET /commits/{commit}` authorization.
+//!
+//! Regression coverage for issue #88 (IDOR): the handler must only return
+//! commit metadata when the caller can reach the commit through an
+//! evaluation in an organization they belong to (or the org is public).
+//! Both authenticated non-members and unauthenticated callers must receive
+//! `404` so existence isn't leaked.
+//!
+//! DB query sequence after the move to `authorize_optional`:
+//!   Authenticated callers:
+//!     1. SELECT session  (jwt decode)
+//!     2. UPDATE session  (last_used_at, returning)
+//!     3. SELECT user
+//!   Then for the commit handler (both auth states):
+//!     4. SELECT commit
+//!     5. SELECT evaluations (filtered by commit)
+//!     6. SELECT projects    (only if any eval has project_id)
+//!     7. SELECT direct_builds (only if any eval has no project_id)
+//!     8. SELECT organizations (filtered by collected ids)
+//!   Then membership probe (only when no org is public AND caller is authenticated):
+//!     9. SELECT organization_user
+
+use axum_test::TestServer;
+use chrono::{Duration, Utc};
+use entity::ids::*;
+use gradient_core::storage::{EmailSender, NarStore};
+use gradient_core::types::{RuntimeConfig, SecretString, ServerState, SessionId, WebDb, WorkerDb};
+use jsonwebtoken::{EncodingKey, Header, encode};
+use sea_orm::{DatabaseBackend, MockDatabase};
+use serde::Serialize;
+use serde_json::Value;
+use std::sync::Arc;
+use test_support::cli::test_cli;
+use test_support::fakes::email::InMemoryEmailSender;
+use test_support::fakes::webhooks::RecordingWebhookClient;
+use test_support::fixtures::{commit_id, eval_at, org, org_id, project_id, test_date, user, user_id};
+use test_support::log_storage::NoopLogStorage;
+use uuid::Uuid;
+use web::create_router;
+
+const JWT_SECRET: &str = "test-commits-jwt-secret";
+
+fn commit_url() -> String {
+    format!("/api/v1/commits/{}", commit_id())
+}
+
+// ── Auth helpers ──────────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct Claims {
+    exp: usize,
+    iat: usize,
+    id: UserId,
+    jti: SessionId,
+}
+
+fn make_token(session_id: SessionId) -> String {
+    let now = Utc::now();
+    let claims = Claims {
+        iat: now.timestamp() as usize,
+        exp: (now + Duration::hours(1)).timestamp() as usize,
+        id: user_id(),
+        jti: session_id,
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(JWT_SECRET.as_bytes()),
+    )
+    .expect("sign jwt")
+}
+
+fn live_session(id: SessionId) -> entity::session::Model {
+    let now = Utc::now().naive_utc();
+    entity::session::Model {
+        id,
+        user_id: user_id(),
+        created_at: now,
+        expires_at: now + Duration::hours(1),
+        last_used_at: now,
+        revoked_at: None,
+        user_agent: None,
+        ip: None,
+        remember_me: false,
+    }
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+fn other_org_id() -> OrganizationId {
+    OrganizationId::new(Uuid::parse_str("00000000-0000-0000-0000-0000000000a0").unwrap())
+}
+
+fn eval_id() -> EvaluationId {
+    EvaluationId::new(Uuid::parse_str("00000000-0000-0000-0000-000000000050").unwrap())
+}
+
+fn direct_build_id() -> DirectBuildId {
+    DirectBuildId::new(Uuid::parse_str("00000000-0000-0000-0000-000000000060").unwrap())
+}
+
+fn project_row() -> entity::project::Model {
+    entity::project::Model {
+        id: project_id(),
+        organization: org_id(),
+        name: "test-project".into(),
+        active: true,
+        display_name: "Test Project".into(),
+        description: "".into(),
+        repository: "https://github.com/test/repo".into(),
+        evaluation_wildcard: "*".into(),
+        last_evaluation: None,
+        last_check_at: test_date(),
+        force_evaluation: false,
+        created_by: user_id(),
+        created_at: test_date(),
+        managed: false,
+        keep_evaluations: 10,
+        concurrency: 3,
+        sign_cache: true,
+    }
+}
+
+fn commit_row() -> entity::commit::Model {
+    entity::commit::Model {
+        id: commit_id(),
+        message: "feat: something".into(),
+        hash: vec![0xab; 20],
+        author: None,
+        author_name: "Tester".into(),
+    }
+}
+
+fn public_org() -> entity::organization::Model {
+    entity::organization::Model {
+        public: true,
+        ..org()
+    }
+}
+
+fn membership_row() -> entity::organization_user::Model {
+    entity::organization_user::Model {
+        id: OrganizationUserId::new(
+            Uuid::parse_str("00000000-0000-0000-0000-0000000000bb").unwrap(),
+        ),
+        organization: org_id(),
+        user: user_id(),
+        role: gradient_core::types::consts::BASE_ROLE_VIEW_ID,
+    }
+}
+
+fn direct_build_row() -> entity::direct_build::Model {
+    entity::direct_build::Model {
+        id: direct_build_id(),
+        organization: org_id(),
+        evaluation: eval_id(),
+        derivation: "/nix/store/aaaa-pkg.drv".into(),
+        repository_path: "/nix/store/aaaa-pkg".into(),
+        created_by: user_id(),
+        created_at: test_date(),
+    }
+}
+
+// ── Server factory ────────────────────────────────────────────────────────────
+
+fn make_server(db: sea_orm::DatabaseConnection) -> TestServer {
+    let cli = test_cli();
+    let config = Arc::new(RuntimeConfig::from_cli(&cli));
+    let nar_storage = NarStore::local(&config.storage.base_path).expect("nar store");
+    let state = Arc::new(ServerState {
+        web_db: WebDb::new(db),
+        worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
+        config,
+        log_storage: Arc::new(NoopLogStorage),
+        webhooks: Arc::new(RecordingWebhookClient::new())
+            as Arc<dyn gradient_core::ci::WebhookClient>,
+        email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,
+        nar_storage,
+        manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        http: gradient_core::http::build_client().expect("http client"),
+        shutdown: gradient_core::shutdown::Shutdown::new(),
+        jwt_secret: SecretString::new(JWT_SECRET.to_string()),
+    });
+    TestServer::new(create_router(state))
+}
+
+fn with_auth(db: MockDatabase, session_id: SessionId) -> MockDatabase {
+    let session = live_session(session_id);
+    db.append_query_results([vec![session.clone()]])
+        .append_query_results([vec![session]])
+        .append_query_results([vec![user()]])
+}
+
+fn run<F: std::future::Future>(fut: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(fut)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// Anonymous caller: commit reachable through a public-org project → 200.
+#[test]
+fn anon_can_read_commit_in_public_org() {
+    run(async {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![commit_row()]])
+            .append_query_results([vec![eval_at(eval_id(), 0)]])
+            .append_query_results([vec![project_row()]])
+            .append_query_results([vec![public_org()]]);
+        let server = make_server(db.into_connection());
+
+        let res = server.get(&commit_url()).await;
+        res.assert_status_ok();
+        let body: Value = res.json();
+        assert_eq!(body["error"], false);
+        assert_eq!(body["message"]["id"], commit_id().to_string());
+    });
+}
+
+/// Anonymous caller: commit reachable only through a private org → 404.
+#[test]
+fn anon_cannot_read_commit_in_private_org() {
+    run(async {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![commit_row()]])
+            .append_query_results([vec![eval_at(eval_id(), 0)]])
+            .append_query_results([vec![project_row()]])
+            .append_query_results([vec![org()]]); // private
+        let server = make_server(db.into_connection());
+
+        let res = server.get(&commit_url()).await;
+        res.assert_status_not_found();
+        let body: Value = res.json();
+        assert_eq!(body["error"], true);
+    });
+}
+
+/// Authenticated org member: commit reachable through a private org they
+/// belong to → 200.
+#[test]
+fn member_can_read_commit_in_private_org() {
+    run(async {
+        let session_id = SessionId::now_v7();
+        let token = make_token(session_id);
+
+        let db = with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id)
+            .append_query_results([vec![commit_row()]])
+            .append_query_results([vec![eval_at(eval_id(), 0)]])
+            .append_query_results([vec![project_row()]])
+            .append_query_results([vec![org()]])
+            .append_query_results([vec![membership_row()]]);
+        let server = make_server(db.into_connection());
+
+        let res = server
+            .get(&commit_url())
+            .add_header("authorization", format!("Bearer {}", token))
+            .await;
+        res.assert_status_ok();
+        let body: Value = res.json();
+        assert_eq!(body["error"], false);
+        assert_eq!(body["message"]["id"], commit_id().to_string());
+    });
+}
+
+/// Authenticated user with no membership in any org that owns the commit's
+/// evaluation → 404 (must not leak existence).
+#[test]
+fn non_member_cannot_read_commit() {
+    run(async {
+        let session_id = SessionId::now_v7();
+        let token = make_token(session_id);
+
+        // Commit reachable through a project in `other_org_id` — caller has no
+        // membership there.
+        let foreign_project = entity::project::Model {
+            organization: other_org_id(),
+            ..project_row()
+        };
+        let foreign_org = entity::organization::Model {
+            id: other_org_id(),
+            ..org()
+        };
+
+        let db = with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id)
+            .append_query_results([vec![commit_row()]])
+            .append_query_results([vec![eval_at(eval_id(), 0)]])
+            .append_query_results([vec![foreign_project]])
+            .append_query_results([vec![foreign_org]])
+            .append_query_results([Vec::<entity::organization_user::Model>::new()]);
+        let server = make_server(db.into_connection());
+
+        let res = server
+            .get(&commit_url())
+            .add_header("authorization", format!("Bearer {}", token))
+            .await;
+        res.assert_status_not_found();
+        let body: Value = res.json();
+        assert_eq!(body["error"], true);
+    });
+}
+
+/// Commit referenced only via a `direct_build` (evaluation has no project):
+/// org member must still see it.
+#[test]
+fn member_can_read_commit_referenced_via_direct_build() {
+    run(async {
+        let session_id = SessionId::now_v7();
+        let token = make_token(session_id);
+
+        let direct_eval = entity::evaluation::Model {
+            project: None,
+            ..eval_at(eval_id(), 0)
+        };
+
+        let db = with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id)
+            .append_query_results([vec![commit_row()]])
+            .append_query_results([vec![direct_eval]])
+            // No project ids → projects query is skipped.
+            .append_query_results([vec![direct_build_row()]])
+            .append_query_results([vec![org()]])
+            .append_query_results([vec![membership_row()]]);
+        let server = make_server(db.into_connection());
+
+        let res = server
+            .get(&commit_url())
+            .add_header("authorization", format!("Bearer {}", token))
+            .await;
+        res.assert_status_ok();
+        let body: Value = res.json();
+        assert_eq!(body["error"], false);
+        assert_eq!(body["message"]["id"], commit_id().to_string());
+    });
+}
+
+/// Commit row doesn't exist → 404 with no further DB lookups needed.
+#[test]
+fn nonexistent_commit_returns_404() {
+    run(async {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([Vec::<entity::commit::Model>::new()]);
+        let server = make_server(db.into_connection());
+
+        let res = server.get(&commit_url()).await;
+        res.assert_status_not_found();
+        let body: Value = res.json();
+        assert_eq!(body["error"], true);
+    });
+}
+
+/// Commit row exists but no evaluation references it (orphan or
+/// race-condition cleanup) → 404.
+#[test]
+fn commit_without_evaluation_returns_404() {
+    run(async {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![commit_row()]])
+            .append_query_results([Vec::<entity::evaluation::Model>::new()]);
+        let server = make_server(db.into_connection());
+
+        let res = server.get(&commit_url()).await;
+        res.assert_status_not_found();
+        let body: Value = res.json();
+        assert_eq!(body["error"], true);
+    });
+}

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -3382,8 +3382,17 @@ paths:
     get:
       tags: [commits]
       summary: Get commit
-      description: Returns commit metadata (message, hash, author). Access control is not yet enforced — any authenticated user can fetch any commit.
+      description: |
+        Returns commit metadata (message, hash, author). Visibility follows the
+        commit's reachability: the caller must be a member of an organization
+        that owns an evaluation (or direct build) referencing the commit, or
+        that organization must be public. Anonymous callers may read commits
+        reachable through public organizations only. All other cases return
+        `404` so existence isn't leaked.
       operationId: getCommit
+      security:
+        - bearerAuth: []
+        - {}
       responses:
         '200':
           description: Commit
@@ -3396,8 +3405,6 @@ paths:
                     properties:
                       message:
                         $ref: '#/components/schemas/Commit'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
 

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -1302,3 +1302,33 @@ on-disk encoding.
 The `concurrency_round_trip` and `trigger_type_round_trip` tests in
 `core/src/types/triggers.rs` cover the integer ↔ enum mapping and assert
 that out-of-range values produce an error rather than panicking.
+
+## `GET /commits/{commit}` authorization (#88)
+
+The endpoint historically returned commit metadata to any authenticated
+caller — the handler held a `// TODO: Check if user has access to the
+commit` and never enforced it, allowing cross-tenant disclosure of
+commit message, hash, and author for any commit UUID an attacker could
+guess or harvest. The route now lives behind `authorize_optional` and
+the handler walks `commit → evaluation → project|direct_build →
+organization` to require either public visibility or membership; every
+other case (non-member, anonymous on private org, missing commit, no
+referencing evaluation) maps to `404` so existence isn't leaked.
+
+Tests (`cargo test -p web --test commits_authorization`):
+
+- `anon_can_read_commit_in_public_org` — an unauthenticated caller may
+  fetch a commit reachable through a project in a public organization.
+- `anon_cannot_read_commit_in_private_org` — the same commit, but the
+  organization is private, returns `404` for an unauthenticated caller.
+- `member_can_read_commit_in_private_org` — an authenticated member of
+  the owning organization sees the commit (200).
+- `non_member_cannot_read_commit` — an authenticated user who is not a
+  member of any organization that owns a referencing evaluation gets
+  `404`. Direct regression for #88.
+- `member_can_read_commit_referenced_via_direct_build` — when the only
+  reachable evaluation has no `project` (direct build), the handler
+  resolves the org via the `direct_build` row and grants access.
+- `nonexistent_commit_returns_404` and
+  `commit_without_evaluation_returns_404` — both shapes of "no path"
+  return `404` without leaking which case applied.


### PR DESCRIPTION
## Summary

- Closes #88. The handler at `backend/web/src/endpoints/commits.rs` previously held a `// TODO: Check if user has access to the commit` and returned commit metadata to any authenticated caller — a cross-tenant IDOR exposing commit message, hash, and author for any commit UUID an attacker could enumerate.
- The handler now resolves `commit → evaluation → project|direct_build → organization` and admits the request only when one of those organizations is public or the caller is a member. Every other shape (non-member, anonymous on private org, missing commit, no referencing evaluation) maps to `404` so existence isn't leaked.
- The route moves under `authorize_optional` for parity with `evals/query.rs`, so anonymous callers can read commits reachable through public orgs.

## Test plan

- [x] `cargo test -p web --test commits_authorization` — 7 new tests covering anon-public 200, anon-private 404, member 200, non-member 404, direct-build path, missing commit, orphaned commit
- [x] `cargo test --tests --workspace` — full suite green; no regressions
- [x] Verified RED before implementing (5 tests failed with the expected status mismatches; 2 passed because the buggy handler happened to return 200 to authenticated callers — both still pass after the fix because they assert 200 against the corrected handler too)
- [x] Updated `docs/gradient-api.yaml` (replaced the "not yet enforced" disclaimer with the new visibility rules and added the optional security scheme) and `docs/src/tests.md` (regression test summary)