### PR TITLE
fix(http): branded "Gradient" user-agent on outbound requests (#205)

### DIFF
--- a/backend/core/src/http.rs
+++ b/backend/core/src/http.rs
@@ -17,7 +17,10 @@ use std::time::Duration;
 pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub fn user_agent() -> String {
-    format!("gradient/{}", env!("CARGO_PKG_VERSION"))
+    format!(
+        "Gradient/{} (+https://github.com/wavelens/gradient)",
+        env!("CARGO_PKG_VERSION")
+    )
 }
 
 fn rustls_config() -> rustls::ClientConfig {
@@ -48,7 +51,14 @@ mod tests {
     }
 
     #[test]
-    fn user_agent_is_prefixed() {
-        assert!(user_agent().starts_with("gradient/"));
+    fn user_agent_includes_brand_and_contact_url() {
+        let ua = user_agent();
+        assert!(ua.starts_with("Gradient/"));
+        assert!(ua.contains("(+https://github.com/wavelens/gradient)"));
+    }
+
+    #[test]
+    fn user_agent_does_not_use_lowercase_brand() {
+        assert!(!user_agent().starts_with("gradient/"));
     }
 }

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -997,8 +997,10 @@ each created a fresh TCP/TLS connection pool with inconsistent (or
 absent) timeout and redirect policy.
 
 `backend/core/src/http.rs` builds the project-wide client with sane
-defaults (30 s timeout, `redirect::none`, `gradient/<version>`
-user-agent). The server stores it once on `ServerState::http`; the
+defaults (30 s timeout, `redirect::none`, and a branded
+`Gradient/<version> (+https://github.com/wavelens/gradient)`
+user-agent so upstream cache operators can attribute traffic). The
+server stores it once on `ServerState::http`; the
 worker exposes it through a `OnceLock` (`worker::http::client()`); the
 CLI exposes it through `connector::http_client()`.
 
@@ -1011,9 +1013,11 @@ Unit tests in `backend/core/src/http.rs`:
 
 - `build_client_succeeds` — the default builder yields a usable
   `reqwest::Client`.
-- `user_agent_is_prefixed` — the user-agent string is namespaced
-  `gradient/...` so server logs can identify outbound calls from
-  Gradient processes.
+- `user_agent_includes_brand_and_contact_url` — the user-agent string
+  starts with `Gradient/` and embeds the project URL so cache operators
+  can identify and contact-trace outbound calls (`#205`).
+- `user_agent_does_not_use_lowercase_brand` — regression guard against
+  the previous lowercase `gradient/` format (`#205`).
 
 ## Graceful shutdown (`#72`)
 

--- a/docs/src/usage/state.md
+++ b/docs/src/usage/state.md
@@ -261,6 +261,11 @@ Each entry in `upstreams` is one of:
 | `url` | string | (`external`) Substituter URL — e.g. `https://cache.nixos.org` |
 | `public_key` | string | (`external`) Trusted public key in `<name>:<base64>` form |
 
+Outbound requests to `external` substituters (and to every other HTTP target the
+server, worker, or CLI talks to) carry the user-agent
+`Gradient/<version> (+https://github.com/wavelens/gradient)`, so cache operators
+can attribute traffic and build allowlists or per-client metrics around it.
+
 ## API Keys
 
 ```nix


### PR DESCRIPTION
## Summary
- Outbound HTTP requests now advertise `Gradient/<version> (+https://github.com/wavelens/gradient)` (capital `G`, RFC 9110-style trailing contact URL).
- Single chokepoint: `backend/core/src/http.rs::build_client` already feeds every reqwest client (server `state.http`, worker `worker::http::client()`, CLI/CI reporters), so no caller-site changes are needed.
- No behavioural change beyond the request header — same timeouts, same redirect policy, same TLS config.

## Test plan
- [x] `cargo test -p core --tests` passes (566/566).
- [x] New regression test `user_agent_does_not_use_lowercase_brand` guards against ever falling back to the old `gradient/...` format.
- [x] Updated test `user_agent_includes_brand_and_contact_url` asserts both the brand prefix and the contact URL.
- [x] Manual smoke (optional): `curl` an upstream that logs UAs and observe `Gradient/<version> (+https://...)` in access logs.

Closes #205