### PR TITLE
fix: entry-point metrics for substituted builds + external_cached build fallback

### DIFF
--- a/backend/web/src/endpoints/projects/metrics.rs
+++ b/backend/web/src/endpoints/projects/metrics.rs
@@ -63,9 +63,10 @@ async fn derivation_closure_reachable<C: sea_orm::ConnectionTrait>(
 
 /// Sum uncompressed NAR size of derivation outputs for `drv_ids`.
 ///
-/// `nar_size` is populated when the worker reports build output metadata;
-/// `file_size` (compressed) is only populated per-cache, so it's unreliable
-/// as a per-output total.
+/// `derivation_output.nar_size` is populated only when the worker actually
+/// built the output. For substituted builds it's `None`, but the size lives
+/// on the matching `cached_path` row (joined by hash). This helper coalesces
+/// the two so that completed and substituted outputs both contribute.
 ///
 /// Returns `Some(total)` when the total is > 0, `None` otherwise.
 async fn sum_output_sizes<C: sea_orm::ConnectionTrait>(
@@ -79,7 +80,31 @@ async fn sum_output_sizes<C: sea_orm::ConnectionTrait>(
         .filter(CDerivationOutput::Derivation.is_in(drv_ids))
         .all(db)
         .await?;
-    let total: i64 = outputs.iter().filter_map(|o| o.nar_size).sum();
+
+    let missing_hashes: Vec<String> = outputs
+        .iter()
+        .filter(|o| o.nar_size.is_none())
+        .map(|o| o.hash.clone())
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+
+    let cached_size_by_hash: std::collections::HashMap<String, i64> = if missing_hashes.is_empty() {
+        std::collections::HashMap::new()
+    } else {
+        ECachedPath::find()
+            .filter(CCachedPath::Hash.is_in(missing_hashes))
+            .all(db)
+            .await?
+            .into_iter()
+            .filter_map(|cp| cp.nar_size.map(|n| (cp.hash, n)))
+            .collect()
+    };
+
+    let total: i64 = outputs
+        .iter()
+        .filter_map(|o| o.nar_size.or_else(|| cached_size_by_hash.get(&o.hash).copied()))
+        .sum();
     Ok(if total > 0 { Some(total) } else { None })
 }
 
@@ -273,4 +298,97 @@ pub async fn get_entry_point_metrics(
         keep_evaluations: project.keep_evaluations,
         points,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use entity::{cached_path, derivation_output};
+    use sea_orm::{DatabaseBackend, MockDatabase};
+
+    fn now() -> chrono::NaiveDateTime {
+        chrono::Utc::now().naive_utc()
+    }
+
+    fn drv_output(
+        derivation: DerivationId,
+        hash: &str,
+        nar_size: Option<i64>,
+        cached: Option<CachedPathId>,
+    ) -> derivation_output::Model {
+        derivation_output::Model {
+            id: DerivationOutputId::now_v7(),
+            derivation,
+            name: "out".into(),
+            output: format!("/nix/store/{hash}-foo"),
+            hash: hash.into(),
+            package: "foo".into(),
+            ca: None,
+            nar_size,
+            is_cached: cached.is_some(),
+            cached_path: cached,
+            created_at: now(),
+        }
+    }
+
+    fn cached_row(id: CachedPathId, hash: &str, nar_size: i64) -> cached_path::Model {
+        cached_path::Model {
+            id,
+            store_path: format!("/nix/store/{hash}-foo"),
+            hash: hash.into(),
+            package: "foo".into(),
+            file_hash: Some("sha256:dummy".into()),
+            file_size: Some(nar_size / 2),
+            nar_size: Some(nar_size),
+            nar_hash: None,
+            references: None,
+            ca: None,
+            deriver: None,
+            created_at: now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn sum_output_sizes_falls_back_to_cached_path_for_substituted() {
+        let drv_id = DerivationId::now_v7();
+        let cached_id = CachedPathId::now_v7();
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![drv_output(drv_id, "abc", None, Some(cached_id))]])
+            .append_query_results([vec![cached_row(cached_id, "abc", 1024)]])
+            .into_connection();
+
+        let total = sum_output_sizes(&db, vec![drv_id]).await.unwrap();
+        assert_eq!(total, Some(1024));
+    }
+
+    #[tokio::test]
+    async fn sum_output_sizes_mixes_built_and_substituted_outputs() {
+        let drv_built = DerivationId::now_v7();
+        let drv_sub = DerivationId::now_v7();
+        let cached_id = CachedPathId::now_v7();
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![
+                drv_output(drv_built, "built", Some(2048), None),
+                drv_output(drv_sub, "subst", None, Some(cached_id)),
+            ]])
+            .append_query_results([vec![cached_row(cached_id, "subst", 512)]])
+            .into_connection();
+
+        let total = sum_output_sizes(&db, vec![drv_built, drv_sub])
+            .await
+            .unwrap();
+        assert_eq!(total, Some(2048 + 512));
+    }
+
+    #[tokio::test]
+    async fn sum_output_sizes_returns_none_when_nothing_known() {
+        let drv_id = DerivationId::now_v7();
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![drv_output(drv_id, "unknown", None, None)]])
+            .append_query_results([Vec::<cached_path::Model>::new()])
+            .into_connection();
+
+        let total = sum_output_sizes(&db, vec![drv_id]).await.unwrap();
+        assert_eq!(total, None);
+    }
 }

--- a/backend/worker/src/executor/mod.rs
+++ b/backend/worker/src/executor/mod.rs
@@ -249,42 +249,48 @@ impl JobExecutor {
             updater.report_building(build_task.build_id.clone())?;
 
             if build_task.external_cached {
-                // The outputs are already realisable from an upstream
-                // cache — skip the daemon build entirely, just pull them
-                // through and report them so they land in our cache via
-                // the unified `compress_and_push_paths` step below.
-                let outputs = crate::proto::nar_import::fetch_external_cached_outputs(
+                // Optimistic path: the worker reported the outputs as
+                // available from an upstream cache during eval. Pull them
+                // through if we can — `compress_and_push_paths` below will
+                // land them in our cache. If anything goes wrong (cache
+                // miss, presigned download error, output missing on disk),
+                // fall through to a real local build instead of failing
+                // the whole job; the optimistic flag is just a hint.
+                match crate::proto::nar_import::fetch_external_cached_outputs(
                     &self.store,
                     build_task,
                     updater,
                 )
                 .await
-                .map_err(|e| {
-                    tracing::error!(
-                        build_id = %build_task.build_id,
-                        error = %e,
-                        "external_cached output fetch failed; aborting build"
-                    );
-                    e
-                })?;
-                let mut reported = Vec::with_capacity(outputs.len());
-                for (name, path) in &outputs {
-                    let hash = gradient_core::sources::get_hash_from_path(path.clone())
-                        .map(|(h, _)| h)
-                        .unwrap_or_default();
-                    let products = build::load_products(path).await;
-                    reported.push(proto::messages::BuildOutput {
-                        name: name.clone(),
-                        store_path: path.clone(),
-                        hash,
-                        nar_size: None,
-                        nar_hash: None,
-                        products,
-                    });
+                {
+                    Ok(outputs) => {
+                        let mut reported = Vec::with_capacity(outputs.len());
+                        for (name, path) in &outputs {
+                            let hash = gradient_core::sources::get_hash_from_path(path.clone())
+                                .map(|(h, _)| h)
+                                .unwrap_or_default();
+                            let products = build::load_products(path).await;
+                            reported.push(proto::messages::BuildOutput {
+                                name: name.clone(),
+                                store_path: path.clone(),
+                                hash,
+                                nar_size: None,
+                                nar_hash: None,
+                                products,
+                            });
+                        }
+                        updater.report_build_output(build_task.build_id.clone(), reported)?;
+                        all_output_paths.extend(outputs.into_iter().map(|(_, p)| p));
+                        continue;
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            build_id = %build_task.build_id,
+                            error = %e,
+                            "external_cached fetch failed; falling back to local build"
+                        );
+                    }
                 }
-                updater.report_build_output(build_task.build_id.clone(), reported)?;
-                all_output_paths.extend(outputs.into_iter().map(|(_, p)| p));
-                continue;
             }
 
             // Import cache-resident inputs the daemon will need. A hard

--- a/backend/worker/src/proto/nar_import.rs
+++ b/backend/worker/src/proto/nar_import.rs
@@ -106,7 +106,7 @@ impl<'a> InputPrefetcher<'a> {
 
         let (by_url, by_request) = self.query_and_split(vec![self.drv_path.to_owned()]).await?;
         let mut batch = self.fetch_by_request(by_request).await?;
-        batch.extend(self.download_by_url(by_url).await);
+        batch.extend(self.download_by_url(by_url).await?);
 
         if batch.is_empty() {
             return Err(anyhow::anyhow!(
@@ -273,9 +273,16 @@ impl<'a> InputPrefetcher<'a> {
     }
 
     /// Stage 4b — download NARs from presigned S3 URLs (S3-backed cache).
-    async fn download_by_url(&self, by_url: Vec<CachedPath>) -> Vec<(String, Vec<u8>, CachedPath)> {
+    ///
+    /// A failed download is fatal: silently dropping it would let the build
+    /// proceed with a missing input or output and surface later as an opaque
+    /// "No such file or directory" when we try to NAR-pack the absent path.
+    async fn download_by_url(
+        &self,
+        by_url: Vec<CachedPath>,
+    ) -> Result<Vec<(String, Vec<u8>, CachedPath)>> {
         if by_url.is_empty() {
-            return vec![];
+            return Ok(vec![]);
         }
 
         let http = crate::http::client();
@@ -303,14 +310,9 @@ impl<'a> InputPrefetcher<'a> {
 
         let mut results = Vec::new();
         while let Some(r) = futs.next().await {
-            match r {
-                Ok(triple) => results.push(triple),
-                Err(e) => {
-                    warn!(error = %e, "presigned NAR download failed; build may need to refetch")
-                }
-            }
+            results.push(r.context("presigned NAR download failed")?);
         }
-        results
+        Ok(results)
     }
 
     /// Stage 5 — import every downloaded NAR into the local nix-daemon in
@@ -484,7 +486,7 @@ impl<'a> InputPrefetcher<'a> {
 
             let (by_url, by_request) = self.query_and_split(to_query).await?;
             let mut batch = self.fetch_by_request(by_request).await?;
-            batch.extend(self.download_by_url(by_url).await);
+            batch.extend(self.download_by_url(by_url).await?);
 
             // Collect any references from this batch that we haven't yet
             // queried and that aren't already in the local store.
@@ -659,6 +661,22 @@ pub async fn fetch_external_cached_outputs(
         .await?;
     if !missing.is_empty() {
         prefetcher.fetch_closure(missing).await?;
+    }
+
+    // Belt-and-suspenders: the daemon can return `is_valid_path=true` for paths
+    // whose registry entry exists but whose on-disk NAR is gone (manual
+    // deletion, interrupted import, GC race), and our own fetch could leave a
+    // path unimported despite returning Ok. Either way, an absent file means
+    // the upcoming NAR-pack step will fail with an opaque IO error — bail now
+    // so the caller can fall back to a real build.
+    for (_, path) in &outputs {
+        if !tokio::fs::try_exists(path).await.unwrap_or(false) {
+            anyhow::bail!(
+                "external_cached output {} is registered but not present on disk; \
+                 cache is missing the NAR or the path was removed locally",
+                path
+            );
+        }
     }
     Ok(outputs)
 }

--- a/frontend/src/app/features/projects/entry-point-metrics/entry-point-metrics.component.html
+++ b/frontend/src/app/features/projects/entry-point-metrics/entry-point-metrics.component.html
@@ -37,6 +37,10 @@
         <span class="summary-label">Failed</span>
       </div>
       <div class="summary-card">
+        <span class="summary-value">{{ substitutedCount() }}</span>
+        <span class="summary-label">Substituted</span>
+      </div>
+      <div class="summary-card">
         <span class="summary-value">{{ points().length }}</span>
         <span class="summary-label">Total evaluations</span>
       </div>

--- a/frontend/src/app/features/projects/entry-point-metrics/entry-point-metrics.component.ts
+++ b/frontend/src/app/features/projects/entry-point-metrics/entry-point-metrics.component.ts
@@ -86,9 +86,7 @@ export class EntryPointMetricsComponent implements OnInit {
 
     this.projectsService.getEntryPointMetrics(this.orgName, this.projectName, evalParam).subscribe({
       next: (data: EntryPointMetricsResponse) => {
-        // Substituted builds didn't actually run on a server in this evaluation,
-        // so their build time / sizes are not meaningful trend data points.
-        this.points.set(data.points.filter((p) => p.build_status !== 'Substituted'));
+        this.points.set(data.points);
         this.keepEvaluations.set(data.keep_evaluations);
         this.loading.set(false);
       },
@@ -170,6 +168,7 @@ export class EntryPointMetricsComponent implements OnInit {
 
   completedCount = computed(() => this.points().filter((p) => p.build_status === 'Completed').length);
   failedCount = computed(() => this.points().filter((p) => p.build_status === 'Failed').length);
+  substitutedCount = computed(() => this.points().filter((p) => p.build_status === 'Substituted').length);
 
   formatBytes(bytes: number): string {
     if (!bytes || bytes === 0) return '0 B';


### PR DESCRIPTION
## Summary

- Fix #119: substituted entry-point builds had `output_size_bytes` and
  `closure_size_bytes` come back null because `sum_output_sizes` only
  read `derivation_output.nar_size` (populated on real build) and never
  consulted the matching `cached_path` row. Now the helper coalesces the
  two so substituted outputs contribute their cache-known sizes, and the
  frontend no longer filters substituted entries out of the chart. A
  `Substituted` count joins the existing Completed/Failed summary cards.
- Fix the "build failed: NAR stream error: No such file or directory"
  failure on `Start Evaluation`. The optimistic `external_cached` path
  could leave a build with a "successful" output that wasn't actually
  on disk — silent presigned download failures, or `is_valid_path`
  returning true for a path whose NAR was gone — and the next NAR-pack
  step died opaquely. `download_by_url` now propagates errors,
  `fetch_external_cached_outputs` verifies every declared output is on
  disk before returning Ok, and the executor falls through to the
  regular prefetch + build path when the optimistic fetch fails.

Closes #119.

## Test plan

- [x] `cargo test -p web --lib endpoints::projects::metrics` — three
      new tests cover `sum_output_sizes` for built-only, substituted-only,
      and mixed inputs.
- [x] `cargo test -p worker --bins proto::nar` — existing 23 tests pass.
- [x] `cargo check -p web --tests` and `cargo check -p worker --tests`.
- [x] Manual: trigger a Start Evaluation on a project whose entry point
      has been previously built; confirm it falls back to a real build
      and the chart shows the new substituted points.