### PR TITLE
proto: enforce max_proto_connections on /proto upgrades (#89)

### DIFF
--- a/backend/proto/src/handler/limiter.rs
+++ b/backend/proto/src/handler/limiter.rs
@@ -1,0 +1,110 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Concurrency cap for inbound `/proto` WebSocket connections.
+//!
+//! Wraps a [`tokio::sync::Semaphore`] sized from
+//! `config.proto.max_proto_connections`. The proto upgrade handler tries to
+//! acquire one permit per connection and holds it for the lifetime of the
+//! session; when no permits are available the upgrade is rejected with 503
+//! instead of queueing, so a misbehaving worker fan-out cannot exhaust file
+//! descriptors, memory, or scheduler slots.
+
+use std::sync::Arc;
+
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+#[derive(Debug, Clone)]
+pub struct ProtoLimiter {
+    semaphore: Arc<Semaphore>,
+    capacity: usize,
+}
+
+impl ProtoLimiter {
+    /// Build a limiter sized for `capacity` simultaneous connections. A
+    /// configured value of `0` is clamped to `1` so the proto endpoint never
+    /// silently rejects every upgrade — operators who want to disable the
+    /// endpoint should set `discoverable = false` instead.
+    pub fn new(capacity: usize) -> Self {
+        let capacity = capacity.max(1);
+        Self {
+            semaphore: Arc::new(Semaphore::new(capacity)),
+            capacity,
+        }
+    }
+
+    /// Try to claim a slot. Returns `Some(permit)` if a slot was free and
+    /// `None` if the configured cap has been hit. The caller must keep the
+    /// permit alive for the entire connection — dropping it returns the slot
+    /// to the pool.
+    pub fn try_acquire(&self) -> Option<OwnedSemaphorePermit> {
+        Arc::clone(&self.semaphore).try_acquire_owned().ok()
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Number of slots currently held by live connections.
+    pub fn in_use(&self) -> usize {
+        self.capacity - self.semaphore.available_permits()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_clamps_zero_capacity_to_one() {
+        let limiter = ProtoLimiter::new(0);
+        assert_eq!(limiter.capacity(), 1);
+        assert!(
+            limiter.try_acquire().is_some(),
+            "clamped limiter must still admit one connection"
+        );
+    }
+
+    #[test]
+    fn try_acquire_returns_none_when_exhausted() {
+        let limiter = ProtoLimiter::new(2);
+        let p1 = limiter.try_acquire().expect("first permit");
+        let p2 = limiter.try_acquire().expect("second permit");
+        assert!(
+            limiter.try_acquire().is_none(),
+            "third acquire must fail when capacity is 2"
+        );
+        assert_eq!(limiter.in_use(), 2);
+        drop(p1);
+        drop(p2);
+    }
+
+    #[test]
+    fn dropping_permit_releases_slot() {
+        let limiter = ProtoLimiter::new(1);
+        let permit = limiter.try_acquire().expect("first permit");
+        assert!(limiter.try_acquire().is_none());
+        drop(permit);
+        assert!(
+            limiter.try_acquire().is_some(),
+            "slot must reopen once the prior permit is dropped"
+        );
+    }
+
+    #[test]
+    fn in_use_tracks_held_permits() {
+        let limiter = ProtoLimiter::new(3);
+        assert_eq!(limiter.in_use(), 0);
+        let p1 = limiter.try_acquire().expect("first permit");
+        assert_eq!(limiter.in_use(), 1);
+        let p2 = limiter.try_acquire().expect("second permit");
+        assert_eq!(limiter.in_use(), 2);
+        drop(p1);
+        assert_eq!(limiter.in_use(), 1);
+        drop(p2);
+        assert_eq!(limiter.in_use(), 0);
+    }
+}

--- a/backend/proto/src/handler/mod.rs
+++ b/backend/proto/src/handler/mod.rs
@@ -7,6 +7,7 @@
 mod auth;
 mod cache;
 mod dispatch;
+mod limiter;
 mod nar;
 mod session;
 mod socket;
@@ -16,16 +17,23 @@ use std::sync::Arc;
 use axum::Router;
 use axum::extract::ws::WebSocketUpgrade;
 use axum::extract::{Extension, State};
-use axum::response::IntoResponse;
+use axum::http::{HeaderValue, StatusCode, header};
+use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use gradient_core::types::*;
 use scheduler::Scheduler;
 
+pub use limiter::ProtoLimiter;
 pub(crate) use session::handle_socket;
 pub(crate) use socket::{MAX_PROTO_MESSAGE_SIZE, ProtoSocket};
 
 #[cfg(test)]
 pub(crate) use socket::{HANDSHAKE_TIMEOUT, NAR_PUSH_CHUNK_SIZE};
+
+/// `Retry-After` value returned with a 503 when the proto connection cap is
+/// hit — long enough to absorb a brief surge, short enough that a recovered
+/// worker reconnects promptly.
+const RETRY_AFTER: HeaderValue = HeaderValue::from_static("10");
 
 /// Returns the axum [`Router`] that serves the `/proto` WebSocket endpoint.
 pub fn proto_router() -> Router<Arc<ServerState>> {
@@ -36,15 +44,32 @@ async fn ws_upgrade(
     ws: WebSocketUpgrade,
     State(state): State<Arc<ServerState>>,
     Extension(scheduler): Extension<Arc<Scheduler>>,
-) -> impl IntoResponse {
+    Extension(limiter): Extension<Arc<ProtoLimiter>>,
+) -> Response {
+    let Some(permit) = limiter.try_acquire() else {
+        tracing::warn!(
+            capacity = limiter.capacity(),
+            in_use = limiter.in_use(),
+            "proto connection limit reached; rejecting upgrade",
+        );
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            [(header::RETRY_AFTER, RETRY_AFTER)],
+            "proto connection limit reached",
+        )
+            .into_response();
+    };
+
     ws.max_message_size(MAX_PROTO_MESSAGE_SIZE)
         .max_frame_size(MAX_PROTO_MESSAGE_SIZE)
-        .on_upgrade(move |sock| {
+        .on_upgrade(move |sock| async move {
+            let _permit = permit;
             session::handle_socket(
                 socket::ProtoSocket::Axum(Box::new(sock)),
                 state,
                 scheduler,
                 false,
             )
+            .await;
         })
 }

--- a/backend/proto/src/lib.rs
+++ b/backend/proto/src/lib.rs
@@ -12,7 +12,7 @@ pub mod traits;
 #[cfg(test)]
 mod tests;
 
-pub use handler::proto_router;
+pub use handler::{ProtoLimiter, proto_router};
 pub use messages::{ClientMessage, PROTO_VERSION, ServerMessage};
 
 // Re-export from the scheduler crate for backward compatibility.

--- a/backend/web/src/lib.rs
+++ b/backend/web/src/lib.rs
@@ -36,7 +36,7 @@ use tracing::Span;
 
 use endpoints::{admin, *};
 use gradient_core::types::ServerState;
-use proto::proto_router;
+use proto::{ProtoLimiter, proto_router};
 use scheduler::Scheduler;
 use std::sync::Arc;
 
@@ -443,6 +443,8 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
     scheduler.start();
     proto::outbound::start_outbound_loop(Arc::clone(&scheduler));
 
+    let proto_limiter = Arc::new(ProtoLimiter::new(state.config.proto.max_proto_connections));
+
     // Default tier covers everything left under /api/v1 (the bulk authenticated
     // surface) plus the proto WS upgrade.
     let api = api.route_layer(GovernorLayer::new(rl_per_ms(200, 150)));
@@ -451,7 +453,8 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
     let mut app = Router::new()
         .nest("/api/v1", api)
         .merge(proto_router().route_layer(GovernorLayer::new(rl_per_ms(200, 150))))
-        .layer(axum::Extension(scheduler));
+        .layer(axum::Extension(scheduler))
+        .layer(axum::Extension(proto_limiter));
 
     // Public NAR cache surface — substituters issue many requests per build,
     // so the burst is generous (1000 / 1000).

--- a/backend/web/tests/proto_connection_limit.rs
+++ b/backend/web/tests/proto_connection_limit.rs
@@ -1,0 +1,109 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! End-to-end check that the proto upgrade route honours
+//! `max_proto_connections` (issue #89).
+//!
+//! Builds the same wiring `web::create_router` produces for the `/proto`
+//! route — `proto_router` + `Extension<Arc<Scheduler>>` +
+//! `Extension<Arc<ProtoLimiter>>` — so the test can pre-acquire the only
+//! configured permit and observe the rejection shape (`503` + `Retry-After`).
+//! The unit tests in `proto::handler::limiter` cover the semaphore semantics
+//! themselves; this test verifies the handler is actually consulting them.
+
+use std::sync::Arc;
+
+use axum::extract::Extension;
+use axum_test::TestServer;
+use http::header;
+use proto::{ProtoLimiter, proto_router};
+use scheduler::Scheduler;
+use sea_orm::{DatabaseBackend, MockDatabase};
+use test_support::state::test_state;
+
+fn upgrade_request(server: &TestServer) -> axum_test::TestRequest {
+    server
+        .get("/proto")
+        .add_header(header::CONNECTION, "upgrade")
+        .add_header(header::UPGRADE, "websocket")
+        .add_header(header::SEC_WEBSOCKET_VERSION, "13")
+        .add_header(header::SEC_WEBSOCKET_KEY, "dGhlIHNhbXBsZSBub25jZQ==")
+}
+
+fn make_server(limiter: Arc<ProtoLimiter>) -> TestServer {
+    let state = test_state(MockDatabase::new(DatabaseBackend::Postgres).into_connection());
+    let scheduler = Arc::new(Scheduler::new(Arc::clone(&state)));
+    let app = proto_router()
+        .with_state(Arc::clone(&state))
+        .layer(Extension(scheduler))
+        .layer(Extension(limiter));
+    // Real HTTP transport: in-memory transport rejects WS-shaped requests with
+    // 426 inside the `WebSocketUpgrade` extractor before the handler body
+    // runs, which would mask the limiter behaviour we're testing.
+    TestServer::builder().http_transport().build(app)
+}
+
+#[test]
+fn upgrade_rejected_with_503_and_retry_after_when_limit_exhausted() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let limiter = Arc::new(ProtoLimiter::new(1));
+        let _hold = limiter.try_acquire().expect("first slot must be free");
+        assert_eq!(limiter.in_use(), 1);
+
+        let server = make_server(Arc::clone(&limiter));
+        let res = upgrade_request(&server).await;
+
+        res.assert_status(http::StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            res.header(header::RETRY_AFTER),
+            "10",
+            "503 must advertise a retry-after",
+        );
+    });
+}
+
+#[test]
+fn upgrade_proceeds_past_limiter_when_slot_is_free() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let limiter = Arc::new(ProtoLimiter::new(1));
+        let server = make_server(Arc::clone(&limiter));
+        let res = upgrade_request(&server).await;
+
+        // The in-memory transport doesn't carry the upgrade through to a real
+        // WebSocket, so we don't check for `101` exactly — but we do check
+        // that the limiter let the request *past* the rejection branch (i.e.
+        // the response is not the 503 we'd see when exhausted).
+        assert_ne!(
+            res.status_code(),
+            http::StatusCode::SERVICE_UNAVAILABLE,
+            "fresh limiter must not reject the upgrade",
+        );
+    });
+}
+
+#[test]
+fn slot_is_released_for_subsequent_upgrades_after_drop() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let limiter = Arc::new(ProtoLimiter::new(1));
+        let hold = limiter.try_acquire().expect("first slot must be free");
+        let server = make_server(Arc::clone(&limiter));
+
+        upgrade_request(&server)
+            .await
+            .assert_status(http::StatusCode::SERVICE_UNAVAILABLE);
+
+        drop(hold);
+        let res = upgrade_request(&server).await;
+        assert_ne!(
+            res.status_code(),
+            http::StatusCode::SERVICE_UNAVAILABLE,
+            "dropping the prior permit must let the next upgrade through",
+        );
+    });
+}

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -46,7 +46,7 @@ openssl rand -base64 48 > /run/secrets/gradient-crypt
 | `databaseUrlFile` | auto | Override the PostgreSQL connection string file |
 | `reportErrors` | `false` | Send errors to Sentry |
 | `discoverable` | `true` | Accept incoming `/proto` WebSocket connections from workers |
-| `settings.maxProtoConnections` | `256` | Max simultaneous worker WebSocket connections |
+| `settings.maxProtoConnections` | `256` | Max simultaneous worker WebSocket connections; further upgrades return `503 Service Unavailable` with `Retry-After: 10` until a slot frees |
 | `settings.keepEvaluations` | `5` | Number of evaluations kept per project |
 | `settings.maxRequestSize` | `2097152` (2 MiB) | Max HTTP request body in bytes for most endpoints (caps webhook/JSON payloads to prevent OOM) |
 | `settings.maxDirectBuildSize` | `1073741824` (1 GiB) | Max body size in bytes for `POST /api/v1/builds` direct-build multipart uploads |

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -1332,3 +1332,39 @@ Tests (`cargo test -p web --test commits_authorization`):
 - `nonexistent_commit_returns_404` and
   `commit_without_evaluation_returns_404` — both shapes of "no path"
   return `404` without leaking which case applied.
+
+## Proto WebSocket connection cap (#89)
+
+`max_proto_connections` (env `GRADIENT_MAX_PROTO_CONNECTIONS`, default
+256) was previously declared as configuration but never read — workers
+could open `/proto` WebSockets without bound, exhausting file
+descriptors, scheduler slots, and memory. The proto upgrade handler now
+holds a permit on a `ProtoLimiter` (a `tokio::sync::Semaphore` sized
+from the config) for the lifetime of each connection; once the limit is
+hit, further upgrade attempts get `503 Service Unavailable` with
+`Retry-After: 10`.
+
+Unit tests (`cargo test -p proto handler::limiter`):
+
+- `new_clamps_zero_capacity_to_one` — a misconfigured `0` collapses to
+  `1` so the endpoint never silently rejects every upgrade; operators
+  who want the endpoint disabled set `discoverable = false`.
+- `try_acquire_returns_none_when_exhausted` — at capacity the next
+  acquire fails immediately rather than queueing.
+- `dropping_permit_releases_slot` — the slot is reclaimed when the
+  permit is dropped, which corresponds to the upgraded session ending.
+- `in_use_tracks_held_permits` — the operator-visible `in_use()` count
+  matches the number of live permits (used in the rejection log line).
+
+Integration tests (`cargo test -p web --test proto_connection_limit`)
+cover the wiring of the limiter into the proto router:
+
+- `upgrade_rejected_with_503_and_retry_after_when_limit_exhausted` — a
+  WS-shaped GET against a saturated limiter returns `503` with the
+  documented `Retry-After: 10` header. Direct regression for #89.
+- `upgrade_proceeds_past_limiter_when_slot_is_free` — a fresh limiter
+  does not produce the rejection response, confirming the handler only
+  short-circuits on exhaustion.
+- `slot_is_released_for_subsequent_upgrades_after_drop` — a held permit
+  forces the first upgrade to `503`; dropping it lets the next request
+  through, confirming the permit lifetime is what gates the slot.


### PR DESCRIPTION
## Summary
- `max_proto_connections` (env `GRADIENT_MAX_PROTO_CONNECTIONS`, default 256) was declared but never consulted — the proto upgrade handler accepted unlimited inbound WebSocket connections, so a worker fan-out (accidental or malicious) could exhaust file descriptors, scheduler slots, and memory.
- Add `ProtoLimiter` (a `tokio::sync::Semaphore` wrapper) sized from the config, attach it via `Extension` in `web::create_router`, and make `ws_upgrade` `try_acquire_owned` a permit before calling `on_upgrade`. The permit is moved into the upgraded future so the slot is released exactly when the session ends.
- When the cap is hit, the upgrade is rejected with `503 Service Unavailable` + `Retry-After: 10` instead of queueing — fail fast rather than build an upgrade backlog.

## Design notes
- Configured `0` is clamped to `1`. Operators who want to disable inbound proto set `discoverable = false`; an always-rejecting limit would be a footgun.
- Inbound only. The outbound (server-initiated) path connects per registered worker URL and is implicitly bounded by the registration set; not in scope for this issue.
- Limiter lives in `proto::handler::limiter` (re-exported as `proto::ProtoLimiter`) so the type stays close to its sole consumer.

## Test plan
- [x] `cargo test -p proto handler::limiter` — 4 unit tests cover clamp, exhaustion, release-on-drop, `in_use` accounting.
- [x] `cargo test -p web --test proto_connection_limit` — 3 integration tests assert the wired-up handler returns `503` + `Retry-After` when the limiter is exhausted, lets fresh requests through, and reopens after a permit drops.
- [x] `cargo test --workspace --tests` — full suite green (no regressions).

## Docs
- `docs/src/configuration.md` — clarifies the rejection shape on `settings.maxProtoConnections`.
- `docs/src/tests.md` — new "Proto WebSocket connection cap (#89)" section documenting both unit and integration coverage.

Closes #89.