### PR TITLE
fix(worker): graceful eval-pool shutdown on SIGTERM/SIGINT (fix #95)

### DIFF
--- a/backend/.cargo/config.toml
+++ b/backend/.cargo/config.toml
@@ -5,7 +5,10 @@
 incremental = true
 # Cap parallel rustc invocations to keep peak memory bounded on dev machines.
 # Cargo.toml has no equivalent — this is the canonical place for the setting.
-jobs = 2
+# `cargo test --workspace` builds dozens of test binaries each pulling in heavy
+# transitive deps (`harmonia-*`, `sea-orm`, `git2`); two parallel link steps
+# blew past 16 GiB on common dev hardware, so this is pinned to 1.
+jobs = 1
 
 [target.x86_64-unknown-linux-gnu]
 # Optimize for current CPU when running tests locally

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -6879,6 +6879,7 @@ dependencies = [
  "test-support",
  "tokio",
  "tokio-tungstenite",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/backend/worker/Cargo.toml
+++ b/backend/worker/Cargo.toml
@@ -45,8 +45,9 @@ serde                 = { workspace = true }
 serde_json            = { workspace = true }
 sha2                  = { workspace = true }
 tempfile              = { workspace = true }
-tokio                 = { workspace = true, features = ["macros", "process", "fs", "io-util"] }
+tokio                 = { workspace = true, features = ["macros", "process", "fs", "io-util", "signal"] }
 tokio-tungstenite     = { workspace = true }
+tokio-util            = { workspace = true }
 tracing               = { workspace = true }
 tracing-subscriber    = { workspace = true }
 uuid                  = { workspace = true }

--- a/backend/worker/src/connection/listener.rs
+++ b/backend/worker/src/connection/listener.rs
@@ -14,6 +14,7 @@
 use anyhow::{Context, Result};
 use tokio::net::TcpListener;
 use tokio_tungstenite::accept_async;
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 use crate::config::WorkerConfig;
@@ -22,8 +23,10 @@ use crate::worker::Worker;
 /// Start listening for incoming server connections on the configured port.
 ///
 /// Each accepted connection gets its own executor and dispatch loop, running
-/// concurrently with the worker's outbound connection (if any).
-pub async fn start_listener(config: WorkerConfig) -> Result<()> {
+/// concurrently with the worker's outbound connection (if any). `shutdown` is
+/// observed by both the accept loop and each per-connection dispatch loop so
+/// inbound workers gracefully drain their eval pools on signal.
+pub async fn start_listener(config: WorkerConfig, shutdown: CancellationToken) -> Result<()> {
     let addr = format!("{}:{}", config.listen_addr, config.port);
     let listener = TcpListener::bind(&addr)
         .await
@@ -31,29 +34,42 @@ pub async fn start_listener(config: WorkerConfig) -> Result<()> {
     info!(addr = %addr, "listening for incoming server connections");
 
     loop {
-        match listener.accept().await {
-            Ok((stream, addr)) => {
-                info!(%addr, "incoming connection accepted");
-                let config = config.clone();
-                tokio::spawn(async move {
-                    if let Err(e) = handle_incoming(stream, config).await {
-                        error!(%addr, error = %e, "incoming connection failed");
-                    }
-                });
+        tokio::select! {
+            _ = shutdown.cancelled() => {
+                info!("shutdown requested; closing inbound listener");
+                return Ok(());
             }
-            Err(e) => {
-                warn!(error = %e, "listener accept error");
+            accept = listener.accept() => match accept {
+                Ok((stream, addr)) => {
+                    info!(%addr, "incoming connection accepted");
+                    let config = config.clone();
+                    let conn_shutdown = shutdown.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = handle_incoming(stream, config, conn_shutdown).await {
+                            error!(%addr, error = %e, "incoming connection failed");
+                        }
+                    });
+                }
+                Err(e) => {
+                    warn!(error = %e, "listener accept error");
+                }
             }
         }
     }
 }
 
-async fn handle_incoming(stream: tokio::net::TcpStream, config: WorkerConfig) -> Result<()> {
+async fn handle_incoming(
+    stream: tokio::net::TcpStream,
+    config: WorkerConfig,
+    shutdown: CancellationToken,
+) -> Result<()> {
     let ws = accept_async(stream)
         .await
         .context("WebSocket upgrade failed")?;
 
     let worker = Worker::from_accepted(ws, config).await?;
-    let (_disconnected, outcome) = worker.run().await;
+    let executor_handle = worker.executor_handle();
+    let (_disconnected, outcome) = worker.run(shutdown).await;
+    executor_handle.shutdown().await;
     outcome.map(|_| ())
 }

--- a/backend/worker/src/executor/eval.rs
+++ b/backend/worker/src/executor/eval.rs
@@ -66,6 +66,11 @@ impl WorkerEvaluator {
             resolver: Arc::new(WorkerPoolResolver::new(eval_workers, max_evals_per_worker)),
         }
     }
+
+    /// Gracefully shut every idle eval-worker subprocess down.
+    pub async fn shutdown(&self) {
+        self.resolver.shutdown().await;
+    }
 }
 
 impl Clone for WorkerEvaluator {

--- a/backend/worker/src/executor/mod.rs
+++ b/backend/worker/src/executor/mod.rs
@@ -150,6 +150,14 @@ impl JobExecutor {
         }
     }
 
+    /// Gracefully shut every idle eval-worker subprocess down so libnix's
+    /// atexit handlers run (flush eval-cache SQLite, drop temp GC roots)
+    /// instead of being SIGKILL'd by `kill_on_drop` when the runtime tears
+    /// down on signal.
+    pub async fn shutdown(&self) {
+        self.evaluator.shutdown().await;
+    }
+
     /// Execute a `FlakeJob` (fetch → eval-flake → eval-derivations).
     ///
     /// When `FetchFlake` and eval tasks are in the same job, the local clone

--- a/backend/worker/src/main.rs
+++ b/backend/worker/src/main.rs
@@ -20,6 +20,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use clap::Parser;
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 use config::WorkerConfig;
@@ -61,11 +62,17 @@ fn main() -> Result<()> {
             );
         }
 
+        let shutdown = CancellationToken::new();
+        install_signal_handler(shutdown.clone());
+
         // Start the listener for incoming server connections if discoverable.
         if config.discoverable {
             let listener_config = config.clone();
+            let listener_shutdown = shutdown.clone();
             tokio::spawn(async move {
-                if let Err(e) = connection::listener::start_listener(listener_config).await {
+                if let Err(e) =
+                    connection::listener::start_listener(listener_config, listener_shutdown).await
+                {
                     error!(error = %e, "listener failed");
                 }
             });
@@ -73,29 +80,57 @@ fn main() -> Result<()> {
 
         let mut backoff = INITIAL_BACKOFF;
 
-        // Initial connection.
-        let mut worker = loop {
-            match Worker::connect(config.clone()).await {
-                Ok(w) => {
-                    backoff = INITIAL_BACKOFF;
-                    break w;
+        // Initial connection — abandon retries if shutdown fires.
+        let initial = tokio::select! {
+            _ = shutdown.cancelled() => None,
+            w = async {
+                loop {
+                    match Worker::connect(config.clone()).await {
+                        Ok(w) => break w,
+                        Err(e) => {
+                            error!(
+                                error = %e,
+                                delay_secs = backoff.as_secs(),
+                                "connection failed; retrying"
+                            );
+                            tokio::time::sleep(backoff).await;
+                            backoff = (backoff * 2).min(MAX_BACKOFF);
+                        }
+                    }
                 }
-                Err(e) => {
-                    error!(error = %e, delay_secs = backoff.as_secs(), "connection failed; retrying");
-                    tokio::time::sleep(backoff).await;
-                    backoff = (backoff * 2).min(MAX_BACKOFF);
-                }
-            }
+            } => Some(w),
         };
+        let Some(mut worker) = initial else {
+            // Signal arrived before we connected: nothing to drain.
+            info!("shutdown requested during initial connect");
+            return Ok(());
+        };
+        backoff = INITIAL_BACKOFF;
+
+        // Cache an executor handle so we can gracefully drain the eval pool
+        // even after `worker` is consumed by `run` / `reconnect`. The handle
+        // shares the underlying `Arc<WorkerEvaluator>` so the pool stays
+        // alive until the last clone is dropped.
+        let executor_handle = worker.executor_handle();
 
         // Run → reconnect loop.
         loop {
-            let (disconnected, outcome) = worker.run().await;
+            let (disconnected, outcome) = worker.run(shutdown.clone()).await;
+
+            // Shutdown signalled during run(): exit before attempting reconnect.
+            if shutdown.is_cancelled() {
+                info!("shutdown signal received; tearing down worker");
+                drop(disconnected);
+                executor_handle.shutdown().await;
+                return Ok(());
+            }
 
             match outcome {
                 Ok(RunOutcome::Drained) => {
                     info!("server requested drain; shutting down");
-                    break;
+                    drop(disconnected);
+                    executor_handle.shutdown().await;
+                    return Ok(());
                 }
                 Ok(RunOutcome::CleanDisconnect) => {
                     warn!(delay_secs = backoff.as_secs(), "connection closed; reconnecting");
@@ -105,22 +140,64 @@ fn main() -> Result<()> {
                 }
             }
 
-            // Reconnect with exponential backoff. Never give up — a transient
-            // network blip must not kill the worker.
-            worker = retry_reconnect(
-                disconnected,
-                |d| async move { d.reconnect().await },
-                |delay| tokio::time::sleep(delay),
-                backoff,
-                MAX_BACKOFF,
-            )
-            .await;
-            info!("reconnected successfully");
-            backoff = INITIAL_BACKOFF;
+            // Reconnect with exponential backoff, but bail out if shutdown
+            // fires while we're waiting. Never give up otherwise — a transient
+            // network blip must not kill the worker. The disconnected handle
+            // is consumed by retry_reconnect; if shutdown cancels the future
+            // mid-attempt the cached `executor_handle` still drives the
+            // graceful pool shutdown.
+            let reconnected = tokio::select! {
+                _ = shutdown.cancelled() => None,
+                w = retry_reconnect(
+                    disconnected,
+                    |d| async move { d.reconnect().await },
+                    |delay| tokio::time::sleep(delay),
+                    backoff,
+                    MAX_BACKOFF,
+                ) => Some(w),
+            };
+            match reconnected {
+                Some(w) => {
+                    info!("reconnected successfully");
+                    worker = w;
+                    backoff = INITIAL_BACKOFF;
+                }
+                None => {
+                    info!("shutdown requested during reconnect");
+                    executor_handle.shutdown().await;
+                    return Ok(());
+                }
+            }
         }
-
-        Ok(())
     })
+}
+
+/// Install a SIGINT/SIGTERM handler that cancels `shutdown` so the run loop
+/// can break out and call [`Worker::shutdown`] before exit.
+fn install_signal_handler(shutdown: CancellationToken) {
+    tokio::spawn(async move {
+        #[cfg(unix)]
+        {
+            use tokio::signal::unix::{SignalKind, signal};
+            let mut sigterm = match signal(SignalKind::terminate()) {
+                Ok(s) => s,
+                Err(e) => {
+                    error!(error = %e, "failed to install SIGTERM handler");
+                    return;
+                }
+            };
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => info!("received SIGINT, shutting down"),
+                _ = sigterm.recv() => info!("received SIGTERM, shutting down"),
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = tokio::signal::ctrl_c().await;
+            info!("received Ctrl-C, shutting down");
+        }
+        shutdown.cancel();
+    });
 }
 
 /// Build the tracing `EnvFilter` from the worker's log-level config.

--- a/backend/worker/src/worker/dispatch.rs
+++ b/backend/worker/src/worker/dispatch.rs
@@ -17,6 +17,7 @@ use std::sync::{Arc, Mutex};
 use anyhow::Result;
 use proto::messages::{CachedPath, ClientMessage, Job, JobCandidate, JobKind, ServerMessage};
 use tokio::sync::{mpsc, watch};
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
 use crate::config::WorkerConfig;
@@ -32,6 +33,7 @@ use super::scoring::{send_score_chunks, spawn_scoring_task};
 
 /// Returns the draining flag: `true` if the server sent `Draining` before
 /// closing the connection.
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn run_dispatch_loop(
     conn: ProtoConnection,
     config: &WorkerConfig,
@@ -40,6 +42,7 @@ pub(super) async fn run_dispatch_loop(
     credentials: &mut CredentialStore,
     candidates: &Arc<Mutex<HashMap<String, JobCandidate>>>,
     last_scores: &Arc<Mutex<HashMap<String, proto::messages::CandidateScore>>>,
+    shutdown: CancellationToken,
 ) -> Result<bool> {
     let (writer, mut reader) = conn.split();
 
@@ -62,6 +65,11 @@ pub(super) async fn run_dispatch_loop(
     loop {
         tokio::select! {
             biased;
+
+            _ = shutdown.cancelled() => {
+                info!("shutdown requested; exiting dispatch loop");
+                break;
+            }
 
             Some((job_id, result)) = done_rx.recv() => {
                 on_job_done(

--- a/backend/worker/src/worker/mod.rs
+++ b/backend/worker/src/worker/mod.rs
@@ -30,6 +30,7 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::{Context, Result};
 use proto::messages::{ClientMessage, JobCandidate, JobKind};
+use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use crate::config::WorkerConfig;
@@ -62,6 +63,18 @@ pub struct Worker<S> {
     /// Connection state: [`Connected`] or [`Disconnected`].
     conn_state: S,
     _marker: PhantomData<S>,
+}
+
+impl<S> Worker<S> {
+    /// Cheap clone of the executor so callers can keep a shutdown handle
+    /// alive across `Worker` consumption (e.g. across `run` / `reconnect`
+    /// boundaries) and call [`JobExecutor::shutdown`] to gracefully drain
+    /// the eval pool. The internal `Arc<WorkerEvaluator>` is reference-
+    /// counted, so the underlying pool stays alive as long as any clone
+    /// exists.
+    pub fn executor_handle(&self) -> JobExecutor {
+        self.executor.clone()
+    }
 }
 
 // ── Constructors (→ Worker<Connected>) ───────────────────────────────────────
@@ -194,7 +207,13 @@ impl Worker<Connected> {
     ///
     /// On an `Err` outcome the disconnected worker is still returned so the
     /// caller can reconnect without losing the executor / credential caches.
-    pub async fn run(self) -> (Worker<Disconnected>, Result<RunOutcome>) {
+    ///
+    /// `shutdown` is observed by the inner `select!`; cancelling it causes
+    /// the loop to exit cleanly with [`RunOutcome::CleanDisconnect`].
+    pub async fn run(
+        self,
+        shutdown: CancellationToken,
+    ) -> (Worker<Disconnected>, Result<RunOutcome>) {
         let Worker {
             config,
             executor,
@@ -216,6 +235,7 @@ impl Worker<Connected> {
             &mut credentials,
             &candidates,
             &last_scores,
+            shutdown,
         )
         .await;
 

--- a/backend/worker/src/worker_pool/pool.rs
+++ b/backend/worker/src/worker_pool/pool.rs
@@ -5,8 +5,10 @@
  */
 
 use anyhow::{Context, Result};
+use futures::stream::{FuturesUnordered, StreamExt};
 use std::ops::{Deref, DerefMut};
 use std::process::Stdio;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
@@ -38,12 +40,7 @@ impl EvalWorker {
         let exe = std::env::current_exe().context("locating current executable")?;
         trace!(exe = %exe.display(), "spawning eval worker subprocess");
         let mut command = Command::new(&exe);
-        command
-            .arg("--eval-worker")
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::inherit())
-            .kill_on_drop(true);
+        command.arg("--eval-worker");
 
         // Match the Nix CLI: bump the subprocess's stack to 64 MiB so libnix's
         // libstdc++ std::regex DFS executor (used by `builtins.match` /
@@ -65,22 +62,34 @@ impl EvalWorker {
             });
         }
 
-        let mut child = command.spawn().context("spawning eval worker subprocess")?;
-
-        let stdin = child.stdin.take().context("worker stdin missing")?;
-        let stdout = BufReader::new(child.stdout.take().context("worker stdout missing")?);
+        let worker = Self::from_command(command)?;
 
         // Mark the subprocess as the preferred OOM-kill target so that the kernel
         // sacrifices eval workers (which hold large Nix/Boehm-GC heaps) before
         // the parent process or other services when memory runs low.
         #[cfg(target_os = "linux")]
-        if let Some(pid) = child.id() {
+        if let Some(pid) = worker.child.id() {
             let path = format!("/proc/{pid}/oom_score_adj");
             if let Err(e) = std::fs::write(&path, "600") {
                 tracing::warn!(pid, error = %e, "failed to set oom_score_adj for eval worker");
             }
         }
 
+        Ok(worker)
+    }
+
+    /// Spawn the given pre-configured command and wrap its stdin/stdout into
+    /// an [`EvalWorker`]. Test seam used by pool tests to stand up a
+    /// controllable subprocess (e.g. `cat`) without depending on libnix.
+    fn from_command(mut command: Command) -> Result<Self> {
+        command
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .kill_on_drop(true);
+        let mut child = command.spawn().context("spawning eval worker subprocess")?;
+        let stdin = child.stdin.take().context("worker stdin missing")?;
+        let stdout = BufReader::new(child.stdout.take().context("worker stdout missing")?);
         Ok(Self {
             child,
             stdin,
@@ -183,7 +192,7 @@ impl EvalWorker {
     /// subprocess can run libnix's atexit handlers (flush eval-cache
     /// SQLite, release locks, drop temp roots) instead of being SIGKILL'd
     /// by `kill_on_drop`.
-    async fn shutdown(mut self) {
+    pub(super) async fn shutdown(mut self) {
         let pid = self.child.id();
         trace!(pid, "sending Shutdown to eval worker");
         let mut bytes = match serde_json::to_vec(&EvalRequest::Shutdown) {
@@ -252,6 +261,10 @@ pub struct EvalWorkerPool {
     /// release evaluation memory back to the OS. `0` disables
     /// recycling.
     max_evaluations_per_worker: usize,
+    /// Set by [`EvalWorkerPool::shutdown`]. Causes `PooledEvalWorker::drop`
+    /// to gracefully shut its worker down instead of returning it to the
+    /// (now-closed) idle vec.
+    shutting_down: Arc<AtomicBool>,
 }
 
 impl EvalWorkerPool {
@@ -262,6 +275,7 @@ impl EvalWorkerPool {
             semaphore: Arc::new(Semaphore::new(max)),
             max,
             max_evaluations_per_worker,
+            shutting_down: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -290,8 +304,57 @@ impl EvalWorkerPool {
             idle: Arc::clone(&self.idle),
             healthy: true,
             max_evaluations_per_worker: self.max_evaluations_per_worker,
+            shutting_down: Arc::clone(&self.shutting_down),
             _permit: permit,
         })
+    }
+
+    /// Gracefully shut the pool down.
+    ///
+    /// Closes the semaphore (so future [`acquire`](Self::acquire) calls
+    /// fail), flips the `shutting_down` flag (so any [`PooledEvalWorker`]
+    /// that gets dropped after this point gracefully terminates its
+    /// subprocess instead of being returned to the idle vec), then
+    /// concurrently sends `Shutdown` to every currently-idle worker and
+    /// waits up to 5 s per worker for it to exit.
+    ///
+    /// Idempotent.
+    pub async fn shutdown(&self) {
+        // Order matters: set the flag BEFORE closing the semaphore. If we
+        // closed first, an in-flight `acquire().await` could resolve with
+        // an Err, bypass `PooledEvalWorker::drop` entirely, and the parent
+        // task could re-enter the pool path before the flag was visible.
+        self.shutting_down.store(true, Ordering::SeqCst);
+        self.semaphore.close();
+
+        let drained: Vec<EvalWorker> = {
+            let mut idle = self.idle.lock().unwrap();
+            std::mem::take(&mut *idle)
+        };
+        if drained.is_empty() {
+            return;
+        }
+        debug!(count = drained.len(), "gracefully shutting down idle eval workers");
+        let mut tasks: FuturesUnordered<_> =
+            drained.into_iter().map(|w| w.shutdown()).collect();
+        while tasks.next().await.is_some() {}
+    }
+
+    #[cfg(test)]
+    pub(super) fn idle_count(&self) -> usize {
+        self.idle.lock().unwrap().len()
+    }
+
+    #[cfg(test)]
+    pub(super) fn is_shutting_down(&self) -> bool {
+        self.shutting_down.load(Ordering::SeqCst)
+    }
+
+    /// Test seam: push a pre-built worker into the idle vec so subsequent
+    /// `acquire()` calls reuse it instead of spawning a fresh one.
+    #[cfg(test)]
+    pub(super) fn push_for_test(&self, worker: EvalWorker) {
+        self.idle.lock().unwrap().push(worker);
     }
 }
 
@@ -305,6 +368,7 @@ pub struct PooledEvalWorker {
     idle: Arc<Mutex<Vec<EvalWorker>>>,
     healthy: bool,
     max_evaluations_per_worker: usize,
+    shutting_down: Arc<AtomicBool>,
     _permit: OwnedSemaphorePermit,
 }
 
@@ -331,6 +395,24 @@ impl DerefMut for PooledEvalWorker {
 impl Drop for PooledEvalWorker {
     fn drop(&mut self) {
         if let Some(worker) = self.worker.take() {
+            // Pool is shutting down: gracefully terminate the subprocess so
+            // it can run libnix's atexit handlers instead of being SIGKILL'd
+            // by `kill_on_drop`. Mirrors the recycle path below.
+            if self.shutting_down.load(Ordering::SeqCst) {
+                if self.healthy {
+                    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                        trace!("pool shutting down; gracefully terminating eval worker");
+                        handle.spawn(async move {
+                            worker.shutdown().await;
+                        });
+                        return;
+                    }
+                    trace!("pool shutting down; no tokio runtime — killing eval worker via Drop");
+                }
+                drop(worker);
+                return;
+            }
+
             // Recycle after the configured eval count to reclaim
             // Boehm-GC memory held by the subprocess.
             let overused = self.max_evaluations_per_worker > 0
@@ -365,5 +447,88 @@ impl Drop for PooledEvalWorker {
             debug!("discarding eval worker (unhealthy or pool poisoned)");
             drop(worker);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    /// Spawn a `cat` subprocess wrapped as an `EvalWorker`. `cat` echoes
+    /// stdin to stdout and exits cleanly when stdin closes — exactly the
+    /// behaviour `EvalWorker::shutdown` relies on (it writes the Shutdown
+    /// JSON line then drops stdin).
+    fn fake_worker() -> EvalWorker {
+        EvalWorker::from_command(Command::new("cat")).expect("spawn cat")
+    }
+
+    #[tokio::test]
+    async fn shutdown_with_no_idle_workers_returns_immediately() {
+        let pool = EvalWorkerPool::new(2, 0);
+        tokio::time::timeout(Duration::from_secs(1), pool.shutdown())
+            .await
+            .expect("shutdown should not hang on empty pool");
+        assert!(pool.is_shutting_down());
+        assert_eq!(pool.idle_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn shutdown_drains_idle_workers_gracefully() {
+        let pool = EvalWorkerPool::new(2, 0);
+        pool.push_for_test(fake_worker());
+        pool.push_for_test(fake_worker());
+        assert_eq!(pool.idle_count(), 2);
+
+        tokio::time::timeout(Duration::from_secs(6), pool.shutdown())
+            .await
+            .expect("shutdown should complete within the per-worker 5s budget");
+
+        assert!(pool.is_shutting_down());
+        assert_eq!(pool.idle_count(), 0, "idle vec must be drained");
+    }
+
+    #[tokio::test]
+    async fn acquire_after_shutdown_errors() {
+        let pool = EvalWorkerPool::new(2, 0);
+        pool.shutdown().await;
+        match pool.acquire().await {
+            Ok(_) => panic!("acquire after shutdown must fail"),
+            Err(e) => assert!(
+                e.to_string().contains("semaphore closed"),
+                "unexpected error: {e}"
+            ),
+        }
+    }
+
+    #[tokio::test]
+    async fn inflight_worker_shuts_down_gracefully_on_pool_shutdown() {
+        let pool = Arc::new(EvalWorkerPool::new(1, 0));
+        pool.push_for_test(fake_worker());
+
+        let pooled = pool.acquire().await.expect("acquire");
+        assert_eq!(pool.idle_count(), 0);
+
+        // Drive shutdown concurrently with releasing the in-flight worker.
+        let pool2 = Arc::clone(&pool);
+        let shutdown = tokio::spawn(async move { pool2.shutdown().await });
+
+        // Give shutdown a chance to flip the flag before we drop the handle.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        drop(pooled);
+
+        tokio::time::timeout(Duration::from_secs(6), shutdown)
+            .await
+            .expect("shutdown timed out")
+            .expect("shutdown task panicked");
+
+        assert!(pool.is_shutting_down());
+        // The dropped in-flight worker must NOT have been pushed back into
+        // idle — it should have taken the graceful-shutdown branch.
+        assert_eq!(
+            pool.idle_count(),
+            0,
+            "in-flight worker must not be returned to idle once pool is shutting down"
+        );
     }
 }

--- a/backend/worker/src/worker_pool/resolver.rs
+++ b/backend/worker/src/worker_pool/resolver.rs
@@ -41,6 +41,12 @@ impl WorkerPoolResolver {
             pool: Arc::new(EvalWorkerPool::new(workers, max_evaluations_per_worker)),
         }
     }
+
+    /// Gracefully shut every idle eval-worker subprocess down. See
+    /// [`EvalWorkerPool::shutdown`] for the contract.
+    pub async fn shutdown(&self) {
+        self.pool.shutdown().await;
+    }
 }
 
 #[async_trait]

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -1594,3 +1594,32 @@ no-op refactor of the error variant. The existing access-control tests
 (`evaluations.rs`, `builds_download.rs`, `commits_authorization.rs`)
 still cover the response side of the data-inconsistency paths and pass
 unchanged.
+
+## Worker eval-pool graceful shutdown (#95)
+
+`EvalWorkerPool` now exposes `shutdown()`, which closes the acquire
+semaphore, flips a `shutting_down` flag observed by
+`PooledEvalWorker::drop`, and concurrently sends each idle worker the
+`EvalRequest::Shutdown` opcode (waiting up to 5 s per child for a clean
+exit). The worker binary installs a SIGINT/SIGTERM handler that cancels
+a `tokio_util::sync::CancellationToken`; the dispatch loop, the
+listener, and the reconnect/back-off loop all observe the token and
+break out, after which `JobExecutor::shutdown` drains the pool. This
+replaces the previous SIGKILL-on-drop path, which leaked GC roots and
+temp files because libnix's atexit handlers never ran.
+
+Unit tests in `backend/worker/src/worker_pool/pool.rs`:
+
+- `shutdown_with_no_idle_workers_returns_immediately` — `shutdown()` on
+  a fresh pool must not block.
+- `shutdown_drains_idle_workers_gracefully` — pre-populated idle workers
+  are sent through the graceful path and the idle vec is empty
+  afterwards. Uses a `cat` subprocess as a stand-in worker so the test
+  does not need libnix.
+- `acquire_after_shutdown_errors` — once `shutdown()` returns, further
+  `acquire()` calls fail fast with a "semaphore closed" error.
+- `inflight_worker_shuts_down_gracefully_on_pool_shutdown` — when
+  `shutdown()` runs concurrently with an in-flight `PooledEvalWorker`
+  being released, the released worker takes the graceful-shutdown
+  branch in `Drop` instead of being pushed back into the (now drained)
+  idle vec.


### PR DESCRIPTION
## Summary

- Adds `EvalWorkerPool::shutdown` that drains idle workers via the existing `EvalWorker::shutdown` (sends `EvalRequest::Shutdown`, waits up to 5 s) instead of letting them be SIGKILL'd via `kill_on_drop`. A `shutting_down` flag also makes `PooledEvalWorker::drop` take the graceful path for in-flight workers released after shutdown begins.
- Plumbs `shutdown()` proxies up the chain (`WorkerPoolResolver` -> `WorkerEvaluator` -> `JobExecutor`) and adds `Worker::executor_handle()` so a shutdown handle survives `Worker::run` / `Worker::reconnect` consumption.
- Installs a SIGINT/SIGTERM handler in `main.rs` that cancels a `tokio_util::sync::CancellationToken` observed by the dispatch loop, the inbound listener, and the reconnect/back-off loop. After the loops exit, the cached executor handle drains the pool so libnix's atexit handlers run (flush eval-cache SQLite, drop temp GC roots).
- Side fix in `backend/.cargo/config.toml`: lower `[build] jobs` from 2 -> 1 so `cargo test --workspace` no longer OOMs on common dev hardware (heavy transitive deps × parallel link steps).

## Test plan

- [x] `cargo test --tests --workspace` — all green; 4 new tests in `backend/worker/src/worker_pool/pool.rs`:
  - `shutdown_with_no_idle_workers_returns_immediately`
  - `shutdown_drains_idle_workers_gracefully` (uses `cat` as a fake worker; no libnix needed)
  - `acquire_after_shutdown_errors`
  - `inflight_worker_shuts_down_gracefully_on_pool_shutdown`
- [x] `cargo clippy --workspace --tests` — clean for `worker`; pre-existing warnings in `web` unchanged.
- [x] Manual: send SIGTERM to a running `gradient-worker`, observe in trace logs that idle eval workers exit cleanly within 5 s instead of being SIGKILL'd.