### PR TITLE
backend: convert remaining printf-style tracing calls to structured fields

### DIFF
--- a/backend/core/src/sources/git.rs
+++ b/backend/core/src/sources/git.rs
@@ -296,7 +296,7 @@ async fn prefetch_flake_inner(
         return Ok(None);
     }
 
-    debug!("SSH repository – cloning via libgit2: {}", repository);
+    debug!(repository, "SSH repository – cloning via libgit2");
 
     let (private_key, public_key) =
         super::ssh_key::decrypt_ssh_private_key(&crypt_secret_file, organization, &serve_url)?;
@@ -342,7 +342,7 @@ async fn prefetch_flake_inner(
                 stderr: e.message().to_string(),
             })?;
 
-        debug!("Cloned repository to {:?} at rev {}", temp_path, rev);
+        debug!(?temp_path, rev, "Cloned repository");
 
         crate::nix::lock_flake_with_ssh_key(&temp_path, &private_key).map_err(|e| {
             SourceError::NixFlakeArchiveFailed {
@@ -350,7 +350,7 @@ async fn prefetch_flake_inner(
             }
         })?;
 
-        debug!("Locked flake and prefetched inputs for {:?}", temp_path);
+        debug!(?temp_path, "Locked flake and prefetched inputs");
 
         Ok::<(), SourceError>(())
     })

--- a/backend/core/src/state/provisioning.rs
+++ b/backend/core/src/state/provisioning.rs
@@ -321,9 +321,9 @@ impl<'a> StateApplicator<'a> {
                 };
                 membership.insert(self.db).await?;
                 tracing::info!(
-                    "Added {} as admin member of organization: {}",
-                    state_org.created_by,
-                    state_org.name
+                    username = %state_org.created_by,
+                    organization = %state_org.name,
+                    "Added admin member to organization"
                 );
             }
         }
@@ -530,9 +530,9 @@ impl<'a> StateApplicator<'a> {
                     };
                     org_cache_model.insert(self.db).await?;
                     tracing::info!(
-                        "Created organization_cache association: {} -> {}",
-                        org_name,
-                        state_cache.name
+                        organization = %org_name,
+                        cache = %state_cache.name,
+                        "Created organization_cache association"
                     );
                 }
             }
@@ -607,9 +607,9 @@ impl<'a> StateApplicator<'a> {
         }
 
         tracing::debug!(
-            "Applied {} upstreams to cache '{}'",
-            upstreams.len(),
-            cache_name
+            count = upstreams.len(),
+            cache = %cache_name,
+            "Applied upstreams to cache"
         );
         Ok(())
     }
@@ -933,8 +933,8 @@ impl<'a> StateApplicator<'a> {
                 row.insert(self.db).await?;
             }
             tracing::info!(
-                "Updated project integration link for '{}'",
-                state_project.name
+                project = %state_project.name,
+                "Updated project integration link"
             );
         }
 

--- a/backend/core/src/storage/email.rs
+++ b/backend/core/src/storage/email.rs
@@ -173,7 +173,7 @@ impl EmailSender for EmailService {
 
         transport.send(&email).context("Failed to send email")?;
 
-        info!("Verification email sent to {}", to_email);
+        info!(to = to_email, "Verification email sent");
         Ok(())
     }
 
@@ -256,7 +256,7 @@ impl EmailSender for EmailService {
 
         transport.send(&email).context("Failed to send email")?;
 
-        info!("Password reset email sent to {}", to_email);
+        info!(to = to_email, "Password reset email sent");
         Ok(())
     }
 }

--- a/backend/proto/src/handler/dispatch.rs
+++ b/backend/proto/src/handler/dispatch.rs
@@ -546,7 +546,7 @@ impl<'a> DispatchContext<'a> {
                 data.len(),
                 nar_buffers.total_bytes().saturating_add(data.len()),
             );
-            warn!(peer_id = %self.peer_id, %job_id, %store_path, "{reason}");
+            warn!(peer_id = %self.peer_id, %job_id, %store_path, %reason, "session NAR upload buffer would exceed limit");
             self.abort_job(&job_id, reason).await;
         }
         // The buffer is held until `on_nar_uploaded` arrives; that handler
@@ -604,7 +604,7 @@ impl<'a> DispatchContext<'a> {
                 .map(str::to_owned)
             else {
                 let reason = format!("NarUploaded for malformed store path {store_path}");
-                error!(peer_id = %self.peer_id, %job_id, %store_path, "{reason}");
+                error!(peer_id = %self.peer_id, %job_id, %store_path, %reason, "NarUploaded for malformed store path");
                 self.abort_job(&job_id, reason).await;
                 return;
             };

--- a/backend/web/src/endpoints/builds/query.rs
+++ b/backend/web/src/endpoints/builds/query.rs
@@ -49,9 +49,9 @@ pub async fn get_build(
         .await?
         .ok_or_else(|| {
             tracing::error!(
-                "Derivation {} not found for build {}",
-                build.derivation,
-                build_id
+                derivation_id = %build.derivation,
+                %build_id,
+                "Derivation not found for build"
             );
             WebError::data_inconsistency("Build")
         })?;

--- a/backend/web/src/endpoints/forge_hooks/mod.rs
+++ b/backend/web/src/endpoints/forge_hooks/mod.rs
@@ -68,7 +68,7 @@ pub async fn github_app_webhook(
     let secret = match load_secret(&github_app.webhook_secret_file) {
         Ok(s) => s,
         Err(e) => {
-            warn!("Failed to load GitHub webhook secret: {}", e);
+            warn!(error = %e, "Failed to load GitHub webhook secret");
             return Err(WebError::internal("webhook secret unavailable"));
         }
     };

--- a/backend/worker/src/worker/mod.rs
+++ b/backend/worker/src/worker/mod.rs
@@ -246,14 +246,14 @@ impl Worker<Connected> {
 
 impl Worker<Connected> {
     async fn setup_connection(conn: &mut ProtoConnection, config: &WorkerConfig) -> Result<()> {
-        perform_setup(conn, config, "capabilities negotiated").await
+        perform_setup(conn, config, "outbound").await
     }
 
     async fn setup_connection_incoming(
         conn: &mut ProtoConnection,
         config: &WorkerConfig,
     ) -> Result<()> {
-        perform_setup(conn, config, "incoming connection: capabilities negotiated").await
+        perform_setup(conn, config, "inbound").await
     }
 
     async fn build_executor(config: &WorkerConfig) -> Result<(JobExecutor, JobScorer)> {
@@ -273,7 +273,7 @@ impl Worker<Connected> {
 async fn perform_setup(
     conn: &mut ProtoConnection,
     config: &WorkerConfig,
-    negotiated_msg: &str,
+    direction: &str,
 ) -> Result<()> {
     let peer_id = load_or_generate_id(&config.data_dir, config.worker_id.as_deref())
         .context("failed to load or generate persistent worker ID")?;
@@ -281,9 +281,10 @@ async fn perform_setup(
     let handshake = perform_handshake(conn, peer_id, peer_tokens, config.capabilities()).await?;
     conn.set_server_version(handshake.server_version);
     info!(
+        direction,
         negotiated = ?handshake.negotiated,
         server_version = conn.server_version(),
-        "{negotiated_msg}"
+        "capabilities negotiated"
     );
     if handshake.negotiated.build {
         let architectures = config

--- a/backend/worker/src/worker_pool/pool.rs
+++ b/backend/worker/src/worker_pool/pool.rs
@@ -149,10 +149,11 @@ impl EvalWorker {
             "received eval worker response"
         );
         serde_json::from_str(self.line.trim_end())
-            .inspect_err(|_| {
+            .inspect_err(|error| {
                 error!(
-                    "Failed to parse JSON. Raw input: |{}|",
-                    self.line.trim_end()
+                    %error,
+                    raw_input = self.line.trim_end(),
+                    "Failed to parse eval worker JSON response"
                 );
             })
             .context("parsing eval worker response")
@@ -188,13 +189,13 @@ impl EvalWorker {
         let mut bytes = match serde_json::to_vec(&EvalRequest::Shutdown) {
             Ok(b) => b,
             Err(e) => {
-                warn!(pid, "failed to serialize Shutdown request: {e}");
+                warn!(pid, error = %e, "failed to serialize Shutdown request");
                 return;
             }
         };
         bytes.push(b'\n');
         if let Err(e) = self.stdin.write_all(&bytes).await {
-            debug!(pid, "failed to write Shutdown to eval worker: {e}");
+            debug!(pid, error = %e, "failed to write Shutdown to eval worker");
             return;
         }
         let _ = self.stdin.flush().await;
@@ -202,7 +203,7 @@ impl EvalWorker {
         trace!(pid, "Shutdown sent; waiting for eval worker to exit");
         match tokio::time::timeout(std::time::Duration::from_secs(5), self.child.wait()).await {
             Ok(Ok(status)) => trace!(pid, ?status, "eval worker exited cleanly"),
-            Ok(Err(e)) => debug!(pid, "waiting on eval worker exit: {e}"),
+            Ok(Err(e)) => debug!(pid, error = %e, "waiting on eval worker exit failed"),
             Err(_) => warn!(
                 pid,
                 "eval worker did not exit within 5s of Shutdown; will be killed"


### PR DESCRIPTION
## Summary
- Converts the 13 remaining `tracing::xxx!("...{}...", val)` call-sites across `core`, `proto`, `web`, and `worker` to structured-field form so log aggregators can filter by field (closes #84).
- Refactors the worker handshake helper: replaces the caller-supplied `negotiated_msg` format string with a structured `direction` field (`"outbound"` / `"inbound"`) and a static event message.
- No behaviour change — pure logging-format refactor.

## Test plan
- [x] `cargo check --workspace --tests` clean
- [x] `cargo test --workspace --tests` — all 1000+ tests pass
- [x] `rg -U 'tracing::?(error|warn|info|debug|trace)!\([^)]*"[^"]*\{\}'` returns no remaining printf-style call-sites

Closes #84