### PR TITLE
feat: configurable permissions and organization pin for API keys

### DIFF
--- a/backend/core/src/db/connection.rs
+++ b/backend/core/src/db/connection.rs
@@ -141,6 +141,7 @@ async fn seed_builtin_role(
                 name: Set(name.to_string()),
                 organization: Set(None),
                 permission: Set(permission),
+                managed: Set(false),
             }
             .insert(db)
             .await?;

--- a/backend/core/src/state/mod.rs
+++ b/backend/core/src/state/mod.rs
@@ -174,6 +174,23 @@ pub struct StateApiKey {
     pub name: String,
     pub key_file: String,
     pub owned_by: String,
+    /// Capability identifiers (matching `Permission::as_wire_name`) the key
+    /// should grant. Required — there is no safe default.
+    pub permissions: Vec<String>,
+    /// Optional organization name to pin the key to. `None` = unscoped.
+    #[serde(default)]
+    pub organization: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StateRole {
+    pub name: String,
+    /// Organization the role belongs to. State-managed roles are always
+    /// org-scoped — there is no way to define a global state-managed role.
+    pub organization: String,
+    /// Capability identifiers (matching `Permission::as_wire_name`) the role
+    /// grants. Required — there is no safe default.
+    pub permissions: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -207,6 +224,8 @@ pub struct StateConfiguration {
     pub projects: HashMap<String, StateProject>,
     #[serde(default)]
     pub caches: HashMap<String, StateCache>,
+    #[serde(default)]
+    pub roles: HashMap<String, StateRole>,
     #[serde(default)]
     pub api_keys: HashMap<String, StateApiKey>,
     #[serde(default)]
@@ -379,11 +398,77 @@ impl StateConfiguration {
             }
         }
 
+        let mut role_keys_seen_per_org: std::collections::HashSet<(String, String)> =
+            std::collections::HashSet::new();
+        for role in self.roles.values() {
+            if !self.organizations.contains_key(&role.organization) {
+                errors.push(ValidationError {
+                    field: format!("roles.{}.organization", role.name),
+                    message: format!("Organization '{}' does not exist", role.organization),
+                });
+            }
+            if role.permissions.is_empty() {
+                errors.push(ValidationError {
+                    field: format!("roles.{}.permissions", role.name),
+                    message: "At least one permission must be declared.".into(),
+                });
+            }
+            for wire in &role.permissions {
+                if crate::permissions::Permission::from_wire_name(wire).is_none() {
+                    errors.push(ValidationError {
+                        field: format!("roles.{}.permissions", role.name),
+                        message: format!("Unknown permission '{}'", wire),
+                    });
+                }
+            }
+            if matches!(role.name.as_str(), "Admin" | "Write" | "View") {
+                errors.push(ValidationError {
+                    field: format!("roles.{}.name", role.name),
+                    message: format!(
+                        "Role name '{}' collides with a built-in role; pick a different name.",
+                        role.name
+                    ),
+                });
+            }
+            let key = (role.organization.clone(), role.name.clone());
+            if !role_keys_seen_per_org.insert(key) {
+                errors.push(ValidationError {
+                    field: format!("roles.{}.name", role.name),
+                    message: format!(
+                        "Duplicate role '{}' in organization '{}'",
+                        role.name, role.organization
+                    ),
+                });
+            }
+        }
+
         for api_key in self.api_keys.values() {
             if !self.users.contains_key(&api_key.owned_by) {
                 errors.push(ValidationError {
                     field: format!("api_keys.{}.owned_by", api_key.name),
                     message: format!("User '{}' does not exist", api_key.owned_by),
+                });
+            }
+            if api_key.permissions.is_empty() {
+                errors.push(ValidationError {
+                    field: format!("api_keys.{}.permissions", api_key.name),
+                    message: "At least one permission must be declared.".into(),
+                });
+            }
+            for wire in &api_key.permissions {
+                if crate::permissions::Permission::from_wire_name(wire).is_none() {
+                    errors.push(ValidationError {
+                        field: format!("api_keys.{}.permissions", api_key.name),
+                        message: format!("Unknown permission '{}'", wire),
+                    });
+                }
+            }
+            if let Some(org) = &api_key.organization
+                && !self.organizations.contains_key(org)
+            {
+                errors.push(ValidationError {
+                    field: format!("api_keys.{}.organization", api_key.name),
+                    message: format!("Organization '{}' does not exist", org),
                 });
             }
         }

--- a/backend/core/src/state/provisioning.rs
+++ b/backend/core/src/state/provisioning.rs
@@ -685,6 +685,8 @@ impl<'a> StateApplicator<'a> {
                     managed: Set(true),
                     expires_at: Set(None),
                     revoked_at: Set(None),
+                    permission: Set(crate::permissions::admin_mask()),
+                    organization: Set(None),
                 };
                 api_key_model.insert(self.db).await?;
                 tracing::info!(name = %state_api_key.name, "Created managed API key");

--- a/backend/core/src/state/provisioning.rs
+++ b/backend/core/src/state/provisioning.rs
@@ -6,7 +6,7 @@
 
 use super::{
     StateApiKey, StateCache, StateConfiguration, StateIntegration, StateOrganization, StateProject,
-    StateTrigger, StateUpstream, StateUser, StateWorker,
+    StateRole, StateTrigger, StateUpstream, StateUser, StateWorker,
 };
 use crate::ci::{
     ForgeType, GITHUB_APP_INTEGRATION_NAME, IntegrationKind, encrypt_webhook_secret,
@@ -46,6 +46,7 @@ pub(super) async fn apply_state_to_database(
 
     app.apply_users(&config.users).await?;
     app.apply_organizations(&config.organizations).await?;
+    app.apply_roles(&config.roles).await?;
     app.apply_projects(&config.projects).await?;
     app.apply_integrations(&config.integrations).await?;
     app.apply_project_integration_links(&config.projects, &config.integrations)
@@ -638,6 +639,64 @@ impl<'a> StateApplicator<'a> {
         Ok(())
     }
 
+    // ── apply_roles ───────────────────────────────────────────────────────────
+
+    async fn apply_roles(
+        &self,
+        state_roles: &HashMap<String, StateRole>,
+    ) -> Result<(), DynError> {
+        let org_lookup = self.org_lookup().await?;
+
+        for state_role in state_roles.values() {
+            let org_id = lookup_id(&org_lookup, &state_role.organization, "Organization")?;
+
+            let mut perms = Vec::with_capacity(state_role.permissions.len());
+            for wire in &state_role.permissions {
+                let p = crate::permissions::Permission::from_wire_name(wire).ok_or_else(|| {
+                    format!(
+                        "Role '{}' references unknown permission '{}'",
+                        state_role.name, wire
+                    )
+                })?;
+                perms.push(p);
+            }
+            if perms.is_empty() {
+                return Err(format!(
+                    "Role '{}' must declare at least one permission",
+                    state_role.name
+                )
+                .into());
+            }
+            let mask = crate::permissions::mask_from(&perms);
+
+            let existing = role::Entity::find()
+                .filter(role::Column::Name.eq(&state_role.name))
+                .filter(role::Column::Organization.eq(org_id))
+                .one(self.db)
+                .await?;
+
+            if let Some(existing) = existing {
+                let mut active: role::ActiveModel = existing.into();
+                active.permission = Set(mask);
+                active.managed = Set(true);
+                active.update(self.db).await?;
+                tracing::info!(name = %state_role.name, "Updated managed role");
+            } else {
+                let active = role::ActiveModel {
+                    id: Set(RoleId::now_v7()),
+                    name: Set(state_role.name.clone()),
+                    organization: Set(Some(org_id)),
+                    permission: Set(mask),
+                    managed: Set(true),
+                };
+                active.insert(self.db).await?;
+                tracing::info!(name = %state_role.name, "Created managed role");
+            }
+        }
+
+        Ok(())
+    }
+
     // ── apply_api_keys ────────────────────────────────────────────────────────
 
     async fn apply_api_keys(
@@ -645,6 +704,7 @@ impl<'a> StateApplicator<'a> {
         state_api_keys: &HashMap<String, StateApiKey>,
     ) -> Result<(), DynError> {
         let user_lookup = self.user_lookup().await?;
+        let org_lookup = self.org_lookup().await?;
         let now = now();
 
         for state_api_key in state_api_keys.values() {
@@ -657,6 +717,35 @@ impl<'a> StateApplicator<'a> {
                         state_api_key.owned_by, state_api_key.name
                     )
                 })?;
+
+            let mut perms = Vec::with_capacity(state_api_key.permissions.len());
+            for wire in &state_api_key.permissions {
+                let p = crate::permissions::Permission::from_wire_name(wire).ok_or_else(|| {
+                    format!(
+                        "API key '{}' references unknown permission '{}'",
+                        state_api_key.name, wire
+                    )
+                })?;
+                perms.push(p);
+            }
+            if perms.is_empty() {
+                return Err(format!(
+                    "API key '{}' must declare at least one permission",
+                    state_api_key.name
+                )
+                .into());
+            }
+            let mask = crate::permissions::mask_from(&perms);
+
+            let pinned_org = match &state_api_key.organization {
+                None => None,
+                Some(name) => Some(org_lookup.get(name).copied().ok_or_else(|| {
+                    format!(
+                        "Organization '{}' referenced by API key '{}' not found",
+                        name, state_api_key.name
+                    )
+                })?),
+            };
 
             let (key_value, key_path) =
                 read_credential("api", &state_api_key.name, "key", "API key file")?;
@@ -672,6 +761,8 @@ impl<'a> StateApplicator<'a> {
                 let mut api_key: api::ActiveModel = api_key_model.into();
                 api_key.key = Set(key_hash);
                 api_key.managed = Set(true);
+                api_key.permission = Set(mask);
+                api_key.organization = Set(pinned_org);
                 api_key.update(self.db).await?;
                 tracing::info!(name = %state_api_key.name, "Updated managed API key");
             } else {
@@ -685,8 +776,8 @@ impl<'a> StateApplicator<'a> {
                     managed: Set(true),
                     expires_at: Set(None),
                     revoked_at: Set(None),
-                    permission: Set(crate::permissions::admin_mask()),
-                    organization: Set(None),
+                    permission: Set(mask),
+                    organization: Set(pinned_org),
                 };
                 api_key_model.insert(self.db).await?;
                 tracing::info!(name = %state_api_key.name, "Created managed API key");
@@ -1004,6 +1095,48 @@ impl<'a> StateApplicator<'a> {
         unmark_managed!(db, project, project_names, name, delete_state, "project");
         unmark_managed!(db, cache, cache_names, name, delete_state, "cache");
         unmark_managed!(db, api, api_key_names, name, delete_state, "API key");
+
+        // Roles: identified by (organization, name) so we can't use the
+        // single-column `unmark_managed!` helper.
+        let role_keys: HashSet<(String, String)> = config
+            .roles
+            .values()
+            .map(|r| (r.organization.clone(), r.name.clone()))
+            .collect();
+        let org_lookup = self.org_lookup().await?;
+        let mut org_name_by_id: HashMap<OrganizationId, String> = HashMap::new();
+        for (name, id) in &org_lookup {
+            org_name_by_id.insert(*id, name.clone());
+        }
+        let managed_roles = role::Entity::find()
+            .filter(role::Column::Managed.eq(true))
+            .all(db)
+            .await?;
+        for managed in managed_roles {
+            let owner_org = match managed.organization {
+                Some(id) => id,
+                None => continue,
+            };
+            let owner_name = match org_name_by_id.get(&owner_org) {
+                Some(n) => n.clone(),
+                None => continue,
+            };
+            let key = (owner_name, managed.name.clone());
+            if role_keys.contains(&key) {
+                continue;
+            }
+            let role_id = managed.id;
+            let role_name = managed.name.clone();
+            if delete_state {
+                role::Entity::delete_by_id(role_id).exec(db).await?;
+                tracing::info!(role = %role_name, "Deleted managed role");
+            } else {
+                let mut active: role::ActiveModel = managed.into();
+                active.managed = Set(false);
+                active.update(db).await?;
+                tracing::info!(role = %role_name, "Unmarked managed role");
+            }
+        }
 
         let managed_workers = worker_registration::Entity::find()
             .filter(worker_registration::Column::Managed.eq(true))

--- a/backend/entity/src/api.rs
+++ b/backend/entity/src/api.rs
@@ -8,7 +8,7 @@ use chrono::NaiveDateTime;
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::ids::{ApiId, UserId};
+use crate::ids::{ApiId, OrganizationId, UserId};
 
 #[derive(Clone, PartialEq, DeriveEntityModel, Deserialize, Serialize)]
 #[sea_orm(table_name = "api")]
@@ -23,6 +23,13 @@ pub struct Model {
     pub managed: bool,
     pub expires_at: Option<NaiveDateTime>,
     pub revoked_at: Option<NaiveDateTime>,
+    /// Bitmask over `gradient_core::permissions::Permission` capabilities;
+    /// caps the key's effective authority on every authenticated request.
+    pub permission: i64,
+    /// Optional org pin. `None` = key works in any org the owning user is a
+    /// member of (legacy behavior). `Some(id)` = key is rejected for any
+    /// other org.
+    pub organization: Option<OrganizationId>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
@@ -33,11 +40,19 @@ pub enum Relation {
         to = "super::user::Column::Id"
     )]
     OwnedBy,
+    #[sea_orm(
+        belongs_to = "super::organization::Entity",
+        from = "Column::Organization",
+        to = "super::organization::Column::Id",
+        on_delete = "SetNull",
+        on_update = "Cascade"
+    )]
+    Organization,
 }
 
 impl std::fmt::Debug for Model {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("User")
+        f.debug_struct("ApiKey")
             .field("id", &self.id)
             .field("owned_by", &self.owned_by)
             .field("name", &self.name)
@@ -47,6 +62,8 @@ impl std::fmt::Debug for Model {
             .field("managed", &self.managed)
             .field("expires_at", &self.expires_at)
             .field("revoked_at", &self.revoked_at)
+            .field("permission", &self.permission)
+            .field("organization", &self.organization)
             .finish()
     }
 }

--- a/backend/entity/src/role.rs
+++ b/backend/entity/src/role.rs
@@ -18,6 +18,10 @@ pub struct Model {
     pub name: String,
     pub organization: Option<OrganizationId>,
     pub permission: i64,
+    /// True for roles created by `gradient-state.nix`. Managed roles are
+    /// immutable through the role-management API, the same way built-in
+    /// roles are.
+    pub managed: bool,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/backend/migration/src/lib.rs
+++ b/backend/migration/src/lib.rs
@@ -99,6 +99,7 @@ mod m20260507_000006_add_subtype_to_build_product;
 mod m20260507_000007_add_sign_cache_to_project;
 mod m20260508_000000_rename_project_evaluation_wildcard;
 mod m20260510_000000_seed_github_app_integrations;
+mod m20260510_000001_api_key_options;
 
 pub struct Migrator;
 
@@ -199,6 +200,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260507_000007_add_sign_cache_to_project::Migration),
             Box::new(m20260508_000000_rename_project_evaluation_wildcard::Migration),
             Box::new(m20260510_000000_seed_github_app_integrations::Migration),
+            Box::new(m20260510_000001_api_key_options::Migration),
         ]
     }
 }

--- a/backend/migration/src/lib.rs
+++ b/backend/migration/src/lib.rs
@@ -100,6 +100,7 @@ mod m20260507_000007_add_sign_cache_to_project;
 mod m20260508_000000_rename_project_evaluation_wildcard;
 mod m20260510_000000_seed_github_app_integrations;
 mod m20260510_000001_api_key_options;
+mod m20260510_000002_add_managed_to_role;
 
 pub struct Migrator;
 
@@ -201,6 +202,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260508_000000_rename_project_evaluation_wildcard::Migration),
             Box::new(m20260510_000000_seed_github_app_integrations::Migration),
             Box::new(m20260510_000001_api_key_options::Migration),
+            Box::new(m20260510_000002_add_managed_to_role::Migration),
         ]
     }
 }

--- a/backend/migration/src/m20260510_000001_api_key_options.rs
+++ b/backend/migration/src/m20260510_000001_api_key_options.rs
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Adds configurable options to API keys: a permission bitmask (subset of
+//! `gradient_core::permissions::Permission::ALL`) and an optional organization
+//! pin. Existing rows receive `permission = admin_mask()` and `organization =
+//! NULL` to preserve today's "key has all the powers of its user, in any org"
+//! behavior. The org pin uses `ON DELETE SET NULL` so that deleting an
+//! organization unpins affected keys rather than destroying them.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+/// Equal to `gradient_core::permissions::admin_mask()` at the time this
+/// migration is authored. Hard-coding the literal keeps the migration
+/// independent of crate-level changes to `Permission::ALL` ordering.
+const ADMIN_MASK: i64 = 0x1FFF; // bits 0..=12 set
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Api::Table)
+                    .add_column(
+                        ColumnDef::new(Api::Permission)
+                            .big_integer()
+                            .not_null()
+                            .default(ADMIN_MASK),
+                    )
+                    .add_column(ColumnDef::new(Api::Organization).uuid().null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_foreign_key(
+                ForeignKey::create()
+                    .name("fk_api_organization")
+                    .from(Api::Table, Api::Organization)
+                    .to(Organization::Table, Organization::Id)
+                    .on_delete(ForeignKeyAction::SetNull)
+                    .on_update(ForeignKeyAction::Cascade)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .name("idx_api_organization")
+                    .table(Api::Table)
+                    .col(Api::Organization)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx_api_organization")
+                    .table(Api::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_foreign_key(
+                ForeignKey::drop()
+                    .name("fk_api_organization")
+                    .table(Api::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Api::Table)
+                    .drop_column(Api::Permission)
+                    .drop_column(Api::Organization)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum Api {
+    Table,
+    Permission,
+    Organization,
+}
+
+#[derive(DeriveIden)]
+enum Organization {
+    Table,
+    Id,
+}

--- a/backend/migration/src/m20260510_000002_add_managed_to_role.rs
+++ b/backend/migration/src/m20260510_000002_add_managed_to_role.rs
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Adds `managed` to the `role` table so state-managed custom roles (defined
+//! in `gradient-state.nix`) can be marked as such. Existing rows default to
+//! `false`, preserving today's behavior — the three built-in roles
+//! (Admin/Write/View) and any user-created custom roles remain unmanaged.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Role::Table)
+                    .add_column(
+                        ColumnDef::new(Role::Managed)
+                            .boolean()
+                            .not_null()
+                            .default(false),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Role::Table)
+                    .drop_column(Role::Managed)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum Role {
+    Table,
+    Managed,
+}

--- a/backend/web/src/access.rs
+++ b/backend/web/src/access.rs
@@ -19,6 +19,7 @@
 //! - Caches: [`load_cache`] with [`CacheAccess`] (owner-scoped, not org-scoped).
 //! - Org-scoped children: [`load_webhook_in_org`], [`load_integration_in_org`].
 
+use crate::authorization::ApiKeyContext;
 use crate::error::{WebError, WebResult};
 use crate::helpers::OptionExt;
 use crate::permissions::{Permission, PermissionMask, mask_grants};
@@ -110,6 +111,7 @@ pub enum CacheAccess {
 pub async fn load_org(
     state: &Arc<ServerState>,
     caller: Caller<'_>,
+    api_key: Option<&ApiKeyContext>,
     org_name: String,
     access: OrgAccess,
 ) -> WebResult<MOrganization> {
@@ -126,7 +128,7 @@ pub async fn load_org(
         OrgAccess::Readable { .. } => {
             if !org.public {
                 let visible = match caller.user_id() {
-                    Some(uid) => is_org_member(state, uid, org.id).await?,
+                    Some(uid) => is_org_member(state, uid, org.id, api_key).await?,
                     None => false,
                 };
                 if !visible {
@@ -136,7 +138,7 @@ pub async fn load_org(
         }
         OrgAccess::Member { reject_managed } => {
             let uid = caller.user_id().ok_or_else(|| WebError::not_found(label))?;
-            if !is_org_member(state, uid, org.id).await? {
+            if !is_org_member(state, uid, org.id, api_key).await? {
                 return Err(WebError::not_found(label));
             }
             if reject_managed {
@@ -148,7 +150,7 @@ pub async fn load_org(
             reject_managed,
         } => {
             let uid = caller.user_id().ok_or_else(|| WebError::not_found(label))?;
-            require_org_permission(state, uid, org.id, permission, label).await?;
+            require_org_permission(state, uid, org.id, permission, label, api_key).await?;
             if reject_managed {
                 reject_managed_org(&org)?;
             }
@@ -163,11 +165,11 @@ pub async fn load_org(
 pub async fn load_project(
     state: &Arc<ServerState>,
     caller: Caller<'_>,
+    api_key: Option<&ApiKeyContext>,
     org_name: String,
     project_name: String,
     access: ProjectAccess,
 ) -> WebResult<(MOrganization, MProject)> {
-    // Project endpoints always report "Project" so org existence isn't leaked.
     let label = "Project";
 
     let (org, project) = get_any_project_by_name(Arc::clone(state), org_name, project_name)
@@ -178,7 +180,7 @@ pub async fn load_project(
         ProjectAccess::Readable => {
             if !org.public {
                 let visible = match caller.user_id() {
-                    Some(uid) => is_org_member(state, uid, org.id).await?,
+                    Some(uid) => is_org_member(state, uid, org.id, api_key).await?,
                     None => false,
                 };
                 if !visible {
@@ -188,7 +190,7 @@ pub async fn load_project(
         }
         ProjectAccess::Member => {
             let uid = caller.user_id().ok_or_else(|| WebError::not_found(label))?;
-            if !is_org_member(state, uid, org.id).await? {
+            if !is_org_member(state, uid, org.id, api_key).await? {
                 return Err(WebError::not_found(label));
             }
         }
@@ -197,7 +199,7 @@ pub async fn load_project(
             reject_managed,
         } => {
             let uid = caller.user_id().ok_or_else(|| WebError::not_found(label))?;
-            require_org_permission(state, uid, org.id, permission, label).await?;
+            require_org_permission(state, uid, org.id, permission, label, api_key).await?;
             if reject_managed && project.managed {
                 return Err(WebError::forbidden(
                     "Cannot modify state-managed project. This project is managed by configuration and cannot be edited through the API.",
@@ -268,7 +270,14 @@ pub async fn is_org_member(
     state: &Arc<ServerState>,
     user_id: UserId,
     organization_id: OrganizationId,
+    api_key: Option<&ApiKeyContext>,
 ) -> WebResult<bool> {
+    if let Some(ctx) = api_key
+        && let Some(pinned) = ctx.organization
+        && pinned != organization_id
+    {
+        return Ok(false);
+    }
     Ok(load_org_membership(state, user_id, organization_id)
         .await?
         .is_some())
@@ -280,9 +289,10 @@ pub async fn has_permission(
     user_id: UserId,
     organization_id: OrganizationId,
     permission: Permission,
+    api_key: Option<&ApiKeyContext>,
 ) -> WebResult<bool> {
     Ok(
-        match load_membership_with_permissions(state, user_id, organization_id).await? {
+        match load_membership_with_permissions(state, user_id, organization_id, api_key).await? {
             Some((_, mask)) => mask_grants(mask, permission),
             None => false,
         },
@@ -314,7 +324,14 @@ pub async fn load_membership_with_permissions(
     state: &Arc<ServerState>,
     user_id: UserId,
     organization_id: OrganizationId,
+    api_key: Option<&ApiKeyContext>,
 ) -> WebResult<Option<(MOrganizationUser, PermissionMask)>> {
+    if let Some(ctx) = api_key
+        && let Some(pinned) = ctx.organization
+        && pinned != organization_id
+    {
+        return Ok(None);
+    }
     let Some(membership) = load_org_membership(state, user_id, organization_id).await? else {
         return Ok(None);
     };
@@ -326,7 +343,11 @@ pub async fn load_membership_with_permissions(
         .await?
         .map(|r| r.permission)
         .unwrap_or(0);
-    Ok(Some((membership, mask)))
+    let effective = match api_key {
+        Some(ctx) => mask & ctx.mask,
+        None => mask,
+    };
+    Ok(Some((membership, effective)))
 }
 
 // ── Internal helpers ─────────────────────────────────────────────────────────
@@ -337,8 +358,9 @@ async fn require_org_permission(
     org_id: OrganizationId,
     permission: Permission,
     not_found_label: &str,
+    api_key: Option<&ApiKeyContext>,
 ) -> WebResult<()> {
-    let (_, mask) = load_membership_with_permissions(state, user_id, org_id)
+    let (_, mask) = load_membership_with_permissions(state, user_id, org_id, api_key)
         .await?
         .ok_or_else(|| WebError::not_found(not_found_label))?;
 
@@ -363,7 +385,9 @@ fn reject_managed_org(org: &MOrganization) -> WebResult<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::authorization::ApiKeyContext;
     use gradient_core::ci::WebhookClient;
+    use gradient_core::permissions::mask_from;
     use gradient_core::storage::{EmailSender, NarStore};
     use gradient_core::types::consts::{BASE_ROLE_ADMIN_ID, BASE_ROLE_VIEW_ID, BASE_ROLE_WRITE_ID};
     use gradient_core::types::ids::{OrganizationUserId, ProjectId, RoleId};
@@ -521,6 +545,7 @@ mod tests {
             let r = load_org(
                 &state,
                 Caller::User(&user),
+                None,
                 "test-org".into(),
                 admin_required(),
             )
@@ -542,6 +567,7 @@ mod tests {
             let err = load_org(
                 &state,
                 Caller::User(&user),
+                None,
                 "test-org".into(),
                 admin_required(),
             )
@@ -564,6 +590,7 @@ mod tests {
             let err = load_org(
                 &state,
                 Caller::User(&user),
+                None,
                 "test-org".into(),
                 admin_required(),
             )
@@ -585,6 +612,7 @@ mod tests {
             let err = load_org(
                 &state,
                 Caller::User(&user),
+                None,
                 "test-org".into(),
                 admin_required(),
             )
@@ -608,7 +636,7 @@ mod tests {
                 .append_query_results([vec![write_role_row()]])
                 .into_connection();
             let state = make_state(db);
-            let r = load_org(&state, Caller::User(&user), "test-org".into(), access).await;
+            let r = load_org(&state, Caller::User(&user), None, "test-org".into(), access).await;
             assert!(r.is_ok(), "{:?}", r.err());
         });
     }
@@ -627,7 +655,7 @@ mod tests {
                 .append_query_results([vec![view_role_row()]])
                 .into_connection();
             let state = make_state(db);
-            let err = load_org(&state, Caller::User(&user), "test-org".into(), access)
+            let err = load_org(&state, Caller::User(&user), None, "test-org".into(), access)
                 .await
                 .expect_err("view-only must be rejected");
             assert!(matches!(err, WebError::Forbidden(..)));
@@ -646,7 +674,7 @@ mod tests {
                 .append_query_results([vec![membership_fixture(BASE_ROLE_VIEW_ID)]])
                 .into_connection();
             let state = make_state(db);
-            let r = load_org(&state, Caller::User(&user), "test-org".into(), access).await;
+            let r = load_org(&state, Caller::User(&user), None, "test-org".into(), access).await;
             assert!(r.is_ok(), "{:?}", r.err());
         });
     }
@@ -661,6 +689,7 @@ mod tests {
             let r = load_org(
                 &state,
                 Caller::Anon,
+                None,
                 "test-org".into(),
                 OrgAccess::Readable {
                     label: "Organization",
@@ -681,6 +710,7 @@ mod tests {
             let err = load_org(
                 &state,
                 Caller::Anon,
+                None,
                 "test-org".into(),
                 OrgAccess::Readable {
                     label: "Organization",
@@ -710,6 +740,7 @@ mod tests {
             let r = load_project(
                 &state,
                 Caller::User(&user),
+                None,
                 "test-org".into(),
                 "test-project".into(),
                 access,
@@ -737,6 +768,7 @@ mod tests {
             let err = load_project(
                 &state,
                 Caller::User(&user),
+                None,
                 "test-org".into(),
                 "test-project".into(),
                 access,
@@ -765,6 +797,7 @@ mod tests {
             let err = load_project(
                 &state,
                 Caller::User(&user),
+                None,
                 "test-org".into(),
                 "test-project".into(),
                 access,
@@ -790,6 +823,7 @@ mod tests {
             let err = load_project(
                 &state,
                 Caller::User(&user),
+                None,
                 "test-org".into(),
                 "test-project".into(),
                 access,
@@ -800,6 +834,126 @@ mod tests {
                 WebError::NotFound(_, msg) => assert!(msg.contains("Project"), "got {}", msg),
                 other => panic!("expected NotFound, got {:?}", other),
             }
+        });
+    }
+
+    fn api_key_ctx(mask: PermissionMask, org: Option<OrganizationId>) -> ApiKeyContext {
+        ApiKeyContext {
+            api_id: entity::ids::ApiId::new(uuid!("a0000000-0000-0000-0000-000000000099")),
+            mask,
+            organization: org,
+        }
+    }
+
+    #[test]
+    fn api_key_intersection_caps_admin_user_to_view_only() {
+        run(async {
+            let user = user_fixture();
+            let key = api_key_ctx(Permission::ViewOrg.bit(), None);
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([vec![org_fixture(false, false)]])
+                .append_query_results([vec![membership_fixture(BASE_ROLE_ADMIN_ID)]])
+                .append_query_results([vec![admin_role_row()]])
+                .into_connection();
+            let state = make_state(db);
+            let access = OrgAccess::Require {
+                permission: Permission::ManageMembers,
+                reject_managed: true,
+            };
+            let err = load_org(
+                &state,
+                Caller::User(&user),
+                Some(&key),
+                "test-org".into(),
+                access,
+            )
+            .await
+            .expect_err("admin user must be capped by view-only key");
+            assert!(matches!(err, WebError::Forbidden(..)));
+        });
+    }
+
+    #[test]
+    fn api_key_pinned_to_other_org_returns_not_found() {
+        run(async {
+            let user = user_fixture();
+            let key = api_key_ctx(
+                mask_from(Permission::ALL),
+                Some(OrganizationId::new(uuid!(
+                    "a0000000-0000-0000-0000-0000000000ff"
+                ))),
+            );
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([vec![org_fixture(false, false)]])
+                .into_connection();
+            let state = make_state(db);
+            let access = OrgAccess::Member {
+                reject_managed: false,
+            };
+            let err = load_org(
+                &state,
+                Caller::User(&user),
+                Some(&key),
+                "test-org".into(),
+                access,
+            )
+            .await
+            .expect_err("pinned-elsewhere key must be invisible to this org");
+            assert!(matches!(err, WebError::NotFound(..)));
+        });
+    }
+
+    #[test]
+    fn api_key_pinned_to_matching_org_passes() {
+        run(async {
+            let user = user_fixture();
+            let key = api_key_ctx(
+                mask_from(Permission::ALL),
+                Some(OrganizationId::new(uuid!(
+                    "a0000000-0000-0000-0000-000000000001"
+                ))),
+            );
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([vec![org_fixture(false, false)]])
+                .append_query_results([vec![membership_fixture(BASE_ROLE_ADMIN_ID)]])
+                .append_query_results([vec![admin_role_row()]])
+                .into_connection();
+            let state = make_state(db);
+            let access = OrgAccess::Require {
+                permission: Permission::ManageMembers,
+                reject_managed: false,
+            };
+            let r = load_org(
+                &state,
+                Caller::User(&user),
+                Some(&key),
+                "test-org".into(),
+                access,
+            )
+            .await;
+            assert!(r.is_ok(), "{:?}", r.err());
+        });
+    }
+
+    #[test]
+    fn session_caller_unaffected_by_api_key_logic() {
+        run(async {
+            let user = user_fixture();
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([vec![org_fixture(false, false)]])
+                .append_query_results([vec![membership_fixture(BASE_ROLE_ADMIN_ID)]])
+                .append_query_results([vec![admin_role_row()]])
+                .into_connection();
+            let state = make_state(db);
+            let r = load_org(
+                &state,
+                Caller::User(&user),
+                None,
+                "test-org".into(),
+                admin_required(),
+            )
+            .await;
+            assert!(r.is_ok(), "{:?}", r.err());
         });
     }
 }

--- a/backend/web/src/access.rs
+++ b/backend/web/src/access.rs
@@ -463,6 +463,7 @@ mod tests {
             name: "fixture".into(),
             organization: None,
             permission,
+            managed: false,
         }
     }
 

--- a/backend/web/src/access.rs
+++ b/backend/web/src/access.rs
@@ -316,6 +316,10 @@ pub async fn load_org_membership(
 
 /// Load the membership row together with the role's permission bitmask.
 ///
+/// When `api_key` is supplied, callers pinned to a different organization see
+/// `None` (the short-circuit looks identical to "not a member"); otherwise the
+/// returned mask is the role mask intersected with the key's mask.
+///
 /// Two queries are issued (membership lookup, then role lookup by id) rather
 /// than a JOIN; this keeps the mock-DB test fixtures readable and the second
 /// roundtrip is gated on the first returning a row, so the cost is paid only

--- a/backend/web/src/audit.rs
+++ b/backend/web/src/audit.rs
@@ -25,6 +25,7 @@ pub mod events {
     pub const REGISTER: &str = "register";
     pub const USER_DELETE: &str = "user.delete";
     pub const API_KEY_CREATE: &str = "api_key.create";
+    pub const API_KEY_UPDATE: &str = "api_key.update";
     pub const API_KEY_REVOKE: &str = "api_key.revoke";
     pub const API_KEY_DELETE: &str = "api_key.delete";
     pub const SESSION_REVOKE: &str = "session.revoke";

--- a/backend/web/src/authorization/api_key.rs
+++ b/backend/web/src/authorization/api_key.rs
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Per-request API-key context.
+//!
+//! When the auth middleware authenticates a request via `GRAD<key>` it inserts
+//! `Extension(MaybeApiKey(Some(ctx)))` into the request; session-JWT requests
+//! get `MaybeApiKey(None)`. The access layer reads this extension to
+//! intersect the key's permission mask with the user's role-derived mask, and
+//! to short-circuit on a pinned-org mismatch.
+
+use crate::permissions::PermissionMask;
+use gradient_core::types::{ApiId, OrganizationId};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ApiKeyContext {
+    /// The id of the `api` row this request was authenticated against.
+    pub api_id: ApiId,
+    /// The key's permission bitmask. The access layer intersects this with
+    /// the user's role-derived mask before granting any capability.
+    pub mask: PermissionMask,
+    /// `None` for unscoped keys; `Some(id)` pins the key to a single org —
+    /// requests for any other org are short-circuited as not-found.
+    pub organization: Option<OrganizationId>,
+}
+
+/// Extension type inserted on every authenticated request.
+/// `Some(ctx)` for API-key requests, `None` for session-JWT requests.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MaybeApiKey(pub Option<ApiKeyContext>);
+
+impl MaybeApiKey {
+    pub fn none() -> Self {
+        Self(None)
+    }
+    pub fn from_key(ctx: ApiKeyContext) -> Self {
+        Self(Some(ctx))
+    }
+    pub fn as_ref(&self) -> Option<&ApiKeyContext> {
+        self.0.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::permissions::{Permission, mask_from};
+    use uuid::uuid;
+
+    #[test]
+    fn from_key_preserves_fields() {
+        let ctx = ApiKeyContext {
+            api_id: ApiId::new(uuid!("a0000000-0000-0000-0000-000000000010")),
+            mask: mask_from(&[Permission::ViewOrg, Permission::TriggerEvaluation]),
+            organization: Some(OrganizationId::new(uuid!(
+                "a0000000-0000-0000-0000-000000000020"
+            ))),
+        };
+        let wrapped = MaybeApiKey::from_key(ctx);
+        assert_eq!(wrapped.as_ref(), Some(&ctx));
+    }
+
+    #[test]
+    fn none_returns_none_ref() {
+        assert!(MaybeApiKey::none().as_ref().is_none());
+    }
+}

--- a/backend/web/src/authorization/api_key.rs
+++ b/backend/web/src/authorization/api_key.rs
@@ -13,7 +13,7 @@
 //! to short-circuit on a pinned-org mismatch.
 
 use crate::permissions::PermissionMask;
-use gradient_core::types::{ApiId, OrganizationId};
+use gradient_core::types::{ApiId, OrganizationId, UserId};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ApiKeyContext {
@@ -44,6 +44,32 @@ impl MaybeApiKey {
     }
 }
 
+/// Result of decoding a request token: a session JWT or an API key.
+#[derive(Debug, Clone)]
+pub enum DecodedRequest {
+    Session { user_id: UserId },
+    ApiKey {
+        user_id: UserId,
+        context: ApiKeyContext,
+    },
+}
+
+impl DecodedRequest {
+    pub fn user_id(&self) -> UserId {
+        match self {
+            DecodedRequest::Session { user_id } => *user_id,
+            DecodedRequest::ApiKey { user_id, .. } => *user_id,
+        }
+    }
+
+    pub fn api_key_context(&self) -> Option<&ApiKeyContext> {
+        match self {
+            DecodedRequest::Session { .. } => None,
+            DecodedRequest::ApiKey { context, .. } => Some(context),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -66,5 +92,39 @@ mod tests {
     #[test]
     fn none_returns_none_ref() {
         assert!(MaybeApiKey::none().as_ref().is_none());
+    }
+
+    #[test]
+    fn decoded_request_session_carries_no_api_key() {
+        let outcome = DecodedRequest::Session {
+            user_id: UserId::new(uuid!("a0000000-0000-0000-0000-000000000004")),
+        };
+        assert!(outcome.api_key_context().is_none());
+        assert_eq!(
+            outcome.user_id(),
+            UserId::new(uuid!("a0000000-0000-0000-0000-000000000004"))
+        );
+    }
+
+    #[test]
+    fn decoded_request_api_key_carries_context() {
+        let api_id = ApiId::new(uuid!("a0000000-0000-0000-0000-000000000011"));
+        let user_id = UserId::new(uuid!("a0000000-0000-0000-0000-000000000004"));
+        let outcome = DecodedRequest::ApiKey {
+            user_id,
+            context: ApiKeyContext {
+                api_id,
+                mask: mask_from(&[Permission::ViewOrg, Permission::TriggerEvaluation]),
+                organization: None,
+            },
+        };
+        let ctx = outcome.api_key_context().expect("present");
+        assert_eq!(ctx.api_id, api_id);
+        assert_eq!(
+            ctx.mask,
+            mask_from(&[Permission::ViewOrg, Permission::TriggerEvaluation])
+        );
+        assert!(ctx.organization.is_none());
+        assert_eq!(outcome.user_id(), user_id);
     }
 }

--- a/backend/web/src/authorization/jwt.rs
+++ b/backend/web/src/authorization/jwt.rs
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+use super::api_key::{ApiKeyContext, DecodedRequest};
 use axum::extract::State;
 use axum::http::StatusCode;
 use chrono::{Duration, Utc};
 use gradient_core::types::*;
-use jsonwebtoken::{DecodingKey, EncodingKey, Header, TokenData, Validation, decode, encode};
+use jsonwebtoken::{DecodingKey, EncodingKey, Header, Validation, decode, encode};
 use rand::distr::{Alphanumeric, SampleString};
 use sea_orm::{ActiveModelTrait, ActiveValue::Set, ColumnTrait, EntityTrait, QueryFilter};
 use serde::{Deserialize, Serialize};
@@ -119,7 +120,7 @@ pub async fn create_session_and_token(
 pub async fn decode_jwt(
     state: State<Arc<ServerState>>,
     jwt: String,
-) -> Result<TokenData<Cliams>, StatusCode> {
+) -> Result<DecodedRequest, StatusCode> {
     if let Some(raw) = jwt.strip_prefix("GRAD") {
         return decode_api_key(state, raw).await;
     }
@@ -149,13 +150,15 @@ pub async fn decode_jwt(
     active.last_used_at = Set(now);
     let _ = active.update(&state.web_db).await;
 
-    Ok(token_data)
+    Ok(DecodedRequest::Session {
+        user_id: token_data.claims.id,
+    })
 }
 
 async fn decode_api_key(
     state: State<Arc<ServerState>>,
     raw: &str,
-) -> Result<TokenData<Cliams>, StatusCode> {
+) -> Result<DecodedRequest, StatusCode> {
     let key_hash = hash_api_key(raw);
     let api_key = EApi::find()
         .filter(CApi::Key.eq(key_hash))
@@ -174,22 +177,21 @@ async fn decode_api_key(
         return Err(StatusCode::UNAUTHORIZED);
     }
 
-    let mut aapi_key: AApi = api_key.clone().into();
+    let context = ApiKeyContext {
+        api_id: api_key.id,
+        mask: api_key.permission,
+        organization: api_key.organization,
+    };
+    let user_id = api_key.owned_by;
+
+    let mut aapi_key: AApi = api_key.into();
     aapi_key.last_used_at = Set(now);
     aapi_key
         .save(&state.web_db)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    Ok(TokenData {
-        claims: Cliams {
-            exp: 0,
-            iat: api_key.created_at.and_utc().timestamp() as usize,
-            id: api_key.owned_by,
-            jti: SessionId::nil(),
-        },
-        header: Default::default(),
-    })
+    Ok(DecodedRequest::ApiKey { user_id, context })
 }
 
 pub fn encode_download_token(

--- a/backend/web/src/authorization/middleware.rs
+++ b/backend/web/src/authorization/middleware.rs
@@ -14,6 +14,7 @@ use gradient_core::types::*;
 use sea_orm::{ActiveModelTrait, ActiveValue::Set, EntityTrait};
 use std::sync::Arc;
 
+use super::api_key::MaybeApiKey;
 use super::jwt::{decode_jwt, extract_bearer_or_cookie, token_from_cookie};
 use crate::audit::{RequestInfo, events, record as audit_record};
 use crate::error::{WebError, WebResult};
@@ -106,7 +107,7 @@ pub async fn authorize(
         return Err(WebError::forbidden("Authorization header not found"));
     };
 
-    let token_data = match decode_jwt(state.clone(), token_str).await {
+    let decoded = match decode_jwt(state.clone(), token_str).await {
         Ok(t) => t,
         Err(_) => {
             audit_deny(&state, None, info, method, path, "Unable to decode token").await;
@@ -114,26 +115,22 @@ pub async fn authorize(
         }
     };
 
-    let current_user = match EUser::find_by_id(token_data.claims.id)
-        .one(&state.web_db)
-        .await?
-    {
+    let user_id = decoded.user_id();
+    let api_key_extension = match decoded.api_key_context() {
+        Some(ctx) => MaybeApiKey::from_key(*ctx),
+        None => MaybeApiKey::none(),
+    };
+
+    let current_user = match EUser::find_by_id(user_id).one(&state.web_db).await? {
         Some(u) => u,
         None => {
-            audit_deny(
-                &state,
-                Some(token_data.claims.id),
-                info,
-                method,
-                path,
-                "User not found",
-            )
-            .await;
+            audit_deny(&state, Some(user_id), info, method, path, "User not found").await;
             return Err(WebError::unauthorized("User not found"));
         }
     };
 
     req.extensions_mut().insert(current_user);
+    req.extensions_mut().insert(api_key_extension);
     Ok(next.run(req).await)
 }
 
@@ -146,20 +143,24 @@ pub async fn authorize_optional(
     mut req: Request,
     next: Next,
 ) -> Response<Body> {
-    let maybe_user = if let Some(token_str) = extract_bearer_or_cookie(req.headers()) {
-        if let Ok(token_data) = decode_jwt(State(Arc::clone(&state)), token_str).await {
-            EUser::find_by_id(token_data.claims.id)
-                .one(&state.web_db)
-                .await
-                .ok()
-                .flatten()
-        } else {
-            None
+    let mut maybe_user: Option<MUser> = None;
+    let mut maybe_api_key = MaybeApiKey::none();
+
+    if let Some(token_str) = extract_bearer_or_cookie(req.headers())
+        && let Ok(decoded) = decode_jwt(State(Arc::clone(&state)), token_str).await
+    {
+        if let Some(ctx) = decoded.api_key_context() {
+            maybe_api_key = MaybeApiKey::from_key(*ctx);
         }
-    } else {
-        None
-    };
+        maybe_user = EUser::find_by_id(decoded.user_id())
+            .one(&state.web_db)
+            .await
+            .ok()
+            .flatten();
+    }
+
     req.extensions_mut().insert(MaybeUser(maybe_user));
+    req.extensions_mut().insert(maybe_api_key);
     next.run(req).await
 }
 

--- a/backend/web/src/authorization/mod.rs
+++ b/backend/web/src/authorization/mod.rs
@@ -9,7 +9,7 @@ mod jwt;
 mod middleware;
 mod oidc;
 
-pub use self::api_key::{ApiKeyContext, MaybeApiKey};
+pub use self::api_key::{ApiKeyContext, DecodedRequest, MaybeApiKey};
 pub use self::jwt::{
     Cliams, DownloadClaims, create_session_and_token, decode_download_token, decode_jwt,
     encode_download_token, extract_bearer_or_cookie, generate_api_key, hash_api_key,

--- a/backend/web/src/authorization/mod.rs
+++ b/backend/web/src/authorization/mod.rs
@@ -4,10 +4,12 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+mod api_key;
 mod jwt;
 mod middleware;
 mod oidc;
 
+pub use self::api_key::{ApiKeyContext, MaybeApiKey};
 pub use self::jwt::{
     Cliams, DownloadClaims, create_session_and_token, decode_download_token, decode_jwt,
     encode_download_token, extract_bearer_or_cookie, generate_api_key, hash_api_key,

--- a/backend/web/src/endpoints/badges.rs
+++ b/backend/web/src/endpoints/badges.rs
@@ -235,10 +235,10 @@ async fn resolve_badge_user(
 ) -> Result<Option<MUser>, WebError> {
     match token {
         Some(tok) => {
-            let token_data = crate::authorization::decode_jwt(State(Arc::clone(state)), tok)
+            let decoded = crate::authorization::decode_jwt(State(Arc::clone(state)), tok)
                 .await
                 .map_err(|_| WebError::unauthorized("Invalid token"))?;
-            Ok(EUser::find_by_id(token_data.claims.id)
+            Ok(EUser::find_by_id(decoded.user_id())
                 .one(&state.web_db)
                 .await?)
         }

--- a/backend/web/src/endpoints/badges.rs
+++ b/backend/web/src/endpoints/badges.rs
@@ -27,7 +27,7 @@ use serde::Deserialize;
 use std::sync::Arc;
 
 use crate::access::is_org_member;
-use crate::authorization::MaybeUser;
+use crate::authorization::{ApiKeyContext, MaybeApiKey, MaybeUser};
 use crate::error::WebError;
 use crate::helpers::OptionExt;
 use gradient_core::db::get_any_organization_by_name;
@@ -228,21 +228,27 @@ fn badge_for_status(status: Option<EvaluationStatus>, has_failed_builds: bool) -
 // ── Badge access helpers ──────────────────────────────────────────────────────
 
 /// Resolve the caller identity: JWT/API-key `token` overrides the session user.
+///
+/// Returns the resolved user plus any API-key context produced by decoding the
+/// token. When `token` is absent we fall back to the session user and the
+/// extension-supplied `MaybeApiKey`.
 async fn resolve_badge_user(
     state: &Arc<ServerState>,
     maybe_user: Option<MUser>,
+    api_key: MaybeApiKey,
     token: Option<String>,
-) -> Result<Option<MUser>, WebError> {
+) -> Result<(Option<MUser>, Option<ApiKeyContext>), WebError> {
     match token {
         Some(tok) => {
             let decoded = crate::authorization::decode_jwt(State(Arc::clone(state)), tok)
                 .await
                 .map_err(|_| WebError::unauthorized("Invalid token"))?;
-            Ok(EUser::find_by_id(decoded.user_id())
+            let user = EUser::find_by_id(decoded.user_id())
                 .one(&state.web_db)
-                .await?)
+                .await?;
+            Ok((user, decoded.api_key_context().copied()))
         }
-        None => Ok(maybe_user),
+        None => Ok((maybe_user, api_key.as_ref().copied())),
     }
 }
 
@@ -251,13 +257,14 @@ async fn check_badge_org_access(
     state: &Arc<ServerState>,
     org: &MOrganization,
     resolved_user: &Option<MUser>,
+    api_key: Option<&ApiKeyContext>,
 ) -> Result<(), WebError> {
     if org.public {
         return Ok(());
     }
     match resolved_user {
         Some(user) => {
-            if !is_org_member(state, user.id, org.id).await? {
+            if !is_org_member(state, user.id, org.id, api_key).await? {
                 return Err(WebError::not_found("Organization"));
             }
         }
@@ -360,6 +367,7 @@ async fn badge_status_for_latest_eval(
 pub async fn get_project_badge(
     state: State<Arc<ServerState>>,
     axum::Extension(MaybeUser(maybe_user)): axum::Extension<MaybeUser>,
+    axum::Extension(api_key): axum::Extension<MaybeApiKey>,
     Path((organization, project)): Path<(String, String)>,
     Query(params): Query<BadgeParams>,
 ) -> Result<Response, WebError> {
@@ -367,8 +375,9 @@ pub async fn get_project_badge(
         .await?
         .or_not_found("Organization")?;
 
-    let resolved_user = resolve_badge_user(&state, maybe_user, params.token).await?;
-    check_badge_org_access(&state, &organization, &resolved_user).await?;
+    let (resolved_user, resolved_key) =
+        resolve_badge_user(&state, maybe_user, api_key, params.token).await?;
+    check_badge_org_access(&state, &organization, &resolved_user, resolved_key.as_ref()).await?;
 
     let project = EProject::find()
         .filter(CProject::Organization.eq(organization.id))

--- a/backend/web/src/endpoints/builds/downloads.rs
+++ b/backend/web/src/endpoints/builds/downloads.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-use crate::authorization::{MaybeUser, decode_download_token, encode_download_token};
+use crate::authorization::{MaybeApiKey, MaybeUser, decode_download_token, encode_download_token};
 use crate::error::{WebError, WebResult};
 use crate::helpers::ok_json;
 use axum::extract::{Path, Query, State};
@@ -213,9 +213,10 @@ pub struct DownloadQuery {
 pub async fn get_build_downloads(
     state: State<Arc<ServerState>>,
     Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(build_id): Path<BuildId>,
 ) -> WebResult<Json<BaseResponse<Vec<BuildProduct>>>> {
-    let ctx = BuildAccessContext::load(&state, build_id, &maybe_user).await?;
+    let ctx = BuildAccessContext::load(&state, build_id, &maybe_user, api_key.as_ref()).await?;
 
     let build_outputs = EDerivationOutput::find()
         .filter(CDerivationOutput::Derivation.eq(ctx.build.derivation))
@@ -230,9 +231,10 @@ pub async fn get_build_downloads(
 pub async fn get_build_download_token(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(build_id): Path<BuildId>,
 ) -> WebResult<Json<BaseResponse<String>>> {
-    BuildAccessContext::load(&state, build_id, &Some(user)).await?;
+    BuildAccessContext::load(&state, build_id, &Some(user), api_key.as_ref()).await?;
 
     let token = encode_download_token(State(Arc::clone(&state)), build_id)
         .map_err(|_| WebError::failed_to_generate_token())?;
@@ -243,6 +245,7 @@ pub async fn get_build_download_token(
 pub async fn get_build_download(
     state: State<Arc<ServerState>>,
     Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((build_id, filename)): Path<(BuildId, String)>,
     Query(query): Query<DownloadQuery>,
 ) -> Result<Response, WebError> {
@@ -259,7 +262,7 @@ pub async fn get_build_download(
         match maybe_user {
             Some(user) => {
                 use crate::access::is_org_member;
-                if !is_org_member(&state, user.id, ctx.organization.id).await? {
+                if !is_org_member(&state, user.id, ctx.organization.id, api_key.as_ref()).await? {
                     return Err(WebError::not_found("Build"));
                 }
             }

--- a/backend/web/src/endpoints/builds/graph.rs
+++ b/backend/web/src/endpoints/builds/graph.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-use crate::authorization::MaybeUser;
+use crate::authorization::{ApiKeyContext, MaybeApiKey, MaybeUser};
 use crate::error::WebResult;
 use crate::helpers::{OptionExt, ok_json};
 use axum::extract::{Path, State};
@@ -30,9 +30,10 @@ pub(super) fn extract_drv_name(path: &str) -> String {
 pub(super) async fn authorize_build_opt(
     state: &Arc<ServerState>,
     maybe_user: &Option<MUser>,
+    api_key: Option<&ApiKeyContext>,
     build_id: BuildId,
 ) -> WebResult<()> {
-    BuildAccessContext::load(state, build_id, maybe_user)
+    BuildAccessContext::load(state, build_id, maybe_user, api_key)
         .await
         .map(|_| ())
 }
@@ -161,9 +162,10 @@ async fn process_graph_wave(
 pub async fn get_build_dependencies(
     state: State<Arc<ServerState>>,
     Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(build_id): Path<BuildId>,
 ) -> WebResult<Json<BaseResponse<Vec<DependencyNode>>>> {
-    authorize_build_opt(&state, &maybe_user, build_id).await?;
+    authorize_build_opt(&state, &maybe_user, api_key.as_ref(), build_id).await?;
 
     let build = EBuild::find_by_id(build_id)
         .one(&state.web_db)
@@ -211,9 +213,10 @@ pub async fn get_build_dependencies(
 pub async fn get_build_graph(
     state: State<Arc<ServerState>>,
     Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(build_id): Path<BuildId>,
 ) -> WebResult<Json<BaseResponse<BuildGraph>>> {
-    authorize_build_opt(&state, &maybe_user, build_id).await?;
+    authorize_build_opt(&state, &maybe_user, api_key.as_ref(), build_id).await?;
 
     let root_build = EBuild::find_by_id(build_id)
         .one(&state.web_db)

--- a/backend/web/src/endpoints/builds/graph.rs
+++ b/backend/web/src/endpoints/builds/graph.rs
@@ -29,9 +29,9 @@ pub(super) fn extract_drv_name(path: &str) -> String {
 
 pub(super) async fn authorize_build_opt(
     state: &Arc<ServerState>,
+    build_id: BuildId,
     maybe_user: &Option<MUser>,
     api_key: Option<&ApiKeyContext>,
-    build_id: BuildId,
 ) -> WebResult<()> {
     BuildAccessContext::load(state, build_id, maybe_user, api_key)
         .await
@@ -165,7 +165,7 @@ pub async fn get_build_dependencies(
     Extension(api_key): Extension<MaybeApiKey>,
     Path(build_id): Path<BuildId>,
 ) -> WebResult<Json<BaseResponse<Vec<DependencyNode>>>> {
-    authorize_build_opt(&state, &maybe_user, api_key.as_ref(), build_id).await?;
+    authorize_build_opt(&state, build_id, &maybe_user, api_key.as_ref()).await?;
 
     let build = EBuild::find_by_id(build_id)
         .one(&state.web_db)
@@ -216,7 +216,7 @@ pub async fn get_build_graph(
     Extension(api_key): Extension<MaybeApiKey>,
     Path(build_id): Path<BuildId>,
 ) -> WebResult<Json<BaseResponse<BuildGraph>>> {
-    authorize_build_opt(&state, &maybe_user, api_key.as_ref(), build_id).await?;
+    authorize_build_opt(&state, build_id, &maybe_user, api_key.as_ref()).await?;
 
     let root_build = EBuild::find_by_id(build_id)
         .one(&state.web_db)

--- a/backend/web/src/endpoints/builds/log.rs
+++ b/backend/web/src/endpoints/builds/log.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-use crate::authorization::MaybeUser;
+use crate::authorization::{MaybeApiKey, MaybeUser};
 use crate::error::{WebError, WebResult};
 use crate::helpers::ok_json;
 use async_stream::stream;
@@ -23,9 +23,10 @@ use super::BuildAccessContext;
 pub async fn get_build_log(
     state: State<Arc<ServerState>>,
     Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(build_id): Path<BuildId>,
 ) -> WebResult<Json<BaseResponse<String>>> {
-    let ctx = BuildAccessContext::load(&state, build_id, &maybe_user).await?;
+    let ctx = BuildAccessContext::load(&state, build_id, &maybe_user, api_key.as_ref()).await?;
     let log_key = ctx.build.log_id.unwrap_or(build_id);
     let log = state.log_storage.read(log_key).await.unwrap_or_default();
 
@@ -35,9 +36,10 @@ pub async fn get_build_log(
 pub async fn post_build_log(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(build_id): Path<BuildId>,
 ) -> Result<Response, WebError> {
-    let ctx = BuildAccessContext::load(&state, build_id, &Some(user)).await?;
+    let ctx = BuildAccessContext::load(&state, build_id, &Some(user), api_key.as_ref()).await?;
 
     // Capture current log length so the stream only delivers new content,
     // avoiding duplication of what the client already received via GET.

--- a/backend/web/src/endpoints/builds/mod.rs
+++ b/backend/web/src/endpoints/builds/mod.rs
@@ -23,6 +23,7 @@ pub use self::log::{get_build_log, post_build_log};
 pub use self::query::{BuildWithOutputs, get_build};
 
 use crate::access::is_org_member;
+use crate::authorization::ApiKeyContext;
 use crate::error::{WebError, WebResult};
 use crate::helpers::OptionExt;
 use gradient_core::types::*;
@@ -111,6 +112,7 @@ impl BuildAccessContext {
         state: &Arc<ServerState>,
         build_id: BuildId,
         maybe_user: &Option<MUser>,
+        api_key: Option<&ApiKeyContext>,
     ) -> WebResult<Self> {
         let ctx = Self::load_unguarded(state, build_id).await?;
 
@@ -118,7 +120,7 @@ impl BuildAccessContext {
             true
         } else {
             match maybe_user {
-                Some(user) => is_org_member(state, user.id, ctx.organization.id).await?,
+                Some(user) => is_org_member(state, user.id, ctx.organization.id, api_key).await?,
                 None => false,
             }
         };

--- a/backend/web/src/endpoints/builds/query.rs
+++ b/backend/web/src/endpoints/builds/query.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-use crate::authorization::MaybeUser;
+use crate::authorization::{MaybeApiKey, MaybeUser};
 use crate::error::{WebError, WebResult};
 use crate::helpers::ok_json;
 use axum::extract::{Path, State};
@@ -39,9 +39,10 @@ pub struct BuildWithOutputs {
 pub async fn get_build(
     state: State<Arc<ServerState>>,
     Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(build_id): Path<BuildId>,
 ) -> WebResult<Json<BaseResponse<BuildWithOutputs>>> {
-    let ctx = BuildAccessContext::load(&state, build_id, &maybe_user).await?;
+    let ctx = BuildAccessContext::load(&state, build_id, &maybe_user, api_key.as_ref()).await?;
     let build = ctx.build;
 
     let derivation = EDerivation::find_by_id(build.derivation)

--- a/backend/web/src/endpoints/caches/helpers.rs
+++ b/backend/web/src/endpoints/caches/helpers.rs
@@ -26,13 +26,13 @@ async fn try_authenticate_basic(state: &Arc<ServerState>, headers: &HeaderMap) -
     let auth = headers.get(axum::http::header::AUTHORIZATION)?;
     let val = auth.to_str().ok()?;
     let encoded = val.strip_prefix("Basic ")?;
-    let decoded = base64::engine::general_purpose::STANDARD
+    let bytes = base64::engine::general_purpose::STANDARD
         .decode(encoded)
         .ok()?;
-    let creds = String::from_utf8(decoded).ok()?;
+    let creds = String::from_utf8(bytes).ok()?;
     let password = creds.split_once(':').map(|(_, p)| p)?.to_string();
-    let token_data = decode_jwt(State(Arc::clone(state)), password).await.ok()?;
-    EUser::find_by_id(token_data.claims.id)
+    let decoded = decode_jwt(State(Arc::clone(state)), password).await.ok()?;
+    EUser::find_by_id(decoded.user_id())
         .one(&state.web_db)
         .await
         .ok()

--- a/backend/web/src/endpoints/evals/actions.rs
+++ b/backend/web/src/endpoints/evals/actions.rs
@@ -5,6 +5,7 @@
  */
 
 use crate::access::is_org_member;
+use crate::authorization::MaybeApiKey;
 use crate::error::{WebError, WebResult};
 use crate::helpers::ok_json;
 use axum::extract::{Path, State};
@@ -18,14 +19,16 @@ use super::types::MakeEvaluationRequest;
 pub async fn post_evaluation(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Extension(scheduler): Extension<Arc<scheduler::Scheduler>>,
     Path(evaluation_id): Path<EvaluationId>,
     Json(body): Json<MakeEvaluationRequest>,
 ) -> WebResult<Json<BaseResponse<String>>> {
-    let ctx = EvalAccessContext::load(&state, evaluation_id, &Some(user.clone())).await?;
+    let api_key_ref = api_key.as_ref();
+    let ctx = EvalAccessContext::load(&state, evaluation_id, &Some(user.clone()), api_key_ref).await?;
 
     // Mutations require explicit org membership even when the org is public.
-    if !is_org_member(&state, user.id, ctx.organization_id).await? {
+    if !is_org_member(&state, user.id, ctx.organization_id, api_key_ref).await? {
         return Err(WebError::not_found("Evaluation"));
     }
 

--- a/backend/web/src/endpoints/evals/log.rs
+++ b/backend/web/src/endpoints/evals/log.rs
@@ -5,6 +5,7 @@
  */
 
 use crate::access::is_org_member;
+use crate::authorization::MaybeApiKey;
 use crate::error::WebError;
 use async_stream::stream;
 use axum::Extension;
@@ -22,12 +23,14 @@ use super::types::drv_display_name;
 pub async fn post_evaluation_builds(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(evaluation_id): Path<EvaluationId>,
 ) -> Result<StreamBodyAs<'static>, WebError> {
-    let ctx = EvalAccessContext::load(&state, evaluation_id, &Some(user.clone())).await?;
+    let api_key_ref = api_key.as_ref();
+    let ctx = EvalAccessContext::load(&state, evaluation_id, &Some(user.clone()), api_key_ref).await?;
 
     // Streaming log access requires org membership (not just public read access).
-    if !is_org_member(&state, user.id, ctx.organization_id).await? {
+    if !is_org_member(&state, user.id, ctx.organization_id, api_key_ref).await? {
         return Err(WebError::not_found("Evaluation"));
     }
 

--- a/backend/web/src/endpoints/evals/mod.rs
+++ b/backend/web/src/endpoints/evals/mod.rs
@@ -15,6 +15,7 @@ pub use self::query::*;
 pub use self::types::*;
 
 use crate::access::is_org_member;
+use crate::authorization::ApiKeyContext;
 use crate::error::{WebError, WebResult};
 use crate::helpers::OptionExt;
 use gradient_core::types::*;
@@ -40,6 +41,7 @@ impl EvalAccessContext {
         state: &Arc<ServerState>,
         evaluation_id: EvaluationId,
         maybe_user: &Option<MUser>,
+        api_key: Option<&ApiKeyContext>,
     ) -> WebResult<Self> {
         let evaluation = EEvaluation::find_by_id(evaluation_id)
             .one(&state.web_db)
@@ -89,7 +91,7 @@ impl EvalAccessContext {
             true
         } else {
             match maybe_user {
-                Some(user) => is_org_member(state, user.id, organization.id).await?,
+                Some(user) => is_org_member(state, user.id, organization.id, api_key).await?,
                 None => false,
             }
         };

--- a/backend/web/src/endpoints/evals/query.rs
+++ b/backend/web/src/endpoints/evals/query.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-use crate::authorization::MaybeUser;
+use crate::authorization::{MaybeApiKey, MaybeUser};
 use crate::error::WebResult;
 use crate::helpers::ok_json;
 use axum::extract::{Path, Query, State};
@@ -25,9 +25,10 @@ use gradient_core::types::triggers::TriggerType;
 pub async fn get_evaluation(
     state: State<Arc<ServerState>>,
     Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(evaluation_id): Path<EvaluationId>,
 ) -> WebResult<Json<BaseResponse<EvaluationResponse>>> {
-    let ctx = EvalAccessContext::load(&state, evaluation_id, &maybe_user).await?;
+    let ctx = EvalAccessContext::load(&state, evaluation_id, &maybe_user, api_key.as_ref()).await?;
     let evaluation = ctx.evaluation;
 
     let commit_hash = ECommit::find_by_id(evaluation.commit)
@@ -142,10 +143,11 @@ pub async fn get_evaluation(
 pub async fn get_evaluation_builds(
     state: State<Arc<ServerState>>,
     Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(evaluation_id): Path<EvaluationId>,
     Query(query): Query<BuildsQuery>,
 ) -> WebResult<Json<BaseResponse<PaginatedBuilds>>> {
-    let ctx = EvalAccessContext::load(&state, evaluation_id, &maybe_user).await?;
+    let ctx = EvalAccessContext::load(&state, evaluation_id, &maybe_user, api_key.as_ref()).await?;
     let evaluation = ctx.evaluation;
 
     let builds = EBuild::find()
@@ -261,9 +263,10 @@ pub async fn get_evaluation_builds(
 pub async fn get_evaluation_messages(
     state: State<Arc<ServerState>>,
     Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(evaluation_id): Path<EvaluationId>,
 ) -> WebResult<Json<BaseResponse<Vec<EvaluationMessageResponse>>>> {
-    let ctx = EvalAccessContext::load(&state, evaluation_id, &maybe_user).await?;
+    let ctx = EvalAccessContext::load(&state, evaluation_id, &maybe_user, api_key.as_ref()).await?;
     let evaluation = ctx.evaluation;
 
     let messages = EEvaluationMessage::find()

--- a/backend/web/src/endpoints/orgs/integrations.rs
+++ b/backend/web/src/endpoints/orgs/integrations.rs
@@ -16,6 +16,7 @@
 //! "has_secret" / "has_access_token" flag.
 
 use crate::access::{Caller, OrgAccess, load_integration_in_org, load_org};
+use crate::authorization::MaybeApiKey;
 use crate::error::{WebError, WebResult};
 use crate::helpers::ok_json;
 use crate::permissions::Permission;
@@ -143,11 +144,13 @@ fn forge_to_str(f: i16) -> &'static str {
 pub async fn get_integrations(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(organization): Path<String>,
 ) -> WebResult<Json<BaseResponse<Vec<IntegrationResponse>>>> {
     let org = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Require {
             permission: Permission::ManageIntegrations,
@@ -170,12 +173,14 @@ pub async fn get_integrations(
 pub async fn put_integration(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(organization): Path<String>,
     Json(body): Json<CreateIntegrationRequest>,
 ) -> WebResult<Json<BaseResponse<IntegrationResponse>>> {
     let org = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Require {
             permission: Permission::ManageIntegrations,
@@ -266,11 +271,13 @@ pub async fn put_integration(
 pub async fn get_integration(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, integration_id)): Path<(String, IntegrationId)>,
 ) -> WebResult<Json<BaseResponse<IntegrationResponse>>> {
     let org = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Require {
             permission: Permission::ManageIntegrations,
@@ -286,12 +293,14 @@ pub async fn get_integration(
 pub async fn patch_integration(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, integration_id)): Path<(String, IntegrationId)>,
     Json(body): Json<PatchIntegrationRequest>,
 ) -> WebResult<Json<BaseResponse<IntegrationResponse>>> {
     let org = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Require {
             permission: Permission::ManageIntegrations,
@@ -393,11 +402,13 @@ pub async fn patch_integration(
 pub async fn delete_integration(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, integration_id)): Path<(String, IntegrationId)>,
 ) -> WebResult<Json<BaseResponse<bool>>> {
     let org = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Require {
             permission: Permission::ManageIntegrations,

--- a/backend/web/src/endpoints/orgs/management.rs
+++ b/backend/web/src/endpoints/orgs/management.rs
@@ -6,7 +6,7 @@
 
 use crate::access::{Caller, OrgAccess, load_org};
 use crate::audit::{RequestInfo, events, record as audit_record};
-use crate::authorization::MaybeUser;
+use crate::authorization::{MaybeApiKey, MaybeUser};
 use crate::error::{WebError, WebResult};
 use crate::helpers::ok_json;
 use crate::permissions::Permission;
@@ -305,11 +305,13 @@ pub async fn get_public_organizations(
 pub async fn get_organization(
     state: State<Arc<ServerState>>,
     Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(organization): Path<String>,
 ) -> WebResult<Json<BaseResponse<OrgResponse>>> {
     let org = load_org(
         &state.0,
         Caller::from_option(&maybe_user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Readable {
             label: "Organization",
@@ -354,12 +356,14 @@ pub async fn get_organization(
 pub async fn patch_organization(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(organization): Path<String>,
     Json(body): Json<PatchOrganizationRequest>,
 ) -> WebResult<Json<BaseResponse<String>>> {
     let organization = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Require {
             permission: Permission::ManageOrgSettings,
@@ -418,11 +422,13 @@ pub async fn delete_organization(
     state: State<Arc<ServerState>>,
     headers: HeaderMap,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(organization): Path<String>,
 ) -> WebResult<Json<BaseResponse<String>>> {
     let organization = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Require {
             permission: Permission::DeleteOrg,

--- a/backend/web/src/endpoints/orgs/members.rs
+++ b/backend/web/src/endpoints/orgs/members.rs
@@ -6,7 +6,7 @@
 
 use crate::access::{Caller, OrgAccess, load_org};
 use crate::audit::{RequestInfo, events, record as audit_record};
-use crate::authorization::MaybeUser;
+use crate::authorization::{MaybeApiKey, MaybeUser};
 use crate::error::{WebError, WebResult};
 use crate::helpers::{OptionExt, ok_json};
 use crate::permissions::Permission;
@@ -69,11 +69,13 @@ async fn find_org_membership(
 pub async fn get_organization_users(
     state: State<Arc<ServerState>>,
     Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(organization): Path<String>,
 ) -> WebResult<Json<BaseResponse<Vec<StringListItem>>>> {
     let organization = load_org(
         &state.0,
         Caller::from_option(&maybe_user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Readable {
             label: "Organization",
@@ -121,12 +123,14 @@ pub async fn post_organization_users(
     state: State<Arc<ServerState>>,
     headers: HeaderMap,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(organization): Path<String>,
     Json(body): Json<AddUserRequest>,
 ) -> WebResult<Json<BaseResponse<String>>> {
     let organization = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Require {
             permission: Permission::ManageMembers,
@@ -185,12 +189,14 @@ pub async fn patch_organization_users(
     state: State<Arc<ServerState>>,
     headers: HeaderMap,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(organization): Path<String>,
     Json(body): Json<AddUserRequest>,
 ) -> WebResult<Json<BaseResponse<String>>> {
     let organization = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Require {
             permission: Permission::ManageMembers,
@@ -243,12 +249,14 @@ pub async fn delete_organization_users(
     state: State<Arc<ServerState>>,
     headers: HeaderMap,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(organization): Path<String>,
     Json(body): Json<RemoveUserRequest>,
 ) -> WebResult<Json<BaseResponse<String>>> {
     let organization = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Require {
             permission: Permission::ManageMembers,

--- a/backend/web/src/endpoints/orgs/roles.rs
+++ b/backend/web/src/endpoints/orgs/roles.rs
@@ -18,7 +18,8 @@ use crate::authorization::MaybeApiKey;
 use crate::error::{WebError, WebResult};
 use crate::helpers::{OptionExt, ok_json};
 use crate::permissions::{
-    self, Permission, PermissionMask, is_builtin_role, mask_from, mask_to_vec,
+    Permission, PermissionEntry, available_permissions, is_builtin_role, mask_to_vec,
+    parse_permission_list,
 };
 use axum::extract::{Path, State};
 use axum::http::HeaderMap;
@@ -65,12 +66,6 @@ impl RoleResponse {
 }
 
 #[derive(Serialize, Debug)]
-pub struct PermissionEntry {
-    pub id: &'static str,
-    pub mutating: bool,
-}
-
-#[derive(Serialize, Debug)]
 pub struct RoleListResponse {
     /// Roles available in this org: the three built-ins plus any custom
     /// roles owned by the org.
@@ -96,20 +91,6 @@ pub struct PatchRoleRequest {
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-fn parse_permissions(wire: &[String]) -> WebResult<PermissionMask> {
-    let mut perms = Vec::with_capacity(wire.len());
-    for w in wire {
-        let parsed = Permission::from_wire_name(w).ok_or_else(|| {
-            WebError::bad_request(format!(
-                "Unknown permission '{}'. See GET /orgs/{{organization}}/roles for the catalogue.",
-                w
-            ))
-        })?;
-        perms.push(parsed);
-    }
-    Ok(mask_from(&perms))
-}
-
 async fn load_org_role(
     state: &Arc<ServerState>,
     org_id: OrganizationId,
@@ -128,17 +109,6 @@ async fn load_org_role(
     }
 
     Ok(role)
-}
-
-fn available_permissions() -> Vec<PermissionEntry> {
-    Permission::ALL
-        .iter()
-        .copied()
-        .map(|p| PermissionEntry {
-            id: p.as_wire_name(),
-            mutating: permissions::is_mutating(p),
-        })
-        .collect()
 }
 
 // ── Handlers ──────────────────────────────────────────────────────────────────
@@ -205,7 +175,7 @@ pub async fn post_organization_role(
         return Err(WebError::invalid_name("Role Name"));
     }
 
-    let mask = parse_permissions(&body.permissions)?;
+    let mask = parse_permission_list(&body.permissions, "GET /orgs/{organization}/roles")?;
 
     // Names must be unique within (org_id, name) and must not collide with a
     // built-in role's name (Admin/Write/View) — otherwise membership lookup
@@ -327,7 +297,8 @@ pub async fn patch_organization_role(
     }
 
     if let Some(perms) = body.permissions {
-        active.permission = Set(parse_permissions(&perms)?);
+        active.permission =
+            Set(parse_permission_list(&perms, "GET /orgs/{organization}/roles")?);
     }
 
     let updated = active.update(&state.web_db).await?;

--- a/backend/web/src/endpoints/orgs/roles.rs
+++ b/backend/web/src/endpoints/orgs/roles.rs
@@ -14,6 +14,7 @@
 
 use crate::access::{Caller, OrgAccess, load_org};
 use crate::audit::{RequestInfo, events, record as audit_record};
+use crate::authorization::MaybeApiKey;
 use crate::error::{WebError, WebResult};
 use crate::helpers::{OptionExt, ok_json};
 use crate::permissions::{
@@ -150,11 +151,13 @@ fn available_permissions() -> Vec<PermissionEntry> {
 pub async fn get_organization_roles(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(organization): Path<String>,
 ) -> WebResult<Json<BaseResponse<RoleListResponse>>> {
     let org = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Member {
             reject_managed: false,
@@ -182,12 +185,14 @@ pub async fn post_organization_role(
     state: State<Arc<ServerState>>,
     headers: HeaderMap,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(organization): Path<String>,
     Json(body): Json<CreateRoleRequest>,
 ) -> WebResult<Json<BaseResponse<RoleResponse>>> {
     let org = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Require {
             permission: Permission::ManageRoles,
@@ -249,11 +254,13 @@ pub async fn post_organization_role(
 pub async fn get_organization_role(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, role_id)): Path<(String, RoleId)>,
 ) -> WebResult<Json<BaseResponse<RoleResponse>>> {
     let org = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Member {
             reject_managed: false,
@@ -271,12 +278,14 @@ pub async fn patch_organization_role(
     state: State<Arc<ServerState>>,
     headers: HeaderMap,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, role_id)): Path<(String, RoleId)>,
     Json(body): Json<PatchRoleRequest>,
 ) -> WebResult<Json<BaseResponse<RoleResponse>>> {
     let org = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Require {
             permission: Permission::ManageRoles,
@@ -351,11 +360,13 @@ pub async fn delete_organization_role(
     state: State<Arc<ServerState>>,
     headers: HeaderMap,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, role_id)): Path<(String, RoleId)>,
 ) -> WebResult<Json<BaseResponse<bool>>> {
     let org = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Require {
             permission: Permission::ManageRoles,

--- a/backend/web/src/endpoints/orgs/roles.rs
+++ b/backend/web/src/endpoints/orgs/roles.rs
@@ -43,6 +43,9 @@ pub struct RoleResponse {
     pub organization: Option<OrganizationId>,
     /// True for the three immutable system roles (Admin/Write/View).
     pub builtin: bool,
+    /// True for roles provisioned from `gradient-state.nix`. Managed roles
+    /// are immutable through this API (the same way built-in roles are).
+    pub managed: bool,
     /// Capability identifiers (camelCase) granted by this role; matches the
     /// strings produced by [`Permission::as_wire_name`].
     pub permissions: Vec<&'static str>,
@@ -60,6 +63,7 @@ impl RoleResponse {
             name: role.name,
             organization: role.organization,
             builtin,
+            managed: role.managed,
             permissions,
         }
     }
@@ -198,6 +202,7 @@ pub async fn post_organization_role(
         name: Set(body.name.clone()),
         organization: Set(Some(org.id)),
         permission: Set(mask),
+        managed: Set(false),
     }
     .insert(&state.web_db)
     .await?;
@@ -269,6 +274,12 @@ pub async fn patch_organization_role(
     if is_builtin_role(role.id) {
         return Err(WebError::forbidden(
             "Built-in roles (Admin, Write, View) cannot be modified.",
+        ));
+    }
+
+    if role.managed {
+        return Err(WebError::forbidden(
+            "State-managed roles cannot be modified via the API.",
         ));
     }
 
@@ -351,6 +362,12 @@ pub async fn delete_organization_role(
     if is_builtin_role(role.id) {
         return Err(WebError::forbidden(
             "Built-in roles (Admin, Write, View) cannot be deleted.",
+        ));
+    }
+
+    if role.managed {
+        return Err(WebError::forbidden(
+            "State-managed roles cannot be deleted via the API.",
         ));
     }
 

--- a/backend/web/src/endpoints/orgs/settings.rs
+++ b/backend/web/src/endpoints/orgs/settings.rs
@@ -5,6 +5,7 @@
  */
 
 use crate::access::{Caller, OrgAccess, load_org};
+use crate::authorization::MaybeApiKey;
 use crate::error::{WebError, WebResult};
 use crate::helpers::{OptionExt, ok_json};
 use crate::permissions::Permission;
@@ -56,11 +57,13 @@ async fn load_subscribable_cache(
 pub async fn post_organization_public(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(organization): Path<String>,
 ) -> WebResult<Json<BaseResponse<String>>> {
     let org = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Require {
             permission: Permission::ManageOrgSettings,
@@ -78,11 +81,13 @@ pub async fn post_organization_public(
 pub async fn delete_organization_public(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(organization): Path<String>,
 ) -> WebResult<Json<BaseResponse<String>>> {
     let org = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Require {
             permission: Permission::ManageOrgSettings,
@@ -100,11 +105,13 @@ pub async fn delete_organization_public(
 pub async fn get_organization_subscribe(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(organization): Path<String>,
 ) -> WebResult<Json<BaseResponse<Vec<CacheSubscriptionItem>>>> {
     let org = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Member {
             reject_managed: false,
@@ -134,12 +141,14 @@ pub async fn get_organization_subscribe(
 pub async fn post_organization_subscribe_cache(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, cache)): Path<(String, String)>,
     body: Option<Json<SubscribeCacheRequest>>,
 ) -> WebResult<Json<BaseResponse<String>>> {
     let org = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Require {
             permission: Permission::ManageSubscriptions,
@@ -255,11 +264,13 @@ async fn enqueue_backfill_signatures(
 pub async fn delete_organization_subscribe_cache(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, cache)): Path<(String, String)>,
 ) -> WebResult<Json<BaseResponse<String>>> {
     let org = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Require {
             permission: Permission::ManageSubscriptions,

--- a/backend/web/src/endpoints/orgs/ssh.rs
+++ b/backend/web/src/endpoints/orgs/ssh.rs
@@ -5,6 +5,7 @@
  */
 
 use crate::access::{Caller, OrgAccess, load_org};
+use crate::authorization::MaybeApiKey;
 use crate::error::{WebError, WebResult};
 use crate::helpers::ok_json;
 use crate::permissions::Permission;
@@ -19,11 +20,13 @@ use std::sync::Arc;
 pub async fn get_organization_ssh(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(organization): Path<String>,
 ) -> WebResult<Json<BaseResponse<String>>> {
     let organization = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Member {
             reject_managed: false,
@@ -40,11 +43,13 @@ pub async fn get_organization_ssh(
 pub async fn post_organization_ssh(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(organization): Path<String>,
 ) -> WebResult<Json<BaseResponse<String>>> {
     let organization = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Require {
             permission: Permission::ManageSshKey,

--- a/backend/web/src/endpoints/orgs/workers.rs
+++ b/backend/web/src/endpoints/orgs/workers.rs
@@ -5,6 +5,7 @@
  */
 
 use crate::access::{Caller, OrgAccess, load_org};
+use crate::authorization::MaybeApiKey;
 use axum::extract::{Path, State};
 use axum::{Extension, Json};
 use base64::Engine as _;
@@ -111,12 +112,14 @@ pub async fn post_org_worker(
     state: State<Arc<ServerState>>,
     Path(organization): Path<String>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Extension(scheduler): Extension<Arc<Scheduler>>,
     Json(body): Json<RegisterWorkerRequest>,
 ) -> WebResult<Json<BaseResponse<RegisterWorkerResponse>>> {
     let org = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Member {
             reject_managed: false,
@@ -184,11 +187,13 @@ pub async fn get_org_workers(
     state: State<Arc<ServerState>>,
     Path(organization): Path<String>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Extension(scheduler): Extension<Arc<Scheduler>>,
 ) -> WebResult<Json<BaseResponse<Vec<OrgWorkerEntry>>>> {
     let org = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Member {
             reject_managed: false,
@@ -254,12 +259,14 @@ pub async fn patch_org_worker(
     state: State<Arc<ServerState>>,
     Path((organization, worker_id)): Path<(String, String)>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Extension(scheduler): Extension<Arc<Scheduler>>,
     Json(body): Json<PatchWorkerRequest>,
 ) -> WebResult<Json<BaseResponse<String>>> {
     let org = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Member {
             reject_managed: false,
@@ -318,11 +325,13 @@ pub async fn delete_org_worker(
     state: State<Arc<ServerState>>,
     Path((organization, worker_id)): Path<(String, String)>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Extension(scheduler): Extension<Arc<Scheduler>>,
 ) -> WebResult<Json<BaseResponse<String>>> {
     let org = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Member {
             reject_managed: false,

--- a/backend/web/src/endpoints/projects/evaluations.rs
+++ b/backend/web/src/endpoints/projects/evaluations.rs
@@ -8,7 +8,7 @@ use super::{
     EntryPointSummary, EvaluationSummary, EvaluationTriggerSummary, ProjectDetailsResponse,
 };
 use crate::access::{Caller, ProjectAccess, has_permission, is_org_member, load_project};
-use crate::authorization::MaybeUser;
+use crate::authorization::{MaybeApiKey, MaybeUser};
 use crate::endpoints::content_type_for_filename;
 use crate::error::{WebError, WebResult};
 use crate::helpers::{OptionExt, ok_json};
@@ -174,12 +174,14 @@ pub(super) async fn evaluations_to_summaries(
 pub async fn post_project_evaluate(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, project)): Path<(String, String)>,
     body: Option<Json<EvaluateRequest>>,
 ) -> WebResult<Json<BaseResponse<String>>> {
     let (_organization, project) = load_project(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         project,
         ProjectAccess::Require {
@@ -250,11 +252,13 @@ pub async fn post_project_evaluate(
 pub async fn get_project_evaluations(
     state: State<Arc<ServerState>>,
     Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, project)): Path<(String, String)>,
 ) -> WebResult<Json<BaseResponse<Vec<EvaluationSummary>>>> {
     let (_organization, project) = load_project(
         &state,
         Caller::from_option(&maybe_user),
+        api_key.as_ref(),
         organization,
         project,
         ProjectAccess::Readable,
@@ -276,11 +280,14 @@ pub async fn get_project_evaluations(
 pub async fn get_project_details(
     state: State<Arc<ServerState>>,
     Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, project)): Path<(String, String)>,
 ) -> WebResult<Json<BaseResponse<ProjectDetailsResponse>>> {
+    let api_key_ref = api_key.as_ref();
     let (organization, project) = load_project(
         &state,
         Caller::from_option(&maybe_user),
+        api_key_ref,
         organization,
         project,
         ProjectAccess::Readable,
@@ -299,7 +306,7 @@ pub async fn get_project_details(
 
     let can_edit = match &maybe_user {
         Some(user) => {
-            has_permission(&state, user.id, organization.id, Permission::EditProject).await?
+            has_permission(&state, user.id, organization.id, Permission::EditProject, api_key_ref).await?
         }
         None => false,
     };
@@ -334,12 +341,14 @@ pub struct EntryPointsQuery {
 pub async fn get_project_entry_points(
     state: State<Arc<ServerState>>,
     Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, project)): Path<(String, String)>,
     Query(params): Query<EntryPointsQuery>,
 ) -> WebResult<Json<BaseResponse<Vec<EntryPointSummary>>>> {
     let (_organization, project) = load_project(
         &state,
         Caller::from_option(&maybe_user),
+        api_key.as_ref(),
         organization,
         project,
         ProjectAccess::Readable,
@@ -634,6 +643,7 @@ async fn serve_hydra_artifact(
 pub async fn get_entry_point_download(
     state: State<Arc<ServerState>>,
     Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, project)): Path<(String, String)>,
     Query(params): Query<EntryPointDownloadQuery>,
 ) -> Result<Response, WebError> {
@@ -649,21 +659,24 @@ pub async fn get_entry_point_download(
         .or_not_found("Project")?;
 
     // Resolve caller identity from ?token= (API key / JWT) or existing session.
-    let resolved_user: Option<MUser> = if let Some(token_str) = params.token {
+    // When a token is supplied it provides its own ApiKeyContext; otherwise the
+    // middleware-supplied extension applies.
+    let (resolved_user, resolved_key) = if let Some(token_str) = params.token {
         let decoded = crate::authorization::decode_jwt(State(Arc::clone(&state)), token_str)
             .await
             .map_err(|_| WebError::unauthorized("Invalid token"))?;
-        EUser::find_by_id(decoded.user_id())
+        let user = EUser::find_by_id(decoded.user_id())
             .one(&state.web_db)
-            .await?
+            .await?;
+        (user, decoded.api_key_context().copied())
     } else {
-        maybe_user
+        (maybe_user, api_key.as_ref().copied())
     };
 
     if !organization.public {
         match resolved_user {
             Some(ref user) => {
-                if !is_org_member(&state, user.id, organization.id).await? {
+                if !is_org_member(&state, user.id, organization.id, resolved_key.as_ref()).await? {
                     return Err(WebError::not_found("Project"));
                 }
             }

--- a/backend/web/src/endpoints/projects/evaluations.rs
+++ b/backend/web/src/endpoints/projects/evaluations.rs
@@ -650,10 +650,10 @@ pub async fn get_entry_point_download(
 
     // Resolve caller identity from ?token= (API key / JWT) or existing session.
     let resolved_user: Option<MUser> = if let Some(token_str) = params.token {
-        let token_data = crate::authorization::decode_jwt(State(Arc::clone(&state)), token_str)
+        let decoded = crate::authorization::decode_jwt(State(Arc::clone(&state)), token_str)
             .await
             .map_err(|_| WebError::unauthorized("Invalid token"))?;
-        EUser::find_by_id(token_data.claims.id)
+        EUser::find_by_id(decoded.user_id())
             .one(&state.web_db)
             .await?
     } else {

--- a/backend/web/src/endpoints/projects/integrations.rs
+++ b/backend/web/src/endpoints/projects/integrations.rs
@@ -7,7 +7,7 @@
 //! Link a project to named org-level integrations (inbound + outbound).
 
 use crate::access::{Caller, ProjectAccess, load_project};
-use crate::authorization::MaybeUser;
+use crate::authorization::{MaybeApiKey, MaybeUser};
 use crate::error::{WebError, WebResult};
 use crate::helpers::{OptionExt, ok_json};
 use crate::permissions::Permission;
@@ -71,12 +71,14 @@ async fn validate_integration(
 pub async fn get_project_integration(
     state: State<Arc<ServerState>>,
     Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, project)): Path<(String, String)>,
 ) -> WebResult<Json<BaseResponse<ProjectIntegrationResponse>>> {
     let user = maybe_user.ok_or_else(|| WebError::unauthorized("Authentication required."))?;
     let (_org, proj) = load_project(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         project,
         ProjectAccess::Member,
@@ -102,12 +104,14 @@ pub async fn get_project_integration(
 pub async fn put_project_integration(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, project)): Path<(String, String)>,
     Json(body): Json<PutProjectIntegrationRequest>,
 ) -> WebResult<Json<BaseResponse<ProjectIntegrationResponse>>> {
     let (org, proj) = load_project(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         project,
         ProjectAccess::Require {
@@ -148,11 +152,13 @@ pub async fn put_project_integration(
 pub async fn delete_project_integration(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, project)): Path<(String, String)>,
 ) -> WebResult<Json<BaseResponse<bool>>> {
     let (_org, proj) = load_project(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         project,
         ProjectAccess::Require {

--- a/backend/web/src/endpoints/projects/management.rs
+++ b/backend/web/src/endpoints/projects/management.rs
@@ -7,7 +7,7 @@
 use super::ProjectResponse;
 use crate::access::{Caller, OrgAccess, ProjectAccess, has_permission, load_org, load_project};
 use crate::audit::{RequestInfo, events, record as audit_record};
-use crate::authorization::MaybeUser;
+use crate::authorization::{MaybeApiKey, MaybeUser};
 use crate::error::{WebError, WebResult};
 use crate::helpers::{OptionExt, ok_json};
 use crate::permissions::Permission;
@@ -85,12 +85,15 @@ pub async fn get_project_name_available(
 pub async fn get(
     state: State<Arc<ServerState>>,
     Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(organization): Path<String>,
     Query(params): Query<PaginationParams>,
 ) -> WebResult<Json<BaseResponse<Paginated<Vec<ProjectResponse>>>>> {
+    let api_key_ref = api_key.as_ref();
     let organization = load_org(
         &state.0,
         Caller::from_option(&maybe_user),
+        api_key_ref,
         organization,
         OrgAccess::Readable {
             label: "Organization",
@@ -102,7 +105,7 @@ pub async fn get(
     let per_page = params.per_page();
     let can_edit = match &maybe_user {
         Some(user) => {
-            has_permission(&state, user.id, organization.id, Permission::EditProject).await?
+            has_permission(&state, user.id, organization.id, Permission::EditProject, api_key_ref).await?
         }
         None => false,
     };
@@ -171,6 +174,7 @@ pub async fn get(
 pub async fn put(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(organization): Path<String>,
     Json(body): Json<MakeProjectRequest>,
 ) -> WebResult<Json<BaseResponse<String>>> {
@@ -192,6 +196,7 @@ pub async fn put(
     let organization = load_org(
         &state.0,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Require {
             permission: Permission::CreateProject,
@@ -273,11 +278,14 @@ pub async fn put(
 pub async fn get_project(
     state: State<Arc<ServerState>>,
     Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, project)): Path<(String, String)>,
 ) -> WebResult<Json<BaseResponse<ProjectResponse>>> {
+    let api_key_ref = api_key.as_ref();
     let (organization, project) = load_project(
         &state.0,
         Caller::from_option(&maybe_user),
+        api_key_ref,
         organization,
         project,
         ProjectAccess::Readable,
@@ -286,7 +294,7 @@ pub async fn get_project(
 
     let can_edit = match &maybe_user {
         Some(user) => {
-            has_permission(&state, user.id, organization.id, Permission::EditProject).await?
+            has_permission(&state, user.id, organization.id, Permission::EditProject, api_key_ref).await?
         }
         None => false,
     };
@@ -326,12 +334,14 @@ pub async fn get_project(
 pub async fn patch_project(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, project)): Path<(String, String)>,
     Json(body): Json<PatchProjectRequest>,
 ) -> WebResult<Json<BaseResponse<String>>> {
     let (organization, project) = load_project(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         project,
         ProjectAccess::Require {
@@ -466,11 +476,13 @@ pub async fn delete_project(
     state: State<Arc<ServerState>>,
     headers: HeaderMap,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, project)): Path<(String, String)>,
 ) -> WebResult<Json<BaseResponse<String>>> {
     let (organization_row, project) = load_project(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         project,
         ProjectAccess::Require {
@@ -509,11 +521,13 @@ pub async fn delete_project(
 pub async fn post_project_active(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, project)): Path<(String, String)>,
 ) -> WebResult<Json<BaseResponse<String>>> {
     let (_organization, project) = load_project(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         project,
         ProjectAccess::Require {
@@ -537,11 +551,13 @@ pub async fn post_project_active(
 pub async fn delete_project_active(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, project)): Path<(String, String)>,
 ) -> WebResult<Json<BaseResponse<String>>> {
     let (_organization, project) = load_project(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         project,
         ProjectAccess::Require {
@@ -565,11 +581,13 @@ pub async fn delete_project_active(
 pub async fn post_project_check_repository(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, project)): Path<(String, String)>,
 ) -> WebResult<Json<BaseResponse<String>>> {
     let (_organization, project) = load_project(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         project,
         ProjectAccess::Require {
@@ -598,12 +616,15 @@ pub async fn post_project_check_repository(
 pub async fn post_project_transfer(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, project)): Path<(String, String)>,
     Json(body): Json<TransferOwnershipRequest>,
 ) -> WebResult<Json<BaseResponse<String>>> {
+    let api_key_ref = api_key.as_ref();
     let (organization, project) = load_project(
         &state,
         Caller::User(&user),
+        api_key_ref,
         organization,
         project,
         ProjectAccess::Member,
@@ -613,7 +634,7 @@ pub async fn post_project_transfer(
     // Only an org member with EditProject permission, or the current owner,
     // may transfer ownership.
     let is_admin =
-        has_permission(&state, user.id, organization.id, Permission::EditProject).await?;
+        has_permission(&state, user.id, organization.id, Permission::EditProject, api_key_ref).await?;
     let is_owner = project.created_by == user.id;
     if !is_admin && !is_owner {
         return Err(WebError::forbidden(
@@ -630,6 +651,7 @@ pub async fn post_project_transfer(
     let new_organization = load_org(
         &state.0,
         Caller::User(&user),
+        api_key_ref,
         body.organization.clone(),
         OrgAccess::Require {
             permission: Permission::CreateProject,

--- a/backend/web/src/endpoints/projects/metrics.rs
+++ b/backend/web/src/endpoints/projects/metrics.rs
@@ -5,7 +5,7 @@
  */
 
 use crate::access::{Caller, OrgAccess, load_org};
-use crate::authorization::MaybeUser;
+use crate::authorization::{MaybeApiKey, MaybeUser};
 use crate::error::WebResult;
 use crate::helpers::{OptionExt, ok_json};
 use axum::extract::{Path, Query, State};
@@ -116,11 +116,13 @@ async fn sum_output_sizes<C: sea_orm::ConnectionTrait>(
 pub async fn get_project_metrics(
     state: State<Arc<ServerState>>,
     Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, project)): Path<(String, String)>,
 ) -> WebResult<Json<BaseResponse<ProjectMetricsResponse>>> {
     let organization = load_org(
         &state.0,
         Caller::from_option(&maybe_user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Readable { label: "Project" },
     )
@@ -232,12 +234,14 @@ pub struct EntryPointMetricsResponse {
 pub async fn get_entry_point_metrics(
     state: State<Arc<ServerState>>,
     Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, project)): Path<(String, String)>,
     Query(params): Query<EntryPointMetricsQuery>,
 ) -> WebResult<Json<BaseResponse<EntryPointMetricsResponse>>> {
     let organization = load_org(
         &state.0,
         Caller::from_option(&maybe_user),
+        api_key.as_ref(),
         organization,
         OrgAccess::Readable { label: "Project" },
     )

--- a/backend/web/src/endpoints/projects/triggers.rs
+++ b/backend/web/src/endpoints/projects/triggers.rs
@@ -7,6 +7,7 @@
 //! CRUD endpoints for `project_trigger` plus a manual-fire endpoint.
 
 use crate::access::{Caller, ProjectAccess, load_project};
+use crate::authorization::MaybeApiKey;
 use crate::error::{WebError, WebResult};
 use crate::helpers::{OptionExt, ok_json};
 use crate::permissions::Permission;
@@ -85,11 +86,13 @@ pub struct DeletedResponse {
 pub async fn list(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, project)): Path<(String, String)>,
 ) -> WebResult<Json<BaseResponse<Vec<TriggerOut>>>> {
     let (_org, proj) = load_project(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         project,
         ProjectAccess::Member,
@@ -108,12 +111,14 @@ pub async fn list(
 pub async fn create(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, project)): Path<(String, String)>,
     Json(body): Json<CreateBody>,
 ) -> WebResult<Json<BaseResponse<TriggerOut>>> {
     let (_org, proj) = load_project(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         project,
         ProjectAccess::Require {
@@ -151,11 +156,13 @@ pub async fn create(
 pub async fn read(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, project, id)): Path<(String, String, ProjectTriggerId)>,
 ) -> WebResult<Json<BaseResponse<TriggerOut>>> {
     let (_org, proj) = load_project(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         project,
         ProjectAccess::Member,
@@ -176,12 +183,14 @@ pub async fn read(
 pub async fn update(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, project, id)): Path<(String, String, ProjectTriggerId)>,
     Json(body): Json<UpdateBody>,
 ) -> WebResult<Json<BaseResponse<TriggerOut>>> {
     let (_org, proj) = load_project(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         project,
         ProjectAccess::Require {
@@ -223,11 +232,13 @@ pub async fn update(
 pub async fn delete_one(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, project, id)): Path<(String, String, ProjectTriggerId)>,
 ) -> WebResult<Json<BaseResponse<DeletedResponse>>> {
     let (_org, proj) = load_project(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         project,
         ProjectAccess::Require {
@@ -254,12 +265,14 @@ pub async fn delete_one(
 pub async fn fire_now(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Extension(scheduler): Extension<Arc<Scheduler>>,
     Path((organization, project, id)): Path<(String, String, ProjectTriggerId)>,
 ) -> WebResult<Json<BaseResponse<serde_json::Value>>> {
     let (_org, proj) = load_project(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         project,
         ProjectAccess::Require {

--- a/backend/web/src/endpoints/user.rs
+++ b/backend/web/src/endpoints/user.rs
@@ -8,7 +8,9 @@ use crate::audit::{RequestInfo, events, record as audit_record};
 use crate::authorization::{MaybeApiKey, generate_api_key, hash_api_key};
 use crate::error::{WebError, WebResult};
 use crate::helpers::{OptionExt, ok_json};
-use crate::permissions::{self, Permission, PermissionMask, mask_from, mask_to_vec};
+use crate::permissions::{
+    PermissionEntry, available_permissions, mask_to_vec, parse_permission_list,
+};
 use axum::extract::{Path, Query, State};
 use axum::http::HeaderMap;
 use axum::{Extension, Json};
@@ -89,12 +91,6 @@ pub struct ApiKeyInfo {
     pub last_used_at: Option<String>,
     pub expires_at: Option<String>,
     pub revoked_at: Option<String>,
-}
-
-#[derive(Serialize, Debug)]
-pub struct PermissionEntry {
-    pub id: &'static str,
-    pub mutating: bool,
 }
 
 #[derive(Serialize, Debug)]
@@ -261,25 +257,6 @@ fn last_used_or_none(dt: chrono::NaiveDateTime) -> Option<String> {
     }
 }
 
-fn parse_permissions(wire: &[String]) -> WebResult<PermissionMask> {
-    let mut perms = Vec::with_capacity(wire.len());
-    for w in wire {
-        let parsed = Permission::from_wire_name(w).ok_or_else(|| {
-            WebError::bad_request(format!(
-                "Unknown permission '{}'. See GET /user/keys/permissions for the catalogue.",
-                w
-            ))
-        })?;
-        perms.push(parsed);
-    }
-    if perms.is_empty() {
-        return Err(WebError::bad_request(
-            "At least one permission is required for an API key.",
-        ));
-    }
-    Ok(mask_from(&perms))
-}
-
 async fn resolve_org_pin(
     state: &Arc<ServerState>,
     user_id: UserId,
@@ -292,15 +269,18 @@ async fn resolve_org_pin(
     if trimmed.is_empty() {
         return Ok(None);
     }
+    let unknown = || {
+        WebError::bad_request(format!(
+            "Unknown organization or not a member: '{}'.",
+            trimmed
+        ))
+    };
     let org = get_any_organization_by_name(Arc::clone(state), trimmed.into())
         .await?
-        .ok_or_else(|| WebError::bad_request(format!("Unknown organization '{}'", trimmed)))?;
+        .ok_or_else(unknown)?;
     let is_member = crate::access::is_org_member(state, user_id, org.id, None).await?;
     if !is_member {
-        return Err(WebError::bad_request(format!(
-            "You are not a member of organization '{}'.",
-            trimmed
-        )));
+        return Err(unknown());
     }
     Ok(Some(org.id))
 }
@@ -350,16 +330,8 @@ fn api_key_info(
 
 pub async fn get_key_permissions()
 -> WebResult<Json<BaseResponse<ApiKeyPermissionsResponse>>> {
-    let available_permissions = Permission::ALL
-        .iter()
-        .copied()
-        .map(|p| PermissionEntry {
-            id: p.as_wire_name(),
-            mutating: permissions::is_mutating(p),
-        })
-        .collect();
     Ok(ok_json(ApiKeyPermissionsResponse {
-        available_permissions,
+        available_permissions: available_permissions(),
     }))
 }
 
@@ -393,7 +365,12 @@ pub async fn post_keys(
 ) -> WebResult<Json<BaseResponse<String>>> {
     forbid_via_api_key(&api_key_caller)?;
 
-    let mask = parse_permissions(&body.permissions)?;
+    let mask = parse_permission_list(&body.permissions, "GET /user/keys/permissions")?;
+    if mask == 0 {
+        return Err(WebError::bad_request(
+            "At least one permission is required for an API key.",
+        ));
+    }
     let org_pin = resolve_org_pin(&state, user.id, body.organization.clone()).await?;
 
     let existing_api_key = EApi::find()
@@ -475,14 +452,34 @@ pub async fn patch_key(
 
     let previous_mask = api_key.permission;
     let previous_org = api_key.organization;
+    let previous_name = api_key.name.clone();
     let mut active: AApi = api_key.into_active_model();
 
     if let Some(name) = body.name {
+        if name != previous_name {
+            let clash = EApi::find()
+                .filter(
+                    Condition::all()
+                        .add(CApi::OwnedBy.eq(user.id))
+                        .add(CApi::Name.eq(name.clone()))
+                        .add(CApi::Id.ne(api_id)),
+                )
+                .one(&state.web_db)
+                .await?;
+            if clash.is_some() {
+                return Err(WebError::already_exists("API-Key Name"));
+            }
+        }
         active.name = Set(name);
     }
     let mut new_mask = previous_mask;
     if let Some(perms) = body.permissions {
-        new_mask = parse_permissions(&perms)?;
+        new_mask = parse_permission_list(&perms, "GET /user/keys/permissions")?;
+        if new_mask == 0 {
+            return Err(WebError::bad_request(
+                "At least one permission is required for an API key.",
+            ));
+        }
         active.permission = Set(new_mask);
     }
     let mut new_org = previous_org;
@@ -501,6 +498,8 @@ pub async fn patch_key(
         &request_info,
         Some(serde_json::json!({
             "api_key_id": api_id.to_string(),
+            "previous_name": previous_name,
+            "new_name": updated.name,
             "previous_permissions_mask": previous_mask,
             "new_permissions_mask": new_mask,
             "previous_organization_id": previous_org.map(|i| i.to_string()),

--- a/backend/web/src/endpoints/user.rs
+++ b/backend/web/src/endpoints/user.rs
@@ -5,14 +5,16 @@
  */
 
 use crate::audit::{RequestInfo, events, record as audit_record};
-use crate::authorization::{generate_api_key, hash_api_key};
+use crate::authorization::{MaybeApiKey, generate_api_key, hash_api_key};
 use crate::error::{WebError, WebResult};
 use crate::helpers::{OptionExt, ok_json};
+use crate::permissions::{self, Permission, PermissionMask, mask_from, mask_to_vec};
 use axum::extract::{Path, Query, State};
 use axum::http::HeaderMap;
 use axum::{Extension, Json};
 
 use chrono::Duration;
+use gradient_core::db::get_any_organization_by_name;
 use gradient_core::types::consts::*;
 use gradient_core::types::input::{validate_display_name, validate_username};
 use gradient_core::types::*;
@@ -43,9 +45,36 @@ pub struct ApiKeyRequest {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CreateApiKeyRequest {
     pub name: String,
-    /// Lifetime in days. `None` means the key never expires (legacy behaviour).
+    /// Lifetime in days. `None` means the key never expires.
     #[serde(default)]
     pub expires_in_days: Option<u32>,
+    /// Capability identifiers (matching `Permission::as_wire_name`) the new
+    /// key should grant. Must be non-empty.
+    pub permissions: Vec<String>,
+    /// Optional organization name to pin the key to. `None` = key works in
+    /// every org the owning user belongs to (legacy behavior).
+    #[serde(default)]
+    pub organization: Option<String>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct PatchApiKeyRequest {
+    pub name: Option<String>,
+    /// Wholesale replacement of the key's permission set. Omit to leave the
+    /// existing mask alone.
+    pub permissions: Option<Vec<String>>,
+    /// Patch semantics for the org pin: omit to leave alone, `Some(name)` to
+    /// pin, `Some(null)` (i.e. JSON null) to unpin.
+    #[serde(default, deserialize_with = "deserialize_optional_field")]
+    pub organization: Option<Option<String>>,
+}
+
+fn deserialize_optional_field<'de, T, D>(de: D) -> Result<Option<Option<T>>, D::Error>
+where
+    T: serde::Deserialize<'de>,
+    D: serde::Deserializer<'de>,
+{
+    Ok(Some(Option::<T>::deserialize(de)?))
 }
 
 #[derive(Serialize, Debug)]
@@ -53,10 +82,24 @@ pub struct ApiKeyInfo {
     pub id: String,
     pub name: String,
     pub managed: bool,
+    pub permissions: Vec<&'static str>,
+    /// Org name (resolved from the pinned org id at response time), or `null`.
+    pub organization: Option<String>,
     pub created_at: String,
     pub last_used_at: Option<String>,
     pub expires_at: Option<String>,
     pub revoked_at: Option<String>,
+}
+
+#[derive(Serialize, Debug)]
+pub struct PermissionEntry {
+    pub id: &'static str,
+    pub mutating: bool,
+}
+
+#[derive(Serialize, Debug)]
+pub struct ApiKeyPermissionsResponse {
+    pub available_permissions: Vec<PermissionEntry>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -218,6 +261,108 @@ fn last_used_or_none(dt: chrono::NaiveDateTime) -> Option<String> {
     }
 }
 
+fn parse_permissions(wire: &[String]) -> WebResult<PermissionMask> {
+    let mut perms = Vec::with_capacity(wire.len());
+    for w in wire {
+        let parsed = Permission::from_wire_name(w).ok_or_else(|| {
+            WebError::bad_request(format!(
+                "Unknown permission '{}'. See GET /user/keys/permissions for the catalogue.",
+                w
+            ))
+        })?;
+        perms.push(parsed);
+    }
+    if perms.is_empty() {
+        return Err(WebError::bad_request(
+            "At least one permission is required for an API key.",
+        ));
+    }
+    Ok(mask_from(&perms))
+}
+
+async fn resolve_org_pin(
+    state: &Arc<ServerState>,
+    user_id: UserId,
+    name: Option<String>,
+) -> WebResult<Option<OrganizationId>> {
+    let Some(name) = name else {
+        return Ok(None);
+    };
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    let org = get_any_organization_by_name(Arc::clone(state), trimmed.into())
+        .await?
+        .ok_or_else(|| WebError::bad_request(format!("Unknown organization '{}'", trimmed)))?;
+    let is_member = crate::access::is_org_member(state, user_id, org.id, None).await?;
+    if !is_member {
+        return Err(WebError::bad_request(format!(
+            "You are not a member of organization '{}'.",
+            trimmed
+        )));
+    }
+    Ok(Some(org.id))
+}
+
+fn forbid_via_api_key(api_key: &MaybeApiKey) -> WebResult<()> {
+    if api_key.as_ref().is_some() {
+        return Err(WebError::forbidden(
+            "API keys cannot manage API keys. Use a session token.",
+        ));
+    }
+    Ok(())
+}
+
+async fn org_name_lookup(
+    state: &Arc<ServerState>,
+    org_ids: &[OrganizationId],
+) -> WebResult<std::collections::HashMap<OrganizationId, String>> {
+    if org_ids.is_empty() {
+        return Ok(std::collections::HashMap::new());
+    }
+    let rows = EOrganization::find()
+        .filter(COrganization::Id.is_in(org_ids.to_vec()))
+        .all(&state.web_db)
+        .await?;
+    Ok(rows.into_iter().map(|o| (o.id, o.name)).collect())
+}
+
+fn api_key_info(
+    key: entity::api::Model,
+    org_names: &std::collections::HashMap<OrganizationId, String>,
+) -> ApiKeyInfo {
+    ApiKeyInfo {
+        id: key.id.to_string(),
+        name: key.name,
+        managed: key.managed,
+        permissions: mask_to_vec(key.permission)
+            .into_iter()
+            .map(|p| p.as_wire_name())
+            .collect(),
+        organization: key.organization.and_then(|id| org_names.get(&id).cloned()),
+        created_at: fmt_dt(key.created_at),
+        last_used_at: last_used_or_none(key.last_used_at),
+        expires_at: fmt_opt_dt(key.expires_at),
+        revoked_at: fmt_opt_dt(key.revoked_at),
+    }
+}
+
+pub async fn get_key_permissions()
+-> WebResult<Json<BaseResponse<ApiKeyPermissionsResponse>>> {
+    let available_permissions = Permission::ALL
+        .iter()
+        .copied()
+        .map(|p| PermissionEntry {
+            id: p.as_wire_name(),
+            mutating: permissions::is_mutating(p),
+        })
+        .collect();
+    Ok(ok_json(ApiKeyPermissionsResponse {
+        available_permissions,
+    }))
+}
+
 pub async fn get_keys(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
@@ -228,28 +373,29 @@ pub async fn get_keys(
         .all(&state.web_db)
         .await?;
 
-    let api_keys: Vec<ApiKeyInfo> = api_keys
+    let pinned: Vec<OrganizationId> = api_keys.iter().filter_map(|k| k.organization).collect();
+    let org_names = org_name_lookup(&state, &pinned).await?;
+
+    let infos: Vec<ApiKeyInfo> = api_keys
         .into_iter()
-        .map(|k| ApiKeyInfo {
-            id: k.id.to_string(),
-            name: k.name,
-            managed: k.managed,
-            created_at: fmt_dt(k.created_at),
-            last_used_at: last_used_or_none(k.last_used_at),
-            expires_at: fmt_opt_dt(k.expires_at),
-            revoked_at: fmt_opt_dt(k.revoked_at),
-        })
+        .map(|k| api_key_info(k, &org_names))
         .collect();
 
-    Ok(ok_json(api_keys))
+    Ok(ok_json(infos))
 }
 
 pub async fn post_keys(
     state: State<Arc<ServerState>>,
     headers: HeaderMap,
     Extension(user): Extension<MUser>,
+    Extension(api_key_caller): Extension<MaybeApiKey>,
     Json(body): Json<CreateApiKeyRequest>,
 ) -> WebResult<Json<BaseResponse<String>>> {
+    forbid_via_api_key(&api_key_caller)?;
+
+    let mask = parse_permissions(&body.permissions)?;
+    let org_pin = resolve_org_pin(&state, user.id, body.organization.clone()).await?;
+
     let existing_api_key = EApi::find()
         .filter(
             Condition::all()
@@ -258,7 +404,6 @@ pub async fn post_keys(
         )
         .one(&state.web_db)
         .await?;
-
     if existing_api_key.is_some() {
         return Err(WebError::already_exists("API-Key Name"));
     }
@@ -278,10 +423,9 @@ pub async fn post_keys(
         managed: Set(false),
         expires_at: Set(expires_at),
         revoked_at: Set(None),
-        permission: Set(gradient_core::permissions::admin_mask()),
-        organization: Set(None),
+        permission: Set(mask),
+        organization: Set(org_pin),
     };
-
     let inserted = api_key.insert(&state.web_db).await?;
 
     let info = RequestInfo::from_headers(&headers);
@@ -294,24 +438,90 @@ pub async fn post_keys(
             "api_key_id": inserted.id.to_string(),
             "name": body.name,
             "expires_in_days": body.expires_in_days,
+            "permissions_mask": mask,
+            "organization_id": org_pin.map(|id| id.to_string()),
         })),
     )
     .await;
 
-    let res = BaseResponse {
+    Ok(Json(BaseResponse {
         error: false,
         message: format!("GRAD{}", raw_key),
-    };
+    }))
+}
 
-    Ok(Json(res))
+pub async fn patch_key(
+    state: State<Arc<ServerState>>,
+    headers: HeaderMap,
+    Extension(user): Extension<MUser>,
+    Extension(api_key_caller): Extension<MaybeApiKey>,
+    Path(api_id): Path<ApiId>,
+    Json(body): Json<PatchApiKeyRequest>,
+) -> WebResult<Json<BaseResponse<ApiKeyInfo>>> {
+    forbid_via_api_key(&api_key_caller)?;
+
+    let api_key = EApi::find_by_id(api_id)
+        .one(&state.web_db)
+        .await?
+        .or_not_found("API-Key")?;
+    if api_key.owned_by != user.id {
+        return Err(WebError::not_found("API-Key"));
+    }
+    if api_key.managed {
+        return Err(WebError::forbidden(
+            "Cannot modify a state-managed API key.",
+        ));
+    }
+
+    let previous_mask = api_key.permission;
+    let previous_org = api_key.organization;
+    let mut active: AApi = api_key.into_active_model();
+
+    if let Some(name) = body.name {
+        active.name = Set(name);
+    }
+    let mut new_mask = previous_mask;
+    if let Some(perms) = body.permissions {
+        new_mask = parse_permissions(&perms)?;
+        active.permission = Set(new_mask);
+    }
+    let mut new_org = previous_org;
+    if let Some(maybe_name) = body.organization {
+        new_org = resolve_org_pin(&state, user.id, maybe_name).await?;
+        active.organization = Set(new_org);
+    }
+
+    let updated = active.update(&state.web_db).await?;
+
+    let request_info = RequestInfo::from_headers(&headers);
+    audit_record(
+        &state.web_db,
+        Some(user.id),
+        events::API_KEY_UPDATE,
+        &request_info,
+        Some(serde_json::json!({
+            "api_key_id": api_id.to_string(),
+            "previous_permissions_mask": previous_mask,
+            "new_permissions_mask": new_mask,
+            "previous_organization_id": previous_org.map(|i| i.to_string()),
+            "new_organization_id": new_org.map(|i| i.to_string()),
+        })),
+    )
+    .await;
+
+    let pinned: Vec<OrganizationId> = updated.organization.iter().copied().collect();
+    let org_names = org_name_lookup(&state, &pinned).await?;
+    Ok(ok_json(api_key_info(updated, &org_names)))
 }
 
 pub async fn delete_keys(
     state: State<Arc<ServerState>>,
     headers: HeaderMap,
     Extension(user): Extension<MUser>,
+    Extension(api_key_caller): Extension<MaybeApiKey>,
     Json(body): Json<ApiKeyRequest>,
 ) -> WebResult<Json<BaseResponse<String>>> {
+    forbid_via_api_key(&api_key_caller)?;
     let api_key = EApi::find()
         .filter(
             Condition::all()
@@ -358,8 +568,10 @@ pub async fn post_key_revoke(
     state: State<Arc<ServerState>>,
     headers: HeaderMap,
     Extension(user): Extension<MUser>,
+    Extension(api_key_caller): Extension<MaybeApiKey>,
     Path(api_id): Path<ApiId>,
 ) -> WebResult<Json<BaseResponse<String>>> {
+    forbid_via_api_key(&api_key_caller)?;
     let api_key = EApi::find_by_id(api_id)
         .one(&state.web_db)
         .await?

--- a/backend/web/src/endpoints/user.rs
+++ b/backend/web/src/endpoints/user.rs
@@ -278,6 +278,8 @@ pub async fn post_keys(
         managed: Set(false),
         expires_at: Set(expires_at),
         revoked_at: Set(None),
+        permission: Set(gradient_core::permissions::admin_mask()),
+        organization: Set(None),
     };
 
     let inserted = api_key.insert(&state.web_db).await?;

--- a/backend/web/src/endpoints/webhooks.rs
+++ b/backend/web/src/endpoints/webhooks.rs
@@ -5,6 +5,7 @@
  */
 
 use crate::access::{Caller, OrgAccess, load_org, load_webhook_in_org};
+use crate::authorization::MaybeApiKey;
 use crate::error::{WebError, WebResult};
 use crate::helpers::ok_json;
 use crate::permissions::Permission;
@@ -77,11 +78,13 @@ impl From<MWebhook> for WebhookResponse {
 pub async fn get(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(organization): Path<String>,
 ) -> WebResult<Json<BaseResponse<Vec<WebhookResponse>>>> {
     let organization = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         webhook_org_access(),
     )
@@ -101,12 +104,14 @@ pub async fn get(
 pub async fn put(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(organization): Path<String>,
     Json(body): Json<CreateWebhookRequest>,
 ) -> WebResult<Json<BaseResponse<WebhookResponse>>> {
     let organization = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         webhook_org_access(),
     )
@@ -159,11 +164,13 @@ pub async fn put(
 pub async fn get_webhook(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, webhook_id)): Path<(String, WebhookId)>,
 ) -> WebResult<Json<BaseResponse<WebhookResponse>>> {
     let organization = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         webhook_org_access(),
     )
@@ -177,12 +184,14 @@ pub async fn get_webhook(
 pub async fn patch_webhook(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, webhook_id)): Path<(String, WebhookId)>,
     Json(body): Json<UpdateWebhookRequest>,
 ) -> WebResult<Json<BaseResponse<WebhookResponse>>> {
     let organization = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         webhook_org_access(),
     )
@@ -221,11 +230,13 @@ pub async fn patch_webhook(
 pub async fn delete_webhook(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, webhook_id)): Path<(String, WebhookId)>,
 ) -> WebResult<Json<BaseResponse<bool>>> {
     let organization = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         webhook_org_access(),
     )
@@ -253,12 +264,14 @@ pub struct WebhookDeliveryResponse {
 pub async fn get_webhook_deliveries(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, webhook_id)): Path<(String, WebhookId)>,
     axum::extract::Query(params): axum::extract::Query<PaginationParams>,
 ) -> WebResult<Json<BaseResponse<Paginated<Vec<WebhookDeliveryResponse>>>>> {
     let organization = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         webhook_org_access(),
     )
@@ -307,11 +320,13 @@ pub async fn get_webhook_deliveries(
 pub async fn post_webhook_test(
     state: State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path((organization, webhook_id)): Path<(String, WebhookId)>,
 ) -> WebResult<Json<BaseResponse<bool>>> {
     let organization = load_org(
         &state,
         Caller::User(&user),
+        api_key.as_ref(),
         organization,
         webhook_org_access(),
     )

--- a/backend/web/src/lib.rs
+++ b/backend/web/src/lib.rs
@@ -337,6 +337,8 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
                 .post(user::post_keys)
                 .delete(user::delete_keys),
         )
+        .route("/user/keys/permissions", get(user::get_key_permissions))
+        .route("/user/keys/{api_id}", patch(user::patch_key))
         .route("/user/keys/{api_id}/revoke", post(user::post_key_revoke))
         .route("/user/sessions", get(user::get_sessions))
         .route(

--- a/backend/web/src/permissions.rs
+++ b/backend/web/src/permissions.rs
@@ -4,9 +4,55 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-//! Re-export of the org permission system. The canonical definition lives in
-//! `gradient_core::permissions` so that startup seeding (in the `core` crate)
-//! and request-time authorization (here in `web`) share a single source of
-//! truth for capability bits.
+//! Re-export of the org permission system, plus web-layer helpers shared
+//! between the role-management API and the API-key endpoints. The canonical
+//! capability set lives in [`gradient_core::permissions`].
 
 pub use gradient_core::permissions::*;
+
+use crate::error::{WebError, WebResult};
+use serde::Serialize;
+
+#[derive(Serialize, Debug)]
+pub struct PermissionEntry {
+    pub id: &'static str,
+    pub mutating: bool,
+}
+
+/// Catalogue of every capability a custom role or API key may grant. Used by
+/// both the role-management UI (`GET /orgs/{org}/roles`) and the API-key UI
+/// (`GET /user/keys/permissions`).
+pub fn available_permissions() -> Vec<PermissionEntry> {
+    Permission::ALL
+        .iter()
+        .copied()
+        .map(|p| PermissionEntry {
+            id: p.as_wire_name(),
+            mutating: is_mutating(p),
+        })
+        .collect()
+}
+
+/// Parse a list of wire-format permission identifiers into a [`PermissionMask`].
+/// `catalogue_hint` appears in the error message so callers can guide users to
+/// the right `available_permissions` endpoint.
+///
+/// Empty input is allowed at this layer (matches role semantics); call sites
+/// that require non-empty (e.g. API-key creation) must check the resulting
+/// mask themselves.
+pub fn parse_permission_list(
+    wire: &[String],
+    catalogue_hint: &str,
+) -> WebResult<PermissionMask> {
+    let mut perms = Vec::with_capacity(wire.len());
+    for w in wire {
+        let parsed = Permission::from_wire_name(w).ok_or_else(|| {
+            WebError::bad_request(format!(
+                "Unknown permission '{}'. See {} for the catalogue.",
+                w, catalogue_hint
+            ))
+        })?;
+        perms.push(parsed);
+    }
+    Ok(mask_from(&perms))
+}

--- a/backend/web/tests/auth_hardening.rs
+++ b/backend/web/tests/auth_hardening.rs
@@ -190,6 +190,8 @@ fn revoked_api_key_is_rejected() {
             managed: false,
             expires_at: None,
             revoked_at: Some(now),
+            permission: gradient_core::permissions::admin_mask(),
+            organization: None,
         };
 
         let s = server_with(|db| db.append_query_results([vec![key]]));
@@ -218,6 +220,8 @@ fn expired_api_key_is_rejected() {
             managed: false,
             expires_at: Some(now - chrono::Duration::seconds(1)),
             revoked_at: None,
+            permission: gradient_core::permissions::admin_mask(),
+            organization: None,
         };
 
         let s = server_with(|db| db.append_query_results([vec![key]]));
@@ -279,5 +283,175 @@ fn delete_user_with_wrong_password_is_forbidden() {
             .json(&serde_json::json!({ "password": "WrongPassword!" }))
             .await;
         res.assert_status_forbidden();
+    });
+}
+
+// ── Configurable API-key options ─────────────────────────────────────────────
+
+#[test]
+fn api_key_with_only_view_cannot_trigger_evaluation() {
+    use gradient_core::permissions::{Permission, mask_from};
+    use test_support::fixtures::{org, org_id};
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let raw = "x".repeat(64);
+        let now = Utc::now().naive_utc();
+        let key = api::Model {
+            id: ApiId::now_v7(),
+            owned_by: user_id(),
+            name: "ci".into(),
+            key: hash_api_key(&raw),
+            last_used_at: now,
+            created_at: now,
+            managed: false,
+            expires_at: None,
+            revoked_at: None,
+            permission: mask_from(&[Permission::ViewOrg]),
+            organization: None,
+        };
+        let admin_membership = entity::organization_user::Model {
+            id: entity::ids::OrganizationUserId::now_v7(),
+            organization: org_id(),
+            user: user_id(),
+            role: gradient_core::types::consts::BASE_ROLE_ADMIN_ID,
+        };
+        let admin_role = entity::role::Model {
+            id: gradient_core::types::consts::BASE_ROLE_ADMIN_ID,
+            name: "Admin".into(),
+            organization: None,
+            permission: gradient_core::permissions::admin_mask(),
+        };
+
+        let s = server_with(|db| {
+            db.append_query_results([vec![key.clone()]])
+                .append_exec_results([MockExecResult {
+                    last_insert_id: 0,
+                    rows_affected: 1,
+                }])
+                .append_query_results([vec![key.clone()]])
+                .append_query_results([vec![user()]])
+                .append_query_results([vec![org()]])
+                .append_query_results([vec![entity::project::Model {
+                    id: test_support::fixtures::project_id(),
+                    organization: org_id(),
+                    name: "test-project".into(),
+                    display_name: "Test".into(),
+                    description: String::new(),
+                    repository: "git@example.com:test/test.git".into(),
+                    wildcard: "*".into(),
+                    active: true,
+                    last_evaluation: None,
+                    last_check_at: chrono::NaiveDate::from_ymd_opt(2026, 1, 1)
+                        .unwrap()
+                        .and_hms_opt(0, 0, 0)
+                        .unwrap(),
+                    force_evaluation: false,
+                    created_by: user_id(),
+                    created_at: chrono::NaiveDate::from_ymd_opt(2026, 1, 1)
+                        .unwrap()
+                        .and_hms_opt(0, 0, 0)
+                        .unwrap(),
+                    managed: false,
+                    keep_evaluations: 30,
+                    concurrency: 3,
+                    sign_cache: true,
+                }]])
+                .append_query_results([vec![admin_membership]])
+                .append_query_results([vec![admin_role]])
+        });
+
+        let res = s
+            .post("/api/v1/projects/test-org/test-project/evaluate")
+            .add_header("authorization", format!("Bearer GRAD{}", raw))
+            .await;
+        res.assert_status(axum::http::StatusCode::FORBIDDEN);
+    });
+}
+
+#[test]
+fn api_key_pinned_to_other_org_is_invisible() {
+    use gradient_core::permissions::{Permission, mask_from};
+    use test_support::fixtures::org;
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let raw = "y".repeat(64);
+        let now = Utc::now().naive_utc();
+        let pinned_elsewhere = entity::ids::OrganizationId::new(uuid::uuid!(
+            "ffffffff-ffff-ffff-ffff-ffffffffffff"
+        ));
+        let key = api::Model {
+            id: ApiId::now_v7(),
+            owned_by: user_id(),
+            name: "ci".into(),
+            key: hash_api_key(&raw),
+            last_used_at: now,
+            created_at: now,
+            managed: false,
+            expires_at: None,
+            revoked_at: None,
+            permission: mask_from(Permission::ALL),
+            organization: Some(pinned_elsewhere),
+        };
+
+        let s = server_with(|db| {
+            db.append_query_results([vec![key.clone()]])
+                .append_exec_results([MockExecResult {
+                    last_insert_id: 0,
+                    rows_affected: 1,
+                }])
+                .append_query_results([vec![key.clone()]])
+                .append_query_results([vec![user()]])
+                .append_query_results([vec![org()]])
+        });
+
+        let res = s
+            .get("/api/v1/orgs/test-org")
+            .add_header("authorization", format!("Bearer GRAD{}", raw))
+            .await;
+        res.assert_status(axum::http::StatusCode::NOT_FOUND);
+    });
+}
+
+#[test]
+fn api_key_cannot_create_api_keys() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let raw = "z".repeat(64);
+        let now = Utc::now().naive_utc();
+        let key = api::Model {
+            id: ApiId::now_v7(),
+            owned_by: user_id(),
+            name: "self".into(),
+            key: hash_api_key(&raw),
+            last_used_at: now,
+            created_at: now,
+            managed: false,
+            expires_at: None,
+            revoked_at: None,
+            permission: gradient_core::permissions::admin_mask(),
+            organization: None,
+        };
+
+        let s = server_with(|db| {
+            db.append_query_results([vec![key.clone()]])
+                .append_exec_results([MockExecResult {
+                    last_insert_id: 0,
+                    rows_affected: 1,
+                }])
+                .append_query_results([vec![key.clone()]])
+                .append_query_results([vec![user()]])
+        });
+
+        let res = s
+            .post("/api/v1/user/keys")
+            .add_header("authorization", format!("Bearer GRAD{}", raw))
+            .json(&serde_json::json!({
+                "name": "child",
+                "permissions": ["viewOrg"],
+            }))
+            .await;
+        res.assert_status(axum::http::StatusCode::FORBIDDEN);
     });
 }

--- a/backend/web/tests/auth_hardening.rs
+++ b/backend/web/tests/auth_hardening.rs
@@ -321,6 +321,7 @@ fn api_key_with_only_view_cannot_trigger_evaluation() {
             name: "Admin".into(),
             organization: None,
             permission: gradient_core::permissions::admin_mask(),
+            managed: false,
         };
 
         let s = server_with(|db| {

--- a/backend/web/tests/projects_integration.rs
+++ b/backend/web/tests/projects_integration.rs
@@ -93,6 +93,7 @@ fn admin_role_row() -> entity::role::Model {
         name: "Admin".into(),
         organization: None,
         permission: gradient_core::permissions::admin_mask(),
+        managed: false,
     }
 }
 

--- a/backend/web/tests/projects_sign_cache.rs
+++ b/backend/web/tests/projects_sign_cache.rs
@@ -110,6 +110,7 @@ fn admin_role_row() -> role::Model {
         name: "Admin".into(),
         organization: None,
         permission: admin_mask(),
+        managed: false,
     }
 }
 

--- a/backend/web/tests/roles_crud.rs
+++ b/backend/web/tests/roles_crud.rs
@@ -52,6 +52,7 @@ fn admin_role_row() -> role::Model {
         name: "Admin".into(),
         organization: None,
         permission: admin_mask(),
+        managed: false,
     }
 }
 
@@ -61,6 +62,7 @@ fn view_role_row() -> role::Model {
         name: "View".into(),
         organization: None,
         permission: view_mask(),
+        managed: false,
     }
 }
 
@@ -70,6 +72,7 @@ fn write_role_row() -> role::Model {
         name: "Write".into(),
         organization: None,
         permission: write_mask(),
+        managed: false,
     }
 }
 
@@ -79,6 +82,7 @@ fn custom_role_row(id: RoleId, name: &str, permission: i64) -> role::Model {
         name: name.into(),
         organization: Some(org_id()),
         permission,
+        managed: false,
     }
 }
 
@@ -461,6 +465,7 @@ fn custom_role_with_manage_webhooks_can_list_webhooks() {
             name: "webhook-ops".into(),
             organization: Some(org_id()),
             permission: Permission::ViewOrg.bit() | Permission::ManageWebhooks.bit(),
+            managed: false,
         };
 
         let db = with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id)
@@ -498,6 +503,7 @@ fn custom_role_without_manage_webhooks_is_rejected() {
             name: "view-only".into(),
             organization: Some(org_id()),
             permission: Permission::ViewOrg.bit(),
+            managed: false,
         };
 
         let db = with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id)

--- a/backend/web/tests/triggers.rs
+++ b/backend/web/tests/triggers.rs
@@ -73,6 +73,7 @@ fn admin_role_row() -> entity::role::Model {
         name: "Admin".into(),
         organization: None,
         permission: gradient_core::permissions::admin_mask(),
+        managed: false,
     }
 }
 

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -661,6 +661,83 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /user/keys/permissions:
+    get:
+      tags: [user]
+      summary: List API-key permission catalogue
+      description: |-
+        Returns the full set of capabilities a user-managed API key may grant.
+        Used by the create / edit dialog to populate the permission checkbox list.
+      operationId: getUserKeyPermissions
+      responses:
+        '200':
+          description: Permission catalogue
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BaseResponse'
+                  - type: object
+                    properties:
+                      message:
+                        type: object
+                        required: [available_permissions]
+                        properties:
+                          available_permissions:
+                            type: array
+                            items:
+                              type: object
+                              required: [id, mutating]
+                              properties:
+                                id: { type: string }
+                                mutating: { type: boolean }
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /user/keys/{api_id}:
+    patch:
+      tags: [user]
+      summary: Update an API key's configurable options
+      description: |-
+        Edit the key's name, permission set, or organization pin in place.
+        Permissions replace the existing set wholesale. State-managed keys
+        cannot be edited. Cannot be called from an API-key-authenticated
+        request — sessions only.
+      operationId: patchUserKey
+      parameters:
+        - name: api_id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchApiKeyRequest'
+      responses:
+        '200':
+          description: Updated key
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BaseResponse'
+                  - type: object
+                    properties:
+                      message:
+                        $ref: '#/components/schemas/ApiKeyInfo'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+
   /user/keys/{api_id}/revoke:
     post:
       tags: [user]
@@ -4656,7 +4733,7 @@ components:
 
     CreateApiKeyRequest:
       type: object
-      required: [name]
+      required: [name, permissions]
       properties:
         name:
           type: string
@@ -4668,15 +4745,40 @@ components:
           nullable: true
           description: |-
             Optional lifetime in days. Omit (or `null`) for a key that never
-            auto-expires. The server stamps `expires_at = now + N days`.
+            auto-expires.
+        permissions:
+          type: array
+          items: { type: string }
+          minItems: 1
+          description: |-
+            Capability identifiers (matching `Permission::as_wire_name`) the
+            new key should grant. The full catalogue is at
+            `GET /user/keys/permissions`.
+          example: [triggerEvaluation, viewOrg]
+        organization:
+          type: string
+          nullable: true
+          description: |-
+            Optional organization name to pin the key to. When set, the key is
+            rejected for any other organization.
 
     ApiKeyInfo:
       type: object
-      required: [id, name, managed, created_at]
+      required: [id, name, managed, permissions, created_at]
       properties:
         id: { type: string, format: uuid }
         name: { type: string }
         managed: { type: boolean }
+        permissions:
+          type: array
+          items: { type: string }
+          description: Capability identifiers granted by this key
+        organization:
+          type: string
+          nullable: true
+          description: |-
+            Organization name this key is pinned to, or `null` if the key is
+            unscoped.
         created_at: { type: string, format: date-time }
         last_used_at:
           type: string
@@ -4691,6 +4793,23 @@ components:
           type: string
           format: date-time
           nullable: true
+
+    PatchApiKeyRequest:
+      type: object
+      properties:
+        name: { type: string }
+        permissions:
+          type: array
+          items: { type: string }
+          minItems: 1
+          description: |-
+            When present, replaces the key's permission set wholesale.
+        organization:
+          type: string
+          nullable: true
+          description: |-
+            Tri-state: omit to leave the pin unchanged; `null` to unpin;
+            string to pin to a specific organization.
 
     SessionInfo:
       type: object
@@ -4716,8 +4835,8 @@ components:
           type: string
           description: |-
             One of: `login.success`, `login.failure`, `logout`, `register`,
-            `user.delete`, `api_key.create`, `api_key.revoke`,
-            `api_key.delete`, `session.revoke`, `auth.deny`,
+            `user.delete`, `api_key.create`, `api_key.update`,
+            `api_key.revoke`, `api_key.delete`, `session.revoke`, `auth.deny`,
             `organization.delete`, `organization.member.add`,
             `organization.member.remove`, `organization.member.role_change`,
             `project.delete`, `cache.delete`.
@@ -4799,7 +4918,7 @@ components:
 
     RoleResponse:
       type: object
-      required: [id, name, organization, builtin, permissions]
+      required: [id, name, builtin, managed, permissions]
       properties:
         id:
           type: string
@@ -4819,6 +4938,11 @@ components:
           description: |
             True for the three immutable system roles (Admin/Write/View).
             Built-in roles cannot be edited or deleted via the API.
+        managed:
+          type: boolean
+          description: |
+            True for state-managed custom roles defined in the NixOS state
+            file. Managed roles cannot be modified or deleted via the API.
         permissions:
           type: array
           items:

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -299,4 +299,29 @@ The token must be the 48-byte random secret returned by the registration API (ge
 
 ## Declarative State
 
-Users, organizations, projects, integrations, caches, API keys, and workers can be declared in `services.gradient.state` and reconciled on every startup. See [Declarative State](usage/state.md) for the full options reference.
+Users, organizations, projects, integrations, caches, API keys, custom roles, and workers can be declared in `services.gradient.state` and reconciled on every startup. See [Declarative State](usage/state.md) for the full options reference.
+
+### API keys
+
+State-managed API keys are declared under `state.api_keys.<name>`:
+
+- `key_file` (required, path): file containing the lowercase 64-char SHA-256
+  hex digest of the token (without the `GRAD` prefix).
+- `owned_by` (required, string): username that owns the key.
+- `permissions` (required, list of strings): permission identifiers the key
+  grants. See `gradient_core::permissions::Permission` (or
+  `GET /user/keys/permissions`) for the full list.
+- `organization` (optional, string): organization name to pin the key to.
+  Omit for an unscoped key.
+
+### Roles
+
+State-managed custom roles are declared under `state.roles.<name>`:
+
+- `name` (defaults to attrset key): role name. Must be unique within the
+  organization and must not collide with built-in role names
+  (`Admin`, `Write`, `View`).
+- `organization` (required, string): the organization this role belongs to.
+- `permissions` (required, list of strings): the capabilities the role grants.
+
+Managed roles cannot be modified or deleted via the API.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -1881,3 +1881,16 @@ The closure walker is exercised end-to-end by the
 builds derivations referencing locally-created sources). Live-daemon
 unit coverage isn't worth the harness cost — the BFS is a few lines
 and the failure mode is loud.
+
+## Configurable API-key options
+
+`backend/web/tests/auth_hardening.rs` (full HTTP via `axum_test`):
+
+- `api_key_with_only_view_cannot_trigger_evaluation` — a key whose mask is
+  `[viewOrg]` returns 403 from the project evaluate endpoint, even when the
+  owning user is admin.
+- `api_key_pinned_to_other_org_is_invisible` — a key pinned to a different
+  org returns 404 (not 403, not 401) on `GET /api/v1/orgs/{name}` so org
+  existence isn't leaked.
+- `api_key_cannot_create_api_keys` — `POST /api/v1/user/keys` from an
+  API-key-authenticated request returns 403 (the self-management guard).

--- a/docs/src/usage/api.md
+++ b/docs/src/usage/api.md
@@ -60,8 +60,44 @@ On errors, `error` is `true` and `message` is a string describing the problem.
 | `GET` | `/user/keys` | List API keys |
 | `POST` | `/user/keys` | Create API key |
 | `DELETE` | `/user/keys` | Delete API key |
+| `GET` | `/user/keys/permissions` | List the permission catalogue |
+| `PATCH` | `/user/keys/{api_id}` | Update an API key's name / permissions / org pin |
 | `GET` | `/user/settings` | Get profile settings |
 | `PATCH` | `/user/settings` | Update profile settings |
+
+### Configuring API-key options
+
+Each API key carries its own permission set and an optional organization pin:
+
+```bash
+curl -X POST $API/user/keys \
+  -H "Authorization: Bearer $SESSION" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "name": "ci-runner",
+        "permissions": ["triggerEvaluation", "viewOrg"],
+        "organization": "acme",
+        "expires_in_days": 90
+      }'
+```
+
+The key's effective authority on every request is `user_role_mask & key_mask`,
+intersected with the org's role assignment for the caller. A key pinned to an
+organization 404s for every other org. The full permission catalogue is at
+`GET /user/keys/permissions`.
+
+To tighten an existing key without rotating the secret:
+
+```bash
+curl -X PATCH $API/user/keys/$KEY_ID \
+  -H "Authorization: Bearer $SESSION" \
+  -H "Content-Type: application/json" \
+  -d '{ "permissions": ["viewOrg"] }'
+```
+
+API-key-authenticated requests **cannot** create, edit, revoke, or delete API
+keys — only session-authenticated calls can. This prevents a leaked key from
+minting more powerful siblings.
 
 ### Organizations
 

--- a/docs/src/usage/state.md
+++ b/docs/src/usage/state.md
@@ -266,13 +266,45 @@ server, worker, or CLI talks to) carry the user-agent
 `Gradient/<version> (+https://github.com/wavelens/gradient)`, so cache operators
 can attribute traffic and build allowlists or per-client metrics around it.
 
+## Roles
+
+State files can declare custom org-scoped roles via the `roles` attribute.
+Each role targets one organization and grants a fixed permission set:
+
+```nix
+services.gradient.state.roles = {
+  releaser = {
+    organization = "acme";
+    permissions  = [ "viewOrg" "triggerEvaluation" ];
+  };
+};
+```
+
+Managed roles are immutable through the role-management API: `PATCH` and
+`DELETE` return `403 Forbidden`. Removing the entry from the state file
+unmarks the role (or deletes it, when `settings.deleteState = true`).
+
+Role names must not collide with the built-in roles (`Admin`, `Write`,
+`View`) or with another state-managed role in the same organization —
+startup fails on collision.
+
+### Role options
+
+| Option | Default | Description |
+|---|---|---|
+| `name` | `<attrset key>` | Role name. Must be unique within the organization and must not collide with a built-in role |
+| `organization` | — | Owning organization name (required) |
+| `permissions` | — | List of capability identifiers granted by the role (required, see `GET /user/keys/permissions` for the catalogue) |
+
 ## API Keys
 
 ```nix
 services.gradient.state.api_keys = {
-  ci-token = {
-    key_file = "/run/secrets/ci-api-key";
-    owned_by = "alice";
+  ci-runner = {
+    key_file     = "/run/secrets/ci-api-key";
+    owned_by     = "alice";
+    permissions  = [ "viewOrg" "triggerEvaluation" ];
+    organization = "acme";        # optional — omit for an unscoped key
   };
 };
 ```
@@ -290,6 +322,10 @@ printf %s "$TOKEN" | sha256sum | cut -d' ' -f1 > /run/secrets/ci-api-key
 Hand `GRAD$TOKEN` to the user/CI pipeline; the server will hash it on the way
 in and compare against the digest in `key_file`.
 
+The `permissions` list is **required** — there is no safe default. When
+`organization` is set, the key is rejected for every other org (404, so org
+existence isn't leaked).
+
 ### API-key options
 
 | Option | Default | Description |
@@ -297,6 +333,8 @@ in and compare against the digest in `key_file`.
 | `name` | `<attrset key>` | Unique key name |
 | `key_file` | — | Path to a file containing the lowercase 64-char SHA-256 hex digest of the token (required) |
 | `owned_by` | — | Username that owns the key (required) |
+| `permissions` | — | Capability identifiers the key grants (required, non-empty). See `GET /user/keys/permissions` for the catalogue |
+| `organization` | `null` | Organization name to pin the key to. Omit for an unscoped key |
 
 ## Workers
 

--- a/frontend/src/app/core/models/index.ts
+++ b/frontend/src/app/core/models/index.ts
@@ -7,6 +7,7 @@
 export * from './api-response.model';
 export * from './user.model';
 export * from './organization.model';
+export * from './permission.model';
 export * from './project.model';
 export * from './build.model';
 export * from './cache.model';

--- a/frontend/src/app/core/models/permission.model.ts
+++ b/frontend/src/app/core/models/permission.model.ts
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export interface PermissionDescriptor {
+  id: string;
+  mutating: boolean;
+}

--- a/frontend/src/app/core/models/user.model.ts
+++ b/frontend/src/app/core/models/user.model.ts
@@ -27,6 +27,8 @@ export interface ApiKey {
   id: string;
   name: string;
   managed: boolean;
+  permissions: string[];
+  organization: string | null;
   created_at: string;
   last_used_at: string | null;
   expires_at: string | null;

--- a/frontend/src/app/core/services/organizations.service.ts
+++ b/frontend/src/app/core/services/organizations.service.ts
@@ -8,6 +8,7 @@ import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { ApiService } from './api.service';
 import { Organization, Paginated } from '@core/models';
+import { PermissionDescriptor } from '@core/models/permission.model';
 
 export interface OrgMember {
   id: string;   // username
@@ -22,10 +23,7 @@ export interface OrgRole {
   permissions: string[];
 }
 
-export interface PermissionDescriptor {
-  id: string;
-  mutating: boolean;
-}
+export type { PermissionDescriptor };
 
 export interface RoleListResponse {
   roles: OrgRole[];

--- a/frontend/src/app/core/services/user.service.ts
+++ b/frontend/src/app/core/services/user.service.ts
@@ -14,6 +14,7 @@ import {
   Session,
   UserSettings,
 } from '@core/models';
+import { PermissionDescriptor } from '@core/models/permission.model';
 
 @Injectable({ providedIn: 'root' })
 export class UserService {
@@ -35,12 +36,39 @@ export class UserService {
     return this.api.get<ApiKey[]>('user/keys');
   }
 
-  createApiKey(name: string, expiresInDays?: number | null): Observable<string> {
-    const body: { name: string; expires_in_days?: number } = { name };
+  createApiKey(
+    name: string,
+    expiresInDays?: number | null,
+    permissions: string[] = ['viewOrg'],
+    organization: string | null = null,
+  ): Observable<string> {
+    const body: {
+      name: string;
+      expires_in_days?: number;
+      permissions: string[];
+      organization: string | null;
+    } = { name, permissions, organization };
     if (expiresInDays !== null && expiresInDays !== undefined) {
       body.expires_in_days = expiresInDays;
     }
     return this.api.post<string>('user/keys', body);
+  }
+
+  updateApiKey(
+    apiId: string,
+    body: {
+      name?: string;
+      permissions?: string[];
+      organization?: string | null;
+    },
+  ): Observable<ApiKey> {
+    return this.api.patch<ApiKey>(`user/keys/${apiId}`, body);
+  }
+
+  getApiKeyPermissions(): Observable<{ available_permissions: PermissionDescriptor[] }> {
+    return this.api.get<{ available_permissions: PermissionDescriptor[] }>(
+      'user/keys/permissions',
+    );
   }
 
   deleteApiKey(name: string): Observable<string> {

--- a/frontend/src/app/features/settings/api-keys/api-keys.component.html
+++ b/frontend/src/app/features/settings/api-keys/api-keys.component.html
@@ -44,15 +44,36 @@
                     <span class="badge badge-revoked">Revoked</span>
                   }
                 </div>
-                <div class="key-id text-secondary">
-                  Last used: {{ key.last_used_at ? (key.last_used_at | date: 'medium') : 'never' }}
+                <div class="key-meta text-secondary">
+                  <span
+                    class="badge badge-info"
+                    [pTooltip]="permissionTooltip(key)"
+                    tooltipPosition="top"
+                  >
+                    {{ key.permissions.length }} permission{{ key.permissions.length === 1 ? '' : 's' }}
+                  </span>
+                  <span class="badge badge-org">
+                    {{ key.organization ?? 'Any org' }}
+                  </span>
+                  <span>
+                    Last used: {{ key.last_used_at ? (key.last_used_at | date: 'medium') : 'never' }}
+                  </span>
                   @if (key.expires_at) {
-                    · Expires: {{ key.expires_at | date: 'medium' }}
+                    <span>· Expires: {{ key.expires_at | date: 'medium' }}</span>
                   }
                 </div>
               </div>
             </div>
             <div class="key-actions">
+              @if (!key.managed && !key.revoked_at) {
+                <button
+                  pButton
+                  label="Edit"
+                  icon="pi pi-pencil"
+                  severity="secondary"
+                  (click)="openEditDialog(key)"
+                ></button>
+              }
               @if (!key.revoked_at) {
                 <button
                   pButton
@@ -81,14 +102,14 @@
   }
 </div>
 
-<!-- Create Key Dialog -->
+<!-- Create / Edit Dialog -->
 <p-dialog
-  header="Create API Key"
-  [(visible)]="showCreateDialog"
+  [(visible)]="showDialog"
   [modal]="true"
-  [style]="{ width: '400px' }"
+  [style]="{ width: '520px' }"
   [draggable]="false"
   [resizable]="false"
+  [header]="editingKey() ? 'Edit API Key' : 'Create API Key'"
 >
   @if (errorMessage()) {
     <div class="dialog-error">
@@ -96,17 +117,83 @@
       {{ errorMessage() }}
     </div>
   }
+
   <div class="form-group">
-    <label for="key-name">Key Name</label>
-    <input pInputText id="key-name" [(ngModel)]="newKeyName" placeholder="e.g. CI/CD Pipeline" class="w-full" />
+    <label for="key-name">Name</label>
+    <input
+      pInputText
+      id="key-name"
+      [(ngModel)]="formName"
+      placeholder="e.g. CI/CD Pipeline"
+      class="w-full"
+    />
   </div>
+
+  @if (!editingKey()) {
+    <div class="form-group">
+      <label for="key-expires">Expires in (days)</label>
+      <input
+        pInputText
+        id="key-expires"
+        type="number"
+        min="1"
+        [(ngModel)]="formExpiresInDays"
+        placeholder="Leave blank for no expiry"
+        class="w-full"
+      />
+    </div>
+  }
+
+  <p-divider />
+
   <div class="form-group">
-    <label for="key-expires">Expires in (days)</label>
-    <input pInputText id="key-expires" type="number" min="1" [(ngModel)]="newKeyExpiresInDays" placeholder="Leave blank for no expiry" class="w-full" />
+    <label for="key-organization">Organization</label>
+    <p-select
+      inputId="key-organization"
+      [options]="orgOptions()"
+      optionLabel="label"
+      optionValue="value"
+      [(ngModel)]="formOrganization"
+      placeholder="Any organization"
+      appendTo="body"
+      styleClass="w-full"
+    />
   </div>
+
+  <p-divider />
+
+  <div class="form-group">
+    <label>Permissions</label>
+    <div class="permission-grid">
+      @for (p of availablePermissions(); track p.id) {
+        <div class="permission-row">
+          <p-checkbox
+            [(ngModel)]="formPermissions[p.id]"
+            [binary]="true"
+            [inputId]="'perm-' + p.id"
+          />
+          <label [for]="'perm-' + p.id">{{ p.id }}</label>
+        </div>
+      }
+    </div>
+  </div>
+
   <ng-template pTemplate="footer">
-    <button pButton label="Cancel" severity="secondary" (click)="showCreateDialog.set(false)" [disabled]="creating()"></button>
-    <button pButton label="Create" icon="pi pi-plus" (click)="createKey()" [loading]="creating()" [disabled]="creating() || !newKeyName.trim()"></button>
+    <button
+      pButton
+      label="Cancel"
+      severity="secondary"
+      (click)="showDialog.set(false)"
+      [disabled]="creating() || saving()"
+    ></button>
+    <button
+      pButton
+      [label]="editingKey() ? 'Save' : 'Create'"
+      [icon]="editingKey() ? 'pi pi-check' : 'pi pi-plus'"
+      (click)="saveKey()"
+      [loading]="creating() || saving()"
+      [disabled]="creating() || saving() || !formName.trim()"
+    ></button>
   </ng-template>
 </p-dialog>
 

--- a/frontend/src/app/features/settings/api-keys/api-keys.component.scss
+++ b/frontend/src/app/features/settings/api-keys/api-keys.component.scss
@@ -132,3 +132,52 @@
     word-break: break-all;
   }
 }
+
+.key-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: $spacing-sm;
+  font-size: $font-size-xs;
+  margin-top: $spacing-xs;
+}
+
+.badge-info {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  padding: 1px 6px;
+  border-radius: $border-radius-sm;
+  background: rgba($color-info, 0.15);
+  color: $color-info;
+  text-transform: uppercase;
+  cursor: help;
+}
+
+.badge-org {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: $border-radius-sm;
+  background: $color-quaternary;
+  color: $text-secondary;
+}
+
+.permission-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: $spacing-xs $spacing-md;
+}
+
+.permission-row {
+  display: flex;
+  align-items: center;
+  gap: $spacing-sm;
+  padding: 2px 0;
+
+  label {
+    font-family: $font-family-mono;
+    font-size: $font-size-sm;
+    cursor: pointer;
+  }
+}

--- a/frontend/src/app/features/settings/api-keys/api-keys.component.ts
+++ b/frontend/src/app/features/settings/api-keys/api-keys.component.ts
@@ -11,9 +11,20 @@ import { FormsModule } from '@angular/forms';
 import { DialogModule } from 'primeng/dialog';
 import { ButtonModule } from 'primeng/button';
 import { InputTextModule } from 'primeng/inputtext';
+import { CheckboxModule } from 'primeng/checkbox';
+import { DividerModule } from 'primeng/divider';
+import { SelectModule } from 'primeng/select';
+import { TooltipModule } from 'primeng/tooltip';
 import { UserService } from '@core/services/user.service';
+import { OrganizationsService } from '@core/services/organizations.service';
 import { ApiKey } from '@core/models';
+import { PermissionDescriptor } from '@core/models/permission.model';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
+
+interface OrgOption {
+  label: string;
+  value: string | null;
+}
 
 @Component({
   selector: 'app-api-keys',
@@ -25,6 +36,10 @@ import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/load
     DialogModule,
     ButtonModule,
     InputTextModule,
+    CheckboxModule,
+    DividerModule,
+    SelectModule,
+    TooltipModule,
     LoadingSpinnerComponent,
   ],
   templateUrl: './api-keys.component.html',
@@ -32,22 +47,45 @@ import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/load
 })
 export class ApiKeysComponent implements OnInit {
   private userService = inject(UserService);
+  private organizationsService = inject(OrganizationsService);
 
   loading = signal(true);
   creating = signal(false);
+  saving = signal(false);
   deletingId = signal<string | null>(null);
   revokingId = signal<string | null>(null);
 
   keys = signal<ApiKey[]>([]);
-  showCreateDialog = signal(false);
+  availablePermissions = signal<PermissionDescriptor[]>([]);
+  orgOptions = signal<OrgOption[]>([{ label: 'Any organization', value: null }]);
+
+  showDialog = signal(false);
+  editingKey = signal<ApiKey | null>(null);
   showKeyDialog = signal(false);
-  newKeyName = '';
-  newKeyExpiresInDays: number | null = null;
   createdKeyValue = signal('');
   errorMessage = signal<string | null>(null);
 
+  formName = '';
+  formExpiresInDays: number | null = null;
+  formPermissions: Record<string, boolean> = {};
+  formOrganization: string | null = null;
+
   ngOnInit(): void {
     this.loadKeys();
+    this.userService.getApiKeyPermissions().subscribe({
+      next: (response) => this.availablePermissions.set(response.available_permissions),
+      error: () => {},
+    });
+    this.organizationsService.getOrganizations(1, 100).subscribe({
+      next: (paginated) => {
+        const options: OrgOption[] = [
+          { label: 'Any organization', value: null },
+          ...paginated.items.map((o) => ({ label: o.name, value: o.name })),
+        ];
+        this.orgOptions.set(options);
+      },
+      error: () => {},
+    });
   }
 
   loadKeys(): void {
@@ -57,39 +95,94 @@ export class ApiKeysComponent implements OnInit {
         this.keys.set(keys);
         this.loading.set(false);
       },
-      error: (error) => {
-        console.error('Failed to load API keys:', error);
-        this.loading.set(false);
-      },
+      error: () => this.loading.set(false),
     });
   }
 
   openCreateDialog(): void {
-    this.newKeyName = '';
-    this.newKeyExpiresInDays = null;
+    this.editingKey.set(null);
+    this.formName = '';
+    this.formExpiresInDays = null;
+    this.formPermissions = this.permissionTemplate(false);
+    this.formPermissions['viewOrg'] = true;
+    this.formOrganization = null;
     this.errorMessage.set(null);
-    this.showCreateDialog.set(true);
+    this.showDialog.set(true);
   }
 
-  createKey(): void {
-    const name = this.newKeyName.trim();
-    if (!name) return;
-
-    this.creating.set(true);
+  openEditDialog(key: ApiKey): void {
+    if (key.managed) return;
+    this.editingKey.set(key);
+    this.formName = key.name;
+    this.formExpiresInDays = null;
+    this.formPermissions = this.permissionTemplate(false);
+    for (const p of key.permissions) this.formPermissions[p] = true;
+    this.formOrganization = key.organization;
     this.errorMessage.set(null);
-    this.userService.createApiKey(name, this.newKeyExpiresInDays).subscribe({
-      next: (keyValue) => {
-        this.creating.set(false);
-        this.showCreateDialog.set(false);
-        this.createdKeyValue.set(keyValue);
-        this.showKeyDialog.set(true);
-        this.loadKeys();
-      },
-      error: (error) => {
-        this.errorMessage.set(error.message || 'Failed to create API key.');
-        this.creating.set(false);
-      },
-    });
+    this.showDialog.set(true);
+  }
+
+  private permissionTemplate(value: boolean): Record<string, boolean> {
+    const out: Record<string, boolean> = {};
+    for (const p of this.availablePermissions()) out[p.id] = value;
+    return out;
+  }
+
+  selectedPermissions(): string[] {
+    return Object.entries(this.formPermissions)
+      .filter(([, on]) => on)
+      .map(([id]) => id);
+  }
+
+  saveKey(): void {
+    const name = this.formName.trim();
+    const perms = this.selectedPermissions();
+    if (!name) {
+      this.errorMessage.set('Name is required.');
+      return;
+    }
+    if (perms.length === 0) {
+      this.errorMessage.set('Select at least one permission.');
+      return;
+    }
+    const editing = this.editingKey();
+    if (editing) {
+      this.saving.set(true);
+      this.userService
+        .updateApiKey(editing.id, {
+          name,
+          permissions: perms,
+          organization: this.formOrganization,
+        })
+        .subscribe({
+          next: () => {
+            this.saving.set(false);
+            this.showDialog.set(false);
+            this.loadKeys();
+          },
+          error: (err) => {
+            this.errorMessage.set(err?.error?.message || 'Failed to save key.');
+            this.saving.set(false);
+          },
+        });
+    } else {
+      this.creating.set(true);
+      this.userService
+        .createApiKey(name, this.formExpiresInDays, perms, this.formOrganization)
+        .subscribe({
+          next: (keyValue) => {
+            this.creating.set(false);
+            this.showDialog.set(false);
+            this.createdKeyValue.set(keyValue);
+            this.showKeyDialog.set(true);
+            this.loadKeys();
+          },
+          error: (err) => {
+            this.errorMessage.set(err?.error?.message || 'Failed to create key.');
+            this.creating.set(false);
+          },
+        });
+    }
   }
 
   revokeKey(key: ApiKey): void {
@@ -99,9 +192,7 @@ export class ApiKeysComponent implements OnInit {
         this.revokingId.set(null);
         this.loadKeys();
       },
-      error: () => {
-        this.revokingId.set(null);
-      },
+      error: () => this.revokingId.set(null),
     });
   }
 
@@ -112,14 +203,16 @@ export class ApiKeysComponent implements OnInit {
         this.deletingId.set(null);
         this.loadKeys();
       },
-      error: (error) => {
-        console.error('Failed to delete API key:', error);
-        this.deletingId.set(null);
-      },
+      error: () => this.deletingId.set(null),
     });
   }
 
   copyKey(): void {
     navigator.clipboard.writeText(this.createdKeyValue());
+  }
+
+  permissionTooltip(key: ApiKey): string {
+    if (key.permissions.length === 0) return 'No permissions';
+    return key.permissions.join(', ');
   }
 }

--- a/nix/modules/gradient-state.nix
+++ b/nix/modules/gradient-state.nix
@@ -564,6 +564,63 @@
         type = types.str;
         description = "Username of the user who owns this API key";
       };
+
+      permissions = mkOption {
+        type = types.listOf types.str;
+        description = ''
+          Capability identifiers (camelCase) the API key grants. Must be
+          non-empty. The full catalogue is defined in
+          `gradient_core::permissions::Permission` and exposed at runtime via
+          `GET /user/keys/permissions`. Common identifiers include
+          `viewOrg`, `triggerEvaluation`, `editProject`, `manageMembers`.
+        '';
+        example = [ "viewOrg" "triggerEvaluation" ];
+      };
+
+      organization = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Optional organization name to pin the key to. When set, the key is
+          rejected for every other organization (the request looks identical
+          to "not a member"). When null, the key works in any org the owning
+          user is a member of.
+        '';
+      };
+    };
+  });
+
+  roleType = types.submodule ({ name, ... }: {
+    options = {
+      name = mkOption {
+        type = types.str;
+        default = name;
+        defaultText = "<attrset key>";
+        description = ''
+          Name of the role. Must not collide with the built-in role names
+          (`Admin`, `Write`, `View`) and must be unique within its
+          organization. State-managed roles cannot be modified via the
+          role-management API.
+        '';
+      };
+
+      organization = mkOption {
+        type = types.str;
+        description = ''
+          Organization the role belongs to. State-managed roles are always
+          org-scoped — there is no way to define a global state-managed
+          role.
+        '';
+      };
+
+      permissions = mkOption {
+        type = types.listOf types.str;
+        description = ''
+          Capability identifiers (camelCase) the role grants. Must be
+          non-empty. See `apiKeyType.permissions` for the catalogue.
+        '';
+        example = [ "viewOrg" "triggerEvaluation" ];
+      };
     };
   });
 
@@ -622,6 +679,17 @@
         type = types.attrsOf cacheType;
         default = { };
         description = "Attribute set of caches to create, keyed by name";
+      };
+
+      roles = mkOption {
+        type = types.attrsOf roleType;
+        default = { };
+        description = ''
+          Attribute set of state-managed custom roles, keyed by role name.
+          Each entry creates a custom role in the specified organization with
+          the given permission set. Managed roles cannot be modified or
+          deleted through the API — only this state file can change them.
+        '';
       };
 
       api_keys = mkOption {
@@ -705,6 +773,20 @@ in
               signing_key_file = "/etc/gradient/secrets/main_cache_key";
               organizations = [ "acme-corp" ];
               created_by = "alice";
+            };
+          };
+          roles = {
+            releaser = {
+              organization = "acme-corp";
+              permissions = [ "viewOrg" "triggerEvaluation" ];
+            };
+          };
+          api_keys = {
+            ci-runner = {
+              key_file = "/etc/gradient/secrets/ci-runner";
+              owned_by = "alice";
+              permissions = [ "viewOrg" "triggerEvaluation" ];
+              organization = "acme-corp";
             };
           };
         }


### PR DESCRIPTION
## Summary

Extends API keys with the same configurable-options model already used by organization roles. Each key carries a permission bitmask (subset of `Permission::ALL`) and an optional organization pin; the access layer intersects the key's mask with the user's role mask on every authenticated request, and a pinned-org mismatch short-circuits to NotFound (no existence leak).

Folded in: state-managed custom roles, since the same state-config and Nix module surface needed them.

### What changed

- **Backend**
  - Migration: `api.permission` (bigint NOT NULL DEFAULT admin_mask) + `api.organization` (uuid NULL, ON DELETE SET NULL).
  - Migration: `role.managed` (bool NOT NULL DEFAULT false) so state-managed roles are immutable through the API.
  - `decode_jwt` now returns a `DecodedRequest` enum; auth middleware injects `Extension<MaybeApiKey>` on every authenticated request.
  - `access.rs::load_membership_with_permissions` intersects role mask with key mask; pinned-org guards return `Ok(None)` so loaders surface NotFound.
  - New endpoints: `GET /user/keys/permissions` (catalogue), `PATCH /user/keys/{api_id}` (edit name/permissions/organization).
  - `POST /user/keys` body now requires `permissions: string[]`; accepts optional `organization` (org name).
  - Self-management guard: API-key-authenticated requests cannot create/edit/revoke/delete API keys.
  - Audit event `api_key.update`; `api_key.create` payload now records the permissions mask + organization id.
  - `crate::permissions::{PermissionEntry, available_permissions, parse_permission_list}` shared between the role and api-key endpoints.

- **State / Nix**
  - `StateApiKey` gains `permissions` (required, non-empty) and `organization` (optional).
  - New `StateRole { name, organization, permissions }` for declarative custom roles.
  - `apply_roles` upserts managed roles; `unmark_removed_entities` cleans them up.
  - `nix/modules/gradient-state.nix` exposes the new options on `apiKeyType`, adds a new `roleType`, and adds `roles` to `stateType`.

- **Frontend**
  - Shared `PermissionDescriptor` lifted to `@core/models/permission.model`.
  - `ApiKey` model + `UserService` extended (`createApiKey` takes permissions/org; new `updateApiKey` and `getApiKeyPermissions`).
  - `features/settings/api-keys/` page rebuilt: single create/edit dialog with a permission checkbox grid + organization dropdown, list rows show permission count (with hover tooltip) and pinned org chip.

- **Docs**
  - `docs/gradient-api.yaml` updated (new endpoints, schemas, audit event).
  - `docs/src/usage/api.md`, `usage/state.md`, `configuration.md`, `tests.md` extended.

## Test plan

CI runs the full suite. Locally verified:

- [x] `cargo check --workspace` clean
- [x] `cargo clippy -p web -p core -p entity -p migration -p test-support --tests -- -D warnings` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `npx ng build --configuration=development` clean
- [x] OpenAPI spec parses (`yaml.safe_load`)
- [x] New integration tests in `auth_hardening.rs` cover the cap, pin, and self-management paths
- [x] New unit tests in `access.rs` cover the intersection + pinned-org short-circuit

Pre-existing `cargo clippy --workspace --tests -- -D warnings` failure in `proto/src/handler/dispatch.rs:901` (`useless_vec`) reproduced against `main` — unrelated to this PR.