### PR TITLE
fix(frontend): truncate long build names in evaluation sidebar (#121)

### DIFF
--- a/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.scss
+++ b/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.scss
@@ -129,6 +129,14 @@ cdk-virtual-scroll-viewport.builds-list {
   contain: strict;
 }
 
+// CDK injects `.cdk-virtual-scroll-content-wrapper` as `position: absolute`
+// with `width: auto`, so flex rows inside it would size to their natural
+// content width and overflow the 260 px sidebar. Pinning the wrapper to the
+// viewport width re-activates `text-overflow: ellipsis` on `.build-name`.
+:host ::ng-deep .builds-list .cdk-virtual-scroll-content-wrapper {
+  width: 100%;
+}
+
 .no-builds {
   padding: $spacing-md;
   font-size: $font-size-sm;


### PR DESCRIPTION
## Summary
- `.build-name` already declared `white-space: nowrap; overflow: hidden; text-overflow: ellipsis;`, but rows still overflowed because the CDK virtual-scroll content wrapper that hosts them is rendered as `position: absolute; width: auto`, so each `.build-item` flex row expanded to its natural content width and broke out of the 260 px sidebar.
- Pin `.cdk-virtual-scroll-content-wrapper` inside `.builds-list` to `width: 100%`, scoped via `:host ::ng-deep` so the rule can't leak to other virtual scrolls (and there are none elsewhere in the app today). The existing ellipsis on `.build-name` then activates as intended.
- The full build name remains accessible via the row's `[title]="build.name"` tooltip.

Closes #121.

## Test plan
- [x] `pnpm ng build` — succeeds. Pre-existing SCSS bundle-budget warning is unrelated to this 8-line addition (file was already 6 kB over budget on `main`).
- [x] Browser sanity-check: open an evaluation page (sidebar 260 px) with a long build name — ellipsis appears, hovering shows the full name in the native tooltip, shorter names render unchanged. *(Not exercised in this run — please verify before merge.)*