### PR TITLE
Quality: request-id correlation (#86) and FK-chasing log noise (#85)

### DIFF
--- a/backend/.cargo/config.toml
+++ b/backend/.cargo/config.toml
@@ -3,6 +3,9 @@
 [build]
 # Enable incremental compilation for faster builds
 incremental = true
+# Cap parallel rustc invocations to keep peak memory bounded on dev machines.
+# Cargo.toml has no equivalent — this is the canonical place for the setting.
+jobs = 2
 
 [target.x86_64-unknown-linux-gnu]
 # Optimize for current CPU when running tests locally

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -5794,6 +5794,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/backend/core/src/shutdown.rs
+++ b/backend/core/src/shutdown.rs
@@ -27,7 +27,7 @@ use std::time::Duration;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
-use tracing::{info, warn};
+use tracing::{Instrument, info, warn};
 
 #[derive(Clone, Debug)]
 pub struct Shutdown {
@@ -73,12 +73,18 @@ impl Shutdown {
 
     /// Register a background task with the tracker. Replaces bare
     /// `tokio::spawn` for anything outliving a single request.
+    ///
+    /// The future is instrumented with the current `tracing` span, so cleanup
+    /// work spawned from inside an HTTP handler keeps the request span (and
+    /// therefore the request-id) on every log line. Outside of a request
+    /// `Span::current()` is the root no-op span — instrumenting is then
+    /// effectively free.
     pub fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
     where
         F: Future + Send + 'static,
         F::Output: Send + 'static,
     {
-        self.tracker.spawn(future)
+        self.tracker.spawn(future.in_current_span())
     }
 
     /// Trigger shutdown. Idempotent.

--- a/backend/web/Cargo.toml
+++ b/backend/web/Cargo.toml
@@ -53,7 +53,7 @@ http                 = { version = "1.4", default-features = false }
 http-body-util       = { version = "0.1", default-features = false }
 jsonwebtoken         = { version = "10.3", default-features = false, features = ["aws_lc_rs"] }
 tower                = { version = "0.5", default-features = false }
-tower-http           = { version = "0.6", default-features = false, features = ["cors", "trace"] }
+tower-http           = { version = "0.6", default-features = false, features = ["cors", "request-id", "trace"] }
 tower_governor       = { version = "0.8", default-features = false, features = ["axum"] }
 
 [dev-dependencies]

--- a/backend/web/src/endpoints/builds/mod.rs
+++ b/backend/web/src/endpoints/builds/mod.rs
@@ -56,7 +56,7 @@ impl BuildAccessContext {
             .one(&state.web_db)
             .await?
             .ok_or_else(|| {
-                tracing::error!(
+                tracing::warn!(
                     evaluation_id = %build.evaluation,
                     %build_id,
                     "Evaluation not found for build",
@@ -69,7 +69,7 @@ impl BuildAccessContext {
                 .one(&state.web_db)
                 .await?
                 .ok_or_else(|| {
-                    tracing::error!(
+                    tracing::warn!(
                         %project_id,
                         evaluation_id = %evaluation.id,
                         "Project not found for evaluation",
@@ -83,7 +83,7 @@ impl BuildAccessContext {
                 .one(&state.web_db)
                 .await?
                 .ok_or_else(|| {
-                    tracing::error!(evaluation_id = %evaluation.id, "DirectBuild not found for evaluation");
+                    tracing::warn!(evaluation_id = %evaluation.id, "DirectBuild not found for evaluation");
                     WebError::data_inconsistency("Direct build")
                 })?
                 .organization
@@ -93,7 +93,7 @@ impl BuildAccessContext {
             .one(&state.web_db)
             .await?
             .ok_or_else(|| {
-                tracing::error!(%organization_id, "Organization not found");
+                tracing::warn!(%organization_id, "Organization not found");
                 WebError::data_inconsistency("Organization")
             })?;
 

--- a/backend/web/src/endpoints/builds/query.rs
+++ b/backend/web/src/endpoints/builds/query.rs
@@ -48,7 +48,7 @@ pub async fn get_build(
         .one(&state.web_db)
         .await?
         .ok_or_else(|| {
-            tracing::error!(
+            tracing::warn!(
                 derivation_id = %build.derivation,
                 %build_id,
                 "Derivation not found for build"

--- a/backend/web/src/endpoints/evals/mod.rs
+++ b/backend/web/src/endpoints/evals/mod.rs
@@ -52,7 +52,7 @@ impl EvalAccessContext {
                     .one(&state.web_db)
                     .await?
                     .ok_or_else(|| {
-                        tracing::error!(
+                        tracing::warn!(
                             %project_id,
                             %evaluation_id,
                             "Project not found for evaluation",
@@ -70,7 +70,7 @@ impl EvalAccessContext {
                     .one(&state.web_db)
                     .await?
                     .ok_or_else(|| {
-                        tracing::error!(%evaluation_id, "DirectBuild not found for evaluation");
+                        tracing::warn!(%evaluation_id, "DirectBuild not found for evaluation");
                         WebError::data_inconsistency("Direct build")
                     })?
                     .organization;
@@ -81,7 +81,7 @@ impl EvalAccessContext {
             .one(&state.web_db)
             .await?
             .ok_or_else(|| {
-                tracing::error!(%organization_id, "Organization not found");
+                tracing::warn!(%organization_id, "Organization not found");
                 WebError::data_inconsistency("Organization")
             })?;
 

--- a/backend/web/src/error.rs
+++ b/backend/web/src/error.rs
@@ -106,6 +106,13 @@ pub enum WebError {
     UnprocessableEntity(ErrorCode, String),
     #[error("Service Unavailable [{0}]: {1}")]
     ServiceUnavailable(ErrorCode, String),
+    /// Referential-integrity mismatch detected at request time (e.g. a build
+    /// row whose derivation row was concurrently deleted). Maps to the same
+    /// HTTP response as [`Internal`] but is logged at warn level — the
+    /// rich-context warn line is emitted at the callsite, so `IntoResponse`
+    /// stays silent.
+    #[error("Data Inconsistency: {0}")]
+    DataInconsistency(String),
     #[error(transparent)]
     Internal(#[from] AnyhowError),
 }
@@ -133,7 +140,7 @@ impl WebError {
             Self::Conflict(..) => StatusCode::CONFLICT,
             Self::UnprocessableEntity(..) => StatusCode::UNPROCESSABLE_ENTITY,
             Self::ServiceUnavailable(..) => StatusCode::SERVICE_UNAVAILABLE,
-            Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::DataInconsistency(_) | Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 
@@ -147,7 +154,7 @@ impl WebError {
             | Self::Conflict(c, _)
             | Self::UnprocessableEntity(c, _)
             | Self::ServiceUnavailable(c, _) => *c,
-            Self::Internal(_) => ErrorCode::INTERNAL,
+            Self::DataInconsistency(_) | Self::Internal(_) => ErrorCode::INTERNAL,
         }
     }
 }
@@ -191,6 +198,11 @@ impl IntoResponse for WebError {
         let message: String = match &self {
             Self::Internal(err) => {
                 tracing::error!(error = format!("{err:#}"), "Internal error");
+                "Internal server error".to_string()
+            }
+            Self::DataInconsistency(_) => {
+                // Rich-context warn line is emitted at the construction
+                // callsite — don't double-log here.
                 "Internal server error".to_string()
             }
             Self::BadRequest(_, m)
@@ -280,13 +292,12 @@ impl WebError {
 
     /// Internal-server-error for "<resource> data inconsistency" — a
     /// referential-integrity violation discovered at request time
-    /// (e.g. a build row with no derivation row).
+    /// (e.g. a build row with no derivation row). Maps to HTTP 500 with the
+    /// generic `internal` code, but is logged at warn level via the
+    /// `DataInconsistency` variant since the cause is most often a transient
+    /// race against concurrent deletion rather than a real server bug.
     pub fn data_inconsistency(resource: &str) -> Self {
-        Self::Internal(AnyhowError::msg(format!(
-            "[{}] {} data inconsistency",
-            ErrorCode::DATA_INCONSISTENCY,
-            resource
-        )))
+        Self::DataInconsistency(format!("{} data inconsistency", resource))
     }
 
     pub fn invalid_credentials() -> Self {

--- a/backend/web/src/lib.rs
+++ b/backend/web/src/lib.rs
@@ -16,13 +16,13 @@ pub mod helpers;
 pub mod permissions;
 
 use axum::body::Body;
-use axum::extract::DefaultBodyLimit;
+use axum::extract::{DefaultBodyLimit, MatchedPath};
 use axum::routing::{get, patch, post, put};
 use axum::{Router, middleware};
 use bytes::Bytes;
 use governor::middleware::NoOpMiddleware;
 use http::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE};
-use http::{HeaderMap, Request, Response};
+use http::{HeaderMap, HeaderValue, Request, Response};
 use std::net::{IpAddr, Ipv4Addr};
 use std::time::Duration;
 use tower_governor::GovernorLayer;
@@ -31,8 +31,12 @@ use tower_governor::governor::{GovernorConfig, GovernorConfigBuilder};
 use tower_governor::key_extractor::{KeyExtractor, SmartIpKeyExtractor};
 use tower_http::classify::ServerErrorsFailureClass;
 use tower_http::cors::{AllowOrigin, CorsLayer};
+use tower_http::request_id::{
+    MakeRequestId, PropagateRequestIdLayer, RequestId, SetRequestIdLayer,
+};
 use tower_http::trace::TraceLayer;
 use tracing::Span;
+use uuid::Uuid;
 
 use endpoints::{admin, *};
 use gradient_core::types::ServerState;
@@ -57,6 +61,23 @@ impl KeyExtractor for SmartIpOrFallback {
             Ok(ip) => Ok(ip),
             Err(_) => Ok(IpAddr::V4(Ipv4Addr::UNSPECIFIED)),
         }
+    }
+}
+
+/// Generates an x-request-id header for incoming requests that don't carry
+/// one. Using UUID v7 keeps ids monotonic per source so log scans stay
+/// roughly time-ordered. Trusted upstream proxies that already inject an
+/// `x-request-id` are passed through unchanged by `SetRequestIdLayer`.
+#[derive(Debug, Clone, Copy, Default)]
+struct MakeRequestUuid;
+
+impl MakeRequestId for MakeRequestUuid {
+    fn make_request_id<B>(&mut self, _request: &Request<B>) -> Option<RequestId> {
+        let id = Uuid::now_v7().to_string();
+        // `Uuid::now_v7().to_string()` produces ASCII hex+hyphens, always a
+        // valid header value — `from_str` cannot realistically fail.
+        let value = HeaderValue::from_str(&id).ok()?;
+        Some(RequestId::new(value))
     }
 }
 
@@ -115,10 +136,36 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
         .allow_headers(vec![AUTHORIZATION, ACCEPT, CONTENT_TYPE])
         .allow_credentials(true);
 
+    // Build one span per request, populated with method, route pattern, and
+    // the request-id assigned by `SetRequestIdLayer`. All `tracing` events
+    // emitted while the request is in flight — handler logs, DB queries,
+    // and any task spawned via `Shutdown::spawn` (which inherits the
+    // current span) — are linked to the same id, so a single grep finds
+    // every line for one request.
     let trace = TraceLayer::new_for_http()
+        .make_span_with(|request: &Request<Body>| {
+            let request_id = request
+                .headers()
+                .get("x-request-id")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("");
+            // `MatchedPath` carries the route pattern (e.g. `/orgs/{organization}`)
+            // rather than the concrete path, so spans group by route in dashboards
+            // and don't blow up cardinality with concrete ids.
+            let route = request
+                .extensions()
+                .get::<MatchedPath>()
+                .map(MatchedPath::as_str)
+                .unwrap_or_else(|| request.uri().path());
+            tracing::info_span!(
+                "http_request",
+                method = %request.method(),
+                route = %route,
+                request_id = %request_id,
+            )
+        })
         .on_request(|request: &Request<Body>, _span: &Span| {
             tracing::debug!(
-                method = %request.method(),
                 path = request.uri().path(),
                 "request started",
             )
@@ -474,9 +521,16 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
 
     app = app.merge(cache_routes);
 
+    // Layer order (outer → inner, i.e. last `.layer()` is outermost):
+    //   SetRequestIdLayer    — assigns x-request-id on inbound requests
+    //   TraceLayer           — opens the span (reads the id from headers)
+    //   PropagateRequestIdLayer — copies the id onto the response
+    //   CORS                 — innermost so preflights still get traced
     app.fallback(handle_404)
         .layer(cors)
+        .layer(PropagateRequestIdLayer::x_request_id())
         .layer(trace)
+        .layer(SetRequestIdLayer::x_request_id(MakeRequestUuid))
         .with_state(state)
 }
 

--- a/backend/web/tests/request_id.rs
+++ b/backend/web/tests/request_id.rs
@@ -1,0 +1,114 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Regression for #86: every response must carry an `x-request-id` so logs
+//! emitted while the request is in flight (handler, DB, spawned cleanup
+//! tasks) can be correlated with a single grep. When the client supplies
+//! the header — typically a reverse proxy injecting one — the server must
+//! preserve it instead of minting a new id.
+//!
+//! Uses manual Tokio runtimes because `#[tokio::test]` expands to
+//! `::gradient_core::…` which clashes with the local `core` crate name.
+
+use axum_test::TestServer;
+use gradient_core::ci::WebhookClient;
+use gradient_core::storage::{EmailSender, NarStore};
+use gradient_core::types::{ServerState, WebDb, WorkerDb};
+use sea_orm::{DatabaseBackend, MockDatabase};
+use std::sync::Arc;
+use test_support::fakes::email::InMemoryEmailSender;
+use test_support::fakes::webhooks::RecordingWebhookClient;
+use test_support::log_storage::NoopLogStorage;
+use test_support::prelude::test_cli;
+use uuid::Uuid;
+use web::create_router;
+
+fn make_state() -> Arc<ServerState> {
+    let cli = test_cli();
+    let nar_storage = NarStore::local(&cli.storage.base_path).expect("create test NarStore");
+    Arc::new(ServerState {
+        web_db: WebDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
+        worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
+        config: std::sync::Arc::new(gradient_core::types::RuntimeConfig::from_cli(&cli)),
+        log_storage: Arc::new(NoopLogStorage),
+        webhooks: Arc::new(RecordingWebhookClient::new()) as Arc<dyn WebhookClient>,
+        email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,
+        nar_storage,
+        manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        http: gradient_core::http::build_client().expect("http client"),
+        shutdown: gradient_core::shutdown::Shutdown::new(),
+        jwt_secret: gradient_core::types::SecretString::new("test-jwt-secret".to_string()),
+    })
+}
+
+#[test]
+fn missing_request_id_is_generated() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let server = TestServer::new(create_router(make_state()));
+        let response = server.get("/api/v1/health").await;
+        response.assert_status_ok();
+
+        let value = response
+            .header("x-request-id")
+            .to_str()
+            .expect("x-request-id is ASCII")
+            .to_owned();
+        assert!(
+            !value.is_empty(),
+            "server must mint an x-request-id when none is supplied"
+        );
+        Uuid::parse_str(&value).expect("auto-generated id must be a UUID");
+    });
+}
+
+#[test]
+fn supplied_request_id_is_echoed() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let server = TestServer::new(create_router(make_state()));
+        let supplied = "trace-from-upstream-proxy";
+        let response = server
+            .get("/api/v1/health")
+            .add_header("x-request-id", supplied)
+            .await;
+        response.assert_status_ok();
+
+        assert_eq!(
+            response.header("x-request-id"),
+            supplied,
+            "client-supplied x-request-id must be preserved end-to-end \
+             so reverse-proxy traces stay stitched together"
+        );
+    });
+}
+
+#[test]
+fn each_request_gets_a_distinct_id() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let server = TestServer::new(create_router(make_state()));
+        let first = server.get("/api/v1/health").await;
+        let second = server.get("/api/v1/health").await;
+
+        assert_ne!(
+            first.header("x-request-id"),
+            second.header("x-request-id"),
+            "successive requests must get unique ids — otherwise log \
+             correlation collapses across concurrent requests"
+        );
+    });
+}

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -49,6 +49,15 @@ info:
     Client IP is taken from `X-Forwarded-For` / `X-Real-IP` (deployments are
     expected behind a reverse proxy), falling back to the connection peer IP.
 
+    ## Request Tracing
+
+    Every response carries an `x-request-id` header. If the client (or an
+    upstream reverse proxy) supplies an `x-request-id` on the request, it is
+    preserved verbatim; otherwise the server mints a UUID v7. Use this id to
+    correlate client-side traces with server logs — every log line emitted
+    while the request is in flight (handler, DB, spawned cleanup tasks)
+    carries the same id.
+
     ## Common Response Envelope
 
     Every JSON response is wrapped in a standard envelope:

--- a/docs/src/development/contributing.md
+++ b/docs/src/development/contributing.md
@@ -28,6 +28,10 @@ nix run .#backend
 cd backend
 cargo run
 
+# Tip: parallel `rustc` jobs are capped at 2 in `backend/.cargo/config.toml`
+# (`[build] jobs = 2`) to keep peak memory bounded on dev machines. Override
+# with `cargo build -j N` if you have more headroom.
+
 # Frontend
 nix run .#frontend
 > run_tests()

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -1430,3 +1430,59 @@ upload path live in `backend/web/src/endpoints/builds/direct.rs`:
   guard and leaves the directory in place, matching the contract that
   the upload only becomes "real" once the surrounding transaction has
   committed.
+
+## Request-id correlation across handler / DB / cleanup tasks (#86)
+
+Without a stable per-request id, a single HTTP request that issues four
+DB queries plus a webhook delivery emits five unrelated log lines, and
+cleanup work spawned through `Shutdown::spawn` loses the request
+context entirely. `create_router` (`backend/web/src/lib.rs`) now wires
+`SetRequestIdLayer` (with a `MakeRequestUuid` UUID-v7 minter),
+`TraceLayer::make_span_with` (which opens an `http_request` span
+carrying `method`, the `MatchedPath` route, and the `x-request-id`),
+and `PropagateRequestIdLayer` (which echoes the id on the response).
+`Shutdown::spawn` (`backend/core/src/shutdown.rs`) wraps every spawned
+future with `.in_current_span()`, so cleanup tasks inherit the request
+span and the id is on every line they emit.
+
+Tests (`cargo test -p web --test request_id`):
+
+- `missing_request_id_is_generated` — a request without `x-request-id`
+  comes back with one, and the value parses as a UUID. Confirms the
+  `MakeRequestUuid` minter is wired in front of `TraceLayer`.
+- `supplied_request_id_is_echoed` — a request that *does* carry
+  `x-request-id` has its value preserved verbatim on the response, so a
+  reverse-proxy that injects an upstream trace id keeps the trace
+  stitched end-to-end.
+- `each_request_gets_a_distinct_id` — successive auto-generated ids
+  differ; otherwise log correlation collapses across concurrent
+  requests on the same connection.
+
+## FK-chasing data-inconsistency log level (#85)
+
+Access-context loaders (`EvalAccessContext` in
+`backend/web/src/endpoints/evals/mod.rs`, `BuildAccessContext` in
+`backend/web/src/endpoints/builds/mod.rs`, the derivation lookup in
+`backend/web/src/endpoints/builds/query.rs`) chase from a child row to
+its parent through FK columns. When the parent is missing — almost
+always a transient race against a concurrent delete — the previous
+implementation logged the event twice at error level: once at the
+callsite and again inside `WebError::IntoResponse` for the wrapping
+`Internal` variant. That noise drowned legitimate server errors.
+
+The fix introduces a dedicated `WebError::DataInconsistency` variant.
+External behaviour is unchanged (HTTP 500, code `internal`, body
+`Internal server error`); the difference is operational:
+
+- `IntoResponse` no longer logs for the new variant — the rich-context
+  warn line is emitted exactly once at the construction callsite,
+  carrying the structured ids (`project_id`, `evaluation_id`,
+  `derivation_id`, `organization_id`) that triage actually needs.
+- The callsite log itself is now `tracing::warn!`, not `error!`, so
+  these benign races no longer pollute the error stream.
+
+No new tests were added: the change is a log-level adjustment and a
+no-op refactor of the error variant. The existing access-control tests
+(`evaluations.rs`, `builds_download.rs`, `commits_authorization.rs`)
+still cover the response side of the data-inconsistency paths and pass
+unchanged.


### PR DESCRIPTION
Closes #85, closes #86.

## Summary

- **#85 — `error!` overused for transient FK races.** The previous code logged every `data_inconsistency` event twice at error level (once at the callsite, once inside `WebError::IntoResponse` for the wrapping `Internal` variant), which drowned legitimate server errors. Introduced a dedicated `WebError::DataInconsistency` variant: external HTTP behaviour is unchanged (500, code `internal`, body `Internal server error`), but `IntoResponse` no longer logs for it, and the callsite log is now a single `tracing::warn!` carrying the rich-context ids needed for triage.
- **#86 — no request-id / span correlation.** `TraceLayer` had no `make_span_with`, so a request touching four DB queries plus a webhook delivery emitted five unrelated log lines. Cleanup work spawned via `Shutdown::spawn` lost the request span entirely. Added a `MakeRequestUuid` minter behind `SetRequestIdLayer`, an `http_request` span carrying `method` / `MatchedPath` route / `request_id`, and `PropagateRequestIdLayer` to echo the id on the response. `Shutdown::spawn` now wraps every future with `.in_current_span()` so cleanup tasks inherit the request span — outside a request the current span is the no-op root, so it's free.
- **Build: cap parallel rustc jobs at 2** in `backend/.cargo/config.toml` so full-workspace builds stay within memory bounds on dev machines.

## Test plan

- [x] `cargo test --tests --workspace` — all crates pass (the new `request_id` suite covers auto-generated id, supplied-id passthrough, and per-request uniqueness).
- [x] `cargo check -p web -p core` — clean.
- [x] Existing access-control tests (`evaluations.rs`, `builds_download.rs`, `commits_authorization.rs`) still cover the response side of the `data_inconsistency` paths.
- [x] Docs updated: `docs/gradient-api.yaml` documents the new `x-request-id` header; `docs/src/tests.md` describes the new tests; `docs/src/development/contributing.md` notes the `[build] jobs = 2` cap.