### PR TITLE
worker: route eval-worker diagnostics through tracing (#87)

### DIFF
--- a/backend/worker/src/nix/eval_worker.rs
+++ b/backend/worker/src/nix/eval_worker.rs
@@ -18,7 +18,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::io::{BufRead, Write};
-use tracing::trace;
+use tracing::{error, trace};
 
 use crate::nix::flake::{discover_derivations, get_derivation_path};
 use crate::nix::nix_eval::{NixEvaluator, escape_nix_str};
@@ -86,8 +86,10 @@ pub struct ResolvedItem {
 /// them with one persistent `NixEvaluator`, writes `EvalResponse` lines to
 /// stdout. Returns when stdin reaches EOF or a `Shutdown` request is received.
 ///
-/// Logs go to stderr (inherited from parent) so the parent's tracing layer
-/// still captures them.
+/// Diagnostics go through `tracing` (configured in `worker::main` to write
+/// formatted records to stderr, which the parent inherits) so init failures
+/// and stdin errors stay visible to JSON log aggregators with structured
+/// fields, target metadata, and `RUST_LOG` filtering applied.
 pub fn run_eval_worker() -> std::io::Result<()> {
     let stdin = std::io::stdin();
     let stdout = std::io::stdout();
@@ -100,7 +102,10 @@ pub fn run_eval_worker() -> std::io::Result<()> {
     let evaluator = match NixEvaluator::new() {
         Ok(e) => Some(e),
         Err(e) => {
-            eprintln!("eval worker: NixEvaluator init failed: {:#}", e);
+            error!(
+                error = format!("{e:#}"),
+                "eval worker: NixEvaluator init failed"
+            );
             None
         }
     };
@@ -111,7 +116,7 @@ pub fn run_eval_worker() -> std::io::Result<()> {
         let n = match reader.read_line(&mut line) {
             Ok(n) => n,
             Err(e) => {
-                eprintln!("eval worker: stdin read error: {}", e);
+                error!(error = %e, "eval worker: stdin read error");
                 return Err(e);
             }
         };


### PR DESCRIPTION
## Summary
- Two `eprintln!` paths in `run_eval_worker` (`NixEvaluator` init failure and stdin read error) bypassed the eval-worker subprocess's `tracing_subscriber::fmt` layer that's installed in `worker::main`. Their raw stderr lines lost structured fields, target metadata, and `RUST_LOG` filtering, and muddled the format JSON log aggregators expect.
- Convert both call sites to `tracing::error!` with structured `error` fields and refresh the doc comment to describe the routing.

## Scope note
Issue #87 also references `core/src/types/input.rs:219-269` (`load_secret`). That portion is already resolved on `main`: `load_secret` / `load_secret_bytes` return `anyhow::Result`, and the only callers that exit (in `init_state`, `core/src/lib.rs`) log via `tracing::error!` before `process::exit(1)` — landed in PR #82 (becdd123) and follow-ups. No action needed there.

## Test plan
- [x] `cargo check -p worker`
- [x] `cargo test -p worker` — 105 tests pass (incl. existing `eval_request_serde_roundtrip` / `eval_response_serde_roundtrip`)
- [x] `cargo clippy -p worker --no-deps` — clean
- [x] `cargo fmt` — only the changed file (unrelated `build.rs` formatting drift was left alone)

Closes #87.