### PR TITLE
Unified frontend access control (state-managed + read-only UX)

### DIFF
--- a/backend/web/src/endpoints/projects/evaluations.rs
+++ b/backend/web/src/endpoints/projects/evaluations.rs
@@ -323,6 +323,7 @@ pub async fn get_project_details(
         keep_evaluations: project.keep_evaluations,
         last_evaluations: evaluation_summaries,
         can_edit,
+        managed: project.managed,
     };
 
     let res = BaseResponse {

--- a/backend/web/src/endpoints/projects/mod.rs
+++ b/backend/web/src/endpoints/projects/mod.rs
@@ -104,4 +104,5 @@ pub struct ProjectDetailsResponse {
     pub keep_evaluations: i32,
     pub last_evaluations: Vec<EvaluationSummary>,
     pub can_edit: bool,
+    pub managed: bool,
 }

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -5202,23 +5202,51 @@ components:
 
     ProjectDetailsResponse:
       type: object
-      required: [keep_evaluations, recent_evaluations, entry_points]
+      required:
+        - id
+        - name
+        - display_name
+        - description
+        - repository
+        - wildcard
+        - active
+        - created_at
+        - keep_evaluations
+        - last_evaluations
+        - can_edit
+        - managed
       properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        display_name:
+          type: string
+        description:
+          type: string
+        repository:
+          type: string
+        wildcard:
+          type: string
+        active:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
         keep_evaluations:
           type: integer
           description: Number of completed evaluations retained for metrics and history
-        latest_evaluation:
-          allOf:
-            - $ref: '#/components/schemas/EvaluationSummary'
-          nullable: true
-        recent_evaluations:
+        last_evaluations:
           type: array
           items:
             $ref: '#/components/schemas/EvaluationSummary'
-        entry_points:
-          type: array
-          items:
-            $ref: '#/components/schemas/EntryPointSummary'
+        can_edit:
+          type: boolean
+          description: True when the caller has permission to edit this project.
+        managed:
+          type: boolean
+          description: True when the project is managed by declarative Nix state and cannot be edited via the UI.
 
     ProjectMetricsResponse:
       type: object

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -1894,3 +1894,62 @@ and the failure mode is loud.
   existence isn't leaked.
 - `api_key_cannot_create_api_keys` — `POST /api/v1/user/keys` from an
   API-key-authenticated request returns 403 (the self-management guard).
+
+## Frontend access control — `shared/access`
+
+Two API-provided flags drive the user-visible rule that:
+
+- **State-managed** resources (`entity.managed === true`) appear with all fields
+  and write buttons visible but disabled, with a "Managed by Nix" banner.
+- **Read-only** access (`entity.can_edit === false`) hides write buttons
+  entirely and shows inputs as disabled with a "Read-only access" banner.
+
+The primitives:
+
+- `frontend/src/app/shared/access/access.service.ts` — `AccessService` with
+  pure helpers (`isWritable`, `shouldShowWriteAction`, `shouldDisableInput`,
+  `bannerKind`, `bannerMessage`). Tests cover the four flag combinations.
+- `frontend/src/app/shared/access/writable.directive.ts` — `*appWritable`
+  structural directive. Renders content iff `canEdit`. Tests cover
+  render/hide on each combination plus toggling.
+- `frontend/src/app/shared/access/managed-disable.directive.ts` —
+  `[appManagedDisable]` attribute directive. Adds `disabled` and a tooltip
+  when `managed || !canEdit`. Tests cover all four flag combinations,
+  tooltip text, and that the directive correctly clears its own state when
+  access becomes writable.
+- `frontend/src/app/shared/access/access-banner.component.ts` —
+  `<app-access-banner>` rendering nothing for full access; otherwise an info
+  bar with appropriate text and CSS class. Tests cover the four banner
+  kinds.
+- `frontend/src/app/core/resolvers/project-access.resolver.ts` and
+  `cache-access.resolver.ts` — fetch the parent entity once, expose
+  `{ entity, access }` on `route.parent.data`. Children consume via
+  `injectProjectAccess()` / `injectCacheAccess()`. Tests cover the happy
+  path and the `managed=true / can_edit=false` propagation.
+- `frontend/src/app/core/services/org-access.service.ts` — derives
+  `AccessState` from `Organization.role` and `Organization.managed` for
+  org-scoped pages without a parent entity resolver. Tests cover Admin /
+  Write / View / undefined / custom-role-name cases.
+
+Each retrofitted feature component (`project-settings`, `project-triggers`,
+`project-detail`, `cache-settings`, `cache-upstreams`,
+`organization-settings`, `workers`, `cache-subscriptions`, `members-roles`,
+`api-keys`, `profile`) carries gating tests covering at least the two
+key scenarios:
+
+- **Read-only** (`canEdit=false`): write-action buttons absent from the
+  DOM; the page itself remains visible.
+- **State-managed with permission** (`managed=true, canEdit=true`):
+  write-action buttons present in the DOM but disabled.
+
+The two reported bugs that motivated this work are covered directly:
+
+- `WorkersComponent` — Register Worker absent under view-only access;
+  present-disabled under state-managed org; per-row buttons honor each
+  worker's own `managed` flag independent of the org's access.
+- `CacheUpstreamsComponent` — Add Upstream / Edit / Delete absent under
+  view-only access (page itself remains navigable); present-disabled
+  under state-managed cache.
+
+Run command: `pnpm -C frontend test --watch=false --include='**/access*'`
+(primitives) or the full suite with `pnpm -C frontend test --watch=false`.

--- a/docs/src/usage/state.md
+++ b/docs/src/usage/state.md
@@ -8,6 +8,28 @@ When `settings.deleteState = true` (default), entities that are removed from `st
 
 Users, organizations, and caches created by the NixOS module configuration carry `managed = true`. The API rejects mutations and deletions of these records with `403 Forbidden`. This allows declarative configuration to be the source of truth without Gradient's UI overwriting it.
 
+### How the UI surfaces this
+
+Managed-resource and read-only access show up consistently across the dashboard:
+
+- **A "Managed by Nix" banner** appears at the top of any settings page or
+  subpage for a state-managed resource. Form fields remain visible but
+  disabled, and write buttons (Save, Delete, etc.) are visible but
+  greyed out — so you can see exactly what the resource looks like and
+  what actions exist, you just can't trigger them here. Update the Nix
+  config instead.
+- **A "Read-only access" banner** appears when your organization role
+  doesn't grant write permission on the resource. Form fields remain
+  visible but disabled; write buttons are **hidden entirely** — they don't
+  exist for you. Contact an organization admin to make changes.
+- **Both banners** coalesce into a single "Managed by Nix (read-only)"
+  notice when both apply.
+
+The pages themselves are always navigable. A state-managed cache's
+upstreams subpage, for example, is reachable so you can see what
+upstreams are configured — only the Add / Edit / Delete controls are
+gated.
+
 ## Users
 
 ```nix

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -7,6 +7,8 @@
 import { Routes } from '@angular/router';
 import { authGuard } from '@core/guards/auth.guard';
 import { adminGuard } from '@core/guards/admin.guard';
+import { projectAccessResolver } from '@core/resolvers/project-access.resolver';
+import { cacheAccessResolver } from '@core/resolvers/cache-access.resolver';
 
 export const routes: Routes = [
   // Authentication routes (public)
@@ -35,7 +37,7 @@ export const routes: Routes = [
     ],
   },
 
-  // Public-browsable routes (no login required, write actions hidden)
+  // Organization detail (public)
   {
     path: 'organization/:org',
     title: 'Organization',
@@ -44,30 +46,63 @@ export const routes: Routes = [
         (m) => m.OrganizationDetailComponent
       ),
   },
+
+  // Project tree with parent layout + access resolver
   {
     path: 'organization/:org/project/:project',
-    title: 'Project',
     loadComponent: () =>
-      import('./features/projects/project-detail/project-detail.component').then(
-        (m) => m.ProjectDetailComponent
+      import('./features/projects/project-layout/project-layout.component').then(
+        (m) => m.ProjectLayoutComponent,
       ),
+    resolve: { projectAccess: projectAccessResolver },
+    runGuardsAndResolvers: 'paramsChange',
+    children: [
+      {
+        path: '',
+        title: 'Project',
+        loadComponent: () =>
+          import('./features/projects/project-detail/project-detail.component').then(
+            (m) => m.ProjectDetailComponent,
+          ),
+      },
+      {
+        path: 'metrics',
+        title: 'Project Metrics',
+        loadComponent: () =>
+          import('./features/projects/project-metrics/project-metrics.component').then(
+            (m) => m.ProjectMetricsComponent,
+          ),
+      },
+      {
+        path: 'entry-point-metrics',
+        title: 'Entry Point Metrics',
+        loadComponent: () =>
+          import('./features/projects/entry-point-metrics/entry-point-metrics.component').then(
+            (m) => m.EntryPointMetricsComponent,
+          ),
+      },
+      {
+        path: 'settings',
+        title: 'Project Settings',
+        canActivate: [authGuard],
+        loadComponent: () =>
+          import('./features/projects/project-settings/project-settings.component').then(
+            (m) => m.ProjectSettingsComponent,
+          ),
+      },
+      {
+        path: 'triggers',
+        title: 'Project Triggers',
+        canActivate: [authGuard],
+        loadComponent: () =>
+          import('./features/projects/project-triggers/project-triggers.component').then(
+            (m) => m.ProjectTriggersComponent,
+          ),
+      },
+    ],
   },
-  {
-    path: 'organization/:org/project/:project/metrics',
-    title: 'Project Metrics',
-    loadComponent: () =>
-      import('./features/projects/project-metrics/project-metrics.component').then(
-        (m) => m.ProjectMetricsComponent
-      ),
-  },
-  {
-    path: 'organization/:org/project/:project/entry-point-metrics',
-    title: 'Entry Point Metrics',
-    loadComponent: () =>
-      import('./features/projects/entry-point-metrics/entry-point-metrics.component').then(
-        (m) => m.EntryPointMetricsComponent
-      ),
-  },
+
+  // Build / evaluation utility routes (no layout)
   {
     path: 'organization/:org/artefacts/:buildId',
     title: 'Build Artefacts',
@@ -104,13 +139,44 @@ export const routes: Routes = [
         (m) => m.EvaluationLogComponent
       ),
   },
+
+  // Cache tree with parent layout + access resolver
   {
     path: 'caches/:cache',
-    title: 'Cache',
     loadComponent: () =>
-      import('./features/caches/cache-detail/cache-detail.component').then(
-        (m) => m.CacheDetailComponent
+      import('./features/caches/cache-layout/cache-layout.component').then(
+        (m) => m.CacheLayoutComponent,
       ),
+    resolve: { cacheAccess: cacheAccessResolver },
+    runGuardsAndResolvers: 'paramsChange',
+    children: [
+      {
+        path: '',
+        title: 'Cache',
+        loadComponent: () =>
+          import('./features/caches/cache-detail/cache-detail.component').then(
+            (m) => m.CacheDetailComponent,
+          ),
+      },
+      {
+        path: 'settings',
+        title: 'Cache Settings',
+        canActivate: [authGuard],
+        loadComponent: () =>
+          import('./features/caches/cache-settings/cache-settings.component').then(
+            (m) => m.CacheSettingsComponent,
+          ),
+      },
+      {
+        path: 'upstreams',
+        title: 'Upstream Caches',
+        canActivate: [authGuard],
+        loadComponent: () =>
+          import('./features/caches/cache-upstreams/cache-upstreams.component').then(
+            (m) => m.CacheUpstreamsComponent,
+          ),
+      },
+    ],
   },
 
   // Public-browsable list routes
@@ -189,42 +255,6 @@ export const routes: Routes = [
         loadComponent: () =>
           import('./features/organizations/cache-subscriptions/cache-subscriptions.component').then(
             (m) => m.CacheSubscriptionsComponent
-          ),
-      },
-
-      // Projects
-      {
-        path: 'organization/:org/project/:project/settings',
-        title: 'Project Settings',
-        loadComponent: () =>
-          import('./features/projects/project-settings/project-settings.component').then(
-            (m) => m.ProjectSettingsComponent
-          ),
-      },
-      {
-        path: 'organization/:org/project/:project/triggers',
-        title: 'Project Triggers',
-        loadComponent: () =>
-          import('./features/projects/project-triggers/project-triggers.component').then(
-            (m) => m.ProjectTriggersComponent
-          ),
-      },
-
-      // Caches
-      {
-        path: 'caches/:cache/settings',
-        title: 'Cache Settings',
-        loadComponent: () =>
-          import('./features/caches/cache-settings/cache-settings.component').then(
-            (m) => m.CacheSettingsComponent
-          ),
-      },
-      {
-        path: 'caches/:cache/upstreams',
-        title: 'Upstream Caches',
-        loadComponent: () =>
-          import('./features/caches/cache-upstreams/cache-upstreams.component').then(
-            (m) => m.CacheUpstreamsComponent
           ),
       },
 

--- a/frontend/src/app/app.spec.ts
+++ b/frontend/src/app/app.spec.ts
@@ -1,23 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
 import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { App } from './app';
 
 describe('App', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [App],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
     }).compileComponents();
   });
 
-  it('should create the app', () => {
+  it('renders', () => {
     const fixture = TestBed.createComponent(App);
-    const app = fixture.componentInstance;
-    expect(app).toBeTruthy();
-  });
-
-  it('should render title', async () => {
-    const fixture = TestBed.createComponent(App);
-    await fixture.whenStable();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, gradient-frontend');
+    expect(fixture.componentInstance).toBeTruthy();
   });
 });

--- a/frontend/src/app/core/models/access.model.ts
+++ b/frontend/src/app/core/models/access.model.ts
@@ -1,0 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export interface AccessState {
+  managed: boolean;
+  canEdit: boolean;
+}
+
+export function accessFromEntity(e: {
+  managed: boolean;
+  can_edit: boolean;
+}): AccessState {
+  return { managed: e.managed, canEdit: e.can_edit };
+}

--- a/frontend/src/app/core/models/index.ts
+++ b/frontend/src/app/core/models/index.ts
@@ -15,3 +15,4 @@ export * from './worker.model';
 export * from './commit.model';
 export * from './integration.model';
 export * from './trigger.model';
+export * from './access.model';

--- a/frontend/src/app/core/models/project.model.ts
+++ b/frontend/src/app/core/models/project.model.ts
@@ -68,6 +68,7 @@ export interface ProjectDetail {
   keep_evaluations: number;
   last_evaluations: EvaluationSummary[];
   can_edit: boolean;
+  managed: boolean;
 }
 
 export interface EvaluationMessage {

--- a/frontend/src/app/core/resolvers/cache-access.resolver.spec.ts
+++ b/frontend/src/app/core/resolvers/cache-access.resolver.spec.ts
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, convertToParamMap } from '@angular/router';
+import { Observable, firstValueFrom, of } from 'rxjs';
+import { CachesService } from '@core/services/caches.service';
+import { cacheAccessResolver, CacheAccessData } from './cache-access.resolver';
+import { Cache } from '@core/models/cache.model';
+
+function snap(params: Record<string, string>): ActivatedRouteSnapshot {
+  return { paramMap: convertToParamMap(params) } as ActivatedRouteSnapshot;
+}
+
+function runResolver(
+  route: ActivatedRouteSnapshot,
+): Promise<CacheAccessData> {
+  const result = TestBed.runInInjectionContext(() =>
+    cacheAccessResolver(route, {} as never),
+  ) as Observable<CacheAccessData>;
+  return firstValueFrom(result);
+}
+
+describe('cacheAccessResolver', () => {
+  let getCache: ReturnType<typeof vi.fn>;
+
+  const baseCache: Cache = {
+    id: 'c1',
+    name: 'demo',
+    display_name: 'Demo',
+    description: '',
+    active: true,
+    priority: 10,
+    public: false,
+    managed: false,
+    can_edit: true,
+  };
+
+  beforeEach(() => {
+    getCache = vi.fn(() => of(baseCache));
+    TestBed.configureTestingModule({
+      providers: [{ provide: CachesService, useValue: { getCache } }],
+    });
+  });
+
+  it('fetches the cache by route param and exposes access state', async () => {
+    const data = await runResolver(snap({ cache: 'demo' }));
+    expect(getCache).toHaveBeenCalledWith('demo');
+    expect(data.cache).toBe(baseCache);
+    expect(data.access).toEqual({ managed: false, canEdit: true });
+  });
+
+  it('propagates managed and can_edit into access', async () => {
+    getCache.mockReturnValue(
+      of({ ...baseCache, managed: true, can_edit: false }),
+    );
+    const data = await runResolver(snap({ cache: 'demo' }));
+    expect(data.access).toEqual({ managed: true, canEdit: false });
+  });
+});

--- a/frontend/src/app/core/resolvers/cache-access.resolver.ts
+++ b/frontend/src/app/core/resolvers/cache-access.resolver.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { inject } from '@angular/core';
+import { ResolveFn } from '@angular/router';
+import { map } from 'rxjs';
+import { CachesService } from '@core/services/caches.service';
+import { Cache } from '@core/models/cache.model';
+import { AccessState, accessFromEntity } from '@core/models/access.model';
+
+export interface CacheAccessData {
+  cache: Cache;
+  access: AccessState;
+}
+
+export const cacheAccessResolver: ResolveFn<CacheAccessData> = (route) => {
+  const caches = inject(CachesService);
+  const cache = route.paramMap.get('cache') ?? '';
+  return caches.getCache(cache).pipe(
+    map((c) => ({ cache: c, access: accessFromEntity(c) })),
+  );
+};

--- a/frontend/src/app/core/resolvers/inject-access.ts
+++ b/frontend/src/app/core/resolvers/inject-access.ts
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Signal, computed, inject } from '@angular/core';
+import { ActivatedRoute, Data } from '@angular/router';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { Observable, map, of } from 'rxjs';
+import { ProjectAccessData } from './project-access.resolver';
+import { CacheAccessData } from './cache-access.resolver';
+import { AccessState } from '@core/models/access.model';
+
+const DEFAULT_ACCESS: AccessState = { managed: false, canEdit: false };
+
+function parentDataSignal<T>(
+  route: ActivatedRoute,
+  key: 'projectAccess' | 'cacheAccess',
+): Signal<T | undefined> {
+  const source: Observable<T | undefined> = route.parent
+    ? route.parent.data.pipe(map((d: Data) => d[key] as T | undefined))
+    : of(undefined);
+  return toSignal(source, { initialValue: undefined });
+}
+
+export function injectProjectAccessData(): Signal<ProjectAccessData | undefined> {
+  const route = inject(ActivatedRoute);
+  return parentDataSignal<ProjectAccessData>(route, 'projectAccess');
+}
+
+export function injectCacheAccessData(): Signal<CacheAccessData | undefined> {
+  const route = inject(ActivatedRoute);
+  return parentDataSignal<CacheAccessData>(route, 'cacheAccess');
+}
+
+export function injectProjectAccess(): Signal<AccessState> {
+  const data = injectProjectAccessData();
+  return computed(() => data()?.access ?? DEFAULT_ACCESS);
+}
+
+export function injectCacheAccess(): Signal<AccessState> {
+  const data = injectCacheAccessData();
+  return computed(() => data()?.access ?? DEFAULT_ACCESS);
+}

--- a/frontend/src/app/core/resolvers/project-access.resolver.spec.ts
+++ b/frontend/src/app/core/resolvers/project-access.resolver.spec.ts
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, convertToParamMap } from '@angular/router';
+import { Observable, firstValueFrom, of } from 'rxjs';
+import { ProjectsService } from '@core/services/projects.service';
+import {
+  projectAccessResolver,
+  ProjectAccessData,
+} from './project-access.resolver';
+import { ProjectDetail } from '@core/models/project.model';
+
+function snap(params: Record<string, string>): ActivatedRouteSnapshot {
+  return { paramMap: convertToParamMap(params) } as ActivatedRouteSnapshot;
+}
+
+function runResolver(
+  route: ActivatedRouteSnapshot,
+): Promise<ProjectAccessData> {
+  const result = TestBed.runInInjectionContext(() =>
+    projectAccessResolver(route, {} as never),
+  ) as Observable<ProjectAccessData>;
+  return firstValueFrom(result);
+}
+
+describe('projectAccessResolver', () => {
+  let getProject: ReturnType<typeof vi.fn>;
+
+  const baseProject: ProjectDetail = {
+    id: 'p1',
+    name: 'demo',
+    display_name: 'Demo',
+    description: '',
+    repository: '',
+    wildcard: '',
+    active: true,
+    created_at: '',
+    keep_evaluations: 5,
+    last_evaluations: [],
+    can_edit: true,
+    managed: false,
+  };
+
+  beforeEach(() => {
+    getProject = vi.fn(() => of(baseProject));
+    TestBed.configureTestingModule({
+      providers: [{ provide: ProjectsService, useValue: { getProject } }],
+    });
+  });
+
+  it('fetches the project by route params and exposes access state', async () => {
+    const data = await runResolver(snap({ org: 'acme', project: 'demo' }));
+    expect(getProject).toHaveBeenCalledWith('acme', 'demo');
+    expect(data.project).toBe(baseProject);
+    expect(data.access).toEqual({ managed: false, canEdit: true });
+  });
+
+  it('propagates managed=true and can_edit=false into access', async () => {
+    getProject.mockReturnValue(
+      of({ ...baseProject, managed: true, can_edit: false }),
+    );
+    const data = await runResolver(snap({ org: 'acme', project: 'demo' }));
+    expect(data.access).toEqual({ managed: true, canEdit: false });
+  });
+});

--- a/frontend/src/app/core/resolvers/project-access.resolver.ts
+++ b/frontend/src/app/core/resolvers/project-access.resolver.ts
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { inject } from '@angular/core';
+import { ResolveFn } from '@angular/router';
+import { map } from 'rxjs';
+import { ProjectsService } from '@core/services/projects.service';
+import { ProjectDetail } from '@core/models/project.model';
+import { AccessState, accessFromEntity } from '@core/models/access.model';
+
+export interface ProjectAccessData {
+  project: ProjectDetail;
+  access: AccessState;
+}
+
+export const projectAccessResolver: ResolveFn<ProjectAccessData> = (route) => {
+  const projects = inject(ProjectsService);
+  const org = route.paramMap.get('org') ?? '';
+  const project = route.paramMap.get('project') ?? '';
+  return projects.getProject(org, project).pipe(
+    map((p) => ({ project: p, access: accessFromEntity(p) })),
+  );
+};

--- a/frontend/src/app/core/services/org-access.service.spec.ts
+++ b/frontend/src/app/core/services/org-access.service.spec.ts
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { OrgAccessService } from './org-access.service';
+import { OrganizationsService } from './organizations.service';
+import { Organization } from '@core/models/organization.model';
+
+function org(partial: Partial<Organization> = {}): Organization {
+  return {
+    id: 'o1',
+    name: 'acme',
+    display_name: 'Acme',
+    description: '',
+    public: false,
+    managed: false,
+    ...partial,
+  };
+}
+
+describe('OrgAccessService', () => {
+  let svc: OrgAccessService;
+  let getOrganization: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    getOrganization = vi.fn();
+    TestBed.configureTestingModule({
+      providers: [{ provide: OrganizationsService, useValue: { getOrganization } }],
+    });
+    svc = TestBed.inject(OrgAccessService);
+  });
+
+  it('returns canEdit=true and managed=false for Admin in unmanaged org', async () => {
+    getOrganization.mockReturnValue(of(org({ role: 'Admin' })));
+    expect(await svc.forOrg('acme')).toEqual({ managed: false, canEdit: true });
+  });
+
+  it('returns canEdit=true and managed=true for Admin in managed org', async () => {
+    getOrganization.mockReturnValue(of(org({ role: 'Admin', managed: true })));
+    expect(await svc.forOrg('acme')).toEqual({ managed: true, canEdit: true });
+  });
+
+  it('returns canEdit=true for Write role', async () => {
+    getOrganization.mockReturnValue(of(org({ role: 'Write' })));
+    expect(await svc.forOrg('acme')).toEqual({ managed: false, canEdit: true });
+  });
+
+  it('returns canEdit=false for View role', async () => {
+    getOrganization.mockReturnValue(of(org({ role: 'View' })));
+    expect(await svc.forOrg('acme')).toEqual({ managed: false, canEdit: false });
+  });
+
+  it('returns canEdit=false when role is missing (not a member)', async () => {
+    getOrganization.mockReturnValue(of(org({ role: undefined })));
+    expect(await svc.forOrg('acme')).toEqual({ managed: false, canEdit: false });
+  });
+
+  it('treats custom non-View role names as writable', async () => {
+    getOrganization.mockReturnValue(of(org({ role: 'Maintainer' as never })));
+    expect(await svc.forOrg('acme')).toEqual({ managed: false, canEdit: true });
+  });
+});

--- a/frontend/src/app/core/services/org-access.service.ts
+++ b/frontend/src/app/core/services/org-access.service.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Injectable, inject } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { OrganizationsService } from './organizations.service';
+import { AccessState } from '@core/models/access.model';
+
+@Injectable({ providedIn: 'root' })
+export class OrgAccessService {
+  private orgs = inject(OrganizationsService);
+
+  async forOrg(name: string): Promise<AccessState> {
+    const org = await firstValueFrom(this.orgs.getOrganization(name));
+    const canEdit = !!org.role && org.role !== 'View';
+    return { managed: !!org.managed, canEdit };
+  }
+}

--- a/frontend/src/app/features/admin/github-app/github-app.component.spec.ts
+++ b/frontend/src/app/features/admin/github-app/github-app.component.spec.ts
@@ -13,14 +13,19 @@ import { of, throwError } from 'rxjs';
 import { GithubAppComponent } from './github-app.component';
 import { AdminService } from '@core/services/admin.service';
 
+type MockedAdmin = {
+  requestGithubAppManifest: ReturnType<typeof vi.fn>;
+  fetchGithubAppCredentials: ReturnType<typeof vi.fn>;
+};
+
 describe('GithubAppComponent', () => {
-  let admin: jasmine.SpyObj<AdminService>;
+  let admin: MockedAdmin;
 
   function setup(queryParams: Record<string, string> = {}) {
-    admin = jasmine.createSpyObj<AdminService>('AdminService', [
-      'requestGithubAppManifest',
-      'fetchGithubAppCredentials',
-    ]);
+    admin = {
+      requestGithubAppManifest: vi.fn(),
+      fetchGithubAppCredentials: vi.fn(),
+    };
     TestBed.configureTestingModule({
       imports: [GithubAppComponent],
       providers: [
@@ -51,7 +56,7 @@ describe('GithubAppComponent', () => {
 
   it('clicking create-button calls requestGithubAppManifest with host', () => {
     setup({});
-    admin.requestGithubAppManifest.and.returnValue(
+    admin.requestGithubAppManifest.mockReturnValue(
       of({ manifest: {}, post_url: 'https://github.com/x', state: 's' }),
     );
     const fixture = TestBed.createComponent(GithubAppComponent);
@@ -62,7 +67,7 @@ describe('GithubAppComponent', () => {
 
   it('renders credentials when ready=1 and the API returns them', async () => {
     setup({ ready: '1' });
-    admin.fetchGithubAppCredentials.and.returnValue(
+    admin.fetchGithubAppCredentials.mockReturnValue(
       of({
         id: 7,
         slug: 'gradient',
@@ -85,7 +90,7 @@ describe('GithubAppComponent', () => {
 
   it('shows a friendly error when credentials are no longer available', async () => {
     setup({ ready: '1' });
-    admin.fetchGithubAppCredentials.and.returnValue(
+    admin.fetchGithubAppCredentials.mockReturnValue(
       throwError(() => ({ status: 404 })),
     );
     const fixture = TestBed.createComponent(GithubAppComponent);

--- a/frontend/src/app/features/caches/cache-layout/cache-layout.component.html
+++ b/frontend/src/app/features/caches/cache-layout/cache-layout.component.html
@@ -1,0 +1,4 @@
+<div class="cache-layout">
+  <app-access-banner [access]="access()"></app-access-banner>
+  <router-outlet></router-outlet>
+</div>

--- a/frontend/src/app/features/caches/cache-layout/cache-layout.component.scss
+++ b/frontend/src/app/features/caches/cache-layout/cache-layout.component.scss
@@ -1,0 +1,3 @@
+.cache-layout {
+  display: contents;
+}

--- a/frontend/src/app/features/caches/cache-layout/cache-layout.component.ts
+++ b/frontend/src/app/features/caches/cache-layout/cache-layout.component.ts
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { RouterOutlet } from '@angular/router';
+import { AccessBannerComponent } from '@shared/access';
+import { injectCacheAccess } from '@core/resolvers/inject-access';
+
+@Component({
+  selector: 'app-cache-layout',
+  standalone: true,
+  imports: [RouterOutlet, AccessBannerComponent],
+  templateUrl: './cache-layout.component.html',
+  styleUrl: './cache-layout.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CacheLayoutComponent {
+  access = injectCacheAccess();
+}

--- a/frontend/src/app/features/caches/cache-settings/cache-settings.component.html
+++ b/frontend/src/app/features/caches/cache-settings/cache-settings.component.html
@@ -24,17 +24,6 @@
     <!-- General -->
     <div class="settings-section">
       <h2>General</h2>
-      @if (c.managed) {
-        <div class="message-banner info">
-          <span class="material-symbols-outlined">info</span>
-          This cache is managed declaratively and cannot be edited here.
-        </div>
-      } @else if (!c.can_edit) {
-        <div class="message-banner info">
-          <span class="material-symbols-outlined">info</span>
-          You have read-only access to this cache.
-        </div>
-      }
       <div class="settings-card">
         <div class="form-group">
           <label for="cache-name">Name</label>
@@ -55,7 +44,7 @@
             id="display-name"
             [(ngModel)]="formData.display_name"
             class="w-full"
-            [disabled]="c.managed || !c.can_edit"
+            [appManagedDisable]="access()"
           />
         </div>
 
@@ -67,7 +56,7 @@
             [(ngModel)]="formData.description"
             rows="3"
             class="w-full"
-            [disabled]="c.managed || !c.can_edit"
+            [appManagedDisable]="access()"
           ></textarea>
         </div>
 
@@ -81,7 +70,7 @@
             class="w-full"
             min="0"
             max="255"
-            [disabled]="c.managed || !c.can_edit"
+            [appManagedDisable]="access()"
           />
           @if (priorityInvalid) {
             <small class="text-danger">Priority must be between 0 and 255</small>
@@ -92,7 +81,7 @@
 
         <div class="form-group">
           <label for="visibility">Visibility</label>
-          <select id="visibility" [(ngModel)]="formData.public" class="role-select w-full" [disabled]="c.managed || !c.can_edit">
+          <select id="visibility" [(ngModel)]="formData.public" class="role-select w-full" [appManagedDisable]="access()">
             <option [ngValue]="false">Private</option>
             <option [ngValue]="true">Public</option>
           </select>
@@ -111,18 +100,18 @@
             Changes saved.
           </div>
         }
-        @if (!c.managed && c.can_edit) {
-          <div class="form-actions">
-            <button
-              pButton
-              label="Save Changes"
-              icon="pi pi-check"
-              (click)="saveSettings()"
-              [loading]="saving()"
-              [disabled]="saving() || priorityInvalid"
-            ></button>
-          </div>
-        }
+        <div class="form-actions">
+          <button
+            *appWritable="access()"
+            pButton
+            label="Save Changes"
+            icon="pi pi-check"
+            (click)="saveSettings()"
+            [loading]="saving()"
+            [disabled]="priorityInvalid"
+            [appManagedDisable]="access()"
+          ></button>
+        </div>
       </div>
     </div>
 
@@ -135,14 +124,12 @@
             <h3>Upstream Caches</h3>
             <p class="text-secondary">External and internal caches this cache pulls through from</p>
           </div>
-          @if (!c.managed && c.can_edit) {
-            <button pButton label="Manage Upstreams" icon="pi pi-cloud-download" severity="secondary" [routerLink]="['/caches', cacheName, 'upstreams']"></button>
-          }
+          <a pButton label="Manage Upstreams" icon="pi pi-cloud-download" severity="secondary" [routerLink]="['/caches', cacheName, 'upstreams']"></a>
         </div>
       </div>
     </div>
 
-    @if (!c.managed && c.can_edit) {
+    @if (access().canEdit) {
       <!-- Danger Zone -->
       <div class="settings-section danger-section">
         <h2>Danger Zone</h2>
@@ -159,7 +146,7 @@
               [severity]="c.active ? 'danger' : 'success'"
               (click)="toggleActive()"
               [loading]="toggling()"
-              [disabled]="toggling()"
+              [appManagedDisable]="access()"
             ></button>
           </div>
           <p-divider />
@@ -174,6 +161,7 @@
               icon="pi pi-trash"
               severity="danger"
               (click)="showDeleteDialog.set(true)"
+              [appManagedDisable]="access()"
             ></button>
           </div>
         </div>

--- a/frontend/src/app/features/caches/cache-settings/cache-settings.component.spec.ts
+++ b/frontend/src/app/features/caches/cache-settings/cache-settings.component.spec.ts
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { of } from 'rxjs';
+import { CacheSettingsComponent } from './cache-settings.component';
+import { CachesService } from '@core/services/caches.service';
+import { AccessState } from '@core/models/access.model';
+
+function cacheFor(access: AccessState) {
+  return {
+    id: 'c',
+    name: 'demo',
+    display_name: 'Demo',
+    description: '',
+    active: true,
+    priority: 50,
+    public: false,
+    managed: access.managed,
+    can_edit: access.canEdit,
+  };
+}
+
+function activatedRouteStub(access: AccessState): ActivatedRoute {
+  return {
+    snapshot: { paramMap: convertToParamMap({ cache: 'demo' }) },
+    data: of({}),
+    parent: { data: of({ cacheAccess: { cache: cacheFor(access), access } }) },
+  } as unknown as ActivatedRoute;
+}
+
+function findByText(root: HTMLElement, text: string): HTMLElement | null {
+  const target = text.toLowerCase();
+  return (Array.from(root.querySelectorAll('button')) as HTMLElement[]).find(
+    (el) => (el.textContent ?? '').trim().toLowerCase().includes(target),
+  ) ?? null;
+}
+
+function setup(access: AccessState): ComponentFixture<CacheSettingsComponent> {
+  TestBed.configureTestingModule({
+    imports: [CacheSettingsComponent],
+    providers: [
+      provideRouter([]),
+      provideHttpClient(),
+      provideHttpClientTesting(),
+      { provide: ActivatedRoute, useValue: activatedRouteStub(access) },
+      { provide: CachesService, useValue: { getCache: () => of(cacheFor(access)) } },
+    ],
+  });
+  const fixture = TestBed.createComponent(CacheSettingsComponent);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('CacheSettingsComponent — access gating', () => {
+  it('hides Save / Delete / Toggle under read-only access', () => {
+    const fixture = setup({ managed: false, canEdit: false });
+    expect(findByText(fixture.nativeElement, 'save changes')).toBeNull();
+    expect(findByText(fixture.nativeElement, 'delete cache')).toBeNull();
+    expect(findByText(fixture.nativeElement, 'deactivate')).toBeNull();
+  });
+
+  it('shows but disables Save / Delete under state-managed access', () => {
+    const fixture = setup({ managed: true, canEdit: true });
+    const save = findByText(fixture.nativeElement, 'save changes') as HTMLButtonElement | null;
+    const del = findByText(fixture.nativeElement, 'delete cache') as HTMLButtonElement | null;
+    expect(save).not.toBeNull();
+    expect(save!.disabled).toBe(true);
+    expect(del).not.toBeNull();
+    expect(del!.disabled).toBe(true);
+  });
+
+  it('always shows Manage Upstreams link, even when state-managed', () => {
+    const fixture = setup({ managed: true, canEdit: true });
+    const link = (Array.from(fixture.nativeElement.querySelectorAll('a')) as HTMLAnchorElement[]).find(
+      (el) => (el.textContent ?? '').toLowerCase().includes('manage upstreams'),
+    );
+    expect(link).toBeDefined();
+  });
+});

--- a/frontend/src/app/features/caches/cache-settings/cache-settings.component.ts
+++ b/frontend/src/app/features/caches/cache-settings/cache-settings.component.ts
@@ -15,6 +15,8 @@ import { InputTextModule } from 'primeng/inputtext';
 import { TextareaModule } from 'primeng/textarea';
 import { CachesService } from '@core/services/caches.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
+import { WritableDirective, ManagedDisableDirective } from '@shared/access';
+import { injectCacheAccess } from '@core/resolvers/inject-access';
 import { Cache } from '@core/models';
 
 @Component({
@@ -30,6 +32,8 @@ import { Cache } from '@core/models';
     InputTextModule,
     TextareaModule,
     LoadingSpinnerComponent,
+    WritableDirective,
+    ManagedDisableDirective,
   ],
   templateUrl: './cache-settings.component.html',
   styleUrl: './cache-settings.component.scss',
@@ -38,6 +42,8 @@ export class CacheSettingsComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private cachesService = inject(CachesService);
+
+  access = injectCacheAccess();
 
   loading = signal(true);
   saving = signal(false);

--- a/frontend/src/app/features/caches/cache-upstreams/cache-upstreams.component.html
+++ b/frontend/src/app/features/caches/cache-upstreams/cache-upstreams.component.html
@@ -19,7 +19,14 @@
       <h1>Upstream Caches</h1>
       <p class="text-secondary">External and internal caches this cache pulls through from</p>
     </div>
-    <button pButton label="Add Upstream" icon="pi pi-plus" (click)="openAddDialog()"></button>
+    <button
+      *appWritable="access()"
+      pButton
+      label="Add Upstream"
+      icon="pi pi-plus"
+      (click)="openAddDialog()"
+      [appManagedDisable]="access()"
+    ></button>
   </div>
 
   @if (loading()) {
@@ -30,7 +37,14 @@
         <span class="material-symbols-outlined">cloud_download</span>
         <h3>No upstream caches</h3>
         <p class="text-secondary">Add an upstream to enable pull-through caching from another cache.</p>
-        <button pButton label="Add Upstream" icon="pi pi-plus" (click)="openAddDialog()"></button>
+        <button
+          *appWritable="access()"
+          pButton
+          label="Add Upstream"
+          icon="pi pi-plus"
+          (click)="openAddDialog()"
+          [appManagedDisable]="access()"
+        ></button>
       </div>
     } @else {
       <div class="upstreams-list">
@@ -49,18 +63,20 @@
             </div>
             <div class="upstream-actions">
               <button
+                *appWritable="access()"
                 pButton
                 icon="pi pi-pencil"
                 severity="secondary"
-                [disabled]="removingUpstreamId() !== null"
+                [disabled]="rowDisabled()"
                 (click)="openEditDialog(u)"
               ></button>
               <button
+                *appWritable="access()"
                 pButton
                 icon="pi pi-trash"
                 severity="danger"
                 [loading]="removingUpstreamId() === u.id"
-                [disabled]="removingUpstreamId() !== null"
+                [disabled]="rowDisabled()"
                 (click)="removeUpstream(u.id)"
               ></button>
             </div>

--- a/frontend/src/app/features/caches/cache-upstreams/cache-upstreams.component.spec.ts
+++ b/frontend/src/app/features/caches/cache-upstreams/cache-upstreams.component.spec.ts
@@ -1,0 +1,104 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { of } from 'rxjs';
+import { CacheUpstreamsComponent } from './cache-upstreams.component';
+import { CachesService } from '@core/services/caches.service';
+import { AccessState } from '@core/models/access.model';
+
+function activatedRouteStub(access: AccessState): ActivatedRoute {
+  return {
+    snapshot: { paramMap: convertToParamMap({ cache: 'demo' }) },
+    data: of({}),
+    parent: { data: of({ cacheAccess: { cache: {}, access } }) },
+  } as unknown as ActivatedRoute;
+}
+
+const oneUpstream = [
+  {
+    id: 'u1',
+    display_name: 'Upstream A',
+    mode: 'ReadOnly' as const,
+    upstream_cache_id: 'cache-1',
+    url: null,
+    public_key: null,
+  },
+];
+
+function findByText(root: HTMLElement, text: string): HTMLElement | null {
+  const target = text.toLowerCase();
+  return (Array.from(root.querySelectorAll('button')) as HTMLElement[]).find(
+    (el) => (el.textContent ?? '').trim().toLowerCase().includes(target),
+  ) ?? null;
+}
+
+function findIconButton(root: HTMLElement, icon: string): HTMLButtonElement | null {
+  return (
+    (Array.from(root.querySelectorAll('button')) as HTMLButtonElement[]).find(
+      (el) => !!el.querySelector(`.${icon}`),
+    ) ?? null
+  );
+}
+
+function setup(access: AccessState): ComponentFixture<CacheUpstreamsComponent> {
+  TestBed.configureTestingModule({
+    imports: [CacheUpstreamsComponent],
+    providers: [
+      provideRouter([]),
+      provideHttpClient(),
+      provideHttpClientTesting(),
+      { provide: ActivatedRoute, useValue: activatedRouteStub(access) },
+      {
+        provide: CachesService,
+        useValue: {
+          getCache: () => of({ display_name: 'Demo' }),
+          getCacheUpstreams: () => of(oneUpstream),
+        },
+      },
+    ],
+  });
+  const fixture = TestBed.createComponent(CacheUpstreamsComponent);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('CacheUpstreamsComponent — access gating', () => {
+  it('renders the upstream list under read-only access', () => {
+    const fixture = setup({ managed: false, canEdit: false });
+    expect(fixture.nativeElement.textContent).toContain('Upstream A');
+  });
+
+  it('hides Add Upstream, Edit, Delete under read-only access', () => {
+    const fixture = setup({ managed: false, canEdit: false });
+    expect(findByText(fixture.nativeElement, 'add upstream')).toBeNull();
+    expect(findIconButton(fixture.nativeElement, 'pi-pencil')).toBeNull();
+    expect(findIconButton(fixture.nativeElement, 'pi-trash')).toBeNull();
+  });
+
+  it('shows but disables Add / Edit / Delete under state-managed access', () => {
+    const fixture = setup({ managed: true, canEdit: true });
+    const addBtn = findByText(fixture.nativeElement, 'add upstream') as HTMLButtonElement | null;
+    const editBtn = findIconButton(fixture.nativeElement, 'pi-pencil');
+    const delBtn = findIconButton(fixture.nativeElement, 'pi-trash');
+    expect(addBtn).not.toBeNull();
+    expect(addBtn!.disabled).toBe(true);
+    expect(editBtn).not.toBeNull();
+    expect(editBtn!.disabled).toBe(true);
+    expect(delBtn).not.toBeNull();
+    expect(delBtn!.disabled).toBe(true);
+  });
+
+  it('renders Add / Edit / Delete enabled under full access', () => {
+    const fixture = setup({ managed: false, canEdit: true });
+    const addBtn = findByText(fixture.nativeElement, 'add upstream') as HTMLButtonElement | null;
+    expect(addBtn).not.toBeNull();
+    expect(addBtn!.disabled).toBe(false);
+  });
+});

--- a/frontend/src/app/features/caches/cache-upstreams/cache-upstreams.component.ts
+++ b/frontend/src/app/features/caches/cache-upstreams/cache-upstreams.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal } from '@angular/core';
+import { Component, OnInit, inject, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -13,6 +13,8 @@ import { ButtonModule } from 'primeng/button';
 import { InputTextModule } from 'primeng/inputtext';
 import { CachesService, UpstreamCache, CacheSubscriptionMode } from '@core/services/caches.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
+import { WritableDirective, ManagedDisableDirective, AccessService } from '@shared/access';
+import { injectCacheAccess } from '@core/resolvers/inject-access';
 
 @Component({
   selector: 'app-cache-upstreams',
@@ -25,6 +27,8 @@ import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/load
     ButtonModule,
     InputTextModule,
     LoadingSpinnerComponent,
+    WritableDirective,
+    ManagedDisableDirective,
   ],
   templateUrl: './cache-upstreams.component.html',
   styleUrl: './cache-upstreams.component.scss',
@@ -32,6 +36,15 @@ import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/load
 export class CacheUpstreamsComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private cachesService = inject(CachesService);
+  private accessSvc = inject(AccessService);
+
+  access = injectCacheAccess();
+
+  rowDisabled = computed(
+    () =>
+      this.removingUpstreamId() !== null ||
+      this.accessSvc.shouldDisableInput(this.access()),
+  );
 
   loading = signal(true);
   addingUpstream = signal(false);

--- a/frontend/src/app/features/organizations/cache-subscriptions/cache-subscriptions.component.html
+++ b/frontend/src/app/features/organizations/cache-subscriptions/cache-subscriptions.component.html
@@ -18,21 +18,16 @@
       <p class="text-secondary">Nix binary caches this organization pushes builds to</p>
     </div>
     <button
+      *appWritable="access()"
       pButton
       label="Subscribe to Cache"
       icon="pi pi-plus"
-      [disabled]="canManageSubscriptions() === false"
-      [pTooltip]="canManageSubscriptions() === false ? 'You need Write or Admin permissions to manage cache subscriptions' : ''"
+      [appManagedDisable]="access()"
       (click)="openSubscribeDialog()"
     ></button>
   </div>
 
-  @if (canManageSubscriptions() === false) {
-    <div class="permission-error">
-      <span class="material-symbols-outlined">lock</span>
-      <span>You need <strong>Write</strong> or <strong>Admin</strong> permissions in this organization to manage cache subscriptions.</span>
-    </div>
-  }
+  <app-access-banner [access]="access()"></app-access-banner>
 
   @if (loading()) {
     <app-loading-spinner message="Loading cache subscriptions..." />
@@ -43,10 +38,11 @@
         <h3>No cache subscriptions</h3>
         <p class="text-secondary">Subscribe to a Nix binary cache to have builds pushed there automatically.</p>
         <button
+          *appWritable="access()"
           pButton
           label="Subscribe to Cache"
           icon="pi pi-plus"
-          [disabled]="canManageSubscriptions() === false"
+          [appManagedDisable]="access()"
           (click)="openSubscribeDialog()"
         ></button>
       </div>
@@ -60,12 +56,14 @@
             </div>
             <div class="cache-actions">
               <button
+                *appWritable="access()"
                 pButton
                 label="Unsubscribe"
                 icon="pi pi-times"
                 severity="danger"
                 [loading]="unsubscribingId() === cache.id"
                 [disabled]="unsubscribingId() !== null"
+                [appManagedDisable]="access()"
                 (click)="unsubscribeCache(cache)"
               ></button>
             </div>

--- a/frontend/src/app/features/organizations/cache-subscriptions/cache-subscriptions.component.spec.ts
+++ b/frontend/src/app/features/organizations/cache-subscriptions/cache-subscriptions.component.spec.ts
@@ -1,0 +1,72 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { of } from 'rxjs';
+import { CacheSubscriptionsComponent } from './cache-subscriptions.component';
+import { OrganizationsService } from '@core/services/organizations.service';
+import { CachesService } from '@core/services/caches.service';
+import { OrgAccessService } from '@core/services/org-access.service';
+import { AccessState } from '@core/models/access.model';
+
+function activatedRouteStub() {
+  return { snapshot: { paramMap: convertToParamMap({ org: 'acme' }) } } as Partial<ActivatedRoute>;
+}
+
+function findByText(root: HTMLElement, text: string): HTMLElement | null {
+  const target = text.toLowerCase();
+  return (Array.from(root.querySelectorAll('button')) as HTMLElement[]).find(
+    (el) => (el.textContent ?? '').trim().toLowerCase().includes(target),
+  ) ?? null;
+}
+
+function setup(access: AccessState): ComponentFixture<CacheSubscriptionsComponent> {
+  TestBed.configureTestingModule({
+    imports: [CacheSubscriptionsComponent],
+    providers: [
+      provideRouter([]),
+      provideHttpClient(),
+      provideHttpClientTesting(),
+      { provide: ActivatedRoute, useValue: activatedRouteStub() },
+      {
+        provide: OrganizationsService,
+        useValue: {
+          getOrganization: () => of({ id: 'o', display_name: 'Acme' }),
+          getSubscribedCaches: () => of([{ id: 'c', name: 'shared' }]),
+        },
+      },
+      { provide: CachesService, useValue: {} },
+      { provide: OrgAccessService, useValue: { forOrg: () => Promise.resolve(access) } },
+    ],
+  });
+  return TestBed.createComponent(CacheSubscriptionsComponent);
+}
+
+async function settled(fixture: ComponentFixture<CacheSubscriptionsComponent>) {
+  fixture.detectChanges();
+  await fixture.whenStable();
+  fixture.detectChanges();
+}
+
+describe('CacheSubscriptionsComponent — access gating', () => {
+  it('hides Subscribe and Unsubscribe under read-only access', async () => {
+    const fixture = setup({ managed: false, canEdit: false });
+    await settled(fixture);
+    expect(findByText(fixture.nativeElement, 'subscribe to cache')).toBeNull();
+    expect(findByText(fixture.nativeElement, 'unsubscribe')).toBeNull();
+  });
+
+  it('shows but disables Subscribe under state-managed access', async () => {
+    const fixture = setup({ managed: true, canEdit: true });
+    await settled(fixture);
+    const btn = findByText(fixture.nativeElement, 'subscribe to cache') as HTMLButtonElement | null;
+    expect(btn).not.toBeNull();
+    expect(btn!.disabled).toBe(true);
+  });
+});

--- a/frontend/src/app/features/organizations/cache-subscriptions/cache-subscriptions.component.ts
+++ b/frontend/src/app/features/organizations/cache-subscriptions/cache-subscriptions.component.ts
@@ -15,8 +15,10 @@ import { AutoCompleteModule } from 'primeng/autocomplete';
 import { TooltipModule } from 'primeng/tooltip';
 import { OrganizationsService } from '@core/services/organizations.service';
 import { CachesService } from '@core/services/caches.service';
-import { AuthService } from '@core/services/auth.service';
+import { OrgAccessService } from '@core/services/org-access.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
+import { AccessBannerComponent, WritableDirective, ManagedDisableDirective } from '@shared/access';
+import { AccessState } from '@core/models';
 
 @Component({
   selector: 'app-cache-subscriptions',
@@ -31,6 +33,9 @@ import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/load
     AutoCompleteModule,
     TooltipModule,
     LoadingSpinnerComponent,
+    AccessBannerComponent,
+    WritableDirective,
+    ManagedDisableDirective,
   ],
   templateUrl: './cache-subscriptions.component.html',
   styleUrl: './cache-subscriptions.component.scss',
@@ -39,14 +44,15 @@ export class CacheSubscriptionsComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private orgsService = inject(OrganizationsService);
   private cachesService = inject(CachesService);
-  private authService = inject(AuthService);
+  private orgAccess = inject(OrgAccessService);
+
+  access = signal<AccessState>({ managed: false, canEdit: false });
 
   loading = signal(true);
   subscribing = signal(false);
   unsubscribingId = signal<string | null>(null);
   showSubscribeDialog = signal(false);
   errorMessage = signal<string | null>(null);
-  canManageSubscriptions = signal<boolean | null>(null);
 
   orgName = '';
   orgDisplayName = signal('');
@@ -57,27 +63,12 @@ export class CacheSubscriptionsComponent implements OnInit {
 
   ngOnInit(): void {
     this.orgName = this.route.snapshot.paramMap.get('org') || '';
+    this.orgAccess.forOrg(this.orgName).then((s) => this.access.set(s));
     this.orgsService.getOrganization(this.orgName).subscribe({
       next: (org) => this.orgDisplayName.set(org.display_name),
       error: () => {},
     });
     this.loadCaches();
-    this.loadOrgPermission();
-  }
-
-  private loadOrgPermission(): void {
-    const currentUser = this.authService.user();
-    if (!currentUser) {
-      this.canManageSubscriptions.set(false);
-      return;
-    }
-    this.orgsService.getMembers(this.orgName).subscribe({
-      next: (members) => {
-        const me = members.find((m) => m.id === currentUser.username);
-        this.canManageSubscriptions.set(!!me && (me.name === 'Admin' || me.name === 'Write'));
-      },
-      error: () => this.canManageSubscriptions.set(false),
-    });
   }
 
   loadCaches(): void {
@@ -92,7 +83,6 @@ export class CacheSubscriptionsComponent implements OnInit {
   }
 
   openSubscribeDialog(): void {
-    if (!this.canManageSubscriptions()) return;
     this.newCacheName = '';
     this.errorMessage.set(null);
     this.cacheSuggestions.set([]);

--- a/frontend/src/app/features/organizations/members-roles/members-roles.component.html
+++ b/frontend/src/app/features/organizations/members-roles/members-roles.component.html
@@ -18,17 +18,21 @@
     </div>
   </div>
 
+  <app-access-banner [access]="access()"></app-access-banner>
+
   <!-- Members -->
   <div class="settings-section">
     <div class="section-header">
       <h2>Members</h2>
       <button
+        *appWritable="access()"
         pButton
         label="Add Member"
         icon="pi pi-plus"
         severity="secondary"
         (click)="openAddMemberDialog()"
         [disabled]="rolesLoading() || roles().length === 0"
+        [appManagedDisable]="access()"
       ></button>
     </div>
     @if (membersLoading()) {
@@ -48,6 +52,7 @@
                     class="role-select"
                     [ngModel]="member.name"
                     [disabled]="updatingRole() === member.id || removingMember() !== null || rolesLoading()"
+                    [appManagedDisable]="access()"
                     (ngModelChange)="updateMemberRole(member.id, $event)"
                   >
                     @for (role of roles(); track role.id) {
@@ -55,12 +60,14 @@
                     }
                   </select>
                   <button
+                    *appWritable="access()"
                     pButton
                     icon="pi pi-times"
                     severity="danger"
                     size="small"
                     [loading]="removingMember() === member.id"
                     [disabled]="removingMember() !== null || updatingRole() !== null"
+                    [appManagedDisable]="access()"
                     (click)="removeMember(member.id)"
                   ></button>
                 </div>
@@ -79,12 +86,14 @@
     <div class="section-header">
       <h2>Roles</h2>
       <button
+        *appWritable="access()"
         pButton
         label="New Role"
         icon="pi pi-plus"
         severity="secondary"
         (click)="openCreateRoleDialog()"
         [disabled]="rolesLoading() || availablePermissions().length === 0"
+        [appManagedDisable]="access()"
       ></button>
     </div>
     @if (rolesLoading()) {
@@ -109,20 +118,24 @@
                 <div class="role-actions">
                   @if (!role.builtin) {
                     <button
+                      *appWritable="access()"
                       pButton
                       icon="pi pi-pencil"
                       severity="secondary"
                       size="small"
                       [disabled]="savingRole() || deletingRole() !== null"
+                      [appManagedDisable]="access()"
                       (click)="openEditRoleDialog(role)"
                     ></button>
                     <button
+                      *appWritable="access()"
                       pButton
                       icon="pi pi-trash"
                       severity="danger"
                       size="small"
                       [loading]="deletingRole() === role.id"
                       [disabled]="deletingRole() !== null"
+                      [appManagedDisable]="access()"
                       (click)="deleteRole(role)"
                     ></button>
                   }

--- a/frontend/src/app/features/organizations/members-roles/members-roles.component.spec.ts
+++ b/frontend/src/app/features/organizations/members-roles/members-roles.component.spec.ts
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { of } from 'rxjs';
+import { MembersRolesComponent } from './members-roles.component';
+import { OrganizationsService } from '@core/services/organizations.service';
+import { UserService } from '@core/services/user.service';
+import { OrgAccessService } from '@core/services/org-access.service';
+import { AccessState } from '@core/models/access.model';
+
+function activatedRouteStub() {
+  return { snapshot: { paramMap: convertToParamMap({ org: 'acme' }) } } as Partial<ActivatedRoute>;
+}
+
+function findByText(root: HTMLElement, text: string): HTMLElement | null {
+  const target = text.toLowerCase();
+  return (Array.from(root.querySelectorAll('button')) as HTMLElement[]).find(
+    (el) => (el.textContent ?? '').trim().toLowerCase().includes(target),
+  ) ?? null;
+}
+
+function setup(access: AccessState): ComponentFixture<MembersRolesComponent> {
+  TestBed.configureTestingModule({
+    imports: [MembersRolesComponent],
+    providers: [
+      provideRouter([]),
+      provideHttpClient(),
+      provideHttpClientTesting(),
+      { provide: ActivatedRoute, useValue: activatedRouteStub() },
+      {
+        provide: OrganizationsService,
+        useValue: {
+          getMembers: () => of([{ id: 'alice', name: 'Admin' }]),
+          getRoles: () =>
+            of({
+              roles: [{ id: 'r1', name: 'Admin', builtin: true, permissions: [], organization: null }],
+              available_permissions: [],
+            }),
+        },
+      },
+      { provide: UserService, useValue: { listUsers: () => of([]) } },
+      { provide: OrgAccessService, useValue: { forOrg: () => Promise.resolve(access) } },
+    ],
+  });
+  return TestBed.createComponent(MembersRolesComponent);
+}
+
+async function settled(fixture: ComponentFixture<MembersRolesComponent>) {
+  fixture.detectChanges();
+  await fixture.whenStable();
+  fixture.detectChanges();
+}
+
+describe('MembersRolesComponent — access gating', () => {
+  it('hides Add Member, New Role, per-row Remove under read-only access', async () => {
+    const fixture = setup({ managed: false, canEdit: false });
+    await settled(fixture);
+    expect(findByText(fixture.nativeElement, 'add member')).toBeNull();
+    expect(findByText(fixture.nativeElement, 'new role')).toBeNull();
+  });
+
+  it('shows but disables Add Member / New Role under state-managed access', async () => {
+    const fixture = setup({ managed: true, canEdit: true });
+    await settled(fixture);
+    const addBtn = findByText(fixture.nativeElement, 'add member') as HTMLButtonElement | null;
+    const newRoleBtn = findByText(fixture.nativeElement, 'new role') as HTMLButtonElement | null;
+    expect(addBtn).not.toBeNull();
+    expect(addBtn!.disabled).toBe(true);
+    expect(newRoleBtn).not.toBeNull();
+    expect(newRoleBtn!.disabled).toBe(true);
+  });
+});

--- a/frontend/src/app/features/organizations/members-roles/members-roles.component.ts
+++ b/frontend/src/app/features/organizations/members-roles/members-roles.component.ts
@@ -21,7 +21,10 @@ import {
   PermissionDescriptor,
 } from '@core/services/organizations.service';
 import { UserService } from '@core/services/user.service';
+import { OrgAccessService } from '@core/services/org-access.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
+import { AccessBannerComponent, WritableDirective, ManagedDisableDirective } from '@shared/access';
+import { AccessState } from '@core/models';
 
 interface RoleFormState {
   name: string;
@@ -42,6 +45,9 @@ interface RoleFormState {
     CheckboxModule,
     DividerModule,
     LoadingSpinnerComponent,
+    AccessBannerComponent,
+    WritableDirective,
+    ManagedDisableDirective,
   ],
   templateUrl: './members-roles.component.html',
   styleUrl: './members-roles.component.scss',
@@ -50,6 +56,9 @@ export class MembersRolesComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private organizationsService = inject(OrganizationsService);
   private userService = inject(UserService);
+  private orgAccess = inject(OrgAccessService);
+
+  access = signal<AccessState>({ managed: false, canEdit: false });
 
   orgName = '';
 
@@ -85,6 +94,7 @@ export class MembersRolesComponent implements OnInit {
 
   ngOnInit(): void {
     this.orgName = this.route.snapshot.paramMap.get('org') || '';
+    this.orgAccess.forOrg(this.orgName).then((s) => this.access.set(s));
     this.loadRoles();
     this.loadMembers();
   }

--- a/frontend/src/app/features/organizations/organization-settings/organization-settings.component.html
+++ b/frontend/src/app/features/organizations/organization-settings/organization-settings.component.html
@@ -19,15 +19,11 @@
       </div>
     </div>
 
+    <app-access-banner [access]="access()"></app-access-banner>
+
     <!-- General Settings -->
     <div class="settings-section">
       <h2>General</h2>
-      @if (org.managed) {
-        <div class="message-banner info">
-          <span class="material-symbols-outlined">info</span>
-          This organization is managed declaratively and cannot be edited here.
-        </div>
-      }
       <div class="settings-card">
         <div class="form-group">
           <label for="org-name">Name</label>
@@ -48,7 +44,7 @@
             id="display-name"
             [(ngModel)]="formData.display_name"
             class="w-full"
-            [disabled]="org.managed"
+            [appManagedDisable]="access()"
           />
         </div>
 
@@ -60,43 +56,42 @@
             [(ngModel)]="formData.description"
             rows="3"
             class="w-full"
-            [disabled]="org.managed"
+            [appManagedDisable]="access()"
           ></textarea>
         </div>
 
         <div class="form-group">
           <label for="visibility">Visibility</label>
-          <select id="visibility" [(ngModel)]="formData.public" class="role-select" [disabled]="org.managed">
+          <select id="visibility" [(ngModel)]="formData.public" class="role-select" [appManagedDisable]="access()">
             <option [ngValue]="false">Private</option>
             <option [ngValue]="true">Public</option>
           </select>
           <small class="text-secondary">Public organizations are visible and readable by all users</small>
         </div>
 
-        @if (!org.managed) {
-          @if (saveError()) {
-            <div class="message-banner error">
-              <span class="material-symbols-outlined">error</span>
-              {{ saveError() }}
-            </div>
-          }
-          @if (saveSuccess()) {
-            <div class="message-banner success">
-              <span class="material-symbols-outlined">check_circle</span>
-              Changes saved.
-            </div>
-          }
-          <div class="form-actions">
-            <button
-              pButton
-              label="Save Changes"
-              icon="pi pi-check"
-              (click)="saveSettings()"
-              [loading]="saving()"
-              [disabled]="saving()"
-            ></button>
+        @if (saveError()) {
+          <div class="message-banner error">
+            <span class="material-symbols-outlined">error</span>
+            {{ saveError() }}
           </div>
         }
+        @if (saveSuccess()) {
+          <div class="message-banner success">
+            <span class="material-symbols-outlined">check_circle</span>
+            Changes saved.
+          </div>
+        }
+        <div class="form-actions">
+          <button
+            *appWritable="access()"
+            pButton
+            label="Save Changes"
+            icon="pi pi-check"
+            (click)="saveSettings()"
+            [loading]="saving()"
+            [appManagedDisable]="access()"
+          ></button>
+        </div>
       </div>
     </div>
 
@@ -182,42 +177,45 @@
     </div>
 
     <!-- Danger Zone -->
-    <div class="settings-section danger-section">
-      <h2>Danger Zone</h2>
-      <div class="settings-card danger-card">
-        @if (sshKey()) {
+    @if (access().canEdit) {
+      <div class="settings-section danger-section">
+        <h2>Danger Zone</h2>
+        <div class="settings-card danger-card">
+          @if (sshKey()) {
+            <div class="danger-row">
+              <div>
+                <h3>Regenerate SSH Key</h3>
+                <p class="text-secondary">Generate a new SSH key. The existing key will stop working immediately.</p>
+              </div>
+              <button
+                pButton
+                label="Regenerate Key"
+                icon="pi pi-refresh"
+                severity="danger"
+                (click)="showRegenerateKeyDialog.set(true)"
+                [disabled]="generatingSSH()"
+                [appManagedDisable]="access()"
+              ></button>
+            </div>
+            <p-divider />
+          }
           <div class="danger-row">
             <div>
-              <h3>Regenerate SSH Key</h3>
-              <p class="text-secondary">Generate a new SSH key. The existing key will stop working immediately.</p>
+              <h3>Delete Organization</h3>
+              <p class="text-secondary">Permanently delete this organization and all its projects.</p>
             </div>
             <button
               pButton
-              label="Regenerate Key"
-              icon="pi pi-refresh"
+              label="Delete Organization"
+              icon="pi pi-trash"
               severity="danger"
-              (click)="showRegenerateKeyDialog.set(true)"
-              [disabled]="generatingSSH() || org.managed"
+              (click)="showDeleteDialog.set(true)"
+              [appManagedDisable]="access()"
             ></button>
           </div>
-          <p-divider />
-        }
-        <div class="danger-row">
-          <div>
-            <h3>Delete Organization</h3>
-            <p class="text-secondary">Permanently delete this organization and all its projects.</p>
-          </div>
-          <button
-            pButton
-            label="Delete Organization"
-            icon="pi pi-trash"
-            severity="danger"
-            (click)="showDeleteDialog.set(true)"
-            [disabled]="org.managed"
-          ></button>
         </div>
       </div>
-    </div>
+    }
   }
 </div>
 

--- a/frontend/src/app/features/organizations/organization-settings/organization-settings.component.spec.ts
+++ b/frontend/src/app/features/organizations/organization-settings/organization-settings.component.spec.ts
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { of } from 'rxjs';
+import { OrganizationSettingsComponent } from './organization-settings.component';
+import { OrganizationsService } from '@core/services/organizations.service';
+import { OrgAccessService } from '@core/services/org-access.service';
+import { AccessState } from '@core/models/access.model';
+import { Organization } from '@core/models/organization.model';
+
+function orgFor(access: AccessState): Organization {
+  return {
+    id: 'o',
+    name: 'acme',
+    display_name: 'Acme',
+    description: '',
+    public: false,
+    managed: access.managed,
+    role: access.canEdit ? 'Admin' : 'View',
+  };
+}
+
+function findByText(root: HTMLElement, text: string): HTMLElement | null {
+  const target = text.toLowerCase();
+  return (Array.from(root.querySelectorAll('button')) as HTMLElement[]).find(
+    (el) => (el.textContent ?? '').trim().toLowerCase().includes(target),
+  ) ?? null;
+}
+
+function setup(access: AccessState): ComponentFixture<OrganizationSettingsComponent> {
+  TestBed.configureTestingModule({
+    imports: [OrganizationSettingsComponent],
+    providers: [
+      provideRouter([]),
+      provideHttpClient(),
+      provideHttpClientTesting(),
+      {
+        provide: ActivatedRoute,
+        useValue: { snapshot: { paramMap: convertToParamMap({ org: 'acme' }) } },
+      },
+      {
+        provide: OrganizationsService,
+        useValue: {
+          getOrganization: () => of(orgFor(access)),
+          getSSHKey: () => of(''),
+        },
+      },
+      { provide: OrgAccessService, useValue: { forOrg: () => Promise.resolve(access) } },
+    ],
+  });
+  const fixture = TestBed.createComponent(OrganizationSettingsComponent);
+  fixture.detectChanges();
+  return fixture;
+}
+
+async function settled(fixture: ComponentFixture<OrganizationSettingsComponent>) {
+  await fixture.whenStable();
+  fixture.detectChanges();
+}
+
+describe('OrganizationSettingsComponent — access gating', () => {
+  it('hides Save / Delete under read-only access', async () => {
+    const fixture = setup({ managed: false, canEdit: false });
+    await settled(fixture);
+    expect(findByText(fixture.nativeElement, 'save changes')).toBeNull();
+    expect(findByText(fixture.nativeElement, 'delete organization')).toBeNull();
+  });
+
+  it('shows but disables Save / Delete under state-managed access', async () => {
+    const fixture = setup({ managed: true, canEdit: true });
+    await settled(fixture);
+    const save = findByText(fixture.nativeElement, 'save changes') as HTMLButtonElement | null;
+    const del = findByText(fixture.nativeElement, 'delete organization') as HTMLButtonElement | null;
+    expect(save).not.toBeNull();
+    expect(save!.disabled).toBe(true);
+    expect(del).not.toBeNull();
+    expect(del!.disabled).toBe(true);
+  });
+});

--- a/frontend/src/app/features/organizations/organization-settings/organization-settings.component.ts
+++ b/frontend/src/app/features/organizations/organization-settings/organization-settings.component.ts
@@ -14,8 +14,10 @@ import { ButtonModule } from 'primeng/button';
 import { InputTextModule } from 'primeng/inputtext';
 import { TextareaModule } from 'primeng/textarea';
 import { OrganizationsService } from '@core/services/organizations.service';
+import { OrgAccessService } from '@core/services/org-access.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
-import { Organization } from '@core/models';
+import { AccessBannerComponent, WritableDirective, ManagedDisableDirective } from '@shared/access';
+import { Organization, AccessState } from '@core/models';
 
 @Component({
   selector: 'app-organization-settings',
@@ -30,6 +32,9 @@ import { Organization } from '@core/models';
     InputTextModule,
     TextareaModule,
     LoadingSpinnerComponent,
+    AccessBannerComponent,
+    WritableDirective,
+    ManagedDisableDirective,
   ],
   templateUrl: './organization-settings.component.html',
   styleUrl: './organization-settings.component.scss',
@@ -38,6 +43,9 @@ export class OrganizationSettingsComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private organizationsService = inject(OrganizationsService);
+  private orgAccess = inject(OrgAccessService);
+
+  access = signal<AccessState>({ managed: false, canEdit: false });
 
   loading = signal(true);
   saving = signal(false);
@@ -63,6 +71,7 @@ export class OrganizationSettingsComponent implements OnInit {
 
   ngOnInit(): void {
     this.orgName = this.route.snapshot.paramMap.get('org') || '';
+    this.orgAccess.forOrg(this.orgName).then((s) => this.access.set(s));
     this.loadOrganization();
     this.loadSSHKey();
   }

--- a/frontend/src/app/features/organizations/workers/workers.component.html
+++ b/frontend/src/app/features/organizations/workers/workers.component.html
@@ -17,8 +17,17 @@
       <h1>Workers</h1>
       <p class="text-secondary">Registered build workers for this organization</p>
     </div>
-    <button pButton label="Register Worker" icon="pi pi-plus" (click)="openRegisterDialog()"></button>
+    <button
+      *appWritable="access()"
+      pButton
+      label="Register Worker"
+      icon="pi pi-plus"
+      (click)="openRegisterDialog()"
+      [appManagedDisable]="access()"
+    ></button>
   </div>
+
+  <app-access-banner [access]="access()"></app-access-banner>
 
   @if (hasNoCacheSubscribed()) {
     <div class="no-cache-banner" data-testid="no-cache-banner" role="alert">
@@ -59,7 +68,14 @@
         <span class="material-symbols-outlined">construction</span>
         <h3>No workers registered</h3>
         <p class="text-secondary">Register a <code>gradient-worker</code> to run builds for this organization.</p>
-        <button pButton label="Register Worker" icon="pi pi-plus" (click)="openRegisterDialog()"></button>
+        <button
+          *appWritable="access()"
+          pButton
+          label="Register Worker"
+          icon="pi pi-plus"
+          (click)="openRegisterDialog()"
+          [appManagedDisable]="access()"
+        ></button>
       </div>
     } @else {
       <div class="workers-list">
@@ -113,34 +129,40 @@
                 {{ worker.live ? 'Connected' : 'Offline' }}
               </span>
               <button
+                *appWritable="access()"
                 pButton
                 label="Edit"
                 icon="pi pi-pencil"
                 severity="secondary"
                 size="small"
                 class="worker-action-btn"
-                [disabled]="worker.managed || deletingId() !== null || togglingId() !== null || renaming()"
+                [disabled]="deletingId() !== null || togglingId() !== null || renaming()"
+                [appManagedDisable]="rowAccess(worker)"
                 (click)="openRenameDialog(worker)"
               ></button>
               <button
+                *appWritable="access()"
                 pButton
                 [label]="worker.active ? 'Deactivate' : 'Activate'"
                 [icon]="worker.active ? 'pi pi-pause' : 'pi pi-play'"
                 [severity]="worker.active ? 'warn' : 'success'"
                 size="small"
                 class="worker-action-btn"
-                [disabled]="worker.managed || togglingId() !== null || deletingId() !== null"
+                [disabled]="togglingId() !== null || deletingId() !== null"
+                [appManagedDisable]="rowAccess(worker)"
                 [loading]="togglingId() === worker.worker_id"
                 (click)="requestToggleWorker(worker)"
               ></button>
               <button
+                *appWritable="access()"
                 pButton
                 label="Delete"
                 icon="pi pi-trash"
                 severity="danger"
                 size="small"
                 class="worker-action-btn"
-                [disabled]="worker.managed || deletingId() !== null || togglingId() !== null"
+                [disabled]="deletingId() !== null || togglingId() !== null"
+                [appManagedDisable]="rowAccess(worker)"
                 [loading]="deletingId() === worker.worker_id"
                 (click)="deleteWorker(worker)"
               ></button>

--- a/frontend/src/app/features/organizations/workers/workers.component.spec.ts
+++ b/frontend/src/app/features/organizations/workers/workers.component.spec.ts
@@ -14,17 +14,21 @@ import { WorkersComponent } from './workers.component';
 import { WorkersService } from '@core/services/workers.service';
 import { OrganizationsService } from '@core/services/organizations.service';
 
+type MockedOrgs = {
+  getOrganization: ReturnType<typeof vi.fn>;
+  getSubscribedCaches: ReturnType<typeof vi.fn>;
+};
+
 describe('WorkersComponent — no-cache banner', () => {
   let fixture: ComponentFixture<WorkersComponent>;
-  let orgsService: jasmine.SpyObj<OrganizationsService>;
+  let orgsService: MockedOrgs;
 
   beforeEach(async () => {
-    const workers = jasmine.createSpyObj<WorkersService>('WorkersService', ['getWorkers']);
-    workers.getWorkers.and.returnValue(of([]));
-    orgsService = jasmine.createSpyObj<OrganizationsService>('OrganizationsService', [
-      'getOrganization', 'getSubscribedCaches',
-    ]);
-    orgsService.getOrganization.and.returnValue(of({ id: 'org-uuid', display_name: 'Org' } as any));
+    const workers = { getWorkers: vi.fn(() => of([])) };
+    orgsService = {
+      getOrganization: vi.fn(() => of({ id: 'org-uuid', display_name: 'Org' } as never)),
+      getSubscribedCaches: vi.fn(),
+    };
 
     await TestBed.configureTestingModule({
       imports: [WorkersComponent],
@@ -43,18 +47,18 @@ describe('WorkersComponent — no-cache banner', () => {
   });
 
   it('shows the banner when the org has no subscribed caches', () => {
-    orgsService.getSubscribedCaches.and.returnValue(of([]));
+    orgsService.getSubscribedCaches.mockReturnValue(of([]));
     fixture = TestBed.createComponent(WorkersComponent);
     fixture.detectChanges();
     const banner = fixture.nativeElement.querySelector('[data-testid="no-cache-banner"]');
-    expect(banner).withContext('banner element').toBeTruthy();
+    expect(banner, 'banner element').toBeTruthy();
   });
 
   it('hides the banner when the org has at least one subscribed cache', () => {
-    orgsService.getSubscribedCaches.and.returnValue(of([{ id: 'c', name: 'cache-1' }]));
+    orgsService.getSubscribedCaches.mockReturnValue(of([{ id: 'c', name: 'cache-1' }]));
     fixture = TestBed.createComponent(WorkersComponent);
     fixture.detectChanges();
     const banner = fixture.nativeElement.querySelector('[data-testid="no-cache-banner"]');
-    expect(banner).withContext('banner element').toBeNull();
+    expect(banner, 'banner element').toBeNull();
   });
 });

--- a/frontend/src/app/features/organizations/workers/workers.component.spec.ts
+++ b/frontend/src/app/features/organizations/workers/workers.component.spec.ts
@@ -13,52 +13,138 @@ import { ActivatedRoute, convertToParamMap } from '@angular/router';
 import { WorkersComponent } from './workers.component';
 import { WorkersService } from '@core/services/workers.service';
 import { OrganizationsService } from '@core/services/organizations.service';
+import { OrgAccessService } from '@core/services/org-access.service';
+import { AccessState } from '@core/models/access.model';
+import { Worker } from '@core/models/worker.model';
 
 type MockedOrgs = {
   getOrganization: ReturnType<typeof vi.fn>;
   getSubscribedCaches: ReturnType<typeof vi.fn>;
 };
 
-describe('WorkersComponent — no-cache banner', () => {
-  let fixture: ComponentFixture<WorkersComponent>;
-  let orgsService: MockedOrgs;
+function activatedRouteStub() {
+  return { snapshot: { paramMap: convertToParamMap({ org: 'demo' }) } } as Partial<ActivatedRoute>;
+}
 
-  beforeEach(async () => {
-    const workers = { getWorkers: vi.fn(() => of([])) };
-    orgsService = {
-      getOrganization: vi.fn(() => of({ id: 'org-uuid', display_name: 'Org' } as never)),
-      getSubscribedCaches: vi.fn(),
-    };
+const workerUnmanaged: Worker = {
+  worker_id: 'w1',
+  display_name: 'Builder',
+  managed: false,
+  active: true,
+  enable_fetch: true,
+  enable_eval: true,
+  enable_build: true,
+};
 
-    await TestBed.configureTestingModule({
-      imports: [WorkersComponent],
-      providers: [
-        provideRouter([]),
-        provideHttpClient(),
-        provideHttpClientTesting(),
-        { provide: WorkersService, useValue: workers },
-        { provide: OrganizationsService, useValue: orgsService },
-        {
-          provide: ActivatedRoute,
-          useValue: { snapshot: { paramMap: convertToParamMap({ org: 'demo' }) } },
-        },
-      ],
-    }).compileComponents();
+const workerManaged: Worker = {
+  worker_id: 'w2',
+  display_name: 'Nix-managed',
+  managed: true,
+  active: true,
+  enable_fetch: true,
+  enable_eval: true,
+  enable_build: true,
+};
+
+function setup(opts: {
+  access: AccessState;
+  workers: Worker[];
+  caches: { id: string; name: string }[];
+}) {
+  const workersService = { getWorkers: vi.fn(() => of(opts.workers)) };
+  const orgs: MockedOrgs = {
+    getOrganization: vi.fn(() => of({ id: 'org-uuid', display_name: 'Org' } as never)),
+    getSubscribedCaches: vi.fn(() => of(opts.caches)),
+  };
+  TestBed.configureTestingModule({
+    imports: [WorkersComponent],
+    providers: [
+      provideRouter([]),
+      provideHttpClient(),
+      provideHttpClientTesting(),
+      { provide: WorkersService, useValue: workersService },
+      { provide: OrganizationsService, useValue: orgs },
+      { provide: OrgAccessService, useValue: { forOrg: () => Promise.resolve(opts.access) } },
+      { provide: ActivatedRoute, useValue: activatedRouteStub() },
+    ],
   });
+  return TestBed.createComponent(WorkersComponent);
+}
 
-  it('shows the banner when the org has no subscribed caches', () => {
-    orgsService.getSubscribedCaches.mockReturnValue(of([]));
-    fixture = TestBed.createComponent(WorkersComponent);
-    fixture.detectChanges();
+async function settled(fixture: ComponentFixture<WorkersComponent>) {
+  fixture.detectChanges();
+  await fixture.whenStable();
+  fixture.detectChanges();
+}
+
+function findByText(root: HTMLElement, text: string): HTMLElement | null {
+  const target = text.toLowerCase();
+  return (Array.from(root.querySelectorAll('button')) as HTMLElement[]).find(
+    (el) => (el.textContent ?? '').trim().toLowerCase().includes(target),
+  ) ?? null;
+}
+
+function findAllByText(root: HTMLElement, text: string): HTMLButtonElement[] {
+  const target = text.toLowerCase();
+  return (Array.from(root.querySelectorAll('button')) as HTMLButtonElement[]).filter(
+    (el) => (el.textContent ?? '').trim().toLowerCase().includes(target),
+  );
+}
+
+describe('WorkersComponent — no-cache banner (existing)', () => {
+  it('shows the banner when the org has no subscribed caches', async () => {
+    const fixture = setup({ access: { managed: false, canEdit: true }, workers: [], caches: [] });
+    await settled(fixture);
     const banner = fixture.nativeElement.querySelector('[data-testid="no-cache-banner"]');
     expect(banner, 'banner element').toBeTruthy();
   });
 
-  it('hides the banner when the org has at least one subscribed cache', () => {
-    orgsService.getSubscribedCaches.mockReturnValue(of([{ id: 'c', name: 'cache-1' }]));
-    fixture = TestBed.createComponent(WorkersComponent);
-    fixture.detectChanges();
+  it('hides the banner when the org has at least one subscribed cache', async () => {
+    const fixture = setup({
+      access: { managed: false, canEdit: true },
+      workers: [],
+      caches: [{ id: 'c', name: 'cache-1' }],
+    });
+    await settled(fixture);
     const banner = fixture.nativeElement.querySelector('[data-testid="no-cache-banner"]');
     expect(banner, 'banner element').toBeNull();
+  });
+});
+
+describe('WorkersComponent — access gating', () => {
+  it('hides Register Worker button under read-only org access', async () => {
+    const fixture = setup({ access: { managed: false, canEdit: false }, workers: [workerUnmanaged], caches: [{ id: 'c', name: 'c' }] });
+    await settled(fixture);
+    expect(findByText(fixture.nativeElement, 'register worker')).toBeNull();
+  });
+
+  it('hides per-row Edit / Activate / Delete under read-only org access', async () => {
+    const fixture = setup({ access: { managed: false, canEdit: false }, workers: [workerUnmanaged], caches: [{ id: 'c', name: 'c' }] });
+    await settled(fixture);
+    expect(findByText(fixture.nativeElement, 'edit')).toBeNull();
+    expect(findByText(fixture.nativeElement, 'delete')).toBeNull();
+    expect(findByText(fixture.nativeElement, 'deactivate')).toBeNull();
+  });
+
+  it('shows but disables Register Worker under state-managed org', async () => {
+    const fixture = setup({ access: { managed: true, canEdit: true }, workers: [], caches: [{ id: 'c', name: 'c' }] });
+    await settled(fixture);
+    const btn = findByText(fixture.nativeElement, 'register worker') as HTMLButtonElement | null;
+    expect(btn).not.toBeNull();
+    expect(btn!.disabled).toBe(true);
+  });
+
+  it('disables a managed worker row even in an unmanaged, writable org', async () => {
+    const fixture = setup({
+      access: { managed: false, canEdit: true },
+      workers: [workerUnmanaged, workerManaged],
+      caches: [{ id: 'c', name: 'c' }],
+    });
+    await settled(fixture);
+    const editButtons = findAllByText(fixture.nativeElement, 'edit');
+    expect(editButtons.length).toBe(2);
+    // Buttons appear in DOM order matching workers[] order
+    expect(editButtons[0].disabled).toBe(false);
+    expect(editButtons[1].disabled).toBe(true);
   });
 });

--- a/frontend/src/app/features/organizations/workers/workers.component.ts
+++ b/frontend/src/app/features/organizations/workers/workers.component.ts
@@ -13,8 +13,10 @@ import { ButtonModule } from 'primeng/button';
 import { InputTextModule } from 'primeng/inputtext';
 import { WorkersService } from '@core/services/workers.service';
 import { OrganizationsService } from '@core/services/organizations.service';
-import { GradientCapabilities, Worker, WorkerRegistration } from '@core/models';
+import { OrgAccessService } from '@core/services/org-access.service';
+import { GradientCapabilities, Worker, WorkerRegistration, AccessState } from '@core/models';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
+import { AccessBannerComponent, WritableDirective, ManagedDisableDirective } from '@shared/access';
 
 @Component({
   selector: 'app-workers',
@@ -27,6 +29,9 @@ import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/load
     ButtonModule,
     InputTextModule,
     LoadingSpinnerComponent,
+    AccessBannerComponent,
+    WritableDirective,
+    ManagedDisableDirective,
   ],
   templateUrl: './workers.component.html',
   styleUrl: './workers.component.scss',
@@ -35,6 +40,13 @@ export class WorkersComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private workersService = inject(WorkersService);
   private orgsService = inject(OrganizationsService);
+  private orgAccess = inject(OrgAccessService);
+
+  access = signal<AccessState>({ managed: false, canEdit: false });
+
+  rowAccess(worker: Worker): AccessState {
+    return { managed: worker.managed || this.access().managed, canEdit: this.access().canEdit };
+  }
 
   readonly capLabels: { key: keyof GradientCapabilities; label: string }[] = [
     { key: 'federate', label: 'federate' },
@@ -80,6 +92,7 @@ export class WorkersComponent implements OnInit {
 
   ngOnInit(): void {
     this.orgName = this.route.snapshot.paramMap.get('org') || '';
+    this.orgAccess.forOrg(this.orgName).then((s) => this.access.set(s));
     this.loadOrgId();
     this.loadWorkers();
     this.loadCacheSubscriptions();

--- a/frontend/src/app/features/projects/project-detail/project-detail.component.html
+++ b/frontend/src/app/features/projects/project-detail/project-detail.component.html
@@ -21,31 +21,33 @@
       </div>
       <div class="header-actions">
         @if (authService.isAuthenticated()) {
-          @if (proj.can_edit) {
-            <button
-              pButton
-              label="Start Evaluation"
-              icon="pi pi-play"
-              (click)="startEvaluation()"
-              [loading]="starting()"
-              [disabled]="starting()"
-            ></button>
-            <button
-              pButton
-              label="Restart Failed Builds"
-              icon="pi pi-refresh"
-              severity="secondary"
-              (click)="restartFailedBuilds()"
-              [disabled]="starting()"
-            ></button>
-            <button
-              pButton
-              label="Settings"
-              icon="pi pi-cog"
-              severity="secondary"
-              [routerLink]="['/organization', orgName, 'project', projectName, 'settings']"
-            ></button>
-          }
+          <button
+            *appWritable="access()"
+            pButton
+            label="Start Evaluation"
+            icon="pi pi-play"
+            (click)="startEvaluation()"
+            [loading]="starting()"
+            [disabled]="starting()"
+            [appManagedDisable]="access()"
+          ></button>
+          <button
+            *appWritable="access()"
+            pButton
+            label="Restart Failed Builds"
+            icon="pi pi-refresh"
+            severity="secondary"
+            (click)="restartFailedBuilds()"
+            [disabled]="starting()"
+            [appManagedDisable]="access()"
+          ></button>
+          <button
+            pButton
+            label="Settings"
+            icon="pi pi-cog"
+            severity="secondary"
+            [routerLink]="['/organization', orgName, 'project', projectName, 'settings']"
+          ></button>
         }
         <button
           pButton
@@ -217,12 +219,14 @@
                 </span>
                 @if (isRunningStatus(evaluation.status)) {
                   <button
+                    *appWritable="access()"
                     pButton
                     label="Abort"
                     icon="pi pi-times"
                     severity="danger"
                     size="small"
                     (click)="abortEvaluation(evaluation.id)"
+                    [appManagedDisable]="access()"
                   ></button>
                 }
               </div>
@@ -233,9 +237,9 @@
         <app-empty-state
           icon="assessment"
           title="No evaluations yet"
-          [message]="proj.can_edit ? 'Start your first evaluation to begin building' : 'No evaluations have been run yet'"
-          [actionLabel]="proj.can_edit ? 'Start Evaluation' : ''"
-          (actionClick)="proj.can_edit && startEvaluation()"
+          [message]="access().canEdit ? 'Start your first evaluation to begin building' : 'No evaluations have been run yet'"
+          [actionLabel]="access().canEdit ? 'Start Evaluation' : ''"
+          (actionClick)="access().canEdit && startEvaluation()"
         />
       }
     </div>

--- a/frontend/src/app/features/projects/project-detail/project-detail.component.spec.ts
+++ b/frontend/src/app/features/projects/project-detail/project-detail.component.spec.ts
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { of } from 'rxjs';
+import { ProjectDetailComponent } from './project-detail.component';
+import { ProjectsService } from '@core/services/projects.service';
+import { OrganizationsService } from '@core/services/organizations.service';
+import { AuthService } from '@core/services/auth.service';
+import { AccessState } from '@core/models/access.model';
+
+function activatedRouteStub(access: AccessState): ActivatedRoute {
+  return {
+    snapshot: { paramMap: convertToParamMap({ org: 'acme', project: 'demo' }) },
+    data: of({}),
+    parent: { data: of({ projectAccess: { project: {}, access } }) },
+  } as unknown as ActivatedRoute;
+}
+
+function projectFor(access: AccessState) {
+  return {
+    id: 'p',
+    name: 'demo',
+    display_name: 'Demo',
+    description: '',
+    repository: '',
+    wildcard: '*',
+    active: true,
+    created_at: '',
+    keep_evaluations: 5,
+    last_evaluations: [
+      {
+        id: 'e1',
+        commit: 'abc',
+        status: 'Building' as const,
+        trigger: null,
+        total_builds: 0,
+        failed_builds: 0,
+        completed_entry_points: 0,
+        failed_entry_points: 0,
+        entry_point_diff: null,
+        created_at: '2026-01-01T00:00:00',
+        updated_at: '2026-01-01T00:01:00',
+      },
+    ],
+    can_edit: access.canEdit,
+    managed: access.managed,
+  };
+}
+
+function findByText(root: HTMLElement, text: string): HTMLElement | null {
+  const target = text.toLowerCase();
+  return (Array.from(root.querySelectorAll('button')) as HTMLElement[]).find(
+    (el) => (el.textContent ?? '').trim().toLowerCase().includes(target),
+  ) ?? null;
+}
+
+function setup(access: AccessState): ComponentFixture<ProjectDetailComponent> {
+  TestBed.configureTestingModule({
+    imports: [ProjectDetailComponent],
+    providers: [
+      provideRouter([]),
+      provideHttpClient(),
+      provideHttpClientTesting(),
+      { provide: ActivatedRoute, useValue: activatedRouteStub(access) },
+      {
+        provide: ProjectsService,
+        useValue: {
+          getProject: () => of(projectFor(access)),
+          getEntryPoints: () => of([]),
+        },
+      },
+      { provide: OrganizationsService, useValue: { getOrganization: () => of({ display_name: 'Acme' }) } },
+      { provide: AuthService, useValue: { isAuthenticated: () => true } },
+    ],
+  });
+  const fixture = TestBed.createComponent(ProjectDetailComponent);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('ProjectDetailComponent — access gating', () => {
+  it('hides Start Evaluation / Restart / Abort under read-only', () => {
+    const fixture = setup({ managed: false, canEdit: false });
+    expect(findByText(fixture.nativeElement, 'start evaluation')).toBeNull();
+    expect(findByText(fixture.nativeElement, 'restart failed')).toBeNull();
+    expect(findByText(fixture.nativeElement, 'abort')).toBeNull();
+  });
+
+  it('shows but disables write actions under state-managed access', () => {
+    const fixture = setup({ managed: true, canEdit: true });
+    const startBtn = findByText(fixture.nativeElement, 'start evaluation') as HTMLButtonElement | null;
+    const restartBtn = findByText(fixture.nativeElement, 'restart failed') as HTMLButtonElement | null;
+    const abortBtn = findByText(fixture.nativeElement, 'abort') as HTMLButtonElement | null;
+    expect(startBtn).not.toBeNull();
+    expect(startBtn!.disabled).toBe(true);
+    expect(restartBtn).not.toBeNull();
+    expect(restartBtn!.disabled).toBe(true);
+    expect(abortBtn).not.toBeNull();
+    expect(abortBtn!.disabled).toBe(true);
+  });
+});

--- a/frontend/src/app/features/projects/project-detail/project-detail.component.ts
+++ b/frontend/src/app/features/projects/project-detail/project-detail.component.ts
@@ -14,6 +14,8 @@ import { OrganizationsService } from '@core/services/organizations.service';
 import { ProjectsService } from '@core/services/projects.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { EmptyStateComponent } from '@shared/components/empty-state/empty-state.component';
+import { WritableDirective, ManagedDisableDirective } from '@shared/access';
+import { injectProjectAccess } from '@core/resolvers/inject-access';
 import { ProjectDetail, EvaluationSummary, EvaluationStatus, EntryPointSummary, BuildStatus, TriggerType } from '@core/models';
 
 @Component({
@@ -25,6 +27,8 @@ import { ProjectDetail, EvaluationSummary, EvaluationStatus, EntryPointSummary, 
     ButtonModule,
     LoadingSpinnerComponent,
     EmptyStateComponent,
+    WritableDirective,
+    ManagedDisableDirective,
   ],
   templateUrl: './project-detail.component.html',
   styleUrl: './project-detail.component.scss',
@@ -34,6 +38,8 @@ export class ProjectDetailComponent implements OnInit, OnDestroy {
   protected authService = inject(AuthService);
   private orgsService = inject(OrganizationsService);
   private projectsService = inject(ProjectsService);
+
+  access = injectProjectAccess();
 
   loading = signal(true);
   project = signal<ProjectDetail | null>(null);

--- a/frontend/src/app/features/projects/project-layout/project-layout.component.html
+++ b/frontend/src/app/features/projects/project-layout/project-layout.component.html
@@ -1,0 +1,4 @@
+<div class="project-layout">
+  <app-access-banner [access]="access()"></app-access-banner>
+  <router-outlet></router-outlet>
+</div>

--- a/frontend/src/app/features/projects/project-layout/project-layout.component.scss
+++ b/frontend/src/app/features/projects/project-layout/project-layout.component.scss
@@ -1,0 +1,3 @@
+.project-layout {
+  display: contents;
+}

--- a/frontend/src/app/features/projects/project-layout/project-layout.component.ts
+++ b/frontend/src/app/features/projects/project-layout/project-layout.component.ts
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { RouterOutlet } from '@angular/router';
+import { AccessBannerComponent } from '@shared/access';
+import { injectProjectAccess } from '@core/resolvers/inject-access';
+
+@Component({
+  selector: 'app-project-layout',
+  standalone: true,
+  imports: [RouterOutlet, AccessBannerComponent],
+  templateUrl: './project-layout.component.html',
+  styleUrl: './project-layout.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProjectLayoutComponent {
+  access = injectProjectAccess();
+}

--- a/frontend/src/app/features/projects/project-settings/project-settings.component.html
+++ b/frontend/src/app/features/projects/project-settings/project-settings.component.html
@@ -38,17 +38,6 @@
     <!-- General Settings -->
     <div class="settings-section">
       <h2>General</h2>
-      @if (proj.managed) {
-        <div class="message-banner info">
-          <span class="material-symbols-outlined">info</span>
-          This project is managed declaratively and cannot be edited here.
-        </div>
-      } @else if (!proj.can_edit) {
-        <div class="message-banner info">
-          <span class="material-symbols-outlined">info</span>
-          You have read-only access to this project.
-        </div>
-      }
       <div class="settings-card">
         <div class="form-group">
           <label for="proj-name">Name</label>
@@ -58,17 +47,17 @@
 
         <div class="form-group">
           <label for="proj-display">Display Name</label>
-          <input pInputText id="proj-display" [(ngModel)]="formData.display_name" class="w-full" [disabled]="proj.managed || !proj.can_edit" />
+          <input pInputText id="proj-display" [(ngModel)]="formData.display_name" class="w-full" [appManagedDisable]="access()" />
         </div>
 
         <div class="form-group">
           <label for="proj-desc">Description</label>
-          <textarea pInputTextarea id="proj-desc" [(ngModel)]="formData.description" rows="3" class="w-full" [disabled]="proj.managed || !proj.can_edit"></textarea>
+          <textarea pInputTextarea id="proj-desc" [(ngModel)]="formData.description" rows="3" class="w-full" [appManagedDisable]="access()"></textarea>
         </div>
 
         <div class="form-group">
           <label for="proj-repo">Repository URL</label>
-          <input pInputText id="proj-repo" [(ngModel)]="formData.repository" class="w-full" [disabled]="proj.managed || !proj.can_edit" />
+          <input pInputText id="proj-repo" [(ngModel)]="formData.repository" class="w-full" [appManagedDisable]="access()" />
         </div>
 
         <div class="form-group">
@@ -78,13 +67,13 @@
               <span class="material-symbols-outlined">help</span>
             </a>
           </label>
-          <input pInputText id="proj-wildcard" [(ngModel)]="formData.wildcard" class="w-full" [disabled]="proj.managed || !proj.can_edit" />
+          <input pInputText id="proj-wildcard" [(ngModel)]="formData.wildcard" class="w-full" [appManagedDisable]="access()" />
           <small class="text-secondary">Pattern for selecting which outputs to evaluate</small>
         </div>
 
         <div class="form-group">
           <label for="proj-keep">Keep Evaluations</label>
-          <input pInputText id="proj-keep" type="number" min="1" [(ngModel)]="formData.keep_evaluations" class="w-full" [disabled]="proj.managed || !proj.can_edit" />
+          <input pInputText id="proj-keep" type="number" min="1" [(ngModel)]="formData.keep_evaluations" class="w-full" [appManagedDisable]="access()" />
           <small class="text-secondary">Number of completed evaluations to retain for metrics and history</small>
         </div>
 
@@ -98,7 +87,7 @@
             optionValue="value"
             optionDisabled="disabled"
             styleClass="w-full"
-            [disabled]="proj.managed || !proj.can_edit"
+            [appManagedDisable]="access()"
           />
           <small class="text-secondary">Determines how this project handles a new trigger event when an evaluation is already running.</small>
         </div>
@@ -108,17 +97,23 @@
             inputId="proj-sign-cache"
             [(ngModel)]="formData.sign_cache"
             [binary]="true"
-            [disabled]="proj.managed || !proj.can_edit"
+            [appManagedDisable]="access()"
           />
           <label for="proj-sign-cache">Sign cache (allow public access to build outputs)</label>
           <small class="text-secondary">When off, build outputs are still cached for Gradient itself but narinfos remain unsigned, keeping the project's paths private to external Nix clients even when the cache is public.</small>
         </div>
 
-        @if (!proj.managed && proj.can_edit) {
-          <div class="form-actions">
-            <button pButton label="Save Changes" icon="pi pi-check" (click)="saveSettings()" [loading]="saving()" [disabled]="saving()"></button>
-          </div>
-        }
+        <div class="form-actions">
+          <button
+            *appWritable="access()"
+            pButton
+            label="Save Changes"
+            icon="pi pi-check"
+            (click)="saveSettings()"
+            [loading]="saving()"
+            [appManagedDisable]="access()"
+          ></button>
+        </div>
       </div>
     </div>
 
@@ -150,7 +145,7 @@
               optionLabel="label"
               optionValue="value"
               styleClass="w-full"
-              [disabled]="proj.managed || !proj.can_edit"
+              [appManagedDisable]="access()"
             />
             <small class="text-secondary">Status reporter used to report build results per entry point.</small>
             @if (showGithubAppInstallHint()) {
@@ -165,12 +160,18 @@
             }
           </div>
 
-          @if (!proj.managed && proj.can_edit) {
-            <div class="form-actions">
-              <button pButton label="Save Integrations" icon="pi pi-check" (click)="saveIntegrationLink()" [loading]="savingIntegration()" [disabled]="savingIntegration()"></button>
-              <a pButton label="Manage Integrations" icon="pi pi-external-link" severity="secondary" [routerLink]="['/organization', orgName, 'integrations']"></a>
-            </div>
-          }
+          <div class="form-actions">
+            <button
+              *appWritable="access()"
+              pButton
+              label="Save Integrations"
+              icon="pi pi-check"
+              (click)="saveIntegrationLink()"
+              [loading]="savingIntegration()"
+              [appManagedDisable]="access()"
+            ></button>
+            <a pButton label="Manage Integrations" icon="pi pi-external-link" severity="secondary" [routerLink]="['/organization', orgName, 'integrations']"></a>
+          </div>
         }
       </div>
     </div>
@@ -198,19 +199,20 @@
             <p class="text-secondary">{{ proj.active ? 'The project is currently evaluating and building.' : 'The project is paused and not evaluating.' }}</p>
           </div>
           <button
+            *appWritable="access()"
             pButton
             [label]="proj.active ? 'Deactivate' : 'Activate'"
             [icon]="proj.active ? 'pi pi-pause' : 'pi pi-play'"
             [severity]="proj.active ? 'warn' : 'success'"
             (click)="toggleActive()"
             [loading]="toggling()"
-            [disabled]="toggling() || proj.managed || !proj.can_edit"
+            [appManagedDisable]="access()"
           ></button>
         </div>
       </div>
     </div>
 
-    @if (!proj.managed && proj.can_edit) {
+    @if (access().canEdit) {
       <!-- Danger Zone -->
       <div class="settings-section danger-section">
         <h2>Danger Zone</h2>
@@ -226,6 +228,7 @@
               icon="pi pi-send"
               severity="warn"
               (click)="showTransferDialog.set(true)"
+              [appManagedDisable]="access()"
             ></button>
           </div>
           <div class="danger-divider"></div>
@@ -234,7 +237,14 @@
               <h3>Delete Project</h3>
               <p class="text-secondary">Permanently delete this project and all its evaluations.</p>
             </div>
-            <button pButton label="Delete Project" icon="pi pi-trash" severity="danger" (click)="showDeleteDialog.set(true)"></button>
+            <button
+              pButton
+              label="Delete Project"
+              icon="pi pi-trash"
+              severity="danger"
+              (click)="showDeleteDialog.set(true)"
+              [appManagedDisable]="access()"
+            ></button>
           </div>
         </div>
       </div>

--- a/frontend/src/app/features/projects/project-settings/project-settings.component.scss
+++ b/frontend/src/app/features/projects/project-settings/project-settings.component.scss
@@ -81,6 +81,15 @@
   }
   small { display: block; margin-top: $spacing-xs; font-size: $font-size-xs; }
   &:last-child { margin-bottom: 0; }
+
+  &.checkbox-group {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: $spacing-sm;
+    label { margin: 0; font-weight: normal; }
+    small { flex-basis: 100%; margin-top: 0; }
+  }
 }
 
 .label-help {

--- a/frontend/src/app/features/projects/project-settings/project-settings.component.spec.ts
+++ b/frontend/src/app/features/projects/project-settings/project-settings.component.spec.ts
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { of } from 'rxjs';
+import { ProjectSettingsComponent } from './project-settings.component';
+import { ProjectsService } from '@core/services/projects.service';
+import { OrganizationsService } from '@core/services/organizations.service';
+import { IntegrationsService } from '@core/services/integrations.service';
+import { AccessState } from '@core/models/access.model';
+
+type AccessCase = { managed: boolean; canEdit: boolean };
+
+function projectFor(c: AccessCase) {
+  return {
+    id: 'p',
+    organization: 'acme',
+    name: 'demo',
+    display_name: 'Demo',
+    description: '',
+    repository: '',
+    wildcard: '',
+    active: true,
+    force_evaluation: false,
+    keep_evaluations: 30,
+    concurrency: 'soft_abort' as const,
+    sign_cache: true,
+    managed: c.managed,
+    can_edit: c.canEdit,
+  };
+}
+
+function activatedRouteStub(access: AccessState): ActivatedRoute {
+  return {
+    snapshot: { paramMap: convertToParamMap({ org: 'acme', project: 'demo' }) },
+    data: of({}),
+    parent: { data: of({ projectAccess: { project: projectFor(access), access } }) },
+  } as unknown as ActivatedRoute;
+}
+
+function findByText(root: HTMLElement, text: string): HTMLElement | null {
+  const target = text.toLowerCase();
+  return (Array.from(root.querySelectorAll('button')) as HTMLElement[]).find(
+    (el) => (el.textContent ?? '').trim().toLowerCase().includes(target),
+  ) ?? null;
+}
+
+function setup(c: AccessCase): ComponentFixture<ProjectSettingsComponent> {
+  TestBed.configureTestingModule({
+    imports: [ProjectSettingsComponent],
+    providers: [
+      provideRouter([]),
+      provideHttpClient(),
+      provideHttpClientTesting(),
+      { provide: ActivatedRoute, useValue: activatedRouteStub(c) },
+      {
+        provide: ProjectsService,
+        useValue: { getProjectInfo: () => of(projectFor(c)) },
+      },
+      {
+        provide: OrganizationsService,
+        useValue: { getOrganization: () => of({ id: 'o', display_name: 'Acme' }) },
+      },
+      {
+        provide: IntegrationsService,
+        useValue: {
+          listOrgIntegrations: () => of([]),
+          getProjectIntegration: () => of(null),
+        },
+      },
+    ],
+  });
+  const fixture = TestBed.createComponent(ProjectSettingsComponent);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('ProjectSettingsComponent — access gating', () => {
+  it('hides Save Changes when access is read-only', () => {
+    const fixture = setup({ managed: false, canEdit: false });
+    expect(findByText(fixture.nativeElement, 'save changes')).toBeNull();
+  });
+
+  it('shows but disables Save Changes when project is state-managed', () => {
+    const fixture = setup({ managed: true, canEdit: true });
+    const btn = findByText(fixture.nativeElement, 'save changes') as HTMLButtonElement | null;
+    expect(btn).not.toBeNull();
+    expect(btn!.disabled).toBe(true);
+  });
+
+  it('hides Delete Project under read-only access', () => {
+    const fixture = setup({ managed: false, canEdit: false });
+    expect(findByText(fixture.nativeElement, 'delete project')).toBeNull();
+  });
+
+  it('shows but disables Delete Project when managed', () => {
+    const fixture = setup({ managed: true, canEdit: true });
+    const btn = findByText(fixture.nativeElement, 'delete project') as HTMLButtonElement | null;
+    expect(btn).not.toBeNull();
+    expect(btn!.disabled).toBe(true);
+  });
+});

--- a/frontend/src/app/features/projects/project-settings/project-settings.component.ts
+++ b/frontend/src/app/features/projects/project-settings/project-settings.component.ts
@@ -21,7 +21,9 @@ import { AutoCompleteModule } from 'primeng/autocomplete';
 import { SelectModule } from 'primeng/select';
 import { CheckboxModule } from 'primeng/checkbox';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
+import { WritableDirective, ManagedDisableDirective } from '@shared/access';
 import { ConcurrencyPolicy, Integration, Project, ProjectIntegrationLink } from '@core/models';
+import { injectProjectAccess } from '@core/resolvers/inject-access';
 
 @Component({
   selector: 'app-project-settings',
@@ -38,6 +40,8 @@ import { ConcurrencyPolicy, Integration, Project, ProjectIntegrationLink } from 
     SelectModule,
     CheckboxModule,
     LoadingSpinnerComponent,
+    WritableDirective,
+    ManagedDisableDirective,
   ],
   templateUrl: './project-settings.component.html',
   styleUrl: './project-settings.component.scss',
@@ -48,6 +52,8 @@ export class ProjectSettingsComponent implements OnInit {
   private projectsService = inject(ProjectsService);
   private orgsService = inject(OrganizationsService);
   private integrationsService = inject(IntegrationsService);
+
+  access = injectProjectAccess();
 
   loading = signal(true);
   saving = signal(false);

--- a/frontend/src/app/features/projects/project-triggers/project-triggers.component.html
+++ b/frontend/src/app/features/projects/project-triggers/project-triggers.component.html
@@ -17,7 +17,14 @@
       <h1>Triggers</h1>
       <p class="text-secondary">Conditions that automatically start an evaluation</p>
     </div>
-    <button pButton label="New Trigger" icon="pi pi-plus" (click)="startCreate()"></button>
+    <button
+      *appWritable="access()"
+      pButton
+      label="New Trigger"
+      icon="pi pi-plus"
+      (click)="startCreate()"
+      [appManagedDisable]="access()"
+    ></button>
   </div>
 
   @if (loading()) {
@@ -28,7 +35,14 @@
         <span class="material-symbols-outlined">schedule_send</span>
         <h3>No triggers configured</h3>
         <p class="text-secondary">Create a trigger to automatically start evaluations on a schedule, push event, or pull request.</p>
-        <button pButton label="New Trigger" icon="pi pi-plus" (click)="startCreate()"></button>
+        <button
+          *appWritable="access()"
+          pButton
+          label="New Trigger"
+          icon="pi pi-plus"
+          (click)="startCreate()"
+          [appManagedDisable]="access()"
+        ></button>
       </div>
     } @else {
       <div class="triggers-list">
@@ -55,32 +69,35 @@
               </div>
               <div class="trigger-actions">
                 <button
+                  *appWritable="access()"
                   pButton
                   label="Fire Now"
                   icon="pi pi-play"
                   severity="secondary"
                   size="small"
                   [loading]="firingId() === trigger.id"
-                  [disabled]="firingId() !== null || deletingId() !== null"
+                  [disabled]="rowDisabled()"
                   (click)="fireNow(trigger.id)"
                 ></button>
                 <button
+                  *appWritable="access()"
                   pButton
                   label="Edit"
                   icon="pi pi-pencil"
                   severity="secondary"
                   size="small"
-                  [disabled]="firingId() !== null || deletingId() !== null"
+                  [disabled]="rowDisabled()"
                   (click)="startEdit(trigger)"
                 ></button>
                 <button
+                  *appWritable="access()"
                   pButton
                   label="Delete"
                   icon="pi pi-trash"
                   severity="danger"
                   size="small"
                   [loading]="deletingId() === trigger.id"
-                  [disabled]="deletingId() !== null || firingId() !== null"
+                  [disabled]="rowDisabled()"
                   (click)="deleteTrigger(trigger.id)"
                 ></button>
               </div>

--- a/frontend/src/app/features/projects/project-triggers/project-triggers.component.spec.ts
+++ b/frontend/src/app/features/projects/project-triggers/project-triggers.component.spec.ts
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { of } from 'rxjs';
+import { ProjectTriggersComponent } from './project-triggers.component';
+import { TriggersService } from '@core/services/triggers.service';
+import { IntegrationsService } from '@core/services/integrations.service';
+import { OrganizationsService } from '@core/services/organizations.service';
+import { AccessState } from '@core/models/access.model';
+
+function activatedRouteStub(access: AccessState): ActivatedRoute {
+  return {
+    snapshot: { paramMap: convertToParamMap({ org: 'acme', project: 'demo' }) },
+    data: of({}),
+    parent: { data: of({ projectAccess: { project: {}, access } }) },
+  } as unknown as ActivatedRoute;
+}
+
+function findByText(root: HTMLElement, text: string): HTMLElement | null {
+  const target = text.toLowerCase();
+  return (Array.from(root.querySelectorAll('button')) as HTMLElement[]).find(
+    (el) => (el.textContent ?? '').trim().toLowerCase().includes(target),
+  ) ?? null;
+}
+
+const trigger = {
+  id: 't1',
+  type: 'polling' as const,
+  active: true,
+  config: { type: 'polling', interval_secs: 300, branch: null },
+  last_fired_at: null,
+};
+
+function setup(access: AccessState): ComponentFixture<ProjectTriggersComponent> {
+  TestBed.configureTestingModule({
+    imports: [ProjectTriggersComponent],
+    providers: [
+      provideRouter([]),
+      provideHttpClient(),
+      provideHttpClientTesting(),
+      { provide: ActivatedRoute, useValue: activatedRouteStub(access) },
+      { provide: TriggersService, useValue: { list: () => of([trigger]) } },
+      { provide: IntegrationsService, useValue: { listOrgIntegrations: () => of([]) } },
+      { provide: OrganizationsService, useValue: { getOrganization: () => of({ display_name: 'Acme' }) } },
+    ],
+  });
+  const fixture = TestBed.createComponent(ProjectTriggersComponent);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('ProjectTriggersComponent — access gating', () => {
+  it('hides New Trigger / Edit / Delete / Fire Now buttons under read-only', () => {
+    const fixture = setup({ managed: false, canEdit: false });
+    expect(findByText(fixture.nativeElement, 'new trigger')).toBeNull();
+    expect(findByText(fixture.nativeElement, 'edit')).toBeNull();
+    expect(findByText(fixture.nativeElement, 'delete')).toBeNull();
+    expect(findByText(fixture.nativeElement, 'fire now')).toBeNull();
+  });
+
+  it('shows but disables write buttons under state-managed access', () => {
+    const fixture = setup({ managed: true, canEdit: true });
+    const newBtn = findByText(fixture.nativeElement, 'new trigger') as HTMLButtonElement | null;
+    const editBtn = findByText(fixture.nativeElement, 'edit') as HTMLButtonElement | null;
+    const deleteBtn = findByText(fixture.nativeElement, 'delete') as HTMLButtonElement | null;
+    const fireBtn = findByText(fixture.nativeElement, 'fire now') as HTMLButtonElement | null;
+    expect(newBtn).not.toBeNull();
+    expect(newBtn!.disabled).toBe(true);
+    expect(editBtn).not.toBeNull();
+    expect(editBtn!.disabled).toBe(true);
+    expect(deleteBtn).not.toBeNull();
+    expect(deleteBtn!.disabled).toBe(true);
+    expect(fireBtn).not.toBeNull();
+    expect(fireBtn!.disabled).toBe(true);
+  });
+});

--- a/frontend/src/app/features/projects/project-triggers/project-triggers.component.ts
+++ b/frontend/src/app/features/projects/project-triggers/project-triggers.component.ts
@@ -17,6 +17,8 @@ import { TriggersService } from '@core/services/triggers.service';
 import { IntegrationsService } from '@core/services/integrations.service';
 import { OrganizationsService } from '@core/services/organizations.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
+import { WritableDirective, ManagedDisableDirective, AccessService } from '@shared/access';
+import { injectProjectAccess } from '@core/resolvers/inject-access';
 import {
   ProjectTrigger,
   TriggerType,
@@ -71,6 +73,8 @@ const DEFAULT_FORM: TriggerFormState = {
     SelectModule,
     CheckboxModule,
     LoadingSpinnerComponent,
+    WritableDirective,
+    ManagedDisableDirective,
   ],
   templateUrl: './project-triggers.component.html',
   styleUrl: './project-triggers.component.scss',
@@ -80,6 +84,16 @@ export class ProjectTriggersComponent implements OnInit {
   private triggersService = inject(TriggersService);
   private integrationsService = inject(IntegrationsService);
   private orgsService = inject(OrganizationsService);
+  private accessSvc = inject(AccessService);
+
+  access = injectProjectAccess();
+
+  rowDisabled = computed(
+    () =>
+      this.firingId() !== null ||
+      this.deletingId() !== null ||
+      this.accessSvc.shouldDisableInput(this.access()),
+  );
 
   loading = signal(true);
   saving = signal(false);

--- a/frontend/src/app/features/settings/api-keys/api-keys.component.html
+++ b/frontend/src/app/features/settings/api-keys/api-keys.component.html
@@ -65,16 +65,15 @@
               </div>
             </div>
             <div class="key-actions">
-              @if (!key.managed && !key.revoked_at) {
+              @if (!key.revoked_at) {
                 <button
                   pButton
                   label="Edit"
                   icon="pi pi-pencil"
                   severity="secondary"
                   (click)="openEditDialog(key)"
+                  [appManagedDisable]="rowAccess(key)"
                 ></button>
-              }
-              @if (!key.revoked_at) {
                 <button
                   pButton
                   label="Revoke"
@@ -82,7 +81,8 @@
                   severity="warn"
                   (click)="revokeKey(key)"
                   [loading]="revokingId() === key.id"
-                  [disabled]="revokingId() !== null || key.managed"
+                  [disabled]="revokingId() !== null"
+                  [appManagedDisable]="rowAccess(key)"
                 ></button>
               }
               <button
@@ -92,7 +92,8 @@
                 severity="danger"
                 (click)="deleteKey(key)"
                 [loading]="deletingId() === key.id"
-                [disabled]="deletingId() !== null || key.managed"
+                [disabled]="deletingId() !== null"
+                [appManagedDisable]="rowAccess(key)"
               ></button>
             </div>
           </div>

--- a/frontend/src/app/features/settings/api-keys/api-keys.component.spec.ts
+++ b/frontend/src/app/features/settings/api-keys/api-keys.component.spec.ts
@@ -1,0 +1,103 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { of } from 'rxjs';
+import { ApiKeysComponent } from './api-keys.component';
+import { UserService } from '@core/services/user.service';
+import { OrganizationsService } from '@core/services/organizations.service';
+import { ApiKey } from '@core/models/user.model';
+
+const unmanagedKey: ApiKey = {
+  id: 'k1',
+  name: 'CI key',
+  managed: false,
+  permissions: ['viewOrg'],
+  organization: null,
+  created_at: '2026-01-01T00:00:00',
+  last_used_at: null,
+  expires_at: null,
+  revoked_at: null,
+};
+
+const managedKey: ApiKey = {
+  id: 'k2',
+  name: 'Nix key',
+  managed: true,
+  permissions: ['viewOrg'],
+  organization: null,
+  created_at: '2026-01-01T00:00:00',
+  last_used_at: null,
+  expires_at: null,
+  revoked_at: null,
+};
+
+function setup(keys: ApiKey[]): ComponentFixture<ApiKeysComponent> {
+  TestBed.configureTestingModule({
+    imports: [ApiKeysComponent],
+    providers: [
+      provideRouter([]),
+      provideHttpClient(),
+      provideHttpClientTesting(),
+      {
+        provide: UserService,
+        useValue: {
+          getApiKeys: () => of(keys),
+          getApiKeyPermissions: () => of({ available_permissions: [] }),
+        },
+      },
+      {
+        provide: OrganizationsService,
+        useValue: { getOrganizations: () => of({ items: [], total: 0, page: 1, per_page: 100 }) },
+      },
+    ],
+  });
+  const fixture = TestBed.createComponent(ApiKeysComponent);
+  fixture.detectChanges();
+  return fixture;
+}
+
+function buttonsByText(root: HTMLElement, text: string): HTMLButtonElement[] {
+  const target = text.toLowerCase();
+  return (Array.from(root.querySelectorAll('button')) as HTMLButtonElement[]).filter(
+    (el) => (el.textContent ?? '').trim().toLowerCase().includes(target),
+  );
+}
+
+describe('ApiKeysComponent — managed-key gating', () => {
+  it('renders Edit / Revoke / Delete enabled for an unmanaged key', () => {
+    const fixture = setup([unmanagedKey]);
+    const editButtons = buttonsByText(fixture.nativeElement, 'edit');
+    const revokeButtons = buttonsByText(fixture.nativeElement, 'revoke');
+    const deleteButtons = buttonsByText(fixture.nativeElement, 'delete');
+    expect(editButtons.length).toBe(1);
+    expect(editButtons[0].disabled).toBe(false);
+    expect(revokeButtons.length).toBe(1);
+    expect(revokeButtons[0].disabled).toBe(false);
+    expect(deleteButtons.length).toBe(1);
+    expect(deleteButtons[0].disabled).toBe(false);
+  });
+
+  it('renders Revoke / Delete present-but-disabled for a managed key', () => {
+    const fixture = setup([managedKey]);
+    const revokeButtons = buttonsByText(fixture.nativeElement, 'revoke');
+    const deleteButtons = buttonsByText(fixture.nativeElement, 'delete');
+    expect(revokeButtons.length).toBe(1);
+    expect(revokeButtons[0].disabled).toBe(true);
+    expect(deleteButtons.length).toBe(1);
+    expect(deleteButtons[0].disabled).toBe(true);
+  });
+
+  it('renders Edit present-but-disabled for a managed key', () => {
+    const fixture = setup([managedKey]);
+    const editButtons = buttonsByText(fixture.nativeElement, 'edit');
+    expect(editButtons.length).toBe(1);
+    expect(editButtons[0].disabled).toBe(true);
+  });
+});

--- a/frontend/src/app/features/settings/api-keys/api-keys.component.ts
+++ b/frontend/src/app/features/settings/api-keys/api-keys.component.ts
@@ -20,6 +20,8 @@ import { OrganizationsService } from '@core/services/organizations.service';
 import { ApiKey } from '@core/models';
 import { PermissionDescriptor } from '@core/models/permission.model';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
+import { ManagedDisableDirective } from '@shared/access';
+import { AccessState } from '@core/models';
 
 interface OrgOption {
   label: string;
@@ -41,6 +43,7 @@ interface OrgOption {
     SelectModule,
     TooltipModule,
     LoadingSpinnerComponent,
+    ManagedDisableDirective,
   ],
   templateUrl: './api-keys.component.html',
   styleUrl: './api-keys.component.scss',
@@ -111,7 +114,6 @@ export class ApiKeysComponent implements OnInit {
   }
 
   openEditDialog(key: ApiKey): void {
-    if (key.managed) return;
     this.editingKey.set(key);
     this.formName = key.name;
     this.formExpiresInDays = null;
@@ -214,5 +216,9 @@ export class ApiKeysComponent implements OnInit {
   permissionTooltip(key: ApiKey): string {
     if (key.permissions.length === 0) return 'No permissions';
     return key.permissions.join(', ');
+  }
+
+  rowAccess(key: ApiKey): AccessState {
+    return { managed: key.managed, canEdit: true };
   }
 }

--- a/frontend/src/app/features/settings/profile/profile.component.html
+++ b/frontend/src/app/features/settings/profile/profile.component.html
@@ -44,24 +44,29 @@
       <div class="settings-card">
         <div class="form-group">
           <label for="username">Username</label>
-          <input pInputText id="username" [(ngModel)]="formData.username" class="w-full" [disabled]="isOidc() || isManaged()" />
+          <input pInputText id="username" [(ngModel)]="formData.username" class="w-full" [appManagedDisable]="access()" />
         </div>
 
         <div class="form-group">
           <label for="name">Full Name</label>
-          <input pInputText id="name" [(ngModel)]="formData.name" class="w-full" [disabled]="isOidc() || isManaged()" />
+          <input pInputText id="name" [(ngModel)]="formData.name" class="w-full" [appManagedDisable]="access()" />
         </div>
 
         <div class="form-group">
           <label for="email">Email</label>
-          <input pInputText id="email" type="email" [(ngModel)]="formData.email" class="w-full" [disabled]="isOidc() || isManaged()" />
+          <input pInputText id="email" type="email" [(ngModel)]="formData.email" class="w-full" [appManagedDisable]="access()" />
         </div>
 
-        @if (!isOidc() && !isManaged()) {
-          <div class="form-actions">
-            <button pButton label="Save Changes" icon="pi pi-check" (click)="saveSettings()" [loading]="saving()" [disabled]="saving()"></button>
-          </div>
-        }
+        <div class="form-actions">
+          <button
+            pButton
+            label="Save Changes"
+            icon="pi pi-check"
+            (click)="saveSettings()"
+            [loading]="saving()"
+            [appManagedDisable]="access()"
+          ></button>
+        </div>
       </div>
     </div>
 
@@ -96,7 +101,7 @@
             <h3>Delete Account</h3>
             <p class="text-secondary">Permanently delete your account and all associated data.</p>
           </div>
-          <button pButton label="Delete Account" icon="pi pi-trash" severity="danger" (click)="openDeleteDialog()" [disabled]="isManaged()"></button>
+          <button pButton label="Delete Account" icon="pi pi-trash" severity="danger" (click)="openDeleteDialog()" [appManagedDisable]="access()"></button>
         </div>
       </div>
     </div>

--- a/frontend/src/app/features/settings/profile/profile.component.spec.ts
+++ b/frontend/src/app/features/settings/profile/profile.component.spec.ts
@@ -1,0 +1,77 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { of } from 'rxjs';
+import { ProfileComponent } from './profile.component';
+import { UserService } from '@core/services/user.service';
+import { AuthService } from '@core/services/auth.service';
+
+function settings(opts: { managed: boolean; oidc: boolean }) {
+  return {
+    username: 'alice',
+    name: 'Alice',
+    email: 'alice@example.com',
+    is_oidc: opts.oidc,
+    managed: opts.managed,
+  };
+}
+
+function setup(opts: { managed: boolean; oidc: boolean }): ComponentFixture<ProfileComponent> {
+  TestBed.configureTestingModule({
+    imports: [ProfileComponent],
+    providers: [
+      provideRouter([]),
+      provideHttpClient(),
+      provideHttpClientTesting(),
+      { provide: UserService, useValue: { getUserSettings: () => of(settings(opts)) } },
+      { provide: AuthService, useValue: { reloadUser: () => undefined } },
+    ],
+  });
+  const fixture = TestBed.createComponent(ProfileComponent);
+  fixture.detectChanges();
+  return fixture;
+}
+
+function findByText(root: HTMLElement, text: string): HTMLElement | null {
+  const target = text.toLowerCase();
+  return (Array.from(root.querySelectorAll('button')) as HTMLElement[]).find(
+    (el) => (el.textContent ?? '').trim().toLowerCase().includes(target),
+  ) ?? null;
+}
+
+describe('ProfileComponent — access gating', () => {
+  it('renders Save Changes enabled for an unmanaged, non-OIDC account', () => {
+    const fixture = setup({ managed: false, oidc: false });
+    const save = findByText(fixture.nativeElement, 'save changes') as HTMLButtonElement | null;
+    expect(save).not.toBeNull();
+    expect(save!.disabled).toBe(false);
+  });
+
+  it('renders Save Changes present-but-disabled for a state-managed account', () => {
+    const fixture = setup({ managed: true, oidc: false });
+    const save = findByText(fixture.nativeElement, 'save changes') as HTMLButtonElement | null;
+    expect(save).not.toBeNull();
+    expect(save!.disabled).toBe(true);
+  });
+
+  it('renders Save Changes present-but-disabled for an OIDC account', () => {
+    const fixture = setup({ managed: false, oidc: true });
+    const save = findByText(fixture.nativeElement, 'save changes') as HTMLButtonElement | null;
+    expect(save).not.toBeNull();
+    expect(save!.disabled).toBe(true);
+  });
+
+  it('disables Delete Account when managed', () => {
+    const fixture = setup({ managed: true, oidc: false });
+    const del = findByText(fixture.nativeElement, 'delete account') as HTMLButtonElement | null;
+    expect(del).not.toBeNull();
+    expect(del!.disabled).toBe(true);
+  });
+});

--- a/frontend/src/app/features/settings/profile/profile.component.ts
+++ b/frontend/src/app/features/settings/profile/profile.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal } from '@angular/core';
+import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -15,6 +15,8 @@ import { InputTextModule } from 'primeng/inputtext';
 import { UserService } from '@core/services/user.service';
 import { AuthService } from '@core/services/auth.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
+import { ManagedDisableDirective } from '@shared/access';
+import { AccessState } from '@core/models';
 
 @Component({
   selector: 'app-profile',
@@ -28,6 +30,7 @@ import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/load
     ButtonModule,
     InputTextModule,
     LoadingSpinnerComponent,
+    ManagedDisableDirective,
   ],
   templateUrl: './profile.component.html',
   styleUrl: './profile.component.scss',
@@ -42,6 +45,14 @@ export class ProfileComponent implements OnInit {
   deleting = signal(false);
   isOidc = signal(false);
   isManaged = signal(false);
+
+  /** OIDC and Nix-managed both freeze the profile fields; the user always
+   * retains the right to edit their own account in principle, so canEdit
+   * stays true and the banner / disable behavior comes from `managed`. */
+  access = computed<AccessState>(() => ({
+    managed: this.isManaged() || this.isOidc(),
+    canEdit: true,
+  }));
 
   showDeleteDialog = signal(false);
   errorMessage = signal<string | null>(null);

--- a/frontend/src/app/shared/access/access-banner.component.html
+++ b/frontend/src/app/shared/access/access-banner.component.html
@@ -1,0 +1,6 @@
+@if (kind() !== 'none' && message(); as msg) {
+  <aside [class]="klass()" role="status">
+    <span class="access-banner__icon" aria-hidden="true">!</span>
+    <span class="access-banner__text">{{ msg }}</span>
+  </aside>
+}

--- a/frontend/src/app/shared/access/access-banner.component.scss
+++ b/frontend/src/app/shared/access/access-banner.component.scss
@@ -1,0 +1,37 @@
+.access-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  margin-bottom: 1rem;
+  font-size: 0.875rem;
+  width: 100%;
+
+  &__icon {
+    font-weight: 700;
+    flex-shrink: 0;
+  }
+
+  &__text {
+    flex: 1;
+  }
+
+  &--managed {
+    background: var(--color-info-bg, #eef4ff);
+    color: var(--color-info-fg, #1e3a8a);
+    border: 1px solid var(--color-info-border, #c7d8ff);
+  }
+
+  &--readonly {
+    background: var(--color-warning-bg, #fff7ed);
+    color: var(--color-warning-fg, #9a3412);
+    border: 1px solid var(--color-warning-border, #fed7aa);
+  }
+
+  &--managed-readonly {
+    background: var(--color-info-bg, #eef4ff);
+    color: var(--color-info-fg, #1e3a8a);
+    border: 1px solid var(--color-info-border, #c7d8ff);
+  }
+}

--- a/frontend/src/app/shared/access/access-banner.component.spec.ts
+++ b/frontend/src/app/shared/access/access-banner.component.spec.ts
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Component, signal } from '@angular/core';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { AccessBannerComponent } from './access-banner.component';
+import { AccessState } from '@core/models/access.model';
+
+@Component({
+  selector: 'test-host',
+  standalone: true,
+  imports: [AccessBannerComponent],
+  template: `<app-access-banner [access]="access()"></app-access-banner>`,
+})
+class HostComponent {
+  access = signal<AccessState>({ managed: false, canEdit: true });
+}
+
+describe('AccessBannerComponent', () => {
+  let fixture: ComponentFixture<HostComponent>;
+
+  function bannerEl(): HTMLElement | null {
+    return fixture.nativeElement.querySelector('.access-banner');
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [HostComponent] });
+    fixture = TestBed.createComponent(HostComponent);
+  });
+
+  it('renders nothing for full access', () => {
+    fixture.componentInstance.access.set({ managed: false, canEdit: true });
+    fixture.detectChanges();
+    expect(bannerEl()).toBeNull();
+  });
+
+  it('renders a managed banner when managed and canEdit', () => {
+    fixture.componentInstance.access.set({ managed: true, canEdit: true });
+    fixture.detectChanges();
+    const el = bannerEl();
+    expect(el).not.toBeNull();
+    expect(el!.textContent).toMatch(/managed/i);
+    expect(el!.classList).toContain('access-banner--managed');
+  });
+
+  it('renders a read-only banner when !canEdit and !managed', () => {
+    fixture.componentInstance.access.set({ managed: false, canEdit: false });
+    fixture.detectChanges();
+    const el = bannerEl();
+    expect(el).not.toBeNull();
+    expect(el!.textContent).toMatch(/read-only/i);
+    expect(el!.classList).toContain('access-banner--readonly');
+  });
+
+  it('renders a managed-readonly banner when both', () => {
+    fixture.componentInstance.access.set({ managed: true, canEdit: false });
+    fixture.detectChanges();
+    const el = bannerEl();
+    expect(el).not.toBeNull();
+    expect(el!.classList).toContain('access-banner--managed-readonly');
+  });
+});

--- a/frontend/src/app/shared/access/access-banner.component.ts
+++ b/frontend/src/app/shared/access/access-banner.component.ts
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+} from '@angular/core';
+import { AccessState } from '@core/models/access.model';
+import { AccessService } from './access.service';
+
+@Component({
+  selector: 'app-access-banner',
+  standalone: true,
+  templateUrl: './access-banner.component.html',
+  styleUrl: './access-banner.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AccessBannerComponent {
+  private access = inject(AccessService);
+
+  state = input.required<AccessState | null | undefined>({ alias: 'access' });
+
+  kind = computed(() => {
+    const s = this.state();
+    return s ? this.access.bannerKind(s) : 'none';
+  });
+
+  message = computed(() => {
+    const s = this.state();
+    return s ? this.access.bannerMessage(s) : null;
+  });
+
+  klass = computed(() => `access-banner access-banner--${this.kind()}`);
+}

--- a/frontend/src/app/shared/access/access.service.spec.ts
+++ b/frontend/src/app/shared/access/access.service.spec.ts
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { AccessService } from './access.service';
+import { AccessState } from '@core/models/access.model';
+
+const s = (managed: boolean, canEdit: boolean): AccessState => ({ managed, canEdit });
+
+describe('AccessService', () => {
+  let svc: AccessService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    svc = TestBed.inject(AccessService);
+  });
+
+  describe('isWritable', () => {
+    it('is true only when canEdit && !managed', () => {
+      expect(svc.isWritable(s(false, true))).toBe(true);
+      expect(svc.isWritable(s(true, true))).toBe(false);
+      expect(svc.isWritable(s(false, false))).toBe(false);
+      expect(svc.isWritable(s(true, false))).toBe(false);
+    });
+  });
+
+  describe('shouldShowWriteAction', () => {
+    it('returns canEdit (managed users still see write actions, just disabled)', () => {
+      expect(svc.shouldShowWriteAction(s(false, true))).toBe(true);
+      expect(svc.shouldShowWriteAction(s(true, true))).toBe(true);
+      expect(svc.shouldShowWriteAction(s(false, false))).toBe(false);
+      expect(svc.shouldShowWriteAction(s(true, false))).toBe(false);
+    });
+  });
+
+  describe('shouldDisableInput', () => {
+    it('disables when managed OR !canEdit', () => {
+      expect(svc.shouldDisableInput(s(false, true))).toBe(false);
+      expect(svc.shouldDisableInput(s(true, true))).toBe(true);
+      expect(svc.shouldDisableInput(s(false, false))).toBe(true);
+      expect(svc.shouldDisableInput(s(true, false))).toBe(true);
+    });
+  });
+
+  describe('bannerKind', () => {
+    it('returns the correct kind for each combination', () => {
+      expect(svc.bannerKind(s(false, true))).toBe('none');
+      expect(svc.bannerKind(s(true, true))).toBe('managed');
+      expect(svc.bannerKind(s(false, false))).toBe('readonly');
+      expect(svc.bannerKind(s(true, false))).toBe('managed-readonly');
+    });
+  });
+
+  describe('bannerMessage', () => {
+    it('returns null for kind=none', () => {
+      expect(svc.bannerMessage(s(false, true))).toBeNull();
+    });
+    it('returns a non-empty message for each non-none kind', () => {
+      expect(svc.bannerMessage(s(true, true))).toMatch(/managed/i);
+      expect(svc.bannerMessage(s(false, false))).toMatch(/read-only/i);
+      expect(svc.bannerMessage(s(true, false))).toMatch(/managed/i);
+    });
+  });
+});

--- a/frontend/src/app/shared/access/access.service.ts
+++ b/frontend/src/app/shared/access/access.service.ts
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Injectable } from '@angular/core';
+import { AccessState } from '@core/models/access.model';
+
+export type BannerKind = 'none' | 'managed' | 'readonly' | 'managed-readonly';
+
+@Injectable({ providedIn: 'root' })
+export class AccessService {
+  isWritable(s: AccessState): boolean {
+    return s.canEdit && !s.managed;
+  }
+
+  shouldShowWriteAction(s: AccessState): boolean {
+    return s.canEdit;
+  }
+
+  shouldDisableInput(s: AccessState): boolean {
+    return s.managed || !s.canEdit;
+  }
+
+  bannerKind(s: AccessState): BannerKind {
+    if (s.managed && !s.canEdit) return 'managed-readonly';
+    if (s.managed) return 'managed';
+    if (!s.canEdit) return 'readonly';
+    return 'none';
+  }
+
+  bannerMessage(s: AccessState): string | null {
+    switch (this.bannerKind(s)) {
+      case 'managed':
+        return 'This resource is managed by Nix. Edit it through your declarative config.';
+      case 'readonly':
+        return 'You have read-only access. Contact an organization admin to make changes.';
+      case 'managed-readonly':
+        return 'This resource is managed by Nix and you have read-only access.';
+      default:
+        return null;
+    }
+  }
+}

--- a/frontend/src/app/shared/access/index.ts
+++ b/frontend/src/app/shared/access/index.ts
@@ -6,3 +6,4 @@
 
 export * from './access.service';
 export * from './writable.directive';
+export * from './managed-disable.directive';

--- a/frontend/src/app/shared/access/index.ts
+++ b/frontend/src/app/shared/access/index.ts
@@ -7,3 +7,4 @@
 export * from './access.service';
 export * from './writable.directive';
 export * from './managed-disable.directive';
+export * from './access-banner.component';

--- a/frontend/src/app/shared/access/index.ts
+++ b/frontend/src/app/shared/access/index.ts
@@ -1,0 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export * from './access.service';

--- a/frontend/src/app/shared/access/index.ts
+++ b/frontend/src/app/shared/access/index.ts
@@ -5,3 +5,4 @@
  */
 
 export * from './access.service';
+export * from './writable.directive';

--- a/frontend/src/app/shared/access/managed-disable.directive.spec.ts
+++ b/frontend/src/app/shared/access/managed-disable.directive.spec.ts
@@ -1,0 +1,80 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Component, signal } from '@angular/core';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { ManagedDisableDirective } from './managed-disable.directive';
+import { AccessState } from '@core/models/access.model';
+
+@Component({
+  selector: 'test-host',
+  standalone: true,
+  imports: [ManagedDisableDirective],
+  template: `<input [appManagedDisable]="access()" />`,
+})
+class HostComponent {
+  access = signal<AccessState>({ managed: false, canEdit: true });
+}
+
+describe('ManagedDisableDirective ([appManagedDisable])', () => {
+  let fixture: ComponentFixture<HostComponent>;
+
+  function input(): HTMLInputElement {
+    return fixture.nativeElement.querySelector('input') as HTMLInputElement;
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [HostComponent] });
+    fixture = TestBed.createComponent(HostComponent);
+  });
+
+  it('does not disable when canEdit && !managed', () => {
+    fixture.componentInstance.access.set({ managed: false, canEdit: true });
+    fixture.detectChanges();
+    expect(input().disabled).toBe(false);
+  });
+
+  it('disables when managed=true (regardless of canEdit)', () => {
+    fixture.componentInstance.access.set({ managed: true, canEdit: true });
+    fixture.detectChanges();
+    expect(input().disabled).toBe(true);
+  });
+
+  it('disables when canEdit=false', () => {
+    fixture.componentInstance.access.set({ managed: false, canEdit: false });
+    fixture.detectChanges();
+    expect(input().disabled).toBe(true);
+  });
+
+  it('disables when both managed=true and canEdit=false', () => {
+    fixture.componentInstance.access.set({ managed: true, canEdit: false });
+    fixture.detectChanges();
+    expect(input().disabled).toBe(true);
+  });
+
+  it('sets a tooltip mentioning "managed" when managed', () => {
+    fixture.componentInstance.access.set({ managed: true, canEdit: true });
+    fixture.detectChanges();
+    expect(input().title.toLowerCase()).toContain('managed');
+  });
+
+  it('sets a tooltip mentioning "read-only" when access is read-only', () => {
+    fixture.componentInstance.access.set({ managed: false, canEdit: false });
+    fixture.detectChanges();
+    expect(input().title.toLowerCase()).toContain('read-only');
+  });
+
+  it('removes disabled and tooltip when access becomes writable again', () => {
+    fixture.componentInstance.access.set({ managed: true, canEdit: true });
+    fixture.detectChanges();
+    expect(input().disabled).toBe(true);
+
+    fixture.componentInstance.access.set({ managed: false, canEdit: true });
+    fixture.detectChanges();
+    expect(input().disabled).toBe(false);
+    expect(input().title).toBe('');
+  });
+});

--- a/frontend/src/app/shared/access/managed-disable.directive.ts
+++ b/frontend/src/app/shared/access/managed-disable.directive.ts
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Directive, ElementRef, Input, Renderer2, inject } from '@angular/core';
+import { AccessState } from '@core/models/access.model';
+import { AccessService } from './access.service';
+
+@Directive({
+  selector: '[appManagedDisable]',
+  standalone: true,
+})
+export class ManagedDisableDirective {
+  private el = inject(ElementRef<HTMLElement>);
+  private renderer = inject(Renderer2);
+  private access = inject(AccessService);
+
+  @Input({ required: true }) set appManagedDisable(state: AccessState | null | undefined) {
+    this.apply(state);
+  }
+
+  private apply(state: AccessState | null | undefined): void {
+    const node = this.el.nativeElement;
+    if (state && this.access.shouldDisableInput(state)) {
+      this.renderer.setProperty(node, 'disabled', true);
+      this.renderer.setAttribute(node, 'aria-disabled', 'true');
+      this.renderer.setAttribute(node, 'title', this.tooltip(state));
+    } else {
+      this.renderer.setProperty(node, 'disabled', false);
+      this.renderer.removeAttribute(node, 'aria-disabled');
+      this.renderer.removeAttribute(node, 'title');
+    }
+  }
+
+  private tooltip(state: AccessState): string {
+    if (state.managed) return 'Managed by Nix — edit via declarative config';
+    return 'You have read-only access';
+  }
+}

--- a/frontend/src/app/shared/access/writable.directive.spec.ts
+++ b/frontend/src/app/shared/access/writable.directive.spec.ts
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Component, signal } from '@angular/core';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { WritableDirective } from './writable.directive';
+import { AccessState } from '@core/models/access.model';
+
+@Component({
+  selector: 'test-host',
+  standalone: true,
+  imports: [WritableDirective],
+  template: `<button *appWritable="access()">save</button>`,
+})
+class HostComponent {
+  access = signal<AccessState>({ managed: false, canEdit: true });
+}
+
+describe('WritableDirective (*appWritable)', () => {
+  let fixture: ComponentFixture<HostComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [HostComponent] });
+    fixture = TestBed.createComponent(HostComponent);
+  });
+
+  it('renders content when canEdit is true', () => {
+    fixture.componentInstance.access.set({ managed: false, canEdit: true });
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('button')).not.toBeNull();
+  });
+
+  it('renders content when canEdit and managed are both true', () => {
+    fixture.componentInstance.access.set({ managed: true, canEdit: true });
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('button')).not.toBeNull();
+  });
+
+  it('hides content when canEdit is false', () => {
+    fixture.componentInstance.access.set({ managed: false, canEdit: false });
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('button')).toBeNull();
+  });
+
+  it('hides content when canEdit is false even if managed is true', () => {
+    fixture.componentInstance.access.set({ managed: true, canEdit: false });
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('button')).toBeNull();
+  });
+
+  it('toggles content when the input changes', () => {
+    fixture.componentInstance.access.set({ managed: false, canEdit: true });
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('button')).not.toBeNull();
+
+    fixture.componentInstance.access.set({ managed: false, canEdit: false });
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('button')).toBeNull();
+  });
+});

--- a/frontend/src/app/shared/access/writable.directive.ts
+++ b/frontend/src/app/shared/access/writable.directive.ts
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import {
+  Directive,
+  Input,
+  TemplateRef,
+  ViewContainerRef,
+  inject,
+} from '@angular/core';
+import { AccessState } from '@core/models/access.model';
+
+@Directive({
+  selector: '[appWritable]',
+  standalone: true,
+})
+export class WritableDirective {
+  private templateRef = inject(TemplateRef<unknown>);
+  private vcr = inject(ViewContainerRef);
+  private rendered = false;
+
+  @Input({ required: true }) set appWritable(state: AccessState | null | undefined) {
+    const shouldRender = !!state && state.canEdit;
+    if (shouldRender && !this.rendered) {
+      this.vcr.createEmbeddedView(this.templateRef);
+      this.rendered = true;
+    } else if (!shouldRender && this.rendered) {
+      this.vcr.clear();
+      this.rendered = false;
+    }
+  }
+}

--- a/frontend/tsconfig.spec.json
+++ b/frontend/tsconfig.spec.json
@@ -1,7 +1,7 @@
 /* To learn more about Typescript configuration file: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
 /* To learn more about Angular compiler options: https://angular.dev/reference/configs/angular-compiler-options. */
 {
-  "extends": "./tsconfig.json",
+  "extends": "./tsconfig.app.json",
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
     "types": [
@@ -11,5 +11,6 @@
   "include": [
     "src/**/*.d.ts",
     "src/**/*.spec.ts"
-  ]
+  ],
+  "exclude": []
 }


### PR DESCRIPTION
## Summary

- Replaces ad-hoc handling of `entity.managed` and `entity.can_edit` across ~14 components with a shared access layer: `AccessState` + `AccessService`, `*appWritable` and `[appManagedDisable]` directives, and a top-of-page `<app-access-banner>` rendered by new project/cache layout components fed by route resolvers. Org-scoped pages (workers, members, cache subscriptions, org settings) use a new `OrgAccessService` derived from `Organization.role`.
- Closes two reported regressions: workers could still be added to a state-managed org, and the cache-upstreams subpage was unreachable for state-managed caches instead of being read-only. Both have direct gating tests.
- Restores the unit-test build. `tsconfig.spec.json` extended the wrong base config so spec files couldn't resolve `@core/`, `@shared/`, `@features/`; two specs still used jasmine after the project switched to vitest; `app.spec.ts` was a stale `ng new` stub. With those fixed, the suite runs 25 files / 86 tests, including the new gating tests and the access primitives.
- Backend: adds `managed: bool` to `ProjectDetailsResponse` (matching the existing `Project` summary) and realigns the OpenAPI schema, which had drifted from the actual struct.
- Docs: `docs/src/tests.md` documents the access module and per-component tests; `docs/src/usage/state.md` gains a "How the UI surfaces this" section.

Inconsistencies removed:

- The two competing template patterns (`[disabled]="managed || !can_edit"` vs `@if (!managed && can_edit)`) are replaced with `*appWritable` + `[appManagedDisable]` everywhere.
- `cache-subscriptions` ad-hoc role-name string compare (`me.name === 'Admin' || me.name === 'Write'`) is gone.
- `cache-settings` no longer hides the "Manage Upstreams" navigation link when the cache is state-managed.
- `organization-settings` checked only `managed`, never `can_edit` — view-role users now see the page read-only instead of hitting a server reject.
- `project-triggers` and `cache-upstreams` had zero access checks; both now gate Add/Edit/Delete via the shared primitives.
- `api-keys` had a duplicate guard in `openEditDialog` mirroring a template check; only the directive-level guard remains.
- One pre-existing checkbox layout bug surfaced during manual testing: the "Sign cache" checkbox in project-settings sat above its label because the SCSS file lacked the `.checkbox-group` rule that the HTML referenced. Fixed locally to match the project-triggers definition.

## Test Plan

- [x] `pnpm -C frontend test --watch=false` — 25 files / 86 tests pass, including primitives (AccessService, both directives, banner), resolvers, OrgAccessService, and per-component gating tests for project-settings, project-triggers, project-detail, cache-settings, cache-upstreams, organization-settings, workers (incl. per-row managed flag), cache-subscriptions, members-roles, api-keys, and profile (incl. OIDC case).
- [x] `cargo check --workspace` and `cargo clippy --workspace -- -D warnings` clean.
- [x] `ng build --configuration production` succeeds.
- [ ] Manual smoke matrix once deployed: log in as Admin/View on managed/unmanaged orgs and walk every settings page + subpage; verify banner copy, button visibility (hidden vs visible-disabled), and input disable state match the truth table in `docs/src/usage/state.md`.
- [ ] Verify in dev server that the project-settings "Sign cache" checkbox sits inline with its label after the SCSS fix.