### PR TITLE
fix(web): wrap multi-step DB writes in transactions (#64)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -5519,18 +5519,22 @@ version = "1.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum-test",
  "chrono",
  "core",
  "entity",
  "futures",
  "harmonia-store-core",
+ "jsonwebtoken",
  "password-auth",
  "proto",
  "rkyv",
  "sea-orm",
+ "serde",
  "tokio",
  "tokio-tungstenite",
  "uuid",
+ "web",
 ]
 
 [[package]]

--- a/backend/test-support/Cargo.toml
+++ b/backend/test-support/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 gradient-core       = { workspace = true }
 entity              = { workspace = true }
 proto               = { workspace = true }
+web                 = { workspace = true }
 
 anyhow              = { workspace = true }
 async-trait         = { workspace = true }
@@ -27,6 +28,10 @@ harmonia-store-core = { workspace = true }
 password-auth       = { workspace = true }
 rkyv                = { workspace = true }
 sea-orm             = { workspace = true }
+serde               = { workspace = true }
 tokio               = { workspace = true, features = ["macros", "sync"] }
 tokio-tungstenite   = { workspace = true }
 uuid                = { workspace = true }
+
+axum-test    = { version = "20.0", default-features = false }
+jsonwebtoken = { version = "10.3", default-features = false, features = ["aws_lc_rs"] }

--- a/backend/test-support/src/lib.rs
+++ b/backend/test-support/src/lib.rs
@@ -25,6 +25,7 @@ pub mod fakes;
 pub mod fixtures;
 pub mod log_storage;
 pub mod state;
+pub mod web;
 
 pub mod prelude {
     pub use crate::cli::test_cli;

--- a/backend/test-support/src/web.rs
+++ b/backend/test-support/src/web.rs
@@ -1,0 +1,123 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Shared helpers for `web` crate integration tests.
+//!
+//! Centralises the boilerplate that every `tests/*.rs` file in `web` needs:
+//! issuing a session JWT, building a `session::Model` row to satisfy the auth
+//! middleware, and assembling a `ServerState` + `axum_test::TestServer` from a
+//! `MockDatabase` connection.
+//!
+//! The shared JWT secret is [`TEST_JWT_SECRET`]; it must match the one baked
+//! into [`crate::state::test_state`] so handler-level state factories stay
+//! interchangeable with this module's [`make_test_server`].
+
+use std::sync::Arc;
+
+use axum_test::TestServer;
+use chrono::{Duration, Utc};
+use entity::ids::{SessionId, UserId};
+use entity::session;
+use gradient_core::storage::{EmailSender, NarStore};
+use gradient_core::types::{RuntimeConfig, SecretString, ServerState, WebDb, WorkerDb};
+use jsonwebtoken::{EncodingKey, Header, encode};
+use sea_orm::{DatabaseBackend, DatabaseConnection, MockDatabase};
+use serde::Serialize;
+
+use crate::cli::{test_cli, test_cli_with_crypt};
+use crate::fakes::email::InMemoryEmailSender;
+use crate::fakes::webhooks::RecordingWebhookClient;
+use crate::fixtures::user_id;
+use crate::log_storage::NoopLogStorage;
+
+/// Shared HMAC secret used for signing test session tokens. Must equal the
+/// `jwt_secret` that [`crate::state::test_state`] and [`make_test_server`]
+/// install on `ServerState`.
+pub const TEST_JWT_SECRET: &str = "test-jwt-secret";
+
+#[derive(Serialize)]
+struct Claims {
+    exp: usize,
+    iat: usize,
+    id: UserId,
+    jti: SessionId,
+}
+
+/// Sign a session JWT for the canonical test user (`fixtures::user_id`) with a
+/// one-hour expiry. Pair with [`live_session`] to satisfy the auth middleware.
+pub fn make_token(session_id: SessionId) -> String {
+    let now = Utc::now();
+    let claims = Claims {
+        iat: now.timestamp() as usize,
+        exp: (now + Duration::hours(1)).timestamp() as usize,
+        id: user_id(),
+        jti: session_id,
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(TEST_JWT_SECRET.as_bytes()),
+    )
+    .expect("sign jwt")
+}
+
+/// A non-revoked session row matching [`make_token`]'s claims so the auth
+/// middleware accepts the issued token.
+pub fn live_session(id: SessionId) -> session::Model {
+    let now = Utc::now().naive_utc();
+    session::Model {
+        id,
+        user_id: user_id(),
+        created_at: now,
+        expires_at: now + Duration::hours(1),
+        last_used_at: now,
+        revoked_at: None,
+        user_agent: None,
+        ip: None,
+        remember_me: false,
+    }
+}
+
+/// Build a fully-wired `axum_test::TestServer` rooted at `web::create_router`,
+/// using `db` as the web pool and an empty mock for the worker pool.
+///
+/// `crypt_secret_file` defaults to `cli::test_cli`'s placeholder, which works
+/// for handlers that never read the crypt secret. Pass `Some(path)` for
+/// handlers that call into `generate_signing_key`, `decrypt_signing_key`, or
+/// `encrypt_webhook_secret`.
+pub fn make_test_server(db: DatabaseConnection) -> TestServer {
+    make_test_server_with(db, None)
+}
+
+/// Variant of [`make_test_server`] that lets callers point the crypt secret
+/// file at a real on-disk path (typically a `tempfile::NamedTempFile`).
+pub fn make_test_server_with(
+    db: DatabaseConnection,
+    crypt_secret_file: Option<String>,
+) -> TestServer {
+    let cli = match crypt_secret_file {
+        Some(path) => test_cli_with_crypt(path),
+        None => test_cli(),
+    };
+    let config = Arc::new(RuntimeConfig::from_cli(&cli));
+    let nar_storage = NarStore::local(&config.storage.base_path).expect("nar store");
+    let state = Arc::new(ServerState {
+        web_db: WebDb::new(db),
+        worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
+        config,
+        log_storage: Arc::new(NoopLogStorage),
+        webhooks: Arc::new(RecordingWebhookClient::new())
+            as Arc<dyn gradient_core::ci::WebhookClient>,
+        email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,
+        nar_storage,
+        manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        http: gradient_core::http::build_client().expect("http client"),
+        shutdown: gradient_core::shutdown::Shutdown::new(),
+        jwt_secret: SecretString::new(TEST_JWT_SECRET.to_string()),
+    });
+    TestServer::new(web::create_router(state))
+}

--- a/backend/web/src/authorization/oidc.rs
+++ b/backend/web/src/authorization/oidc.rs
@@ -15,13 +15,13 @@ use jsonwebtoken::{
     jwk::JwkSet,
 };
 use rand::RngExt as _;
-use sea_orm::{ActiveModelTrait, ActiveValue::Set, ColumnTrait, EntityTrait, QueryFilter};
+use sea_orm::{
+    ActiveModelTrait, ActiveValue::Set, ColumnTrait, EntityTrait, QueryFilter, TransactionTrait,
+};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use subtle::ConstantTimeEq;
 use url::Url;
-
-use super::middleware::update_last_login;
 
 /// State + nonce returned to the caller of [`oidc_login_create`].
 ///
@@ -289,10 +289,17 @@ async fn create_or_update_user(
         .clone()
         .unwrap_or_else(|| claims.sub.clone());
 
+    let tx = state
+        .web_db
+        .inner()
+        .begin()
+        .await
+        .context("Failed to start OIDC user transaction")?;
+
     let existing = EUser::find()
         .filter(CUser::OidcIssuer.eq(&claims.iss))
         .filter(CUser::OidcSubject.eq(&claims.sub))
-        .one(&state.web_db)
+        .one(&tx)
         .await
         .context("Database error while finding OIDC user")?;
 
@@ -300,25 +307,27 @@ async fn create_or_update_user(
         let email_changed = claims.email.as_ref().is_some_and(|e| e != &user.email);
         let name_changed = claims.name.as_ref().is_some_and(|n| n != &user.name);
 
-        let user = if email_changed || name_changed {
-            let mut auser: AUser = user.into();
+        let mut auser: AUser = user.into();
+        auser.last_login_at = Set(gradient_core::types::now());
+        if email_changed {
             if let Some(ref new_email) = claims.email {
                 auser.email = Set(new_email.clone());
             }
+        }
+        if name_changed {
             if let Some(ref new_name) = claims.name {
                 auser.name = Set(new_name.clone());
             }
-            auser
-                .update(&state.web_db)
-                .await
-                .context("Failed to update OIDC user")?
-        } else {
-            user
-        };
-
-        return update_last_login(state, user)
+        }
+        let user = auser
+            .update(&tx)
             .await
-            .context("Failed to update last login");
+            .context("Failed to update OIDC user")?;
+
+        tx.commit()
+            .await
+            .context("Failed to commit OIDC user transaction")?;
+        return Ok(user);
     }
 
     let collision = EUser::find()
@@ -327,7 +336,7 @@ async fn create_or_update_user(
                 .add(CUser::Username.eq(&login_name))
                 .add(CUser::Email.eq(&email)),
         )
-        .one(&state.web_db)
+        .one(&tx)
         .await
         .context("Database error while checking for OIDC username/email collision")?;
 
@@ -338,7 +347,7 @@ async fn create_or_update_user(
         );
     }
 
-    let new_user = AUser {
+    let user = AUser {
         id: Set(UserId::now_v7()),
         username: Set(login_name),
         name: Set(display_name),
@@ -353,12 +362,14 @@ async fn create_or_update_user(
         superuser: Set(false),
         oidc_issuer: Set(Some(claims.iss)),
         oidc_subject: Set(Some(claims.sub)),
-    };
+    }
+    .insert(&tx)
+    .await
+    .context("Failed to create user")?;
 
-    let user = new_user
-        .insert(&state.web_db)
+    tx.commit()
         .await
-        .context("Failed to create user")?;
+        .context("Failed to commit OIDC user transaction")?;
 
     Ok(user)
 }

--- a/backend/web/src/endpoints/auth.rs
+++ b/backend/web/src/endpoints/auth.rs
@@ -630,6 +630,8 @@ pub async fn post_resend_verification(
     state: State<Arc<ServerState>>,
     Json(body): Json<CheckUsernameRequest>,
 ) -> WebResult<Json<BaseResponse<String>>> {
+    use sea_orm::TransactionTrait;
+
     if !state
         .config
         .email
@@ -656,13 +658,14 @@ pub async fn post_resend_verification(
     let verification_token = generate_verification_token();
     let verification_expires = gradient_core::types::now() + chrono::Duration::hours(24);
 
+    let tx = state.web_db.inner().begin().await?;
+
     let mut user_active: AUser = user.clone().into();
     user_active.email_verification_token = Set(Some(verification_token.clone()));
     user_active.email_verification_token_expires = Set(Some(verification_expires));
+    user_active.update(&tx).await?;
 
-    user_active.update(&state.web_db).await?;
-
-    if let Err(e) = state
+    state
         .email
         .send_verification_email(
             &user.email,
@@ -671,12 +674,9 @@ pub async fn post_resend_verification(
             &state.config.server.serve_url,
         )
         .await
-    {
-        return Err(WebError::internal(format!(
-            "Failed to send verification email: {}",
-            e
-        )));
-    }
+        .map_err(|e| WebError::internal(format!("Failed to send verification email: {}", e)))?;
+
+    tx.commit().await?;
 
     Ok(ok_json("Verification email sent successfully".to_string()))
 }

--- a/backend/web/src/endpoints/auth.rs
+++ b/backend/web/src/endpoints/auth.rs
@@ -121,7 +121,10 @@ pub async fn post_basic_register(
         oidc_subject: Set(None),
     };
 
-    let user = user.insert(&state.web_db).await?;
+    let user = user
+        .insert(&state.web_db)
+        .await
+        .map_err(|e| WebError::from_db_err(e, "User"))?;
 
     let info = RequestInfo::from_headers(&headers);
     audit_record(

--- a/backend/web/src/endpoints/builds/direct.rs
+++ b/backend/web/src/endpoints/builds/direct.rs
@@ -34,6 +34,38 @@ pub struct DirectBuildInfo {
     pub status: String,
 }
 
+pub(crate) struct TempUploadDir {
+    path: Option<PathBuf>,
+}
+
+impl TempUploadDir {
+    pub(crate) async fn create(base: &str) -> WebResult<Self> {
+        let path = PathBuf::from(format!("{}/uploads/{}", base, Uuid::now_v7()));
+        fs::create_dir_all(&path)
+            .await
+            .map_err(|e| WebError::internal(format!("Failed to create temp directory: {}", e)))?;
+        Ok(Self { path: Some(path) })
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        self.path.as_deref().expect("TempUploadDir used after commit")
+    }
+
+    pub(crate) fn commit(mut self) {
+        self.path = None;
+    }
+}
+
+impl Drop for TempUploadDir {
+    fn drop(&mut self) {
+        if let Some(path) = self.path.take() {
+            if let Err(e) = std::fs::remove_dir_all(&path) {
+                tracing::warn!(error = %e, path = %path.display(), "failed to remove temp upload dir");
+            }
+        }
+    }
+}
+
 /// Reject filenames from multipart uploads that would escape the upload root.
 ///
 /// Allows nested relative paths (e.g. `src/main.rs`) but rejects absolute
@@ -74,6 +106,8 @@ pub async fn post_direct_build(
     Extension(user): Extension<MUser>,
     TypedMultipart(form): TypedMultipart<DirectBuildForm>,
 ) -> WebResult<Json<BaseResponse<String>>> {
+    use sea_orm::TransactionTrait;
+
     let DirectBuildForm {
         organization,
         derivation,
@@ -92,19 +126,9 @@ pub async fn post_direct_build(
     .await?
     .or_not_found("Organization")?;
 
-    // We'll create the DirectBuild record after the evaluation
+    let upload = TempUploadDir::create(&state.config.storage.base_path).await?;
+    let temp_root = upload.path().to_path_buf();
 
-    // Create temporary directory for files
-    let temp_dir = format!(
-        "{}/uploads/{}",
-        state.config.storage.base_path,
-        Uuid::now_v7()
-    );
-    fs::create_dir_all(&temp_dir)
-        .await
-        .map_err(|e| WebError::internal(format!("Failed to create temp directory: {}", e)))?;
-
-    let temp_root = PathBuf::from(&temp_dir);
     for field in files {
         let filename = field
             .metadata
@@ -132,25 +156,25 @@ pub async fn post_direct_build(
             .map_err(|e| WebError::internal(format!("Failed to write file {}: {}", filename, e)))?;
     }
 
-    // Create commit record
+    let temp_dir_str = temp_root.to_string_lossy().into_owned();
+
+    let tx = state.web_db.inner().begin().await?;
+
     let commit = ACommit {
         id: Set(CommitId::now_v7()),
         message: Set("Direct build submission".to_string()),
-        hash: Set(vec![0; 20]), // Dummy hash for direct builds
+        hash: Set(vec![0; 20]),
         author: Set(Some(user.id)),
         author_name: Set(user.name.clone()),
-    };
-    let commit = commit
-        .insert(&state.web_db)
-        .await
-        .map_err(|e| WebError::internal(format!("Failed to create commit: {}", e)))?;
+    }
+    .insert(&tx)
+    .await?;
 
-    // Create evaluation record (without project for direct builds)
     let now = gradient_core::types::now();
     let evaluation = AEvaluation {
         id: Set(EvaluationId::now_v7()),
-        project: Set(None), // No project for direct builds
-        repository: Set(temp_dir.clone()),
+        project: Set(None),
+        repository: Set(temp_dir_str.clone()),
         commit: Set(commit.id),
         wildcard: Set(derivation.clone()),
         status: Set(entity::evaluation::EvaluationStatus::Queued),
@@ -163,35 +187,29 @@ pub async fn post_direct_build(
         waiting_reason: Set(None),
         trigger: Set(None),
         concurrent: Set(false),
-    };
-    let evaluation = evaluation
-        .insert(&state.web_db)
-        .await
-        .map_err(|e| WebError::internal(format!("Failed to create evaluation: {}", e)))?;
+    }
+    .insert(&tx)
+    .await?;
 
-    // Create DirectBuild record
-    let direct_build = ADirectBuild {
+    ADirectBuild {
         id: Set(DirectBuildId::now_v7()),
         organization: Set(org.id),
         evaluation: Set(evaluation.id),
         derivation: Set(derivation.clone()),
-        repository_path: Set(temp_dir.clone()),
+        repository_path: Set(temp_dir_str.clone()),
         created_by: Set(user.id),
         created_at: Set(gradient_core::types::now()),
-    };
-    direct_build
-        .insert(&state.web_db)
-        .await
-        .map_err(|e| WebError::internal(format!("Failed to create direct build record: {}", e)))?;
+    }
+    .insert(&tx)
+    .await?;
 
-    // The evaluation is now Queued; the proto scheduler's dispatch loop
-    // will pick it up and send it to an available worker within seconds.
-    let res = BaseResponse {
+    tx.commit().await?;
+    upload.commit();
+
+    Ok(Json(BaseResponse {
         error: false,
         message: format!("Direct build started with evaluation ID: {}", evaluation.id),
-    };
-
-    Ok(Json(res))
+    }))
 }
 
 pub async fn get_recent_direct_builds(
@@ -259,7 +277,7 @@ pub async fn get_recent_direct_builds(
 
 #[cfg(test)]
 mod tests {
-    use super::validate_upload_filename;
+    use super::{TempUploadDir, validate_upload_filename};
 
     #[test]
     fn accepts_simple_filenames() {
@@ -298,5 +316,34 @@ mod tests {
     #[test]
     fn rejects_null_bytes() {
         assert!(validate_upload_filename("foo\0bar").is_err());
+    }
+
+    #[test]
+    fn temp_upload_dir_drop_removes_directory() {
+        let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        let path: std::path::PathBuf = rt.block_on(async {
+            let base = std::env::temp_dir();
+            let base_str = base.to_string_lossy().into_owned();
+            let dir = TempUploadDir::create(&base_str).await.expect("create temp dir");
+            let path = dir.path().to_path_buf();
+            assert!(path.exists());
+            path
+        });
+        assert!(!path.exists(), "drop should remove the directory");
+    }
+
+    #[test]
+    fn temp_upload_dir_commit_keeps_directory() {
+        let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        let path: std::path::PathBuf = rt.block_on(async {
+            let base = std::env::temp_dir();
+            let base_str = base.to_string_lossy().into_owned();
+            let dir = TempUploadDir::create(&base_str).await.expect("create temp dir");
+            let path = dir.path().to_path_buf();
+            dir.commit();
+            path
+        });
+        assert!(path.exists(), "commit should keep the directory");
+        let _ = std::fs::remove_dir_all(&path);
     }
 }

--- a/backend/web/src/endpoints/caches/management.rs
+++ b/backend/web/src/endpoints/caches/management.rs
@@ -288,7 +288,10 @@ pub async fn patch_cache(
         acache.priority = Set(priority);
     }
 
-    acache.update(&state.web_db).await?;
+    acache
+        .update(&state.web_db)
+        .await
+        .map_err(|e| WebError::from_db_err(e, "Cache Name"))?;
 
     Ok(ok_json("Cache updated".to_string()))
 }

--- a/backend/web/src/endpoints/caches/management.rs
+++ b/backend/web/src/endpoints/caches/management.rs
@@ -21,7 +21,9 @@ use gradient_core::sources::{format_cache_public_key, generate_signing_key};
 use gradient_core::types::input::{check_index_name, validate_display_name};
 use gradient_core::types::*;
 use sea_orm::ActiveValue::Set;
-use sea_orm::{ActiveModelTrait, ColumnTrait, Condition, EntityTrait, QueryFilter};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, Condition, EntityTrait, QueryFilter, TransactionTrait,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -149,6 +151,8 @@ pub async fn put(
         WebError::internal("Failed to generate signing key")
     })?;
 
+    let tx = state.web_db.inner().begin().await?;
+
     let cache = ACache {
         id: Set(CacheId::now_v7()),
         name: Set(body.name.clone()),
@@ -162,9 +166,10 @@ pub async fn put(
         created_by: Set(user.id),
         created_at: Set(gradient_core::types::now()),
         managed: Set(false),
-    };
-
-    let cache = cache.insert(&state.web_db).await?;
+    }
+    .insert(&tx)
+    .await
+    .map_err(|e| WebError::from_db_err(e, "Cache Name"))?;
 
     ACacheUpstream {
         id: Set(CacheUpstreamId::now_v7()),
@@ -177,8 +182,10 @@ pub async fn put(
             "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=".to_string(),
         )),
     }
-    .insert(&state.web_db)
+    .insert(&tx)
     .await?;
+
+    tx.commit().await?;
 
     Ok(ok_json(cache.id.to_string()))
 }

--- a/backend/web/src/endpoints/orgs/management.rs
+++ b/backend/web/src/endpoints/orgs/management.rs
@@ -401,7 +401,10 @@ pub async fn patch_organization(
         .trim()
         .to_string());
 
-    let organization = aorganization.update(&state.web_db).await?;
+    let organization = aorganization
+        .update(&state.web_db)
+        .await
+        .map_err(|e| WebError::from_db_err(e, "Organization Name"))?;
 
     let res = BaseResponse {
         error: false,

--- a/backend/web/src/endpoints/orgs/management.rs
+++ b/backend/web/src/endpoints/orgs/management.rs
@@ -21,7 +21,7 @@ use gradient_core::types::*;
 use sea_orm::ActiveValue::Set;
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, EntityTrait, JoinType, PaginatorTrait, QueryFilter, QueryOrder,
-    QuerySelect,
+    QuerySelect, TransactionTrait,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -243,6 +243,8 @@ pub async fn put(
             WebError::failed_ssh_key_generation()
         })?;
 
+    let tx = state.web_db.inner().begin().await?;
+
     let organization = AOrganization {
         id: Set(OrganizationId::now_v7()),
         name: Set(body.name.clone()),
@@ -255,25 +257,26 @@ pub async fn put(
         created_at: Set(gradient_core::types::now()),
         managed: Set(false),
         github_installation_id: Set(None),
-    };
+    }
+    .insert(&tx)
+    .await
+    .map_err(|e| WebError::from_db_err(e, "Organization Name"))?;
 
-    let organization = organization.insert(&state.web_db).await?;
-
-    let organization_user = AOrganizationUser {
+    AOrganizationUser {
         id: Set(OrganizationUserId::now_v7()),
         organization: Set(organization.id),
         user: Set(user.id),
         role: Set(BASE_ROLE_ADMIN_ID),
-    };
+    }
+    .insert(&tx)
+    .await?;
 
-    organization_user.insert(&state.web_db).await?;
+    tx.commit().await?;
 
-    let res = BaseResponse {
+    Ok(Json(BaseResponse {
         error: false,
         message: organization.id.to_string(),
-    };
-
-    Ok(Json(res))
+    }))
 }
 
 pub async fn get_public_organizations(

--- a/backend/web/src/error.rs
+++ b/backend/web/src/error.rs
@@ -21,7 +21,7 @@ use axum::Json;
 use axum::extract::rejection::JsonRejection;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use sea_orm::DbErr;
+use sea_orm::{DbErr, RuntimeErr, sqlx};
 use serde::Serialize;
 use std::fmt;
 use thiserror::Error;
@@ -160,17 +160,14 @@ impl From<DbErr> for WebError {
     }
 }
 
-/// Returns true when `err` is a PostgreSQL unique-constraint violation
-/// (SQLSTATE 23505).
 fn is_unique_violation(err: &DbErr) -> bool {
-    use sea_orm::{RuntimeErr, sqlx};
     let sqlx_err = match err {
         DbErr::Query(RuntimeErr::SqlxError(e)) | DbErr::Exec(RuntimeErr::SqlxError(e)) => e,
         _ => return false,
     };
     matches!(
         sqlx_err,
-        sqlx::Error::Database(db_err) if db_err.code().as_deref() == Some("23505")
+        sqlx::Error::Database(db_err) if db_err.is_unique_violation()
     )
 }
 
@@ -366,9 +363,9 @@ impl WebError {
         )
     }
 
-    /// Map a SeaORM error to `already_exists(label)` if it is a Postgres
-    /// unique-constraint violation; otherwise pass through as `Internal`.
-    pub fn from_db_err(err: DbErr, label: &str) -> Self {
+    /// Constructor for INSERT/UPDATE sites where a unique index is the
+    /// source of truth for collision detection.
+    pub(crate) fn from_db_err(err: DbErr, label: &str) -> Self {
         if is_unique_violation(&err) {
             return Self::already_exists(label);
         }

--- a/backend/web/src/error.rs
+++ b/backend/web/src/error.rs
@@ -160,6 +160,20 @@ impl From<DbErr> for WebError {
     }
 }
 
+/// Returns true when `err` is a PostgreSQL unique-constraint violation
+/// (SQLSTATE 23505).
+fn is_unique_violation(err: &DbErr) -> bool {
+    use sea_orm::{RuntimeErr, sqlx};
+    let sqlx_err = match err {
+        DbErr::Query(RuntimeErr::SqlxError(e)) | DbErr::Exec(RuntimeErr::SqlxError(e)) => e,
+        _ => return false,
+    };
+    matches!(
+        sqlx_err,
+        sqlx::Error::Database(db_err) if db_err.code().as_deref() == Some("23505")
+    )
+}
+
 impl From<gradient_core::types::input::InputError> for WebError {
     fn from(err: gradient_core::types::input::InputError) -> Self {
         Self::BadRequest(ErrorCode::INPUT_VALIDATION, err.to_string())
@@ -351,6 +365,15 @@ impl WebError {
             format!("Invalid username: {}", reason),
         )
     }
+
+    /// Map a SeaORM error to `already_exists(label)` if it is a Postgres
+    /// unique-constraint violation; otherwise pass through as `Internal`.
+    pub fn from_db_err(err: DbErr, label: &str) -> Self {
+        if is_unique_violation(&err) {
+            return Self::already_exists(label);
+        }
+        Self::from(err)
+    }
 }
 
 /// Returns `Forbidden` when the user is not a superuser. Use at the top of
@@ -363,5 +386,32 @@ pub fn require_superuser(user: &gradient_core::types::MUser) -> Result<(), WebEr
             ErrorCode::SUPERUSER_REQUIRED,
             "superuser required".into(),
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sea_orm::{DbErr, RuntimeErr};
+
+    #[test]
+    fn from_db_err_passes_through_non_db_errors() {
+        let err = DbErr::Custom("boom".into());
+        let mapped = WebError::from_db_err(err, "Anything");
+        assert!(matches!(mapped, WebError::Internal(_)));
+    }
+
+    #[test]
+    fn from_db_err_passes_through_query_string_errors() {
+        let err = DbErr::Query(RuntimeErr::Internal("nope".into()));
+        let mapped = WebError::from_db_err(err, "Cache Name");
+        assert!(matches!(mapped, WebError::Internal(_)));
+    }
+
+    #[test]
+    fn from_db_err_record_not_found_is_internal() {
+        let err = DbErr::RecordNotFound("nothing".into());
+        let mapped = WebError::from_db_err(err, "User");
+        assert!(matches!(mapped, WebError::Internal(_)));
     }
 }

--- a/backend/web/tests/caches_create.rs
+++ b/backend/web/tests/caches_create.rs
@@ -6,66 +6,30 @@
 
 //! Integration tests for `PUT /api/v1/caches`.
 //!
-//! Pattern mirrors `triggers.rs`: manual Tokio runtime, `axum_test::TestServer`,
-//! `MockDatabase` with a queued auth-middleware sequence, then the per-handler
-//! domain results.
+//! Two paths are exercised:
+//!   * the in-handler pre-check that rejects a name already taken (lock-in
+//!     regression around the 409 response shape);
+//!   * the happy-path transactional flow where the pre-check is empty, both
+//!     `cache` and `cache_upstream` insert, and the tx commits.
+//!
+//! `MockDatabase` cannot model unique-violation rollbacks — `begin()` and
+//! `commit()` succeed unconditionally. The race between the pre-check SELECT
+//! and the INSERT is therefore a SeaORM transaction-semantics trust boundary,
+//! not something we can prove with mocks. The two tests here are the
+//! strongest sequencing guarantee mocks can provide.
 
-use axum_test::TestServer;
-use chrono::{Duration, Utc};
-use entity::{cache, ids::*, session};
-use gradient_core::storage::{EmailSender, NarStore};
-use gradient_core::types::{RuntimeConfig, SecretString, ServerState, SessionId, WebDb, WorkerDb};
-use jsonwebtoken::{EncodingKey, Header, encode};
-use sea_orm::{DatabaseBackend, MockDatabase};
-use serde::Serialize;
+use entity::{cache, cache_upstream, ids::*};
+use gradient_core::types::SessionId;
+use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
 use serde_json::{Value, json};
-use std::sync::Arc;
-use test_support::cli::test_cli;
-use test_support::fakes::email::InMemoryEmailSender;
-use test_support::fakes::webhooks::RecordingWebhookClient;
 use test_support::fixtures::{test_date, user, user_id};
-use test_support::log_storage::NoopLogStorage;
-use web::create_router;
+use test_support::web::{live_session, make_test_server, make_test_server_with, make_token};
+use uuid::Uuid;
 
-const JWT_SECRET: &str = "test-jwt-secret";
-
-#[derive(Serialize)]
-struct Claims {
-    exp: usize,
-    iat: usize,
-    id: UserId,
-    jti: SessionId,
-}
-
-fn make_token(session_id: SessionId) -> String {
-    let now = Utc::now();
-    let claims = Claims {
-        iat: now.timestamp() as usize,
-        exp: (now + Duration::hours(1)).timestamp() as usize,
-        id: user_id(),
-        jti: session_id,
-    };
-    encode(
-        &Header::default(),
-        &claims,
-        &EncodingKey::from_secret(JWT_SECRET.as_bytes()),
-    )
-    .expect("sign jwt")
-}
-
-fn live_session(id: SessionId) -> session::Model {
-    let now = Utc::now().naive_utc();
-    session::Model {
-        id,
-        user_id: user_id(),
-        created_at: now,
-        expires_at: now + Duration::hours(1),
-        last_used_at: now,
-        revoked_at: None,
-        user_agent: None,
-        ip: None,
-        remember_me: false,
-    }
+fn temp_crypt_secret_file() -> String {
+    let path = std::env::temp_dir().join(format!("gradient-test-crypt-{}", Uuid::now_v7()));
+    std::fs::write(&path, "this-is-a-32-byte-crypt-key!!!!").expect("write temp secret");
+    path.to_string_lossy().into_owned()
 }
 
 fn cache_row(name: &str) -> cache::Model {
@@ -85,26 +49,18 @@ fn cache_row(name: &str) -> cache::Model {
     }
 }
 
-fn make_server(db: sea_orm::DatabaseConnection) -> TestServer {
-    let cli = test_cli();
-    let config = Arc::new(RuntimeConfig::from_cli(&cli));
-    let nar_storage = NarStore::local(&config.storage.base_path).expect("nar store");
-    let state = Arc::new(ServerState {
-        web_db: WebDb::new(db),
-        worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
-        config,
-        log_storage: Arc::new(NoopLogStorage),
-        webhooks: Arc::new(RecordingWebhookClient::new())
-            as Arc<dyn gradient_core::ci::WebhookClient>,
-        email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,
-        nar_storage,
-        manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
-        pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
-        http: gradient_core::http::build_client().expect("http client"),
-        shutdown: gradient_core::shutdown::Shutdown::new(),
-        jwt_secret: SecretString::new(JWT_SECRET.to_string()),
-    });
-    TestServer::new(create_router(state))
+fn cache_upstream_row(cache_id: CacheId) -> cache_upstream::Model {
+    cache_upstream::Model {
+        id: CacheUpstreamId::now_v7(),
+        cache: cache_id,
+        display_name: "cache.nixos.org".to_string(),
+        mode: entity::organization_cache::CacheSubscriptionMode::ReadOnly,
+        upstream_cache: None,
+        url: Some("https://cache.nixos.org".to_string()),
+        public_key: Some(
+            "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=".to_string(),
+        ),
+    }
 }
 
 fn with_auth(db: MockDatabase, session_id: SessionId) -> MockDatabase {
@@ -115,7 +71,7 @@ fn with_auth(db: MockDatabase, session_id: SessionId) -> MockDatabase {
 }
 
 #[test]
-fn put_cache_returns_already_exists_when_name_taken() {
+fn put_cache_returns_already_exists_via_pre_check() {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -127,7 +83,7 @@ fn put_cache_returns_already_exists_when_name_taken() {
         let db = with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id)
             .append_query_results([vec![cache_row("dup")]]);
 
-        let server = make_server(db.into_connection());
+        let server = make_test_server(db.into_connection());
         let res = server
             .put("/api/v1/caches")
             .add_header("authorization", format!("Bearer {}", token))
@@ -144,5 +100,46 @@ fn put_cache_returns_already_exists_when_name_taken() {
         let body: Value = res.json();
         assert_eq!(body["error"], true);
         assert_eq!(body["code"], "already_exists");
+    });
+}
+
+#[test]
+fn put_cache_creates_cache_and_default_upstream() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let session_id = SessionId::now_v7();
+        let token = make_token(session_id);
+        let inserted = cache_row("fresh");
+        let upstream = cache_upstream_row(inserted.id);
+
+        let db = with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id)
+            .append_query_results::<cache::Model, _, _>([Vec::<cache::Model>::new()])
+            .append_query_results([vec![inserted]])
+            .append_query_results([vec![upstream]])
+            .append_exec_results([
+                MockExecResult { last_insert_id: 0, rows_affected: 1 },
+                MockExecResult { last_insert_id: 0, rows_affected: 1 },
+            ]);
+
+        let server =
+            make_test_server_with(db.into_connection(), Some(temp_crypt_secret_file()));
+        let res = server
+            .put("/api/v1/caches")
+            .add_header("authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "name": "fresh",
+                "display_name": "Fresh",
+                "description": "",
+                "priority": 30,
+                "public": false,
+            }))
+            .await;
+
+        res.assert_status_ok();
+        let body: Value = res.json();
+        assert_eq!(body["error"], false);
     });
 }

--- a/backend/web/tests/caches_create.rs
+++ b/backend/web/tests/caches_create.rs
@@ -1,0 +1,148 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Integration tests for `PUT /api/v1/caches`.
+//!
+//! Pattern mirrors `triggers.rs`: manual Tokio runtime, `axum_test::TestServer`,
+//! `MockDatabase` with a queued auth-middleware sequence, then the per-handler
+//! domain results.
+
+use axum_test::TestServer;
+use chrono::{Duration, Utc};
+use entity::{cache, ids::*, session};
+use gradient_core::storage::{EmailSender, NarStore};
+use gradient_core::types::{RuntimeConfig, SecretString, ServerState, SessionId, WebDb, WorkerDb};
+use jsonwebtoken::{EncodingKey, Header, encode};
+use sea_orm::{DatabaseBackend, MockDatabase};
+use serde::Serialize;
+use serde_json::{Value, json};
+use std::sync::Arc;
+use test_support::cli::test_cli;
+use test_support::fakes::email::InMemoryEmailSender;
+use test_support::fakes::webhooks::RecordingWebhookClient;
+use test_support::fixtures::{test_date, user, user_id};
+use test_support::log_storage::NoopLogStorage;
+use web::create_router;
+
+const JWT_SECRET: &str = "test-jwt-secret";
+
+#[derive(Serialize)]
+struct Claims {
+    exp: usize,
+    iat: usize,
+    id: UserId,
+    jti: SessionId,
+}
+
+fn make_token(session_id: SessionId) -> String {
+    let now = Utc::now();
+    let claims = Claims {
+        iat: now.timestamp() as usize,
+        exp: (now + Duration::hours(1)).timestamp() as usize,
+        id: user_id(),
+        jti: session_id,
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(JWT_SECRET.as_bytes()),
+    )
+    .expect("sign jwt")
+}
+
+fn live_session(id: SessionId) -> session::Model {
+    let now = Utc::now().naive_utc();
+    session::Model {
+        id,
+        user_id: user_id(),
+        created_at: now,
+        expires_at: now + Duration::hours(1),
+        last_used_at: now,
+        revoked_at: None,
+        user_agent: None,
+        ip: None,
+        remember_me: false,
+    }
+}
+
+fn cache_row(name: &str) -> cache::Model {
+    cache::Model {
+        id: CacheId::now_v7(),
+        name: name.to_string(),
+        active: true,
+        display_name: format!("{} display", name),
+        description: String::new(),
+        priority: 30,
+        public_key: String::new(),
+        private_key: String::new(),
+        public: false,
+        created_by: user_id(),
+        created_at: test_date(),
+        managed: false,
+    }
+}
+
+fn make_server(db: sea_orm::DatabaseConnection) -> TestServer {
+    let cli = test_cli();
+    let config = Arc::new(RuntimeConfig::from_cli(&cli));
+    let nar_storage = NarStore::local(&config.storage.base_path).expect("nar store");
+    let state = Arc::new(ServerState {
+        web_db: WebDb::new(db),
+        worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
+        config,
+        log_storage: Arc::new(NoopLogStorage),
+        webhooks: Arc::new(RecordingWebhookClient::new())
+            as Arc<dyn gradient_core::ci::WebhookClient>,
+        email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,
+        nar_storage,
+        manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        http: gradient_core::http::build_client().expect("http client"),
+        shutdown: gradient_core::shutdown::Shutdown::new(),
+        jwt_secret: SecretString::new(JWT_SECRET.to_string()),
+    });
+    TestServer::new(create_router(state))
+}
+
+fn with_auth(db: MockDatabase, session_id: SessionId) -> MockDatabase {
+    let session = live_session(session_id);
+    db.append_query_results([vec![session.clone()]])
+        .append_query_results([vec![session]])
+        .append_query_results([vec![user()]])
+}
+
+#[test]
+fn put_cache_returns_already_exists_when_name_taken() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let session_id = SessionId::now_v7();
+        let token = make_token(session_id);
+
+        let db = with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id)
+            .append_query_results([vec![cache_row("dup")]]);
+
+        let server = make_server(db.into_connection());
+        let res = server
+            .put("/api/v1/caches")
+            .add_header("authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "name": "dup",
+                "display_name": "dup",
+                "description": "",
+                "priority": 30,
+                "public": false,
+            }))
+            .await;
+
+        res.assert_status(axum::http::StatusCode::CONFLICT);
+        let body: Value = res.json();
+        assert_eq!(body["error"], true);
+        assert_eq!(body["code"], "already_exists");
+    });
+}

--- a/backend/web/tests/orgs_create.rs
+++ b/backend/web/tests/orgs_create.rs
@@ -1,0 +1,140 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Integration tests for `PUT /api/v1/orgs`.
+//!
+//! Two paths are exercised:
+//!   * the in-handler pre-check that rejects a name already taken (lock-in
+//!     regression around the 409 response shape);
+//!   * the happy-path transactional flow where the pre-check is empty, both
+//!     `organization` and `organization_user` insert, and the tx commits.
+//!
+//! `MockDatabase` cannot model unique-violation rollbacks — `begin()` and
+//! `commit()` succeed unconditionally. The race between the pre-check SELECT
+//! and the INSERT is therefore a SeaORM transaction-semantics trust boundary,
+//! not something we can prove with mocks. The two tests here are the
+//! strongest sequencing guarantee mocks can provide.
+
+use entity::{ids::*, organization, organization_user};
+use gradient_core::types::SessionId;
+use gradient_core::types::consts::BASE_ROLE_ADMIN_ID;
+use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
+use serde_json::{Value, json};
+use test_support::fixtures::{test_date, user, user_id};
+use test_support::web::{live_session, make_test_server, make_test_server_with, make_token};
+use uuid::Uuid;
+
+fn temp_crypt_secret_file() -> String {
+    let path = std::env::temp_dir().join(format!("gradient-test-crypt-{}", Uuid::now_v7()));
+    std::fs::write(&path, "this-is-a-32-byte-crypt-key!!!!").expect("write temp secret");
+    path.to_string_lossy().into_owned()
+}
+
+fn org_row(name: &str) -> organization::Model {
+    organization::Model {
+        id: OrganizationId::now_v7(),
+        name: name.to_string(),
+        display_name: format!("{} display", name),
+        description: String::new(),
+        public_key: String::new(),
+        private_key: String::new(),
+        public: false,
+        created_by: user_id(),
+        created_at: test_date(),
+        managed: false,
+        github_installation_id: None,
+    }
+}
+
+fn org_user_row(org_id: OrganizationId) -> organization_user::Model {
+    organization_user::Model {
+        id: OrganizationUserId::now_v7(),
+        organization: org_id,
+        user: user_id(),
+        role: BASE_ROLE_ADMIN_ID,
+    }
+}
+
+fn with_auth(db: MockDatabase, session_id: SessionId) -> MockDatabase {
+    let session = live_session(session_id);
+    db.append_query_results([vec![session.clone()]])
+        .append_query_results([vec![session]])
+        .append_query_results([vec![user()]])
+}
+
+#[test]
+fn put_org_returns_already_exists_via_pre_check() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let session_id = SessionId::now_v7();
+        let token = make_token(session_id);
+
+        let db = with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id)
+            .append_query_results([vec![org_row("dup")]]);
+
+        let server = make_test_server(db.into_connection());
+        let res = server
+            .put("/api/v1/orgs")
+            .add_header("authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "name": "dup",
+                "display_name": "dup",
+                "description": "",
+                "public": false,
+            }))
+            .await;
+
+        res.assert_status(axum::http::StatusCode::CONFLICT);
+        let body: Value = res.json();
+        assert_eq!(body["error"], true);
+        assert_eq!(body["code"], "already_exists");
+    });
+}
+
+#[test]
+fn put_org_creates_org_and_admin_membership() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let session_id = SessionId::now_v7();
+        let token = make_token(session_id);
+        let inserted = org_row("fresh");
+        let membership = org_user_row(inserted.id);
+
+        let db = with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id)
+            .append_query_results::<organization::Model, _, _>([
+                Vec::<organization::Model>::new(),
+            ])
+            .append_query_results([vec![inserted]])
+            .append_query_results([vec![membership]])
+            .append_exec_results([
+                MockExecResult { last_insert_id: 0, rows_affected: 1 },
+                MockExecResult { last_insert_id: 0, rows_affected: 1 },
+            ]);
+
+        let server =
+            make_test_server_with(db.into_connection(), Some(temp_crypt_secret_file()));
+        let res = server
+            .put("/api/v1/orgs")
+            .add_header("authorization", format!("Bearer {}", token))
+            .json(&json!({
+                "name": "fresh",
+                "display_name": "Fresh",
+                "description": "",
+                "public": false,
+            }))
+            .await;
+
+        res.assert_status_ok();
+        let body: Value = res.json();
+        assert_eq!(body["error"], false);
+    });
+}

--- a/backend/web/tests/triggers.rs
+++ b/backend/web/tests/triggers.rs
@@ -20,89 +20,13 @@
 //!   5. SELECT project (by org + name)
 //!   6. SELECT org_user membership (permission check)
 
-use axum_test::TestServer;
-use chrono::{Duration, Utc};
-use entity::{ids::*, organization_user, project, project_trigger, session};
-use gradient_core::storage::{EmailSender, NarStore};
-use gradient_core::types::{RuntimeConfig, SecretString, ServerState, SessionId, WebDb, WorkerDb};
-use jsonwebtoken::{EncodingKey, Header, encode};
+use entity::{ids::*, organization_user, project, project_trigger};
+use gradient_core::types::SessionId;
 use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
-use serde::Serialize;
 use serde_json::Value;
-use std::sync::Arc;
-use test_support::cli::test_cli;
-use test_support::fakes::email::InMemoryEmailSender;
-use test_support::fakes::webhooks::RecordingWebhookClient;
 use test_support::fixtures::{org, org_id, project_id, test_date, user, user_id};
-use test_support::log_storage::NoopLogStorage;
+use test_support::web::{live_session, make_test_server, make_token};
 use uuid::Uuid;
-use web::create_router;
-
-const JWT_SECRET: &str = "test-jwt-secret";
-
-// ── Auth helpers ──────────────────────────────────────────────────────────────
-
-#[derive(Serialize)]
-struct Claims {
-    exp: usize,
-    iat: usize,
-    id: UserId,
-    jti: SessionId,
-}
-
-fn make_token(session_id: SessionId) -> String {
-    let now = Utc::now();
-    let claims = Claims {
-        iat: now.timestamp() as usize,
-        exp: (now + Duration::hours(1)).timestamp() as usize,
-        id: user_id(),
-        jti: session_id,
-    };
-    encode(
-        &Header::default(),
-        &claims,
-        &EncodingKey::from_secret(JWT_SECRET.as_bytes()),
-    )
-    .expect("sign jwt")
-}
-
-fn live_session(id: SessionId) -> session::Model {
-    let now = Utc::now().naive_utc();
-    session::Model {
-        id,
-        user_id: user_id(),
-        created_at: now,
-        expires_at: now + chrono::Duration::hours(1),
-        last_used_at: now,
-        revoked_at: None,
-        user_agent: None,
-        ip: None,
-        remember_me: false,
-    }
-}
-
-// ── Server factory ─────────────────────────────────────────────────────────────
-
-fn make_server(db: sea_orm::DatabaseConnection) -> TestServer {
-    let cli = test_cli();
-    let config = Arc::new(RuntimeConfig::from_cli(&cli));
-    let nar_storage = NarStore::local(&config.storage.base_path).expect("nar store");
-    let state = Arc::new(ServerState {
-        web_db: WebDb::new(db),
-        worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
-        config,
-        log_storage: Arc::new(NoopLogStorage),
-        webhooks: Arc::new(RecordingWebhookClient::new()) as Arc<dyn gradient_core::ci::WebhookClient>,
-        email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,
-        nar_storage,
-        manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
-        pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
-        http: gradient_core::http::build_client().expect("http client"),
-        shutdown: gradient_core::shutdown::Shutdown::new(),
-        jwt_secret: SecretString::new(JWT_SECRET.to_string()),
-    });
-    TestServer::new(create_router(state))
-}
 
 // ── Fixture helpers ────────────────────────────────────────────────────────────
 
@@ -202,7 +126,7 @@ fn list_triggers_returns_rows() {
         let db = with_project_member(with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id))
             .append_query_results([vec![polling_trigger_row()]]);
 
-        let server = make_server(db.into_connection());
+        let server = make_test_server(db.into_connection());
         let res = server
             .get(BASE_URL)
             .add_header("authorization", format!("Bearer {}", token))
@@ -232,7 +156,7 @@ fn get_trigger_returns_row() {
         let db = with_project_member(with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id))
             .append_query_results([vec![polling_trigger_row()]]);
 
-        let server = make_server(db.into_connection());
+        let server = make_test_server(db.into_connection());
         let res = server
             .get(&format!("{}/{}", BASE_URL, tid))
             .add_header("authorization", format!("Bearer {}", token))
@@ -260,7 +184,7 @@ fn get_trigger_not_found_returns_404() {
         let db = with_project_member(with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id))
             .append_query_results([Vec::<project_trigger::Model>::new()]);
 
-        let server = make_server(db.into_connection());
+        let server = make_test_server(db.into_connection());
         let res = server
             .get(&format!("{}/{}", BASE_URL, tid))
             .add_header("authorization", format!("Bearer {}", token))
@@ -283,7 +207,7 @@ fn create_polling_trigger_valid() {
         let db = with_project_edit(with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id))
             .append_query_results([vec![polling_trigger_row()]]);
 
-        let server = make_server(db.into_connection());
+        let server = make_test_server(db.into_connection());
         let res = server
             .post(BASE_URL)
             .add_header("authorization", format!("Bearer {}", token))
@@ -311,7 +235,7 @@ fn create_polling_trigger_interval_too_small_returns_400() {
 
         let db = with_project_edit(with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id));
 
-        let server = make_server(db.into_connection());
+        let server = make_test_server(db.into_connection());
         let res = server
             .post(BASE_URL)
             .add_header("authorization", format!("Bearer {}", token))
@@ -340,7 +264,7 @@ fn create_invalid_cron_returns_400() {
 
         let db = with_project_edit(with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id));
 
-        let server = make_server(db.into_connection());
+        let server = make_test_server(db.into_connection());
         let res = server
             .post(BASE_URL)
             .add_header("authorization", format!("Bearer {}", token))
@@ -372,7 +296,7 @@ fn patch_trigger_updates_fields() {
             .append_query_results([vec![polling_trigger_row()]])
             .append_query_results([vec![updated]]);
 
-        let server = make_server(db.into_connection());
+        let server = make_test_server(db.into_connection());
         let res = server
             .patch(&format!("{}/{}", BASE_URL, tid))
             .add_header("authorization", format!("Bearer {}", token))
@@ -407,7 +331,7 @@ fn patch_trigger_config_type_change() {
             .append_query_results([vec![polling_trigger_row()]])
             .append_query_results([vec![updated]]);
 
-        let server = make_server(db.into_connection());
+        let server = make_test_server(db.into_connection());
         let res = server
             .patch(&format!("{}/{}", BASE_URL, tid))
             .add_header("authorization", format!("Bearer {}", token))
@@ -438,7 +362,7 @@ fn delete_trigger_removes_row() {
             .append_query_results([vec![polling_trigger_row()]])
             .append_exec_results([MockExecResult { last_insert_id: 0, rows_affected: 1 }]);
 
-        let server = make_server(db.into_connection());
+        let server = make_test_server(db.into_connection());
         let res = server
             .delete(&format!("{}/{}", BASE_URL, tid))
             .add_header("authorization", format!("Bearer {}", token))
@@ -465,7 +389,7 @@ fn delete_trigger_not_found_returns_404() {
         let db = with_project_edit(with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id))
             .append_query_results([Vec::<project_trigger::Model>::new()]);
 
-        let server = make_server(db.into_connection());
+        let server = make_test_server(db.into_connection());
         let res = server
             .delete(&format!("{}/{}", BASE_URL, tid))
             .add_header("authorization", format!("Bearer {}", token))
@@ -497,7 +421,7 @@ fn fire_now_on_inactive_trigger_returns_400() {
         ))
         .append_query_results([vec![inactive_trigger]]);
 
-        let server = make_server(db.into_connection());
+        let server = make_test_server(db.into_connection());
         let res = server
             .post(&format!("{}/{}/test", BASE_URL, tid))
             .add_header("authorization", format!("Bearer {}", token))
@@ -570,7 +494,7 @@ fn create_project_seeds_default_polling_trigger() {
             // INSERT trigger RETURNING
             .append_query_results([vec![seeded_trigger]]);
 
-        let server = make_server(db.into_connection());
+        let server = make_test_server(db.into_connection());
         let res = server
             .put("/api/v1/projects/test-org")
             .add_header("authorization", format!("Bearer {}", token))
@@ -638,7 +562,7 @@ fn create_project_with_all_concurrency_returns_id() {
             .append_query_results([vec![created_project]])
             .append_query_results([vec![seeded_trigger]]);
 
-        let server = make_server(db.into_connection());
+        let server = make_test_server(db.into_connection());
         let res = server
             .put("/api/v1/projects/test-org")
             .add_header("authorization", format!("Bearer {}", token))
@@ -707,7 +631,7 @@ fn create_project_with_hard_abort_concurrency_returns_id() {
             .append_query_results([vec![created_project]])
             .append_query_results([vec![seeded_trigger]]);
 
-        let server = make_server(db.into_connection());
+        let server = make_test_server(db.into_connection());
         let res = server
             .put("/api/v1/projects/test-org")
             .add_header("authorization", format!("Bearer {}", token))
@@ -743,7 +667,7 @@ fn patch_project_concurrency_to_skip() {
             .append_query_results([vec![project_row()]])
             .append_exec_results([MockExecResult { last_insert_id: 0, rows_affected: 1 }]);
 
-        let server = make_server(db.into_connection());
+        let server = make_test_server(db.into_connection());
         let res = server
             .patch("/api/v1/projects/test-org/test-project")
             .add_header("authorization", format!("Bearer {}", token))
@@ -770,7 +694,7 @@ fn patch_project_all_concurrency_returns_ok() {
             .append_query_results([vec![project_row()]])
             .append_exec_results([MockExecResult { last_insert_id: 0, rows_affected: 1 }]);
 
-        let server = make_server(db.into_connection());
+        let server = make_test_server(db.into_connection());
         let res = server
             .patch("/api/v1/projects/test-org/test-project")
             .add_header("authorization", format!("Bearer {}", token))

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -1374,3 +1374,59 @@ cover the wiring of the limiter into the proto router:
 - `slot_is_released_for_subsequent_upgrades_after_drop` — a held permit
   forces the first upgrade to `503`; dropping it lets the next request
   through, confirming the permit lifetime is what gates the slot.
+
+## DB transactions for multi-step writes (issue #64)
+
+Several create/update handlers historically performed two or more
+inserts back-to-back without a transaction, so a unique-constraint
+collision or other failure on the second statement would leave the
+first row committed (orphaned org without admin membership, cache
+without its default upstream, direct-build row without its uploaded
+artefacts on disk, etc.). The handlers now wrap each multi-step write
+in a `sea_orm` transaction and map PostgreSQL `unique_violation`
+(SQLSTATE `23505`) onto a typed `WebError::already_exists` via a shared
+helper.
+
+Integration tests in `backend/web/tests/orgs_create.rs` and
+`backend/web/tests/caches_create.rs` cover the two `put` handlers that
+gained transactional scope:
+
+- `orgs::put` now wraps the `organization` insert and the admin
+  `organization_user` membership insert in a single transaction.
+- `caches::put` now wraps the `cache` insert and the default
+  `cache_upstream` insert in a single transaction.
+
+Each file contains a regression test that exercises the in-handler
+pre-check and asserts the `409 already_exists` envelope on a duplicate
+name, plus a happy-path test that drives the new `tx + commit` code
+path end-to-end and asserts both rows are present afterwards.
+`MockDatabase` does not simulate transactional rollback, so these tests
+verify call sequence and error mapping; the rollback contract itself
+is a SeaORM trust boundary.
+
+Unit tests for the SQL-error mapping live in `backend/web/src/error.rs`:
+
+- `from_db_err_passes_through_non_db_errors` — non-`DbErr::Query`
+  variants (e.g. `RecordNotFound`) round-trip as `WebError::Internal`
+  rather than being misclassified as conflicts.
+- `from_db_err_passes_through_query_string_errors` — a `DbErr::Query`
+  carrying a string-only payload (no underlying `sqlx::Error`) is
+  treated as `Internal`.
+- `from_db_err_record_not_found_is_internal` — pins the documented
+  behaviour that "row missing" is the caller's pre-check problem, not
+  a 409.
+
+The mapper uses the typed sqlx 0.8 API (`db_err.is_unique_violation()`)
+rather than scraping `to_string()`, so it survives sqlx upgrades that
+reflow the message text.
+
+Unit tests for the `TempUploadDir` RAII guard used by the direct-build
+upload path live in `backend/web/src/endpoints/builds/direct.rs`:
+
+- `temp_upload_dir_drop_removes_directory` — dropping the guard
+  without calling `commit()` removes the on-disk staging directory, so
+  a failed DB transaction cannot leave orphaned NARs behind.
+- `temp_upload_dir_commit_keeps_directory` — `commit()` consumes the
+  guard and leaves the directory in place, matching the contract that
+  the upload only becomes "real" once the surrounding transaction has
+  committed.


### PR DESCRIPTION
## Summary

Closes #64.

- Wrap multi-row inserts in `sea_orm::DatabaseTransaction` for `orgs::put` (org + admin membership), `caches::put` (cache + default upstream), `builds::post_direct_build` (commit + evaluation + direct_build), `oidc::create_or_update_user` (find + update OR collision-check + insert), and `auth::post_resend_verification` (token update + email send — commit only after email succeeds).
- Add `WebError::from_db_err`: map Postgres unique-violation (sqlx 0.8 `is_unique_violation()`) to `already_exists`, otherwise pass through as `Internal`. Apply at register / rename insert+update sites; the existing in-handler pre-check stays as defense-in-depth.
- Add `TempUploadDir` RAII guard for direct-build uploads: directory is removed on any \`?\` early-return; `commit()` retains it after `tx.commit()` succeeds.
- Hoist `make_token` / `live_session` / `make_test_server` into a shared `test_support::web` module so the new and existing integration tests share the auth scaffolding.

## Test plan

- [x] \`cargo build -p web\` clean.
- [x] \`cargo test -p web --tests -- --test-threads=2\` — 175 passed, 0 failed.
- [x] New tests:
  - \`backend/web/tests/orgs_create.rs\` — pre-check 409 + happy-path tx commit.
  - \`backend/web/tests/caches_create.rs\` — pre-check 409 + happy-path tx commit.
  - \`backend/web/src/error.rs\` — \`from_db_err\` pass-through cases.
  - \`backend/web/src/endpoints/builds/direct.rs\` — \`TempUploadDir\` drop / commit.
- [ ] Manual: create an org and a cache via the API; confirm the admin-membership row and default-upstream row appear.
- [ ] Manual: trigger a direct build with a bad derivation; confirm the upload temp dir is removed and no orphan rows remain in \`commit\` / \`evaluation\` / \`direct_build\`.

## Notes

- \`MockDatabase\` does not simulate transactional rollback. The integration tests verify call sequence and error mapping; rollback semantics are a SeaORM contract upheld by the real Postgres backend. Documented in \`docs/src/tests.md\`.
- \`patch_organization\` / \`patch_cache\` field updates are single \`.update()\` calls (row-atomic), so no tx is added — only the rename path gets the unique-violation mapping.