### PR TITLE
fix(worker): raise nix-daemon pool acquire timeout and default size

### DIFF
--- a/backend/scheduler/src/build.rs
+++ b/backend/scheduler/src/build.rs
@@ -125,7 +125,7 @@ impl<'a> BuildStateHandler<'a> {
         self.check_evaluation_done(evaluation_id).await
     }
 
-    pub async fn handle_build_job_failed(&self, build_id: BuildId, _error: &str) -> Result<()> {
+    pub async fn handle_build_job_failed(&self, build_id: BuildId, error: &str) -> Result<()> {
         let build = match EBuild::find_by_id(build_id)
             .one(&self.state.worker_db)
             .await?
@@ -136,6 +136,23 @@ impl<'a> BuildStateHandler<'a> {
                 return Ok(());
             }
         };
+
+        // Surface the worker's failure reason in the build log so the
+        // frontend's log viewer renders it. Without this, pre-`nix build`
+        // aborts (prefetch-time errors, daemon connection failures, etc.)
+        // produce a Failed badge with an empty log — useless for diagnosis.
+        // Followers share this `log_id` via `propagate_to_followers`, so a
+        // single append covers the whole leader→followers fan-out.
+        let log_id = build.log_id.unwrap_or(build.id);
+        if let Err(e) = self
+            .state
+            .log_storage
+            .append(log_id, &format!("\n=== build failed: {error} ===\n"))
+            .await
+        {
+            warn!(%build_id, error = %e, "failed to append worker error to build log");
+        }
+
         let evaluation_id = build.evaluation;
         let derivation_id = build.derivation;
         let leader = update_build_status(Arc::clone(self.state), build, BuildStatus::Failed).await;

--- a/backend/scheduler/src/handler_tests.rs
+++ b/backend/scheduler/src/handler_tests.rs
@@ -989,6 +989,68 @@ async fn build_failed_cascades_to_direct_dependent() {
     assert!(result.is_ok());
 }
 
+/// Regression: when a build fails (e.g. worker reports a prefetch-time
+/// `acquire local store for import: timeout`), the worker's error string
+/// must be appended to the build log so the frontend's log viewer surfaces
+/// it instead of rendering "No log available". Previously
+/// `handle_build_job_failed` accepted the error and dropped it on the floor.
+#[tokio::test]
+async fn build_failed_appends_worker_error_to_log() {
+    use std::sync::Arc;
+    use test_support::prelude::{RecordingLogStorage, test_state_with_log_storage};
+
+    let eval_id = EvaluationId::now_v7();
+    let drv_id = DerivationId::now_v7();
+    let build_id = BuildId::now_v7();
+
+    let build = make_build(build_id, eval_id, drv_id, BuildStatus::Building);
+    let build_failed = make_build(build_id, eval_id, drv_id, BuildStatus::Failed);
+
+    let db = MockDatabase::new(DatabaseBackend::Postgres)
+        // 1. find_by_id(build)
+        .append_query_results([vec![build]])
+        // 2. update → Failed
+        .append_query_results([vec![build_failed.clone()]])
+        // 2a. propagate_to_followers: empty
+        .append_query_results([Vec::<MBuild>::new()])
+        // 3. cascade: no candidates
+        .append_query_results([Vec::<MBuild>::new()])
+        // 4. check active → empty
+        .append_query_results([Vec::<MBuild>::new()])
+        // 5. find eval → Building
+        .append_query_results([vec![make_eval(eval_id, EvaluationStatus::Building)]])
+        // 6. find failed → [build]
+        .append_query_results([vec![build_failed]])
+        // 7. find eval error messages → empty
+        .append_query_results([Vec::<MEvaluationMessage>::new()])
+        // 8. update eval → Failed
+        .append_exec_results([MockExecResult {
+            last_insert_id: 0,
+            rows_affected: 1,
+        }])
+        .append_query_results([vec![make_eval(eval_id, EvaluationStatus::Failed)]])
+        .into_connection();
+
+    let log = Arc::new(RecordingLogStorage::new());
+    let state = test_state_with_log_storage(db, log.clone());
+
+    let worker_error = "input prefetch failed: acquire local store for import: timeout: \
+                        acquiring connection from pool";
+    let result = build_handler::handle_build_job_failed(&state, build_id, worker_error).await;
+    assert!(result.is_ok(), "handler returned error: {result:?}");
+
+    let entries = log.entries();
+    let appended = entries
+        .iter()
+        .find(|(b, _)| *b == build_id)
+        .map(|(_, t)| t.as_str())
+        .unwrap_or_else(|| panic!("expected an append for build {build_id}, got {entries:?}"));
+    assert!(
+        appended.contains(worker_error),
+        "appended log must include the worker's error string verbatim, got: {appended:?}"
+    );
+}
+
 /// Build fails with no Created/Queued dependents — cascade is a no-op.
 /// check_evaluation_done sees only the Failed build → eval → Failed.
 #[tokio::test]

--- a/backend/test-support/src/lib.rs
+++ b/backend/test-support/src/lib.rs
@@ -37,6 +37,6 @@ pub mod prelude {
     pub use crate::fakes::webhooks::RecordingWebhookClient;
     pub use crate::fakes::worker_store::FakeWorkerStore;
     pub use crate::fixtures::*;
-    pub use crate::log_storage::NoopLogStorage;
-    pub use crate::state::{test_state, test_state_recorded};
+    pub use crate::log_storage::{NoopLogStorage, RecordingLogStorage};
+    pub use crate::state::{test_state, test_state_recorded, test_state_with_log_storage};
 }

--- a/backend/test-support/src/log_storage.rs
+++ b/backend/test-support/src/log_storage.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+use std::sync::Mutex;
+
 use anyhow::Result;
 use futures::future::BoxFuture;
 use gradient_core::storage::LogStorage;
@@ -22,5 +24,59 @@ impl LogStorage for NoopLogStorage {
     }
     fn delete<'a>(&'a self, _build_id: BuildId) -> BoxFuture<'a, Result<()>> {
         Box::pin(async { Ok(()) })
+    }
+}
+
+/// Recording log storage: keeps every `(build_id, text)` append in memory so
+/// tests can assert what would have been written to the log.
+///
+/// `read` returns the concatenation of every append for that build (matching
+/// the on-disk semantics of [`gradient_core::storage::FileLogStorage`]).
+#[derive(Debug, Default)]
+pub struct RecordingLogStorage {
+    entries: Mutex<Vec<(BuildId, String)>>,
+}
+
+impl RecordingLogStorage {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns a clone of every recorded `(build_id, text)` append.
+    pub fn entries(&self) -> Vec<(BuildId, String)> {
+        self.entries.lock().expect("recording log mutex").clone()
+    }
+}
+
+impl LogStorage for RecordingLogStorage {
+    fn append<'a>(&'a self, build_id: BuildId, text: &'a str) -> BoxFuture<'a, Result<()>> {
+        Box::pin(async move {
+            self.entries
+                .lock()
+                .expect("recording log mutex")
+                .push((build_id, text.to_owned()));
+            Ok(())
+        })
+    }
+
+    fn read<'a>(&'a self, build_id: BuildId) -> BoxFuture<'a, Result<String>> {
+        Box::pin(async move {
+            let entries = self.entries.lock().expect("recording log mutex");
+            Ok(entries
+                .iter()
+                .filter(|(b, _)| *b == build_id)
+                .map(|(_, t)| t.as_str())
+                .collect::<String>())
+        })
+    }
+
+    fn delete<'a>(&'a self, build_id: BuildId) -> BoxFuture<'a, Result<()>> {
+        Box::pin(async move {
+            self.entries
+                .lock()
+                .expect("recording log mutex")
+                .retain(|(b, _)| *b != build_id);
+            Ok(())
+        })
     }
 }

--- a/backend/test-support/src/state.rs
+++ b/backend/test-support/src/state.rs
@@ -10,6 +10,7 @@ use crate::fakes::webhooks::RecordingWebhookClient;
 use crate::log_storage::NoopLogStorage;
 use gradient_core::ci::WebhookClient;
 use gradient_core::storage::EmailSender;
+use gradient_core::storage::LogStorage;
 use gradient_core::storage::NarStore;
 use gradient_core::types::{RuntimeConfig, SecretString, ServerState, WebDb, WorkerDb};
 use sea_orm::{DatabaseBackend, DatabaseConnection, MockDatabase};
@@ -29,6 +30,34 @@ pub fn test_state(db: DatabaseConnection) -> Arc<ServerState> {
         worker_db: WorkerDb::new(db),
         config,
         log_storage: Arc::new(NoopLogStorage),
+        webhooks: Arc::new(RecordingWebhookClient::new()) as Arc<dyn WebhookClient>,
+        email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,
+        nar_storage,
+        manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        http: gradient_core::http::build_client().expect("build test HTTP client"),
+        shutdown: gradient_core::shutdown::Shutdown::new(),
+        jwt_secret: SecretString::new("test-jwt-secret".to_string()),
+        started_at: chrono::Utc::now(),
+    })
+}
+
+/// Like `test_state` but plumbs through a caller-supplied [`LogStorage`].
+///
+/// Use with `RecordingLogStorage` to assert what handlers append to the
+/// build log.
+pub fn test_state_with_log_storage(
+    db: DatabaseConnection,
+    log_storage: Arc<dyn LogStorage>,
+) -> Arc<ServerState> {
+    let cli = test_cli();
+    let config = Arc::new(RuntimeConfig::from_cli(&cli));
+    let nar_storage = NarStore::local(&config.storage.base_path).expect("create test NarStore");
+    Arc::new(ServerState {
+        web_db: WebDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
+        worker_db: WorkerDb::new(db),
+        config,
+        log_storage,
         webhooks: Arc::new(RecordingWebhookClient::new()) as Arc<dyn WebhookClient>,
         email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,
         nar_storage,

--- a/backend/worker/src/config.rs
+++ b/backend/worker/src/config.rs
@@ -78,8 +78,13 @@ pub struct WorkerConfig {
     #[arg(long, env = "GRADIENT_MAX_CONCURRENT_BUILDS", default_value_t = 1)]
     pub max_concurrent_builds: u32,
 
-    /// Maximum number of simultaneous connections in the local nix-daemon pool.
-    #[arg(long, env = "GRADIENT_MAX_NIXDAEMON_CONNECTIONS", default_value_t = 8)]
+    /// Maximum number of simultaneous connections in the local nix-daemon
+    /// pool. Each in-flight `add_to_store_nar` (NAR import during prefetch)
+    /// holds one connection for the duration of the upload, so the pool
+    /// must comfortably fit `max_concurrent_builds *
+    /// nar_import::PREFETCH_CONCURRENCY` plus headroom for `has_path`
+    /// probes and build dispatch.
+    #[arg(long, env = "GRADIENT_MAX_NIXDAEMON_CONNECTIONS", default_value_t = 32)]
     pub max_nixdaemon_connections: usize,
 
     // ── Logging ───────────────────────────────────────────────────────────────

--- a/backend/worker/src/nix/store.rs
+++ b/backend/worker/src/nix/store.rs
@@ -11,6 +11,8 @@
 //! operations the worker needs: path presence checks, path-info queries,
 //! and triggering builds.
 
+use std::time::Duration;
+
 use anyhow::Result;
 use async_trait::async_trait;
 use harmonia_protocol::types::{DaemonError, DaemonErrorKind};
@@ -19,6 +21,33 @@ use harmonia_store_remote::DaemonStore as _;
 use harmonia_store_remote::pool::{ConnectionPool, PoolConfig};
 
 use proto::traits::WorkerStore;
+
+/// Maximum time `pool.acquire()` blocks before failing with a timeout.
+///
+/// `add_to_store_nar` legitimately holds a connection for the duration of a
+/// NAR upload + daemon ingest, which can run into the tens of seconds for
+/// large closures. With concurrent build jobs each issuing parallel
+/// prefetch imports, the pool's acquire queue can grow well past the
+/// harmonia default of 30 s — long enough that downstream acquires time
+/// out spuriously even though the pool is making forward progress.
+///
+/// 10 minutes mirrors the `HTTP_DOWNLOAD_TIMEOUT` for presigned-URL NAR
+/// fetches in `proto::nar_import` — both bound the absolute longest a
+/// single import is allowed to take. Any acquire that legitimately needs
+/// more than that points at a stuck connection and is the right thing
+/// to surface as an error.
+const POOL_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// Build the harmonia [`PoolConfig`] used by [`LocalNixStore::connect_at`].
+///
+/// Extracted so the policy is asserted in tests without a live daemon.
+pub(crate) fn build_pool_config(pool_size: usize) -> PoolConfig {
+    PoolConfig {
+        max_size: pool_size,
+        acquire_timeout: POOL_ACQUIRE_TIMEOUT,
+        ..Default::default()
+    }
+}
 
 /// Decide whether a daemon error leaves the pooled connection in an unusable
 /// state. Only clean server-side `Remote` errors are safe to recover from —
@@ -49,12 +78,8 @@ impl LocalNixStore {
 
     /// Connect to a nix-daemon at a custom socket path with the given pool size.
     pub fn connect_at(socket_path: &str, pool_size: usize) -> Result<Self> {
-        let config = PoolConfig {
-            max_size: pool_size,
-            ..Default::default()
-        };
         Ok(Self {
-            pool: ConnectionPool::new(socket_path, config),
+            pool: ConnectionPool::new(socket_path, build_pool_config(pool_size)),
         })
     }
 
@@ -148,5 +173,24 @@ mod tests {
         // connection.
         let err = DaemonError::custom("parse error L, non-absolute store path \"L\"");
         assert!(is_connection_corrupt(&err));
+    }
+
+    /// Regression for the dispatch-time pool exhaustion observed in
+    /// production: with `max_concurrent_builds * PREFETCH_CONCURRENCY`
+    /// imports queued against the pool, the harmonia default
+    /// `acquire_timeout` of 30 s fires before the pool can serve them
+    /// even though it is making forward progress. We override it to
+    /// 10 min — anything shorter is an artificial cap that surfaces as
+    /// "acquire local store for import: timeout" mid-build.
+    #[test]
+    fn pool_config_acquire_timeout_is_generous() {
+        let cfg = build_pool_config(8);
+        assert_eq!(cfg.max_size, 8);
+        assert!(
+            cfg.acquire_timeout >= Duration::from_secs(600),
+            "acquire_timeout must accommodate worst-case queue depth across \
+             concurrent build jobs; got {:?}",
+            cfg.acquire_timeout
+        );
     }
 }

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -290,7 +290,7 @@ The token must be the 48-byte random secret returned by the registration API (ge
 | `settings.evalWorkers` | `1` | Number of evaluator subprocesses |
 | `settings.maxConcurrentEvaluations` | `1` | Parallel evaluations |
 | `settings.maxEvaluationsPerWorker` | `20` | Recycle evaluator subprocess after N jobs (0 = never) |
-| `settings.maxNixdaemonConnections` | `8` | Worker's local nix-daemon connection pool size |
+| `settings.maxNixdaemonConnections` | `32` | Worker's local nix-daemon connection pool size. Each in-flight NAR import holds one connection; size for `maxConcurrentBuilds * 8` plus headroom |
 | `settings.maxProtoConnections` | `16` | Max simultaneous WebSocket connections (for discoverable mode) |
 | `settings.logLevel.default` | `info` | Worker log level |
 | `settings.logLevel.eval` | null | Evaluator log level override |

--- a/nix/modules/gradient-worker.nix
+++ b/nix/modules/gradient-worker.nix
@@ -174,9 +174,14 @@ in {
       };
 
       maxNixdaemonConnections = lib.mkOption {
-        description = "Maximum number of simultaneous local Nix daemon connections in the connection pool";
+        description = ''
+          Maximum number of simultaneous local Nix daemon connections in
+          the connection pool. Should comfortably fit
+          `maxConcurrentBuilds * 8` (parallel NAR imports per build) plus
+          headroom for path-presence checks and build dispatch.
+        '';
         type = lib.types.ints.positive;
-        default = 8;
+        default = 32;
       };
 
       evalWorkers = lib.mkOption {


### PR DESCRIPTION
Fixes the production worker error chain seen during multi-build prefetch:

```
ERROR gradient_worker::proto::nar_import: dep NAR import failed; aborting
Caused by: acquire local store for import: timeout: acquiring connection from pool
```

…which surfaced in the frontend as a build with a Failed badge and a completely empty log.

## Root causes (two layers)

**1. Pool acquire timeout too short for the import workload.**
Each build job's `prefetch_inputs` runs up to `PREFETCH_CONCURRENCY = 8` parallel `add_to_store_nar` calls. With `max_concurrent_builds` at typical values, peak demand on the harmonia `ConnectionPool` reaches `max_concurrent_builds * 8` simultaneous acquires against a pool of 8 connections, each held for the duration of an upload (5–30 s for non-trivial NARs). Harmonia's default `acquire_timeout` is 30 s — the back of the queue legitimately waits longer, the acquire fails, the dep NAR import errors out, and `prefetch_inputs` aborts the build.

**2. Worker `JobFailed` error was dropped on the floor server-side.**
`BuildStateHandler::handle_build_job_failed` declared the parameter as `_error: &str` (note the underscore) and never used it. The build moved to `Failed` status with no log content because the worker had aborted before streaming any. Frontend rendered "No log available".

## Fix

Worker pool sizing:
- Override `PoolConfig::acquire_timeout` to 10 min in `LocalNixStore::connect_at` (mirrors the existing `HTTP_DOWNLOAD_TIMEOUT` for presigned-URL fetches; an acquire that needs longer points at a stuck connection and is the right thing to surface).
- Bump `--max-nixdaemon-connections` default from 8 → 32 so the pool fits worst-case `max_concurrent_builds * 8` out of the box.
- Document the sizing rationale on the CLI flag and the matching NixOS option.
- Unit test `pool_config_acquire_timeout_is_generous` so the timeout can't silently regress to the harmonia default.

Server-side error surfacing:
- `handle_build_job_failed` now appends the worker's error to the build log behind a `=== build failed: ... ===` separator.
- Followers share the leader's `log_id` via `propagate_to_followers`, so a single append covers the entire fan-out without duplicating into per-follower logs.
- Adds `RecordingLogStorage` + `test_state_with_log_storage` test helpers and a regression test (`build_failed_appends_worker_error_to_log`) asserting the worker error string lands in the build log verbatim.

Net result: even if the pool exhausts again under heavier-than-expected load, the user sees the actual worker error in the existing log viewer instead of an empty pane.

## Test plan
- [x] `cargo test -p scheduler --tests` (130 passed)
- [x] `cargo clippy -p scheduler -p test-support -p worker --tests --no-deps -- -D warnings` clean
- [x] New test `build_failed_appends_worker_error_to_log` exercises the empty-log + JobFailed → log-append path
- [x] New test `pool_config_acquire_timeout_is_generous` pins the timeout policy
- [x] `nix-instantiate --parse nix/modules/gradient-worker.nix` OK