### PR TITLE
fix: emit trigger on /evals/{eval} so auto-fired runs aren't labelled 'Manual'

### DIFF
--- a/backend/web/src/endpoints/evals/query.rs
+++ b/backend/web/src/endpoints/evals/query.rs
@@ -18,8 +18,9 @@ use std::sync::Arc;
 use super::EvalAccessContext;
 use super::types::{
     BuildItem, BuildsQuery, EntryPointBrief, EvaluationMessageResponse, EvaluationResponse,
-    PaginatedBuilds,
+    EvaluationTriggerSummary, PaginatedBuilds,
 };
+use gradient_core::types::triggers::TriggerType;
 
 pub async fn get_evaluation(
     state: State<Arc<ServerState>>,
@@ -93,6 +94,26 @@ pub async fn get_evaluation(
         None
     };
 
+    // Resolve `evaluation.trigger -> project_trigger.trigger_type` so the eval
+    // log page can render the correct "Via" badge. `None` here means the run
+    // was started manually (API / UI), not by a project trigger — the frontend
+    // renders that as "Manual".
+    let trigger = if let Some(trigger_id) = evaluation.trigger {
+        EProjectTrigger::find_by_id(trigger_id)
+            .one(&state.web_db)
+            .await?
+            .and_then(|t| {
+                TriggerType::try_from(t.trigger_type)
+                    .ok()
+                    .map(|tt| EvaluationTriggerSummary {
+                        id: trigger_id,
+                        trigger_type: tt,
+                    })
+            })
+    } else {
+        None
+    };
+
     let res = BaseResponse {
         error: false,
         message: EvaluationResponse {
@@ -110,6 +131,7 @@ pub async fn get_evaluation(
             error_count,
             warning_count,
             entry_points,
+            trigger,
             waiting_reason,
         },
     };

--- a/backend/web/src/endpoints/evals/types.rs
+++ b/backend/web/src/endpoints/evals/types.rs
@@ -6,6 +6,7 @@
 
 use gradient_core::types::WaitingReason;
 use gradient_core::types::ids::*;
+use gradient_core::types::triggers::TriggerType;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -55,11 +56,28 @@ pub struct EvaluationResponse {
     pub error_count: u64,
     pub warning_count: u64,
     pub entry_points: Vec<EntryPointBrief>,
+    /// `null` for manually-triggered evaluations (Web UI / API), populated for
+    /// evaluations that fired from a project trigger (polling, schedule,
+    /// reporter push/PR). Mirrors `EvaluationSummary::trigger` on the project
+    /// list endpoint so the eval-log "Via" badge can render the same labels
+    /// without falling back to "Manual" for trigger-fired runs.
+    pub trigger: Option<EvaluationTriggerSummary>,
     /// Populated only when `status == Waiting`. Explains which
     /// `(architecture, required_features)` combos no connected worker can
     /// satisfy, alongside the architectures the connected pool *does* offer.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub waiting_reason: Option<WaitingReason>,
+}
+
+/// Trigger that fired an evaluation. Same shape as
+/// `crate::endpoints::projects::EvaluationTriggerSummary` — duplicated here to
+/// keep the `evals` endpoint module self-contained (the projects module
+/// re-exports a long chain of unrelated types).
+#[derive(Serialize, Debug)]
+pub struct EvaluationTriggerSummary {
+    pub id: ProjectTriggerId,
+    #[serde(rename = "type")]
+    pub trigger_type: TriggerType,
 }
 
 /// Compact entry-point representation returned inline on the evaluation.


### PR DESCRIPTION
## Summary

`EvaluationResponse` — the payload behind `GET /api/v1/evals/{evaluation}`, used by the eval-log page — was missing the `trigger` field. The frontend reads `ev.trigger?.type ?? null` and maps `null` to `"Manual"` (`evaluation-log.component.ts:807`), so every run shown on the log page was labelled **Manual** even when it had been fired by polling, a schedule, a push webhook, or a PR webhook.

The OpenAPI schema (`Evaluation.trigger`) and the frontend `Evaluation` interface already declared the field — only the Rust handler was failing to populate it.

## Fix

Resolve `evaluation.trigger -> project_trigger.trigger_type` inside `get_evaluation` and surface the result as `EvaluationTriggerSummary { id, type }`, matching the shape `EvaluationSummary::trigger` already exposes on the project-list endpoint. Manual runs (where `evaluation.trigger IS NULL`) keep emitting `null`, which the frontend continues to render as "Manual".

`EvaluationTriggerSummary` is duplicated in the `evals` module rather than re-exported from `projects` to keep the eval endpoint self-contained — the `projects` module re-exports a long chain of unrelated DTOs that the `evals` module shouldn't pull in.

## Test plan

- [x] `cargo check -p web` clean
- [x] `cargo test -p web --lib` (99 passing)
- [ ] Manual: open an evaluation that was fired by a polling/schedule/push trigger — "Via" badge should show "Polling" / "Schedule" / "Push" / "PR", not "Manual"
- [ ] Manual: open an API-triggered evaluation — "Via" badge should still show "Manual"