### PR TITLE
fix(scheduler): raise wait-time cap so anti-starvation can outscore cached-fresh (#112)

### DIFF
--- a/backend/scheduler/src/policy.rs
+++ b/backend/scheduler/src/policy.rs
@@ -196,12 +196,20 @@ impl Rule for DependencyCountRule {
 ///
 /// Score contribution: seconds since `queued_at`, capped at `max_wait_secs`,
 /// scaled by `bonus_per_second`.
+///
+/// The default cap (`max_wait_secs = 3600`) yields a maximum bonus of `360`,
+/// chosen so that a build which has waited an hour outscores a fresh
+/// fully-cached candidate (`MissingPathsRule::scored_bonus = 200`) even
+/// after typical penalties on the older job. Lowering the cap re-introduces
+/// the starvation case where a stream of fresh ready-to-run jobs keeps
+/// older builds permanently behind.
 #[derive(Debug)]
 pub struct WaitTimeRule {
     /// Score bonus per second the build has been waiting (should be positive).
     pub bonus_per_second: f64,
     /// Cap on wait time used for scoring, in seconds.
-    /// Prevents very old jobs from dominating all other rules.
+    /// Prevents very old jobs from dominating all other rules while still
+    /// allowing the wait bonus to overcome the cached-fresh preference.
     pub max_wait_secs: f64,
 }
 
@@ -209,7 +217,7 @@ impl Default for WaitTimeRule {
     fn default() -> Self {
         Self {
             bonus_per_second: 0.1,
-            max_wait_secs: 600.0, // 10 minutes
+            max_wait_secs: 3600.0,
         }
     }
 }
@@ -546,6 +554,47 @@ mod tests {
         assert!(
             ancient >= cap - 0.01,
             "ancient wait should reach the cap, got {ancient}"
+        );
+    }
+
+    #[test]
+    fn default_policy_long_waiting_build_overcomes_fresh_cached() {
+        // Anti-starvation: a build waiting an hour must outscore a fresh
+        // job that the requesting worker can serve without fetching.
+        // If it doesn't, a steady stream of fresh fully-cached candidates
+        // starves older builds indefinitely. Guards against the
+        // `WaitTimeRule` cap being lowered below the `MissingPathsRule`
+        // scored bonus.
+        let policy = Policy::default_build_policy();
+        let archs = vec!["x86_64-linux".into()];
+        let feats: Vec<String> = vec![];
+        let w = worker_ctx(&archs, &feats);
+        let now = gradient_core::types::now();
+
+        let (j_fresh, ..) = build_job_ctx("x86_64-linux", Some(0), Some(0));
+        let c_fresh = JobContext {
+            job: &j_fresh,
+            missing_count: Some(0),
+            missing_nar_size: Some(0),
+            dependency_count: 0,
+            queued_at: now,
+        };
+
+        let (j_old, ..) = build_job_ctx("x86_64-linux", None, None);
+        let c_old = JobContext {
+            job: &j_old,
+            missing_count: None,
+            missing_nar_size: None,
+            dependency_count: 0,
+            queued_at: now - chrono::Duration::seconds(3600),
+        };
+
+        let s_old = policy.score(&c_old, &w);
+        let s_fresh = policy.score(&c_fresh, &w);
+        assert!(
+            s_old > s_fresh,
+            "1-hour-old build must beat fresh fully-cached candidate \
+             (anti-starvation): old={s_old} fresh={s_fresh}"
         );
     }
 

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -1340,6 +1340,29 @@ Tests (`cargo test -p scheduler --tests substitut`):
   eval completes without dispatching a build. Confirms the hash-based
   fallback in `compute_truly_substituted`.
 
+## Scheduler policy — anti-starvation cap (#112)
+
+`WaitTimeRule::max_wait_secs` caps how much wait time can contribute to a
+job's score. The previous default (600s, +60 max) was below
+`MissingPathsRule::scored_bonus` (200), so a steady stream of fresh
+fully-cached candidates outscored older queued builds indefinitely —
+builds older than 10 minutes were no longer differentiated by wait time.
+The default is now 3600s (+360 max), enough to overcome the cached-fresh
+preference plus typical penalties on the older job.
+
+Tests (`cargo test -p scheduler --lib policy`):
+
+- `default_policy_long_waiting_build_overcomes_fresh_cached` — locks in
+  the anti-starvation guarantee by composing the full
+  `Policy::default_build_policy()`: a build queued an hour ago must
+  outscore a fresh candidate the worker can serve directly. Fails if
+  `WaitTimeRule::max_wait_secs` is lowered back below the
+  `MissingPathsRule` scored bonus.
+- `wait_time_rule_longer_wait_scores_higher_but_capped` — preserved from
+  before; still asserts that the score saturates at
+  `max_wait_secs * bonus_per_second` so ancient jobs cannot dominate
+  every other rule.
+
 ## Build artefacts — `external_cached` outputs include `hydra-build-products`
 
 Builds that are dispatched as `external_cached` (substituted from upstream,


### PR DESCRIPTION
## Summary
- `WaitTimeRule::max_wait_secs` was 600s, capping the anti-starvation bonus at +60 — well below `MissingPathsRule::scored_bonus = 200`. A fresh job that the requesting worker could serve directly always outscored a build that had been queued for an hour, and wait-time differentiation plateaued after 10 minutes.
- Default cap is now 3600s (+360 max), enough to overcome the cached-fresh preference plus typical penalties on the older job. The cap is preserved so very old jobs still cannot dominate every other rule.
- Adds a policy-level regression that composes `Policy::default_build_policy()` and asserts a 1-hour-old build outscores a fresh fully-cached candidate. Fails for any future tweak of the cap or the scored bonus that re-introduces the starvation case.
- Updates `docs/src/tests.md` with a short section describing both the new regression and the still-passing `wait_time_rule_longer_wait_scores_higher_but_capped` (which pins the upper end of the curve).

Closes #112.

## Test plan
- [x] `cargo test --manifest-path backend/Cargo.toml -p scheduler --lib policy` — 9/9 pass, including the new regression.
- [x] `cargo test --manifest-path backend/Cargo.toml -p scheduler --lib` — 129/129 pass.
- [x] Confirmed the new test FAILS on `max_wait_secs = 600` (`old=60 fresh=200`) before the fix and PASSES after.
- [x] `cargo clippy --manifest-path backend/Cargo.toml -p scheduler --tests` — no new warnings.