### PR TITLE
fix(scheduler): waiting state for stuck pre-build evals (#97)

### DIFF
--- a/backend/core/src/state_machine/eval.rs
+++ b/backend/core/src/state_machine/eval.rs
@@ -31,8 +31,10 @@ impl std::error::Error for InvalidEvalTransition {}
 /// The valid transition graph is:
 /// ```text
 /// Queued → Fetching → EvaluatingFlake → EvaluatingDerivation
-///        → Building → Waiting → Building (back-and-forth)
+///        → Building ⇄ Waiting
 ///        → Completed | Failed | Aborted
+/// {Queued,Fetching,EvaluatingFlake,EvaluatingDerivation} → Waiting
+/// Waiting → Queued (recovery once a worker becomes available)
 /// * → Aborted (from any non-terminal state)
 /// * → Failed  (from any non-terminal state)
 /// ```
@@ -72,6 +74,15 @@ impl EvalStateMachine {
             (EvaluationStatus::Building, EvaluationStatus::Waiting) => Ok(to),
             (EvaluationStatus::Waiting, EvaluationStatus::Building) => Ok(to),
             (EvaluationStatus::Building, EvaluationStatus::Completed) => Ok(to),
+
+            // Pre-build phases stall into Waiting when no worker can pick up
+            // the eval job; recovery routes through Queued so the dispatch
+            // loop replays the normal progression.
+            (EvaluationStatus::Queued, EvaluationStatus::Waiting) => Ok(to),
+            (EvaluationStatus::Fetching, EvaluationStatus::Waiting) => Ok(to),
+            (EvaluationStatus::EvaluatingFlake, EvaluationStatus::Waiting) => Ok(to),
+            (EvaluationStatus::EvaluatingDerivation, EvaluationStatus::Waiting) => Ok(to),
+            (EvaluationStatus::Waiting, EvaluationStatus::Queued) => Ok(to),
 
             // Terminal transitions from any non-terminal state
             (_, EvaluationStatus::Failed) => Ok(to),
@@ -165,6 +176,45 @@ mod tests {
             assert!(
                 EvalStateMachine::validate(from, EvaluationStatus::Aborted).is_ok(),
                 "{from:?} → Aborted failed"
+            );
+        }
+    }
+
+    #[test]
+    fn eval_sm_pre_build_states_can_enter_waiting() {
+        let pre_build = [
+            EvaluationStatus::Queued,
+            EvaluationStatus::Fetching,
+            EvaluationStatus::EvaluatingFlake,
+            EvaluationStatus::EvaluatingDerivation,
+        ];
+        for from in pre_build {
+            assert!(
+                EvalStateMachine::validate(from, EvaluationStatus::Waiting).is_ok(),
+                "{from:?} → Waiting should be allowed"
+            );
+        }
+    }
+
+    #[test]
+    fn eval_sm_waiting_recovers_to_queued() {
+        assert!(
+            EvalStateMachine::validate(EvaluationStatus::Waiting, EvaluationStatus::Queued).is_ok()
+        );
+    }
+
+    #[test]
+    fn eval_sm_waiting_cannot_skip_into_pre_build_phases() {
+        // Recovery from Waiting goes via Queued; jumping straight to a later
+        // pre-build phase would let us bypass the dispatch path.
+        for to in [
+            EvaluationStatus::Fetching,
+            EvaluationStatus::EvaluatingFlake,
+            EvaluationStatus::EvaluatingDerivation,
+        ] {
+            assert!(
+                EvalStateMachine::validate(EvaluationStatus::Waiting, to).is_err(),
+                "Waiting → {to:?} should be rejected"
             );
         }
     }

--- a/backend/scheduler/src/build.rs
+++ b/backend/scheduler/src/build.rs
@@ -304,30 +304,34 @@ impl<'a> BuildStateHandler<'a> {
         Ok(())
     }
 
-    /// Sweep every in-flight evaluation (`Building` or `Waiting`) and reconcile
-    /// its status against the current set of connected workers' capabilities.
+    /// Sweep every in-flight evaluation and reconcile its status against the
+    /// current set of connected workers.
     ///
-    /// - `Building` → `Waiting` when **none** of the eval's still-pending builds
-    ///   has a connected worker whose `architectures` + `system_features` can
-    ///   satisfy it. Surfaces "no worker configured for these builds" in the UI
-    ///   instead of leaving the eval stuck silently.
-    /// - `Waiting` → `Building` when **any** pending build now has a matching
-    ///   worker (e.g. an aarch64 worker just connected, or an existing worker
-    ///   added a new system feature via re-advertised capabilities).
+    /// Two regimes apply, keyed on whether the eval has any pending builds:
     ///
-    /// Cheap: one query for the small set of in-flight evals, one query for
-    /// their non-terminal builds + derivations, one query for required features.
-    /// Worker caps are taken as a snapshot from the in-memory pool. Safe to call
-    /// from the dispatch loop and from worker-capability change hooks.
+    /// - **Pre-build phase** (no pending builds yet, status in
+    ///   `Queued`/`Fetching`/`EvaluatingFlake`/`EvaluatingDerivation`): if no
+    ///   worker is connected, flip to `Waiting` so the UI can explain why the
+    ///   eval is stuck. A `Waiting` eval with no pending builds came from this
+    ///   path; if a worker has since connected, recover to `Queued` and let the
+    ///   dispatch loop replay the normal progression.
+    /// - **Build phase** (pending builds present, status in
+    ///   `Building`/`Waiting`): flip `Building ↔ Waiting` based on whether any
+    ///   pending build's `(architecture, required_features)` is satisfiable by
+    ///   the connected pool, persisting the structured reason for the UI.
     pub async fn reconcile_waiting_state(
         &self,
         worker_caps: &[(Vec<String>, Vec<String>)],
     ) -> Result<()> {
         let evals = EEvaluation::find()
-            .filter(
-                CEvaluation::Status
-                    .is_in(vec![EvaluationStatus::Building, EvaluationStatus::Waiting]),
-            )
+            .filter(CEvaluation::Status.is_in(vec![
+                EvaluationStatus::Queued,
+                EvaluationStatus::Fetching,
+                EvaluationStatus::EvaluatingFlake,
+                EvaluationStatus::EvaluatingDerivation,
+                EvaluationStatus::Building,
+                EvaluationStatus::Waiting,
+            ]))
             .all(&self.state.worker_db)
             .await
             .context("fetch in-flight evaluations")?;
@@ -347,24 +351,37 @@ impl<'a> BuildStateHandler<'a> {
                 .await
                 .context("fetch pending builds")?;
 
-            if pending_builds.is_empty() {
-                // Nothing left to gate — terminal-status decision happens in
-                // `check_evaluation_done`, not here.
-                continue;
-            }
-
-            let drv_ids: Vec<DerivationId> = pending_builds.iter().map(|b| b.derivation).collect();
-            let checker = BuildabilityChecker::load(self.state, &drv_ids).await?;
-            let target = if checker.any_buildable(&pending_builds, worker_caps) {
-                EvaluationStatus::Building
+            let (target, new_reason) = if pending_builds.is_empty() {
+                match eval.status {
+                    EvaluationStatus::Building => continue,
+                    EvaluationStatus::Queued
+                    | EvaluationStatus::Fetching
+                    | EvaluationStatus::EvaluatingFlake
+                    | EvaluationStatus::EvaluatingDerivation
+                    | EvaluationStatus::Waiting => decide_pre_build_target(worker_caps.len()),
+                    _ => continue,
+                }
             } else {
-                EvaluationStatus::Waiting
-            };
-
-            let new_reason = if matches!(target, EvaluationStatus::Waiting) {
-                Some(checker.compute_waiting_reason(&pending_builds, worker_caps))
-            } else {
-                None
+                if !matches!(
+                    eval.status,
+                    EvaluationStatus::Building | EvaluationStatus::Waiting
+                ) {
+                    continue;
+                }
+                let drv_ids: Vec<DerivationId> =
+                    pending_builds.iter().map(|b| b.derivation).collect();
+                let checker = BuildabilityChecker::load(self.state, &drv_ids).await?;
+                let target = if checker.any_buildable(&pending_builds, worker_caps) {
+                    EvaluationStatus::Building
+                } else {
+                    EvaluationStatus::Waiting
+                };
+                let reason = if matches!(target, EvaluationStatus::Waiting) {
+                    Some(checker.compute_waiting_reason(&pending_builds, worker_caps))
+                } else {
+                    None
+                };
+                (target, reason)
             };
 
             if eval.status != target {
@@ -378,9 +395,6 @@ impl<'a> BuildStateHandler<'a> {
                 );
             }
 
-            // Persist the structured reason whenever the eval is (or stays in)
-            // Waiting so the API surface refreshes as the worker pool changes,
-            // and clear it on transitions back to Building.
             persist_waiting_reason(self.state, eval.id, &eval.waiting_reason, new_reason.as_ref())
                 .await;
 
@@ -390,6 +404,26 @@ impl<'a> BuildStateHandler<'a> {
         }
 
         Ok(())
+    }
+}
+
+/// Picks the target status for a pre-build evaluation based on whether any
+/// worker is currently connected. When no worker is connected we surface
+/// `Waiting` with an empty `unmet` list so the frontend explains the stall;
+/// otherwise we leave it (or recover it) to `Queued` and clear any stored
+/// reason.
+fn decide_pre_build_target(connected_workers: usize) -> (EvaluationStatus, Option<WaitingReason>) {
+    if connected_workers == 0 {
+        (
+            EvaluationStatus::Waiting,
+            Some(WaitingReason {
+                unmet: Vec::new(),
+                connected_workers: 0,
+                available_architectures: Vec::new(),
+            }),
+        )
+    } else {
+        (EvaluationStatus::Queued, None)
     }
 }
 
@@ -765,6 +799,23 @@ mod waiting_reason_tests {
         assert_eq!(reason.unmet.len(), 1);
         assert_eq!(reason.unmet[0].architecture, "aarch64-linux");
         assert_eq!(reason.unmet[0].build_count, 3);
+    }
+
+    #[test]
+    fn pre_build_target_no_workers_yields_waiting_with_empty_unmet() {
+        let (target, reason) = decide_pre_build_target(0);
+        assert_eq!(target, EvaluationStatus::Waiting);
+        let reason = reason.expect("waiting target must carry a reason");
+        assert_eq!(reason.connected_workers, 0);
+        assert!(reason.unmet.is_empty());
+        assert!(reason.available_architectures.is_empty());
+    }
+
+    #[test]
+    fn pre_build_target_with_workers_yields_queued_and_clears_reason() {
+        let (target, reason) = decide_pre_build_target(2);
+        assert_eq!(target, EvaluationStatus::Queued);
+        assert!(reason.is_none());
     }
 
     #[test]

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -5154,7 +5154,7 @@ components:
         | `EvaluatingFlake` | Running `nix eval` on the flake |
         | `EvaluatingDerivation` | Resolving derivation paths |
         | `Building` | Builds are in progress |
-        | `Waiting` | Waiting for build servers to become available |
+        | `Waiting` | Stalled because no connected worker can pick up the evaluation — either no worker is connected at all (pre-build phase) or none of the connected workers can satisfy the pending builds' `(architecture, required_features)` |
         | `Completed` | All builds finished successfully |
         | `Failed` | At least one build failed |
         | `Aborted` | Cancelled by user |
@@ -5216,12 +5216,14 @@ components:
     WaitingReason:
       type: object
       description: |
-        Populated only when `status == "Waiting"`. Explains which
-        `(architecture, required_features)` combinations no connected worker
-        can satisfy, alongside the architectures the connected pool *does*
-        offer. Refreshed whenever the scheduler reconciles the evaluation
-        against the live worker pool (worker connect/disconnect, capability
-        update, dispatch tick).
+        Populated only when `status == "Waiting"`. In the build phase, lists
+        the `(architecture, required_features)` combinations no connected
+        worker can satisfy, alongside the architectures the connected pool
+        *does* offer. In the pre-build phase, an empty `unmet` list with
+        `connected_workers == 0` indicates the evaluation is stalled simply
+        because no worker is connected at all. Refreshed whenever the
+        scheduler reconciles the evaluation against the live worker pool
+        (worker connect/disconnect, capability update, dispatch tick).
       required: [unmet, connected_workers, available_architectures]
       properties:
         unmet:

--- a/docs/src/development/tests.md
+++ b/docs/src/development/tests.md
@@ -1065,6 +1065,9 @@ Tests use `RecordingJobReporter` — no real git server or WebSocket needed.
 | `eval_sm_building_waiting_cycle` | Building↔Waiting back-and-forth is valid |
 | `eval_sm_any_nonterminal_to_failed` | All non-terminal states → Failed valid |
 | `eval_sm_any_nonterminal_to_aborted` | All non-terminal states → Aborted valid |
+| `eval_sm_pre_build_states_can_enter_waiting` | Queued/Fetching/EvaluatingFlake/EvaluatingDerivation → Waiting all valid (pre-build stall when no worker is connected, issue #97) |
+| `eval_sm_waiting_recovers_to_queued` | Waiting → Queued valid (pre-build recovery once a worker becomes available) |
+| `eval_sm_waiting_cannot_skip_into_pre_build_phases` | Waiting → Fetching/EvaluatingFlake/EvaluatingDerivation rejected; recovery routes through Queued only |
 | `eval_sm_terminal_rejects_all` | Completed/Failed/Aborted cannot transition away |
 | `eval_sm_skip_fetching_ok` | Queued → EvaluatingFlake (skip Fetching) is valid |
 | `eval_sm_same_state_ok` | from == to → Ok |

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -1209,8 +1209,37 @@ returned by `GET /evals/{evaluation}` is locked in:
 - `builtin_arch_satisfied_by_any_worker` — `architecture == "builtin"`
   derivations are never counted as unmet so long as any worker is
   connected.
+- `pre_build_target_no_workers_yields_waiting_with_empty_unmet` — when an
+  evaluation is in a pre-build phase (`Queued`/`Fetching`/`EvaluatingFlake`/
+  `EvaluatingDerivation`) and no worker is connected, the reconciler picks
+  `Waiting` with an empty `unmet` list so the UI can explain the stall
+  without inventing fake build requirements (issue #97).
+- `pre_build_target_with_workers_yields_queued_and_clears_reason` — once
+  any worker is connected the pre-build helper recovers the eval to
+  `Queued` and clears any stored `WaitingReason`, letting the dispatch
+  loop replay the normal progression.
 
 Run with `cargo test -p scheduler --tests waiting_reason_tests`.
+
+## Pre-build evaluation stall when no worker exists (issue #97)
+
+`backend/core/src/state_machine/eval.rs::tests` extends the evaluation
+state machine to allow the scheduler to surface a "no worker connected"
+stall before any builds have been queued:
+
+- `eval_sm_pre_build_states_can_enter_waiting` — every pre-build status
+  (`Queued`, `Fetching`, `EvaluatingFlake`, `EvaluatingDerivation`) can
+  transition to `Waiting`, matching what `BuildStateHandler::reconcile_waiting_state`
+  now does when `worker_caps.is_empty()`.
+- `eval_sm_waiting_recovers_to_queued` — the recovery edge `Waiting →
+  Queued` is valid; this is the path the reconciler takes once a worker
+  reconnects, so the dispatch loop replays the normal pre-build chain
+  rather than skipping straight back into a later phase.
+- `eval_sm_waiting_cannot_skip_into_pre_build_phases` — direct
+  `Waiting → Fetching/EvaluatingFlake/EvaluatingDerivation` transitions
+  are rejected so that recovery always flows through `Queued`.
+
+Run with `cargo test -p core --tests state_machine::eval`.
 
 ## Project triggers (issue #116)
 


### PR DESCRIPTION
## Summary
- Extend `EvalStateMachine` so any pre-build phase (`Queued`, `Fetching`, `EvaluatingFlake`, `EvaluatingDerivation`) can transition to `Waiting`, plus a `Waiting → Queued` recovery edge so the dispatch loop replays the normal pre-build chain instead of jumping straight back into a later phase.
- Extend `BuildStateHandler::reconcile_waiting_state` to sweep pre-build evals: when an eval has no pending builds and is in a pre-build (or recoverable `Waiting`) status, a small `decide_pre_build_target` helper flips it to `Waiting` with an empty `unmet` list when no worker is connected, or recovers it to `Queued` and clears the stored reason once any worker reappears. Build-phase logic for evals with pending builds is unchanged.
- Broaden the `EvaluationStatus` / `WaitingReason` API documentation so `connected_workers == 0` with empty `unmet` is recognised as a valid pre-build stall, not just a build-phase reason.

## Test plan
- [x] `cargo test -p core --tests state_machine::eval` — covers the new `eval_sm_pre_build_states_can_enter_waiting`, `eval_sm_waiting_recovers_to_queued`, and `eval_sm_waiting_cannot_skip_into_pre_build_phases` cases (plus the pre-existing happy-path/cycle/terminal coverage).
- [x] `cargo test -p scheduler --tests waiting_reason_tests` — covers `pre_build_target_no_workers_yields_waiting_with_empty_unmet` and `pre_build_target_with_workers_yields_queued_and_clears_reason` alongside the existing build-phase reason tests.
- [x] `cargo test -p core --tests` and `cargo test -p scheduler --tests` — full suites green.
- [x] Manual smoke: start the server with no workers connected, trigger an evaluation, confirm it lands in `Waiting` with an empty `unmet` and the UI shows "No build workers are currently available…". Then connect a worker and confirm the eval flips back through `Queued` and progresses normally.

Closes #97