### PR TITLE
web: extend audit log + migrate tracing to structured fields (#83, #84)

### DIFF
--- a/backend/core/src/state/mod.rs
+++ b/backend/core/src/state/mod.rs
@@ -419,7 +419,7 @@ pub async fn load_and_apply_state(
         return Ok(());
     };
 
-    tracing::info!("Loading state configuration from: {}", path);
+    tracing::info!(path, "Loading state configuration");
 
     let config = StateConfiguration::from_file(path)?;
 

--- a/backend/core/src/state/provisioning.rs
+++ b/backend/core/src/state/provisioning.rs
@@ -137,12 +137,12 @@ macro_rules! unmark_managed {
             let label_value = model.$name_field.clone();
             if $delete_state {
                 $entity::Entity::delete_by_id(model.id).exec($db).await?;
-                tracing::info!(concat!("Deleted ", $label, ": {}"), label_value);
+                tracing::info!(kind = $label, name = %label_value, "Deleted managed entity");
             } else {
                 let mut active: $entity::ActiveModel = model.into();
                 active.managed = Set(false);
                 active.update($db).await?;
-                tracing::info!(concat!("Unmanaged ", $label, ": {}"), label_value);
+                tracing::info!(kind = $label, name = %label_value, "Unmanaged entity");
             }
         }
     }};
@@ -216,7 +216,7 @@ impl<'a> StateApplicator<'a> {
                 user.superuser = Set(state_user.superuser);
                 user.managed = Set(true);
                 user.update(self.db).await?;
-                tracing::info!("Updated managed user: {}", state_user.username);
+                tracing::info!(username = %state_user.username, "Updated managed user");
             } else {
                 let user = user::ActiveModel {
                     id: Set(UserId::now_v7()),
@@ -235,7 +235,7 @@ impl<'a> StateApplicator<'a> {
                     oidc_subject: Set(None),
                 };
                 user.insert(self.db).await?;
-                tracing::info!("Created managed user: {}", state_user.username);
+                tracing::info!(username = %state_user.username, "Created managed user");
             }
         }
 
@@ -284,7 +284,7 @@ impl<'a> StateApplicator<'a> {
                 }
                 org.managed = Set(true);
                 org.update(self.db).await?;
-                tracing::info!("Updated managed organization: {}", state_org.name);
+                tracing::info!(name = %state_org.name, "Updated managed organization");
                 org_id
             } else {
                 let org_id = OrganizationId::now_v7();
@@ -302,7 +302,7 @@ impl<'a> StateApplicator<'a> {
                     github_installation_id: Set(state_org.github_installation_id),
                 };
                 org.insert(self.db).await?;
-                tracing::info!("Created managed organization: {}", state_org.name);
+                tracing::info!(name = %state_org.name, "Created managed organization");
                 org_id
             };
 
@@ -366,7 +366,7 @@ impl<'a> StateApplicator<'a> {
                 proj.sign_cache = Set(state_project.sign_cache);
                 proj.managed = Set(true);
                 proj.update(self.db).await?;
-                tracing::info!("Updated managed project: {}", state_project.name);
+                tracing::info!(name = %state_project.name, "Updated managed project");
                 project::Entity::find_by_id(project_id)
                     .one(self.db)
                     .await?
@@ -392,7 +392,7 @@ impl<'a> StateApplicator<'a> {
                     sign_cache: Set(state_project.sign_cache),
                 };
                 let inserted = proj.insert(self.db).await?;
-                tracing::info!("Created managed project: {}", state_project.name);
+                tracing::info!(name = %state_project.name, "Created managed project");
                 inserted
             };
 
@@ -481,7 +481,7 @@ impl<'a> StateApplicator<'a> {
                 cache_model.public = Set(state_cache.public);
                 cache_model.managed = Set(true);
                 cache_model.update(self.db).await?;
-                tracing::info!("Updated managed cache: {}", state_cache.name);
+                tracing::info!(name = %state_cache.name, "Updated managed cache");
                 existing.id
             } else {
                 let cache_id = CacheId::now_v7();
@@ -500,7 +500,7 @@ impl<'a> StateApplicator<'a> {
                     managed: Set(true),
                 };
                 cache_model.insert(self.db).await?;
-                tracing::info!("Created managed cache: {}", state_cache.name);
+                tracing::info!(name = %state_cache.name, "Created managed cache");
                 cache_id
             };
 
@@ -649,7 +649,7 @@ impl<'a> StateApplicator<'a> {
                 api_key.key = Set(key_hash);
                 api_key.managed = Set(true);
                 api_key.update(self.db).await?;
-                tracing::info!("Updated managed API key: {}", state_api_key.name);
+                tracing::info!(name = %state_api_key.name, "Updated managed API key");
             } else {
                 let api_key_model = api::ActiveModel {
                     id: Set(ApiId::now_v7()),
@@ -663,7 +663,7 @@ impl<'a> StateApplicator<'a> {
                     revoked_at: Set(None),
                 };
                 api_key_model.insert(self.db).await?;
-                tracing::info!("Created managed API key: {}", state_api_key.name);
+                tracing::info!(name = %state_api_key.name, "Created managed API key");
             }
         }
 
@@ -715,7 +715,7 @@ impl<'a> StateApplicator<'a> {
                 reg.enable_build = Set(state_worker.enable_build);
                 reg.created_by = Set(Some(created_by_id));
                 reg.update(self.db).await?;
-                tracing::info!("Updated worker registration: {}", state_worker.worker_id);
+                tracing::info!(worker_id = %state_worker.worker_id, "Updated worker registration");
             } else {
                 let reg = worker_registration::ActiveModel {
                     id: Set(WorkerRegistrationId::now_v7()),
@@ -733,7 +733,7 @@ impl<'a> StateApplicator<'a> {
                     created_at: Set(now()),
                 };
                 reg.insert(self.db).await?;
-                tracing::info!("Created worker registration: {}", state_worker.worker_id);
+                tracing::info!(worker_id = %state_worker.worker_id, "Created worker registration");
             }
         }
 
@@ -832,7 +832,7 @@ impl<'a> StateApplicator<'a> {
                 active.access_token = Set(encrypted_token);
                 active.created_by = Set(created_by_id);
                 active.update(self.db).await?;
-                tracing::info!("Updated managed integration: {}", state_int.name);
+                tracing::info!(name = %state_int.name, "Updated managed integration");
             } else {
                 let row = integration::ActiveModel {
                     id: Set(IntegrationId::now_v7()),
@@ -848,7 +848,7 @@ impl<'a> StateApplicator<'a> {
                     created_at: Set(now()),
                 };
                 row.insert(self.db).await?;
-                tracing::info!("Created managed integration: {}", state_int.name);
+                tracing::info!(name = %state_int.name, "Created managed integration");
             }
         }
 
@@ -982,7 +982,7 @@ impl<'a> StateApplicator<'a> {
                 worker_registration::Entity::delete_by_id(reg.id)
                     .exec(db)
                     .await?;
-                tracing::info!("Deleted worker registration: {}", worker_id);
+                tracing::info!(worker_id, "Deleted worker registration");
             }
         }
 

--- a/backend/web/src/audit.rs
+++ b/backend/web/src/audit.rs
@@ -28,6 +28,13 @@ pub mod events {
     pub const API_KEY_REVOKE: &str = "api_key.revoke";
     pub const API_KEY_DELETE: &str = "api_key.delete";
     pub const SESSION_REVOKE: &str = "session.revoke";
+    pub const AUTH_DENY: &str = "auth.deny";
+    pub const ORG_DELETE: &str = "organization.delete";
+    pub const ORG_MEMBER_ADD: &str = "organization.member.add";
+    pub const ORG_MEMBER_REMOVE: &str = "organization.member.remove";
+    pub const ORG_MEMBER_ROLE_CHANGE: &str = "organization.member.role_change";
+    pub const PROJECT_DELETE: &str = "project.delete";
+    pub const CACHE_DELETE: &str = "cache.delete";
 }
 
 /// Caller context derived from the inbound HTTP request — used to enrich
@@ -60,7 +67,10 @@ impl RequestInfo {
     }
 }
 
-/// Insert an `audit_log` row. Errors are logged at `warn` level and dropped.
+/// Insert an `audit_log` row and emit a structured tracing event. DB errors
+/// are warned and dropped; the tracing event always fires so operators
+/// tailing the live log see security-relevant activity even if the DB
+/// insert is failing.
 pub async fn record<C: ConnectionTrait>(
     db: &C,
     user_id: Option<UserId>,
@@ -68,6 +78,16 @@ pub async fn record<C: ConnectionTrait>(
     info: &RequestInfo,
     metadata: Option<serde_json::Value>,
 ) {
+    tracing::info!(
+        target: "audit",
+        event,
+        user_id = user_id.map(|id| id.to_string()),
+        ip = info.ip.as_deref(),
+        user_agent = info.user_agent.as_deref(),
+        metadata = metadata.as_ref().map(|m| m.to_string()),
+        "security event",
+    );
+
     let row = AAuditLog {
         id: Set(AuditLogId::now_v7()),
         user_id: Set(user_id),

--- a/backend/web/src/authorization/middleware.rs
+++ b/backend/web/src/authorization/middleware.rs
@@ -15,6 +15,7 @@ use sea_orm::{ActiveModelTrait, ActiveValue::Set, EntityTrait};
 use std::sync::Arc;
 
 use super::jwt::{decode_jwt, extract_bearer_or_cookie, token_from_cookie};
+use crate::audit::{RequestInfo, events, record as audit_record};
 use crate::error::{WebError, WebResult};
 
 /// Extension type for optional authentication.
@@ -23,37 +24,84 @@ use crate::error::{WebError, WebResult};
 #[derive(Clone)]
 pub struct MaybeUser(pub Option<MUser>);
 
+async fn audit_deny(
+    state: &Arc<ServerState>,
+    user_id: Option<UserId>,
+    info: RequestInfo,
+    method: String,
+    path: String,
+    reason: &'static str,
+) {
+    audit_record(
+        &state.web_db,
+        user_id,
+        events::AUTH_DENY,
+        &info,
+        Some(serde_json::json!({
+            "reason": reason,
+            "method": method,
+            "path": path,
+        })),
+    )
+    .await;
+}
+
 pub async fn authorize(
     state: State<Arc<ServerState>>,
     mut req: Request,
     next: Next,
 ) -> WebResult<Response<Body>> {
-    let auth_header = req.headers().get(axum::http::header::AUTHORIZATION);
+    let info = RequestInfo::from_headers(req.headers());
+    let method = req.method().as_str().to_string();
+    let path = req.uri().path().to_string();
+
+    let auth_header = req.headers().get(axum::http::header::AUTHORIZATION).cloned();
 
     let token_str: String = if let Some(header) = auth_header {
-        let val = header
-            .to_str()
-            .map_err(|_| WebError::forbidden("Authorization header empty"))?;
+        let val = match header.to_str() {
+            Ok(v) => v.to_string(),
+            Err(_) => {
+                audit_deny(&state, None, info, method, path, "Authorization header empty").await;
+                return Err(WebError::forbidden("Authorization header empty"));
+            }
+        };
         let mut parts = val.split_whitespace();
         let (bearer, token) = (parts.next(), parts.next());
         if bearer != Some("Bearer") || token.is_none() {
+            audit_deny(&state, None, info, method, path, "Invalid Authorization header").await;
             return Err(WebError::forbidden("Invalid Authorization header"));
         }
         token.unwrap().to_string()
     } else if let Some(t) = token_from_cookie(&req) {
         t
     } else {
+        audit_deny(&state, None, info, method, path, "Authorization header not found").await;
         return Err(WebError::forbidden("Authorization header not found"));
     };
 
-    let token_data = decode_jwt(state.clone(), token_str)
-        .await
-        .map_err(|_| WebError::unauthorized("Unable to decode token"))?;
+    let token_data = match decode_jwt(state.clone(), token_str).await {
+        Ok(t) => t,
+        Err(_) => {
+            audit_deny(&state, None, info, method, path, "Unable to decode token").await;
+            return Err(WebError::unauthorized("Unable to decode token"));
+        }
+    };
 
-    let current_user = EUser::find_by_id(token_data.claims.id)
-        .one(&state.web_db)
-        .await?
-        .ok_or_else(|| WebError::unauthorized("User not found"))?;
+    let current_user = match EUser::find_by_id(token_data.claims.id).one(&state.web_db).await? {
+        Some(u) => u,
+        None => {
+            audit_deny(
+                &state,
+                Some(token_data.claims.id),
+                info,
+                method,
+                path,
+                "User not found",
+            )
+            .await;
+            return Err(WebError::unauthorized("User not found"));
+        }
+    };
 
     req.extensions_mut().insert(current_user);
     Ok(next.run(req).await)

--- a/backend/web/src/endpoints/auth.rs
+++ b/backend/web/src/endpoints/auth.rs
@@ -149,7 +149,7 @@ pub async fn post_basic_register(
             )
             .await
     {
-        tracing::warn!("Failed to send verification email: {}", e);
+        tracing::warn!(error = %e, "Failed to send verification email");
     }
 
     let message = if state
@@ -414,7 +414,7 @@ pub async fn get_oidc_login(
         )
         .body(Body::empty())
         .map_err(|e| {
-            tracing::error!("Failed to build HTTP response: {}", e);
+            tracing::error!(error = %e, "Failed to build HTTP response");
             WebError::internal("Failed to build redirect response")
         })
 }
@@ -471,7 +471,7 @@ pub async fn get_oidc_callback(
         .header("Set-Cookie", &clear_csrf)
         .body(Body::empty())
         .map_err(|e| {
-            tracing::error!("Failed to build HTTP response: {}", e);
+            tracing::error!(error = %e, "Failed to build HTTP response");
             WebError::internal("Failed to build redirect response")
         })
 }

--- a/backend/web/src/endpoints/builds/mod.rs
+++ b/backend/web/src/endpoints/builds/mod.rs
@@ -57,9 +57,9 @@ impl BuildAccessContext {
             .await?
             .ok_or_else(|| {
                 tracing::error!(
-                    "Evaluation {} not found for build {}",
-                    build.evaluation,
-                    build_id
+                    evaluation_id = %build.evaluation,
+                    %build_id,
+                    "Evaluation not found for build",
                 );
                 WebError::data_inconsistency("Build")
             })?;
@@ -70,9 +70,9 @@ impl BuildAccessContext {
                 .await?
                 .ok_or_else(|| {
                     tracing::error!(
-                        "Project {} not found for evaluation {}",
-                        project_id,
-                        evaluation.id
+                        %project_id,
+                        evaluation_id = %evaluation.id,
+                        "Project not found for evaluation",
                     );
                     WebError::data_inconsistency("Evaluation")
                 })?
@@ -83,7 +83,7 @@ impl BuildAccessContext {
                 .one(&state.web_db)
                 .await?
                 .ok_or_else(|| {
-                    tracing::error!("DirectBuild not found for evaluation {}", evaluation.id);
+                    tracing::error!(evaluation_id = %evaluation.id, "DirectBuild not found for evaluation");
                     WebError::data_inconsistency("Direct build")
                 })?
                 .organization
@@ -93,7 +93,7 @@ impl BuildAccessContext {
             .one(&state.web_db)
             .await?
             .ok_or_else(|| {
-                tracing::error!("Organization {} not found", organization_id);
+                tracing::error!(%organization_id, "Organization not found");
                 WebError::data_inconsistency("Organization")
             })?;
 

--- a/backend/web/src/endpoints/caches/keys.rs
+++ b/backend/web/src/endpoints/caches/keys.rs
@@ -67,7 +67,7 @@ pub async fn get_cache_key(
         state.config.server.serve_url.clone(),
     )
     .map_err(|e| {
-        tracing::error!("Failed to generate cache key: {}", e);
+        tracing::error!(error = %e, "Failed to generate cache key");
         WebError::internal("Failed to generate cache key")
     })?;
 
@@ -87,7 +87,7 @@ pub async fn get_cache_public_key(
         state.config.server.serve_url.clone(),
     )
     .map_err(|e| {
-        tracing::error!("Failed to derive public key: {}", e);
+        tracing::error!(error = %e, "Failed to derive public key");
         WebError::internal("Failed to derive public key")
     })?;
 

--- a/backend/web/src/endpoints/caches/management.rs
+++ b/backend/web/src/endpoints/caches/management.rs
@@ -145,7 +145,7 @@ pub async fn put(
 
     let (private_key, public_key) = generate_signing_key(&state.config.secrets.crypt_secret_file)
         .map_err(|e| {
-        tracing::error!("Failed to generate signing key: {}", e);
+        tracing::error!(error = %e, "Failed to generate signing key");
         WebError::internal("Failed to generate signing key")
     })?;
 
@@ -216,7 +216,7 @@ pub async fn get_cache(
         state.config.server.serve_url.clone(),
     )
     .map_err(|e| {
-        tracing::error!("Failed to derive public key: {}", e);
+        tracing::error!(error = %e, "Failed to derive public key");
         WebError::internal("Failed to derive public key")
     })?;
 

--- a/backend/web/src/endpoints/caches/management.rs
+++ b/backend/web/src/endpoints/caches/management.rs
@@ -6,12 +6,14 @@
 
 use super::helpers::cleanup_nars_for_orgs;
 use crate::access::{CacheAccess, load_cache};
+use crate::audit::{RequestInfo, events, record as audit_record};
 use crate::authorization::MaybeUser;
 use crate::error::{WebError, WebResult};
 use crate::helpers::{OptionExt, ok_json};
 use axum::Extension;
 use axum::Json;
 use axum::extract::{Path, Query, State};
+use axum::http::HeaderMap;
 use chrono::NaiveDateTime;
 use entity::organization_cache::CacheSubscriptionMode;
 use gradient_core::db::get_any_cache_by_name;
@@ -286,13 +288,14 @@ pub async fn patch_cache(
 
 pub async fn delete_cache(
     state: State<Arc<ServerState>>,
+    headers: HeaderMap,
     Extension(user): Extension<MUser>,
     Path(cache): Path<String>,
 ) -> WebResult<Json<BaseResponse<String>>> {
     let cache = load_cache(&state, user.id, cache, CacheAccess::Editable).await?;
+    let cache_id = cache.id;
+    let cache_name = cache.name.clone();
 
-    // Collect orgs that subscribe to this cache before deleting it, so we can
-    // clean up orphaned NAR files in the background afterwards.
     let subscribing_orgs: Vec<OrganizationId> = EOrganizationCache::find()
         .filter(COrganizationCache::Cache.eq(cache.id))
         .all(&state.web_db)
@@ -305,9 +308,20 @@ pub async fn delete_cache(
     let acache: ACache = cache.into();
     acache.delete(&state.web_db).await?;
 
-    // Spawn background task to delete now-orphaned NAR files. Tracked via
-    // the shared shutdown registry so SIGTERM drains it instead of leaving
-    // orphaned NAR files only partially removed.
+    let info = RequestInfo::from_headers(&headers);
+    audit_record(
+        &state.web_db,
+        Some(user.id),
+        events::CACHE_DELETE,
+        &info,
+        Some(serde_json::json!({
+            "cache_id": cache_id.to_string(),
+            "cache_name": cache_name,
+            "subscribing_orgs": subscribing_orgs.iter().map(|o| o.to_string()).collect::<Vec<_>>(),
+        })),
+    )
+    .await;
+
     let state_bg = Arc::clone(&state);
     state.shutdown.spawn(async move {
         cleanup_nars_for_orgs(state_bg, subscribing_orgs).await;

--- a/backend/web/src/endpoints/evals/mod.rs
+++ b/backend/web/src/endpoints/evals/mod.rs
@@ -53,9 +53,9 @@ impl EvalAccessContext {
                     .await?
                     .ok_or_else(|| {
                         tracing::error!(
-                            "Project {} not found for evaluation {}",
-                            project_id,
-                            evaluation_id
+                            %project_id,
+                            %evaluation_id,
+                            "Project not found for evaluation",
                         );
                         WebError::data_inconsistency("Evaluation")
                     })?;
@@ -70,7 +70,7 @@ impl EvalAccessContext {
                     .one(&state.web_db)
                     .await?
                     .ok_or_else(|| {
-                        tracing::error!("DirectBuild not found for evaluation {}", evaluation_id);
+                        tracing::error!(%evaluation_id, "DirectBuild not found for evaluation");
                         WebError::data_inconsistency("Direct build")
                     })?
                     .organization;
@@ -81,7 +81,7 @@ impl EvalAccessContext {
             .one(&state.web_db)
             .await?
             .ok_or_else(|| {
-                tracing::error!("Organization {} not found", organization_id);
+                tracing::error!(%organization_id, "Organization not found");
                 WebError::data_inconsistency("Organization")
             })?;
 

--- a/backend/web/src/endpoints/orgs/management.rs
+++ b/backend/web/src/endpoints/orgs/management.rs
@@ -239,7 +239,7 @@ pub async fn put(
 
     let (private_key, public_key) = generate_ssh_key(&state.config.secrets.crypt_secret_file)
         .map_err(|e| {
-            tracing::error!("Failed to generate SSH key: {}", e);
+            tracing::error!(error = %e, "Failed to generate SSH key");
             WebError::failed_ssh_key_generation()
         })?;
 

--- a/backend/web/src/endpoints/orgs/management.rs
+++ b/backend/web/src/endpoints/orgs/management.rs
@@ -5,11 +5,13 @@
  */
 
 use crate::access::{Caller, OrgAccess, load_org};
+use crate::audit::{RequestInfo, events, record as audit_record};
 use crate::authorization::MaybeUser;
 use crate::error::{WebError, WebResult};
 use crate::helpers::ok_json;
 use crate::permissions::Permission;
 use axum::extract::{Path, Query, State};
+use axum::http::HeaderMap;
 use axum::{Extension, Json};
 
 use gradient_core::sources::generate_ssh_key;
@@ -408,6 +410,7 @@ pub async fn patch_organization(
 
 pub async fn delete_organization(
     state: State<Arc<ServerState>>,
+    headers: HeaderMap,
     Extension(user): Extension<MUser>,
     Path(organization): Path<String>,
 ) -> WebResult<Json<BaseResponse<String>>> {
@@ -421,8 +424,23 @@ pub async fn delete_organization(
         },
     )
     .await?;
+    let org_id = organization.id;
+    let org_name = organization.name.clone();
     let aorganization: AOrganization = organization.into();
     aorganization.delete(&state.web_db).await?;
+
+    let info = RequestInfo::from_headers(&headers);
+    audit_record(
+        &state.web_db,
+        Some(user.id),
+        events::ORG_DELETE,
+        &info,
+        Some(serde_json::json!({
+            "organization_id": org_id.to_string(),
+            "organization_name": org_name,
+        })),
+    )
+    .await;
 
     let res = BaseResponse {
         error: false,

--- a/backend/web/src/endpoints/orgs/members.rs
+++ b/backend/web/src/endpoints/orgs/members.rs
@@ -5,11 +5,13 @@
  */
 
 use crate::access::{Caller, OrgAccess, load_org};
+use crate::audit::{RequestInfo, events, record as audit_record};
 use crate::authorization::MaybeUser;
 use crate::error::{WebError, WebResult};
 use crate::helpers::{OptionExt, ok_json};
 use crate::permissions::Permission;
 use axum::extract::{Path, State};
+use axum::http::HeaderMap;
 use axum::{Extension, Json};
 use gradient_core::types::*;
 use sea_orm::ActiveValue::Set;
@@ -117,6 +119,7 @@ pub async fn get_organization_users(
 
 pub async fn post_organization_users(
     state: State<Arc<ServerState>>,
+    headers: HeaderMap,
     Extension(user): Extension<MUser>,
     Path(organization): Path<String>,
     Json(body): Json<AddUserRequest>,
@@ -161,11 +164,26 @@ pub async fn post_organization_users(
     .insert(&state.web_db)
     .await?;
 
+    let info = RequestInfo::from_headers(&headers);
+    audit_record(
+        &state.web_db,
+        Some(user.id),
+        events::ORG_MEMBER_ADD,
+        &info,
+        Some(serde_json::json!({
+            "organization_id": organization.id.to_string(),
+            "target_user_id": target_user.id.to_string(),
+            "role": role.name,
+        })),
+    )
+    .await;
+
     Ok(ok_json("User invited".to_string()))
 }
 
 pub async fn patch_organization_users(
     state: State<Arc<ServerState>>,
+    headers: HeaderMap,
     Extension(user): Extension<MUser>,
     Path(organization): Path<String>,
     Json(body): Json<AddUserRequest>,
@@ -186,6 +204,7 @@ pub async fn patch_organization_users(
         .await?
         .ok_or_else(|| WebError::bad_request("User not in Organization"))?;
 
+    let previous_role_id = membership.role;
     let role = ERole::find()
         .filter(CRole::Name.eq(body.role.clone()))
         .one(&state.web_db)
@@ -196,11 +215,27 @@ pub async fn patch_organization_users(
     active.role = Set(role.id);
     active.update(&state.web_db).await?;
 
+    let info = RequestInfo::from_headers(&headers);
+    audit_record(
+        &state.web_db,
+        Some(user.id),
+        events::ORG_MEMBER_ROLE_CHANGE,
+        &info,
+        Some(serde_json::json!({
+            "organization_id": organization.id.to_string(),
+            "target_user_id": target_user.id.to_string(),
+            "previous_role_id": previous_role_id.to_string(),
+            "new_role": role.name,
+        })),
+    )
+    .await;
+
     Ok(ok_json("User role updated".to_string()))
 }
 
 pub async fn delete_organization_users(
     state: State<Arc<ServerState>>,
+    headers: HeaderMap,
     Extension(user): Extension<MUser>,
     Path(organization): Path<String>,
     Json(body): Json<RemoveUserRequest>,
@@ -223,6 +258,19 @@ pub async fn delete_organization_users(
 
     let active: AOrganizationUser = membership.into();
     active.delete(&state.web_db).await?;
+
+    let info = RequestInfo::from_headers(&headers);
+    audit_record(
+        &state.web_db,
+        Some(user.id),
+        events::ORG_MEMBER_REMOVE,
+        &info,
+        Some(serde_json::json!({
+            "organization_id": organization.id.to_string(),
+            "target_user_id": target_user.id.to_string(),
+        })),
+    )
+    .await;
 
     Ok(ok_json("User kicked".to_string()))
 }

--- a/backend/web/src/endpoints/orgs/ssh.rs
+++ b/backend/web/src/endpoints/orgs/ssh.rs
@@ -55,7 +55,7 @@ pub async fn post_organization_ssh(
 
     let (private_key, public_key) = generate_ssh_key(&state.config.secrets.crypt_secret_file)
         .map_err(|e| {
-            tracing::error!("Failed to generate SSH key: {}", e);
+            tracing::error!(error = %e, "Failed to generate SSH key");
             WebError::failed_ssh_key_generation()
         })?;
 

--- a/backend/web/src/endpoints/projects/management.rs
+++ b/backend/web/src/endpoints/projects/management.rs
@@ -6,11 +6,13 @@
 
 use super::ProjectResponse;
 use crate::access::{Caller, OrgAccess, ProjectAccess, has_permission, load_org, load_project};
+use crate::audit::{RequestInfo, events, record as audit_record};
 use crate::authorization::MaybeUser;
 use crate::error::{WebError, WebResult};
 use crate::helpers::{OptionExt, ok_json};
 use crate::permissions::Permission;
 use axum::extract::{Path, Query, State};
+use axum::http::HeaderMap;
 use axum::{Extension, Json};
 
 use gradient_core::db::get_any_organization_by_name;
@@ -459,10 +461,11 @@ impl<'a> ProjectPatcher<'a> {
 
 pub async fn delete_project(
     state: State<Arc<ServerState>>,
+    headers: HeaderMap,
     Extension(user): Extension<MUser>,
     Path((organization, project)): Path<(String, String)>,
 ) -> WebResult<Json<BaseResponse<String>>> {
-    let (_organization, project) = load_project(
+    let (organization_row, project) = load_project(
         &state,
         Caller::User(&user),
         organization,
@@ -473,8 +476,24 @@ pub async fn delete_project(
         },
     )
     .await?;
+    let project_id = project.id;
+    let project_name = project.name.clone();
     let aproject: AProject = project.into();
     aproject.delete(&state.web_db).await?;
+
+    let info = RequestInfo::from_headers(&headers);
+    audit_record(
+        &state.web_db,
+        Some(user.id),
+        events::PROJECT_DELETE,
+        &info,
+        Some(serde_json::json!({
+            "organization_id": organization_row.id.to_string(),
+            "project_id": project_id.to_string(),
+            "project_name": project_name,
+        })),
+    )
+    .await;
 
     let res = BaseResponse {
         error: false,

--- a/backend/web/src/error.rs
+++ b/backend/web/src/error.rs
@@ -179,7 +179,7 @@ impl IntoResponse for WebError {
 
         let message: String = match &self {
             Self::Internal(err) => {
-                tracing::error!("Internal error: {:#}", err);
+                tracing::error!(error = format!("{err:#}"), "Internal error");
                 "Internal server error".to_string()
             }
             Self::BadRequest(_, m)

--- a/backend/web/src/lib.rs
+++ b/backend/web/src/lib.rs
@@ -117,24 +117,31 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
 
     let trace = TraceLayer::new_for_http()
         .on_request(|request: &Request<Body>, _span: &Span| {
-            tracing::debug!("started {} {}", request.method(), request.uri().path())
+            tracing::debug!(
+                method = %request.method(),
+                path = request.uri().path(),
+                "request started",
+            )
         })
         .on_response(
             |_response: &Response<Body>, latency: Duration, _span: &Span| {
-                tracing::debug!("response generated in {:?}", latency)
+                tracing::debug!(latency_ms = latency.as_millis() as u64, "response generated")
             },
         )
         .on_body_chunk(|chunk: &Bytes, _latency: Duration, _span: &Span| {
-            tracing::debug!("sending {} bytes", chunk.len())
+            tracing::debug!(bytes = chunk.len(), "sending chunk")
         })
         .on_eos(
             |_trailers: Option<&HeaderMap>, stream_duration: Duration, _span: &Span| {
-                tracing::debug!("stream closed after {:?}", stream_duration)
+                tracing::debug!(
+                    duration_ms = stream_duration.as_millis() as u64,
+                    "stream closed",
+                )
             },
         )
         .on_failure(
             |error: ServerErrorsFailureClass, _latency: Duration, _span: &Span| {
-                tracing::debug!("request failed with {:?}", error)
+                tracing::debug!(error = ?error, "request failed")
             },
         );
 
@@ -481,7 +488,7 @@ pub async fn serve_web(state: Arc<ServerState>) -> std::io::Result<()> {
     let listener = tokio::net::TcpListener::bind(&server_url)
         .await
         .map_err(|e| {
-            tracing::error!("Failed to bind to {}: {}", server_url, e);
+            tracing::error!(addr = %server_url, error = %e, "Failed to bind listener");
             e
         })?;
 

--- a/backend/worker/src/connection/mod.rs
+++ b/backend/worker/src/connection/mod.rs
@@ -156,7 +156,7 @@ impl ProtoConnection {
                     let bytes = match rkyv::to_bytes::<RkyvError>(&msg) {
                         Ok(b) => b,
                         Err(e) => {
-                            tracing::warn!("serialisation error: {}", e);
+                            tracing::warn!(error = %e, "serialisation error");
                             continue;
                         }
                     };
@@ -164,13 +164,13 @@ impl ProtoConnection {
                     if let Err(e) =
                         SinkExt::feed(&mut sink, Message::Binary(bytes.to_vec().into())).await
                     {
-                        tracing::warn!("WebSocket write error: {}", e);
+                        tracing::warn!(error = %e, "WebSocket write error");
                         break 'drain;
                     }
                     tracing::trace!(?msg, bytes = len, "send ClientMessage (split)");
                 }
                 if let Err(e) = SinkExt::flush(&mut sink).await {
-                    tracing::warn!("WebSocket flush error: {}", e);
+                    tracing::warn!(error = %e, "WebSocket flush error");
                     break;
                 }
             }

--- a/backend/worker/src/worker_pool/pool.rs
+++ b/backend/worker/src/worker_pool/pool.rs
@@ -77,7 +77,7 @@ impl EvalWorker {
         if let Some(pid) = child.id() {
             let path = format!("/proc/{pid}/oom_score_adj");
             if let Err(e) = std::fs::write(&path, "600") {
-                tracing::warn!(pid, "failed to set oom_score_adj for eval worker: {e}");
+                tracing::warn!(pid, error = %e, "failed to set oom_score_adj for eval worker");
             }
         }
 

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -4505,7 +4505,10 @@ components:
           description: |-
             One of: `login.success`, `login.failure`, `logout`, `register`,
             `user.delete`, `api_key.create`, `api_key.revoke`,
-            `api_key.delete`, `session.revoke`.
+            `api_key.delete`, `session.revoke`, `auth.deny`,
+            `organization.delete`, `organization.member.add`,
+            `organization.member.remove`, `organization.member.role_change`,
+            `project.delete`, `cache.delete`.
         ip: { type: string, nullable: true }
         user_agent: { type: string, nullable: true }
         metadata:


### PR DESCRIPTION
Closes #83 and #84.

## Summary

Two related logging fixes in one PR:

### #83 — security-event audit coverage

The `audit_log` table already covered authentication and API-key flows. Extended to also cover authorization denials, role changes, and destructive ops:

- `auth.deny` from the `authorize` middleware on every reject path (missing/invalid header, bad token, missing user)
- `organization.delete`, `project.delete`, `cache.delete`
- `organization.member.{add,remove,role_change}`

`audit::record` now also emits a `tracing::info!` with structured fields (`target = "audit"`), so operators tailing the live log see security activity in real time without querying the DB.

### #84 — structured tracing fields

Converted every remaining printf-style `tracing::*!("…{}…", x)` call to `tracing::*!(field = %x, "…")` so log aggregators can filter and group on the field name. Constant-string events (e.g. shutdown signals) left alone — no values to extract.

Files touched: web request/response trace layer, `serve_web` bind error, `WebError::Internal` renderer, auth/orgs/caches/projects/evals/builds endpoints, worker websocket sink, worker_pool oom_score_adj, core state load + provisioning info logs (managed entities), `unmark_managed!` macro.

## Why one PR

#83 adds new audit events; #84 standardises the tracing call style. Doing them together avoids re-touching `audit::record`'s tracing emission and keeps the structured-fields convention consistent across both old and new sites.

## Notes

- #83's literal claim ("zero `info!` events for any auth decision") was already partially stale: the audit-log infrastructure existed and recorded login/logout/API-key events. The real gaps were (a) no tracing dual-emission and (b) missing coverage for middleware deny / role / destructive ops. Both fixed here.
- OpenAPI spec (`docs/gradient-api.yaml`) updated with the new audit-event identifiers.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test --tests --workspace` — all tests pass
- [x] `grep` of remaining printf-style `tracing!` sites: only `error = format!(…)`-style structured emitters remain