### PR TITLE
Cross-cache leader/follower deduplication

### DIFF
--- a/backend/core/src/ci/trigger.rs
+++ b/backend/core/src/ci/trigger.rs
@@ -228,7 +228,8 @@ pub async fn trigger_restart_builds<C: ConnectionTrait>(
         .collect::<std::collections::HashSet<_>>()
         .into_iter()
         .collect();
-    let leader_for_drv = crate::db::find_active_leaders(db, &queued_drv_ids).await?;
+    let leader_for_drv =
+        crate::db::find_active_leaders(db, project.organization, &queued_drv_ids).await?;
 
     // Create new builds for the new evaluation and track old→new build ID mapping.
     let mut build_id_map: std::collections::HashMap<BuildId, BuildId> =

--- a/backend/core/src/db/cache_reach.rs
+++ b/backend/core/src/db/cache_reach.rs
@@ -1,0 +1,151 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Compute the set of organizations whose Gradient build outputs a given
+//! organization can substitute through its cache subscriptions and the
+//! `cache_upstream` graph.
+//!
+//! Two organizations are "cache-connected" when the writer org pushes into
+//! a cache that lies in the upstream closure of one of the reader org's
+//! caches. External (URL-based) upstreams are excluded — they don't host
+//! Gradient builds.
+
+use std::collections::{HashSet, VecDeque};
+
+use sea_orm::{ColumnTrait, ConnectionTrait, DbErr, EntityTrait, QueryFilter};
+
+use entity::cache_upstream::{Column as CCacheUpstream, Entity as ECacheUpstream};
+use entity::ids::{CacheId, OrganizationId};
+use entity::organization_cache::{
+    CacheSubscriptionMode, Column as COrganizationCache, Entity as EOrganizationCache,
+};
+
+/// Returns every organization (including `reader_org` itself) whose build
+/// outputs `reader_org` could substitute through its current cache
+/// subscriptions and the `cache_upstream` graph.
+///
+/// Algorithm:
+/// 1. Load reader's `organization_cache` rows with mode `ReadWrite`/`ReadOnly`.
+/// 2. BFS forward over `cache_upstream` edges (`cache → upstream_cache`) to
+///    compute the upstream closure of the reader's caches. Cycles tolerated.
+/// 3. Load every `organization_cache` row with mode `ReadWrite`/`WriteOnly`
+///    on any cache in that closure; return the distinct org ids.
+pub async fn writer_orgs_reachable_from<C: ConnectionTrait>(
+    db: &C,
+    reader_org: OrganizationId,
+) -> Result<HashSet<OrganizationId>, DbErr> {
+    let reader_rows = EOrganizationCache::find()
+        .filter(COrganizationCache::Organization.eq(reader_org))
+        .filter(COrganizationCache::Mode.is_in(vec![
+            CacheSubscriptionMode::ReadWrite,
+            CacheSubscriptionMode::ReadOnly,
+        ]))
+        .all(db)
+        .await?;
+    let seed: Vec<CacheId> = reader_rows.into_iter().map(|r| r.cache).collect();
+
+    let upstream_rows = ECacheUpstream::find()
+        .filter(CCacheUpstream::UpstreamCache.is_not_null())
+        .all(db)
+        .await?;
+
+    let mut closure: HashSet<CacheId> = seed.iter().copied().collect();
+    let mut queue: VecDeque<CacheId> = seed.into_iter().collect();
+    while let Some(cache_id) = queue.pop_front() {
+        for edge in &upstream_rows {
+            if edge.cache != cache_id {
+                continue;
+            }
+            let Some(up) = edge.upstream_cache else { continue };
+            if closure.insert(up) {
+                queue.push_back(up);
+            }
+        }
+    }
+
+    if closure.is_empty() {
+        return Ok(HashSet::new());
+    }
+
+    let writer_rows = EOrganizationCache::find()
+        .filter(COrganizationCache::Cache.is_in(closure.into_iter().collect::<Vec<_>>()))
+        .filter(COrganizationCache::Mode.is_in(vec![
+            CacheSubscriptionMode::ReadWrite,
+            CacheSubscriptionMode::WriteOnly,
+        ]))
+        .all(db)
+        .await?;
+    Ok(writer_rows.into_iter().map(|r| r.organization).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use entity::cache_upstream::Model as MCacheUpstream;
+    use entity::ids::{CacheId, CacheUpstreamId, OrganizationCacheId, OrganizationId};
+    use entity::organization_cache::Model as MOrganizationCache;
+    use sea_orm::{DatabaseBackend, MockDatabase};
+    use uuid::Uuid;
+
+    fn org(n: u8) -> OrganizationId {
+        let mut bytes = [0u8; 16];
+        bytes[15] = n;
+        OrganizationId::new(Uuid::from_bytes(bytes))
+    }
+
+    fn cid(n: u8) -> CacheId {
+        let mut bytes = [0u8; 16];
+        bytes[14] = n;
+        CacheId::new(Uuid::from_bytes(bytes))
+    }
+
+    fn org_cache(
+        org_id: OrganizationId,
+        cache_id: CacheId,
+        mode: CacheSubscriptionMode,
+    ) -> MOrganizationCache {
+        MOrganizationCache {
+            id: OrganizationCacheId::now_v7(),
+            organization: org_id,
+            cache: cache_id,
+            mode,
+        }
+    }
+
+    fn run<F: std::future::Future>(fut: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(fut)
+    }
+
+    #[test]
+    fn direct_overlap_reader_sees_writer() {
+        run(async {
+            // Reader (org B) reads cache X; writer (org A) writes cache X.
+            let cache_x = cid(1);
+            let reader_rows = vec![org_cache(org(2), cache_x, CacheSubscriptionMode::ReadOnly)];
+            let upstream_rows: Vec<MCacheUpstream> = vec![];
+            let writer_rows = vec![
+                org_cache(org(1), cache_x, CacheSubscriptionMode::ReadWrite),
+                org_cache(org(2), cache_x, CacheSubscriptionMode::ReadOnly),
+            ];
+
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([reader_rows])
+                .append_query_results([upstream_rows])
+                .append_query_results([writer_rows])
+                .into_connection();
+
+            let got = writer_orgs_reachable_from(&db, org(2))
+                .await
+                .expect("query succeeds");
+
+            assert!(got.contains(&org(1)), "got: {:?}", got);
+        });
+    }
+}

--- a/backend/core/src/db/cache_reach.rs
+++ b/backend/core/src/db/cache_reach.rs
@@ -148,4 +148,144 @@ mod tests {
             assert!(got.contains(&org(1)), "got: {:?}", got);
         });
     }
+
+    #[test]
+    fn transitive_internal_chain() {
+        run(async {
+            // chain: cache_a → upstream cache_b → upstream cache_c
+            // reader on a, writer on c
+            let a = cid(1);
+            let b = cid(2);
+            let c = cid(3);
+
+            let reader_rows = vec![org_cache(org(2), a, CacheSubscriptionMode::ReadOnly)];
+            let upstream_rows = vec![
+                MCacheUpstream {
+                    id: CacheUpstreamId::now_v7(),
+                    cache: a,
+                    display_name: "ab".into(),
+                    mode: CacheSubscriptionMode::ReadOnly,
+                    upstream_cache: Some(b),
+                    url: None,
+                    public_key: None,
+                },
+                MCacheUpstream {
+                    id: CacheUpstreamId::now_v7(),
+                    cache: b,
+                    display_name: "bc".into(),
+                    mode: CacheSubscriptionMode::ReadOnly,
+                    upstream_cache: Some(c),
+                    url: None,
+                    public_key: None,
+                },
+            ];
+            let writer_rows = vec![org_cache(org(1), c, CacheSubscriptionMode::ReadWrite)];
+
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([reader_rows])
+                .append_query_results([upstream_rows])
+                .append_query_results([writer_rows])
+                .into_connection();
+
+            let got = writer_orgs_reachable_from(&db, org(2)).await.unwrap();
+            assert!(got.contains(&org(1)), "got: {:?}", got);
+        });
+    }
+
+    #[test]
+    fn external_upstream_skipped() {
+        run(async {
+            // Reader on a; the production helper filters `upstream_cache IS NOT NULL`,
+            // so an external (URL-based) upstream row never reaches the BFS. Writer on
+            // a separate cache b is therefore unreachable.
+            let a = cid(1);
+            let b = cid(2);
+
+            let reader_rows = vec![org_cache(org(2), a, CacheSubscriptionMode::ReadOnly)];
+            let upstream_rows: Vec<MCacheUpstream> = vec![];
+            let writer_rows: Vec<MOrganizationCache> = vec![];
+
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([reader_rows])
+                .append_query_results([upstream_rows])
+                .append_query_results([writer_rows])
+                .into_connection();
+
+            let got = writer_orgs_reachable_from(&db, org(2)).await.unwrap();
+            assert!(
+                !got.contains(&org(1)),
+                "external upstream must not reach org 1, got: {:?}",
+                got
+            );
+            let _ = b;
+        });
+    }
+
+    #[test]
+    fn write_only_reader_excluded() {
+        run(async {
+            // Reader has WriteOnly on cache X; the production helper's mode filter
+            // (`ReadWrite`/`ReadOnly`) returns no reader rows, so the closure is
+            // empty and no writers are discovered.
+            let x = cid(1);
+            let reader_rows: Vec<MOrganizationCache> = vec![];
+            let upstream_rows: Vec<MCacheUpstream> = vec![];
+            let writer_rows: Vec<MOrganizationCache> = vec![];
+
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([reader_rows])
+                .append_query_results([upstream_rows])
+                .append_query_results([writer_rows])
+                .into_connection();
+
+            let got = writer_orgs_reachable_from(&db, org(2)).await.unwrap();
+            assert!(got.is_empty(), "WriteOnly reader must see nobody, got: {:?}", got);
+            let _ = x;
+        });
+    }
+
+    #[test]
+    fn cycle_tolerated() {
+        run(async {
+            // cache_a.upstream = b; cache_b.upstream = a → cycle. BFS must
+            // terminate via the visited set.
+            let a = cid(1);
+            let b = cid(2);
+
+            let reader_rows = vec![org_cache(org(2), a, CacheSubscriptionMode::ReadOnly)];
+            let upstream_rows = vec![
+                MCacheUpstream {
+                    id: CacheUpstreamId::now_v7(),
+                    cache: a,
+                    display_name: "ab".into(),
+                    mode: CacheSubscriptionMode::ReadOnly,
+                    upstream_cache: Some(b),
+                    url: None,
+                    public_key: None,
+                },
+                MCacheUpstream {
+                    id: CacheUpstreamId::now_v7(),
+                    cache: b,
+                    display_name: "ba".into(),
+                    mode: CacheSubscriptionMode::ReadOnly,
+                    upstream_cache: Some(a),
+                    url: None,
+                    public_key: None,
+                },
+            ];
+            let writer_rows = vec![
+                org_cache(org(1), b, CacheSubscriptionMode::ReadWrite),
+                org_cache(org(2), a, CacheSubscriptionMode::ReadOnly),
+            ];
+
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([reader_rows])
+                .append_query_results([upstream_rows])
+                .append_query_results([writer_rows])
+                .into_connection();
+
+            let got = writer_orgs_reachable_from(&db, org(2)).await.unwrap();
+            assert!(got.contains(&org(1)), "cycle must still include reachable writer, got: {:?}", got);
+        });
+    }
 }

--- a/backend/core/src/db/mod.rs
+++ b/backend/core/src/db/mod.rs
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+pub mod cache_reach;
 pub mod connection;
 pub mod dependency_graph;
 pub mod derivation;
@@ -11,6 +12,7 @@ pub mod drv_output_spec;
 pub mod gc;
 pub mod status;
 
+pub use self::cache_reach::*;
 pub use self::connection::*;
 pub use self::dependency_graph::*;
 pub use self::derivation::*;

--- a/backend/core/src/db/status.rs
+++ b/backend/core/src/db/status.rs
@@ -354,36 +354,115 @@ async fn abort_follower(state: &Arc<ServerState>, build: MBuild) {
     update_build_status(Arc::clone(state), reloaded, BuildStatus::Aborted).await;
 }
 
-/// Promote one follower of `leader` to be the new leader, then re-point any
-/// remaining followers at the new leader's id. Picks the oldest follower by
-/// `created_at` for stability. No-op if no followers exist.
-async fn reelect_leader(state: &Arc<ServerState>, leader: &MBuild) -> Result<(), sea_orm::DbErr> {
-    use sea_orm::QueryOrder;
+/// Promote one same-org follower of `leader` to be the new leader.
+/// Cross-org followers have their `via` cleared (made independent).
+/// No-op if no followers exist.
+pub(crate) async fn reelect_leader(
+    state: &Arc<ServerState>,
+    leader: &MBuild,
+) -> Result<(), sea_orm::DbErr> {
+    use entity::derivation::{Column as CDerivation, Entity as EDerivation};
 
-    let new_leader = EBuild::find()
-        .filter(CBuild::Via.eq(leader.id))
-        .order_by_asc(CBuild::CreatedAt)
+    let leader_org = EDerivation::find_by_id(leader.derivation)
         .one(&state.worker_db)
-        .await?;
-    let Some(new_leader) = new_leader else {
-        return Ok(());
-    };
+        .await?
+        .map(|d| d.organization);
 
-    let mut active: ABuild = new_leader.clone().into_active_model();
-    active.via = Set(None);
-    active.update(&state.worker_db).await?;
-
-    EBuild::update_many()
-        .col_expr(CBuild::Via, sea_orm::sea_query::Expr::value(new_leader.id))
+    let all_followers = EBuild::find()
         .filter(CBuild::Via.eq(leader.id))
-        .exec(&state.worker_db)
+        .all(&state.worker_db)
         .await?;
+    if all_followers.is_empty() {
+        return Ok(());
+    }
 
-    debug!(
-        old_leader = %leader.id,
-        new_leader = %new_leader.id,
-        "re-elected build leader"
-    );
+    let follower_drv_ids: Vec<DerivationId> =
+        all_followers.iter().map(|f| f.derivation).collect();
+    let drv_org: std::collections::HashMap<DerivationId, OrganizationId> =
+        EDerivation::find()
+            .filter(CDerivation::Id.is_in(follower_drv_ids))
+            .all(&state.worker_db)
+            .await?
+            .into_iter()
+            .map(|d| (d.id, d.organization))
+            .collect();
+
+    let mut same_org: Vec<MBuild> = Vec::new();
+    let mut cross_org: Vec<MBuild> = Vec::new();
+    for f in all_followers {
+        let org = drv_org.get(&f.derivation).copied();
+        if org == leader_org && org.is_some() {
+            same_org.push(f);
+        } else {
+            cross_org.push(f);
+        }
+    }
+
+    fn rank(s: BuildStatus) -> u8 {
+        match s {
+            BuildStatus::Building => 2,
+            BuildStatus::Queued => 1,
+            _ => 0,
+        }
+    }
+    same_org.sort_by(|a, b| {
+        rank(b.status)
+            .cmp(&rank(a.status))
+            .then_with(|| a.created_at.cmp(&b.created_at))
+    });
+
+    if let Some(new_leader) = same_org.first().cloned() {
+        let mut active: ABuild = new_leader.clone().into_active_model();
+        active.via = Set(None);
+        active.update(&state.worker_db).await?;
+
+        let same_org_remaining_ids: Vec<BuildId> =
+            same_org.iter().skip(1).map(|f| f.id).collect();
+        if !same_org_remaining_ids.is_empty() {
+            EBuild::update_many()
+                .col_expr(CBuild::Via, sea_orm::sea_query::Expr::value(new_leader.id))
+                .filter(CBuild::Id.is_in(same_org_remaining_ids))
+                .exec(&state.worker_db)
+                .await?;
+        }
+
+        let cross_org_ids: Vec<BuildId> = cross_org.iter().map(|f| f.id).collect();
+        if !cross_org_ids.is_empty() {
+            EBuild::update_many()
+                .col_expr(
+                    CBuild::Via,
+                    sea_orm::sea_query::Expr::value(Option::<BuildId>::None),
+                )
+                .filter(CBuild::Id.is_in(cross_org_ids))
+                .exec(&state.worker_db)
+                .await?;
+        }
+
+        debug!(
+            old_leader = %leader.id,
+            new_leader = %new_leader.id,
+            cross_org_orphaned = cross_org.len(),
+            "re-elected build leader (same-org), cross-org followers made independent"
+        );
+        return Ok(());
+    }
+
+    let cross_org_ids: Vec<BuildId> = cross_org.iter().map(|f| f.id).collect();
+    if !cross_org_ids.is_empty() {
+        EBuild::update_many()
+            .col_expr(
+                CBuild::Via,
+                sea_orm::sea_query::Expr::value(Option::<BuildId>::None),
+            )
+            .filter(CBuild::Id.is_in(cross_org_ids))
+            .exec(&state.worker_db)
+            .await?;
+        debug!(
+            old_leader = %leader.id,
+            orphaned = cross_org.len(),
+            "leader aborted with no same-org followers; cross-org followers made independent"
+        );
+    }
     Ok(())
 }
 
@@ -520,6 +599,146 @@ pub async fn find_active_leaders<C: ConnectionTrait>(
     }
 
     Ok(out)
+}
+
+#[cfg(test)]
+mod reelect_leader_tests {
+    use super::*;
+    use entity::build::{BuildStatus, Model as MBuild};
+    use entity::derivation::Model as MDerivation;
+    use sea_orm::{DatabaseBackend, MockDatabase};
+    use uuid::Uuid;
+
+    fn org(n: u8) -> OrganizationId {
+        let mut bytes = [0u8; 16];
+        bytes[15] = n;
+        OrganizationId::new(Uuid::from_bytes(bytes))
+    }
+    fn did(n: u8) -> DerivationId {
+        let mut bytes = [0u8; 16];
+        bytes[13] = n;
+        DerivationId::new(Uuid::from_bytes(bytes))
+    }
+    fn bid(n: u8) -> BuildId {
+        let mut bytes = [0u8; 16];
+        bytes[12] = n;
+        BuildId::new(Uuid::from_bytes(bytes))
+    }
+
+    fn build(id: BuildId, drv: DerivationId, via: Option<BuildId>, status: BuildStatus) -> MBuild {
+        MBuild {
+            id,
+            evaluation: EvaluationId::now_v7(),
+            derivation: drv,
+            status,
+            log_id: None,
+            build_time_ms: None,
+            worker: None,
+            via,
+            external_cached: false,
+            created_at: chrono::NaiveDateTime::default(),
+            updated_at: chrono::NaiveDateTime::default(),
+        }
+    }
+
+    fn drv_row(id: DerivationId, owner: OrganizationId) -> MDerivation {
+        MDerivation {
+            id,
+            organization: owner,
+            derivation_path: "/nix/store/x.drv".into(),
+            architecture: "x86_64-linux".into(),
+            created_at: chrono::NaiveDateTime::default(),
+        }
+    }
+
+    fn make_state(db: sea_orm::DatabaseConnection) -> std::sync::Arc<crate::types::ServerState> {
+        test_support::state::test_state(db)
+    }
+
+    fn run<F: std::future::Future>(fut: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(fut)
+    }
+
+    /// Same-org follower is promoted to leader; cross-org follower's via is cleared.
+    #[test]
+    fn promotes_same_org_and_orphans_cross_org_follower() {
+        run(async {
+            let leader_drv = did(1);
+            let same_org_drv = did(2);
+            let cross_org_drv = did(3);
+            let leader = build(bid(10), leader_drv, None, BuildStatus::Queued);
+            let same_org_follower =
+                build(bid(11), same_org_drv, Some(leader.id), BuildStatus::Created);
+            let cross_org_follower =
+                build(bid(12), cross_org_drv, Some(leader.id), BuildStatus::Created);
+
+            // Query sequence:
+            //   1. EDerivation::find_by_id(leader.derivation) → drv with org(1)
+            //   2. EBuild::find().filter(Via = leader.id) → [same_org_follower, cross_org_follower]
+            //   3. EDerivation::find().filter(Id IN follower_drv_ids) → org map
+            //   4. active.update() for promotion (Postgres RETURNING → query_results)
+            //   5. EBuild::update_many (clear via for cross_org_follower → exec_results)
+            // No "remaining same-org" update_many: only one same-org follower → skip(1) is empty.
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([vec![drv_row(leader_drv, org(1))]])
+                .append_query_results([vec![
+                    same_org_follower.clone(),
+                    cross_org_follower.clone(),
+                ]])
+                .append_query_results([vec![
+                    drv_row(same_org_drv, org(1)),
+                    drv_row(cross_org_drv, org(2)),
+                ]])
+                .append_query_results([vec![same_org_follower.clone()]])
+                .append_exec_results([sea_orm::MockExecResult {
+                    last_insert_id: 0,
+                    rows_affected: 1,
+                }])
+                .into_connection();
+
+            let state = make_state(db);
+            reelect_leader(&state, &leader).await.expect("reelect ok");
+        });
+    }
+
+    /// Leader has only cross-org followers: every follower's via is cleared.
+    #[test]
+    fn all_cross_org_followers_orphaned_when_no_same_org() {
+        run(async {
+            let leader_drv = did(1);
+            let foll_drv_b = did(2);
+            let foll_drv_c = did(3);
+            let leader = build(bid(20), leader_drv, None, BuildStatus::Queued);
+            let f1 = build(bid(21), foll_drv_b, Some(leader.id), BuildStatus::Created);
+            let f2 = build(bid(22), foll_drv_c, Some(leader.id), BuildStatus::Created);
+
+            // Query sequence:
+            //   1. EDerivation::find_by_id(leader.derivation) → drv with org(1)
+            //   2. EBuild::find().filter(Via = leader.id) → [f1, f2]
+            //   3. EDerivation::find().filter(Id IN follower_drv_ids) → org map (all cross-org)
+            //   4. EBuild::update_many (clear via for all cross-org → exec_results)
+            // No same-org candidates, so no active.update() promotion.
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([vec![drv_row(leader_drv, org(1))]])
+                .append_query_results([vec![f1.clone(), f2.clone()]])
+                .append_query_results([vec![
+                    drv_row(foll_drv_b, org(2)),
+                    drv_row(foll_drv_c, org(3)),
+                ]])
+                .append_exec_results([sea_orm::MockExecResult {
+                    last_insert_id: 0,
+                    rows_affected: 2,
+                }])
+                .into_connection();
+
+            let state = make_state(db);
+            reelect_leader(&state, &leader).await.expect("reelect ok");
+        });
+    }
 }
 
 #[cfg(test)]

--- a/backend/core/src/db/status.rs
+++ b/backend/core/src/db/status.rs
@@ -390,11 +390,10 @@ async fn reelect_leader(state: &Arc<ServerState>, leader: &MBuild) -> Result<(),
 /// For each derivation in `drv_ids`, return the id of the leader build whose
 /// result a new build for that derivation should follow.
 ///
-/// First checks for an in-flight build within `inserting_org` (the previous
-/// behavior). When no same-org candidate exists for a drv, this function
-/// will also consult cache-connected organisations via
-/// [`cache_reach::writer_orgs_reachable_from`] — that pass is added in a
-/// later task; this step only widens the signature.
+/// First checks for an in-flight build within `inserting_org`. When no
+/// same-org candidate exists for a drv, consults cache-connected organisations
+/// via [`cache_reach::writer_orgs_reachable_from`] and picks the most-advanced
+/// active build (tie-break: oldest `created_at`).
 ///
 /// Drvs with no active build are omitted from the result.
 pub async fn find_active_leaders<C: ConnectionTrait>(
@@ -402,12 +401,12 @@ pub async fn find_active_leaders<C: ConnectionTrait>(
     inserting_org: OrganizationId,
     drv_ids: &[DerivationId],
 ) -> Result<HashMap<DerivationId, BuildId>, sea_orm::DbErr> {
-    let _ = inserting_org;
     if drv_ids.is_empty() {
         return Ok(HashMap::new());
     }
 
-    let rows = EBuild::find()
+    // ── Same-org pass ────────────────────────────────────────────────────
+    let same_org_rows = EBuild::find()
         .filter(CBuild::Derivation.is_in(drv_ids.to_vec()))
         .filter(CBuild::Status.is_in(vec![
             BuildStatus::Created,
@@ -418,7 +417,7 @@ pub async fn find_active_leaders<C: ConnectionTrait>(
         .await?;
 
     let mut out: HashMap<DerivationId, BuildId> = HashMap::new();
-    for b in rows {
+    for b in same_org_rows {
         let head = b.via.unwrap_or(b.id);
         out.entry(b.derivation)
             .and_modify(|cur| {
@@ -428,5 +427,261 @@ pub async fn find_active_leaders<C: ConnectionTrait>(
             })
             .or_insert(head);
     }
+
+    let unmatched: Vec<DerivationId> = drv_ids
+        .iter()
+        .copied()
+        .filter(|d| !out.contains_key(d))
+        .collect();
+    if unmatched.is_empty() {
+        return Ok(out);
+    }
+
+    // ── Cross-org pass ───────────────────────────────────────────────────
+    use entity::derivation::{Column as CDerivation, Entity as EDerivation};
+
+    let inserting_drv_rows = EDerivation::find()
+        .filter(CDerivation::Id.is_in(unmatched.clone()))
+        .all(db)
+        .await?;
+    let mut path_to_drv: HashMap<String, DerivationId> = HashMap::new();
+    let mut drv_paths: Vec<String> = Vec::new();
+    for d in &inserting_drv_rows {
+        path_to_drv.insert(d.derivation_path.clone(), d.id);
+        drv_paths.push(d.derivation_path.clone());
+    }
+    if drv_paths.is_empty() {
+        return Ok(out);
+    }
+
+    let mut reachable =
+        crate::db::cache_reach::writer_orgs_reachable_from(db, inserting_org).await?;
+    reachable.remove(&inserting_org);
+    if reachable.is_empty() {
+        return Ok(out);
+    }
+
+    let candidate_drvs = EDerivation::find()
+        .filter(CDerivation::DerivationPath.is_in(drv_paths.clone()))
+        .filter(CDerivation::Organization.is_in(reachable.into_iter().collect::<Vec<_>>()))
+        .all(db)
+        .await?;
+    if candidate_drvs.is_empty() {
+        return Ok(out);
+    }
+    let candidate_drv_ids: Vec<DerivationId> = candidate_drvs.iter().map(|d| d.id).collect();
+    let leader_drv_to_path: HashMap<DerivationId, String> = candidate_drvs
+        .into_iter()
+        .map(|d| (d.id, d.derivation_path))
+        .collect();
+
+    let candidate_builds = EBuild::find()
+        .filter(CBuild::Derivation.is_in(candidate_drv_ids))
+        .filter(CBuild::Status.is_in(vec![
+            BuildStatus::Created,
+            BuildStatus::Queued,
+            BuildStatus::Building,
+        ]))
+        .filter(CBuild::Via.is_null())
+        .filter(CBuild::ExternalCached.eq(false))
+        .all(db)
+        .await?;
+
+    fn status_rank(s: BuildStatus) -> u8 {
+        match s {
+            BuildStatus::Building => 2,
+            BuildStatus::Queued => 1,
+            _ => 0,
+        }
+    }
+    let mut best_by_path: HashMap<String, MBuild> = HashMap::new();
+    for b in candidate_builds {
+        let Some(path) = leader_drv_to_path.get(&b.derivation).cloned() else {
+            continue;
+        };
+        match best_by_path.get(&path) {
+            Some(cur) => {
+                let cur_rank = status_rank(cur.status);
+                let new_rank = status_rank(b.status);
+                if new_rank > cur_rank || (new_rank == cur_rank && b.created_at < cur.created_at) {
+                    best_by_path.insert(path, b);
+                }
+            }
+            None => {
+                best_by_path.insert(path, b);
+            }
+        }
+    }
+
+    for (path, b) in best_by_path {
+        if let Some(&local_drv_id) = path_to_drv.get(&path) {
+            out.insert(local_drv_id, b.id);
+        }
+    }
+
     Ok(out)
+}
+
+#[cfg(test)]
+mod find_active_leaders_tests {
+    use super::*;
+    use entity::build::{BuildStatus, Model as MBuild};
+    use entity::cache_upstream::Model as MCacheUpstream;
+    use entity::derivation::Model as MDerivation;
+    use entity::ids::{BuildId, CacheId, DerivationId, OrganizationCacheId, OrganizationId};
+    use entity::organization_cache::{CacheSubscriptionMode, Model as MOrganizationCache};
+    use sea_orm::{DatabaseBackend, MockDatabase};
+    use uuid::Uuid;
+
+    fn org(n: u8) -> OrganizationId {
+        let mut bytes = [0u8; 16];
+        bytes[15] = n;
+        OrganizationId::new(Uuid::from_bytes(bytes))
+    }
+    fn cid(n: u8) -> CacheId {
+        let mut bytes = [0u8; 16];
+        bytes[14] = n;
+        CacheId::new(Uuid::from_bytes(bytes))
+    }
+    fn did(n: u8) -> DerivationId {
+        let mut bytes = [0u8; 16];
+        bytes[13] = n;
+        DerivationId::new(Uuid::from_bytes(bytes))
+    }
+    fn bid(n: u8) -> BuildId {
+        let mut bytes = [0u8; 16];
+        bytes[12] = n;
+        BuildId::new(Uuid::from_bytes(bytes))
+    }
+
+    fn build(
+        id: BuildId,
+        drv: DerivationId,
+        status: BuildStatus,
+        external_cached: bool,
+        offset_secs: i64,
+    ) -> MBuild {
+        let t = chrono::NaiveDate::from_ymd_opt(2026, 1, 1)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap()
+            + chrono::Duration::seconds(offset_secs);
+        MBuild {
+            id,
+            evaluation: entity::ids::EvaluationId::now_v7(),
+            derivation: drv,
+            status,
+            log_id: None,
+            build_time_ms: None,
+            worker: None,
+            via: None,
+            external_cached,
+            created_at: t,
+            updated_at: t,
+        }
+    }
+
+    fn drv_row(id: DerivationId, owner: OrganizationId, path: &str) -> MDerivation {
+        MDerivation {
+            id,
+            organization: owner,
+            derivation_path: path.into(),
+            architecture: "x86_64-linux".into(),
+            created_at: chrono::NaiveDateTime::default(),
+        }
+    }
+
+    fn run<F: std::future::Future>(fut: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(fut)
+    }
+
+    #[test]
+    fn cross_org_match_when_no_same_org_candidate() {
+        run(async {
+            let drv_b = did(2);
+            let drv_a = did(1);
+            let leader_build = bid(10);
+
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([Vec::<MBuild>::new()])
+                .append_query_results([vec![drv_row(drv_b, org(2), "/nix/store/x.drv")]])
+                .append_query_results([vec![MOrganizationCache {
+                    id: OrganizationCacheId::now_v7(),
+                    organization: org(2),
+                    cache: cid(1),
+                    mode: CacheSubscriptionMode::ReadOnly,
+                }]])
+                .append_query_results([Vec::<MCacheUpstream>::new()])
+                .append_query_results([vec![MOrganizationCache {
+                    id: OrganizationCacheId::now_v7(),
+                    organization: org(1),
+                    cache: cid(1),
+                    mode: CacheSubscriptionMode::ReadWrite,
+                }]])
+                .append_query_results([vec![drv_row(drv_a, org(1), "/nix/store/x.drv")]])
+                .append_query_results([vec![build(
+                    leader_build,
+                    drv_a,
+                    BuildStatus::Building,
+                    false,
+                    0,
+                )]])
+                .into_connection();
+
+            let got = find_active_leaders(&db, org(2), &[drv_b]).await.unwrap();
+            assert_eq!(got.get(&drv_b), Some(&leader_build), "got: {:?}", got);
+        });
+    }
+
+    #[test]
+    fn cross_org_tie_break_most_advanced_then_oldest() {
+        run(async {
+            let drv_b = did(2);
+            let drv_a = did(1);
+            let drv_c = did(3);
+            let queued_old = bid(20);
+            let building_new = bid(21);
+
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([Vec::<MBuild>::new()])
+                .append_query_results([vec![drv_row(drv_b, org(2), "/nix/store/x.drv")]])
+                .append_query_results([vec![MOrganizationCache {
+                    id: OrganizationCacheId::now_v7(),
+                    organization: org(2),
+                    cache: cid(1),
+                    mode: CacheSubscriptionMode::ReadOnly,
+                }]])
+                .append_query_results([Vec::<MCacheUpstream>::new()])
+                .append_query_results([vec![
+                    MOrganizationCache {
+                        id: OrganizationCacheId::now_v7(),
+                        organization: org(1),
+                        cache: cid(1),
+                        mode: CacheSubscriptionMode::ReadWrite,
+                    },
+                    MOrganizationCache {
+                        id: OrganizationCacheId::now_v7(),
+                        organization: org(3),
+                        cache: cid(1),
+                        mode: CacheSubscriptionMode::ReadWrite,
+                    },
+                ]])
+                .append_query_results([vec![
+                    drv_row(drv_a, org(1), "/nix/store/x.drv"),
+                    drv_row(drv_c, org(3), "/nix/store/x.drv"),
+                ]])
+                .append_query_results([vec![
+                    build(queued_old, drv_a, BuildStatus::Queued, false, 0),
+                    build(building_new, drv_c, BuildStatus::Building, false, 60),
+                ]])
+                .into_connection();
+
+            let got = find_active_leaders(&db, org(2), &[drv_b]).await.unwrap();
+            assert_eq!(got.get(&drv_b), Some(&building_new), "got: {:?}", got);
+        });
+    }
 }

--- a/backend/core/src/db/status.rs
+++ b/backend/core/src/db/status.rs
@@ -652,7 +652,76 @@ mod reelect_leader_tests {
     }
 
     fn make_state(db: sea_orm::DatabaseConnection) -> std::sync::Arc<crate::types::ServerState> {
-        test_support::state::test_state(db)
+        use crate::ci::WebhookClient;
+        use crate::storage::{EmailSender, LogStorage, NarStore};
+        use crate::types::{RuntimeConfig, SecretString, WebDb, WorkerDb};
+        use futures::future::BoxFuture;
+
+        #[derive(Debug)]
+        struct NoopLog;
+        impl LogStorage for NoopLog {
+            fn append<'a>(&'a self, _: entity::ids::BuildId, _: &'a str) -> BoxFuture<'a, anyhow::Result<()>> {
+                Box::pin(async { Ok(()) })
+            }
+            fn read<'a>(&'a self, _: entity::ids::BuildId) -> BoxFuture<'a, anyhow::Result<String>> {
+                Box::pin(async { Ok(String::new()) })
+            }
+            fn delete<'a>(&'a self, _: entity::ids::BuildId) -> BoxFuture<'a, anyhow::Result<()>> {
+                Box::pin(async { Ok(()) })
+            }
+        }
+
+        #[derive(Debug)]
+        struct NoopWebhook;
+        #[async_trait::async_trait]
+        impl WebhookClient for NoopWebhook {
+            async fn deliver(&self, _: &str, _: &str, _: &str, _: String) -> anyhow::Result<u16> {
+                Ok(200)
+            }
+        }
+
+        #[derive(Debug)]
+        struct NoopEmail;
+        #[async_trait::async_trait]
+        impl EmailSender for NoopEmail {
+            fn is_enabled(&self) -> bool { false }
+            async fn send_verification_email(&self, _: &str, _: &str, _: &str, _: &str) -> anyhow::Result<()> { Ok(()) }
+            async fn send_password_reset_email(&self, _: &str, _: &str, _: &str, _: &str) -> anyhow::Result<()> { Ok(()) }
+        }
+
+        let cli = crate::types::Cli {
+            logging: crate::types::LoggingArgs::default(),
+            server: crate::types::ServerArgs::default(),
+            database: crate::types::DatabaseArgs::default(),
+            eval: crate::types::EvalArgs::default(),
+            storage: crate::types::StorageArgs { base_path: "/tmp/gradient-test".into(), ..Default::default() },
+            secrets: crate::types::SecretsArgs { crypt_secret_file: "test-secret".into(), jwt_secret_file: "test-jwt".into() },
+            limits: crate::types::LimitsArgs::default(),
+            registration: crate::types::RegistrationArgs::default(),
+            proto: crate::types::ProtoArgs::default(),
+            oidc: crate::types::OidcArgs::default(),
+            email: crate::types::EmailArgs::default(),
+            s3: crate::types::S3Args::default(),
+            github_app: crate::types::GitHubAppArgs::default(),
+            metrics: crate::types::MetricsArgs::default(),
+        };
+        let config = std::sync::Arc::new(RuntimeConfig::from_cli(&cli));
+        let nar_storage = NarStore::local(&config.storage.base_path).expect("nar store");
+        std::sync::Arc::new(crate::types::ServerState {
+            web_db: WebDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
+            worker_db: WorkerDb::new(db),
+            config,
+            log_storage: std::sync::Arc::new(NoopLog),
+            webhooks: std::sync::Arc::new(NoopWebhook) as std::sync::Arc<dyn WebhookClient>,
+            email: std::sync::Arc::new(NoopEmail) as std::sync::Arc<dyn EmailSender>,
+            nar_storage,
+            manifest_state: std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            pending_credentials: std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            http: crate::http::build_client().expect("http client"),
+            shutdown: crate::shutdown::Shutdown::new(),
+            jwt_secret: SecretString::new("test-jwt-secret".to_string()),
+            started_at: chrono::Utc::now(),
+        })
     }
 
     fn run<F: std::future::Future>(fut: F) -> F::Output {
@@ -952,7 +1021,7 @@ mod find_active_leaders_tests {
                 .into_connection();
 
             let got = find_active_leaders(&db, org(2), &[drv_b]).await.unwrap();
-            assert!(got.get(&drv_b).is_none(), "external_cached must be skipped");
+            assert!(!got.contains_key(&drv_b), "external_cached must be skipped");
         });
     }
 }

--- a/backend/core/src/db/status.rs
+++ b/backend/core/src/db/status.rs
@@ -684,4 +684,56 @@ mod find_active_leaders_tests {
             assert_eq!(got.get(&drv_b), Some(&building_new), "got: {:?}", got);
         });
     }
+
+    #[test]
+    fn same_org_preferred_over_cross_org() {
+        run(async {
+            let drv_b = did(2);
+            let same_org_build = bid(30);
+
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([vec![build(
+                    same_org_build,
+                    drv_b,
+                    BuildStatus::Queued,
+                    false,
+                    0,
+                )]])
+                .into_connection();
+
+            let got = find_active_leaders(&db, org(2), &[drv_b]).await.unwrap();
+            assert_eq!(got.get(&drv_b), Some(&same_org_build));
+        });
+    }
+
+    #[test]
+    fn cross_org_external_cached_candidate_skipped() {
+        run(async {
+            let drv_b = did(2);
+            let drv_a = did(1);
+
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([Vec::<MBuild>::new()])
+                .append_query_results([vec![drv_row(drv_b, org(2), "/nix/store/x.drv")]])
+                .append_query_results([vec![MOrganizationCache {
+                    id: OrganizationCacheId::now_v7(),
+                    organization: org(2),
+                    cache: cid(1),
+                    mode: CacheSubscriptionMode::ReadOnly,
+                }]])
+                .append_query_results([Vec::<MCacheUpstream>::new()])
+                .append_query_results([vec![MOrganizationCache {
+                    id: OrganizationCacheId::now_v7(),
+                    organization: org(1),
+                    cache: cid(1),
+                    mode: CacheSubscriptionMode::ReadWrite,
+                }]])
+                .append_query_results([vec![drv_row(drv_a, org(1), "/nix/store/x.drv")]])
+                .append_query_results([Vec::<MBuild>::new()])
+                .into_connection();
+
+            let got = find_active_leaders(&db, org(2), &[drv_b]).await.unwrap();
+            assert!(got.get(&drv_b).is_none(), "external_cached must be skipped");
+        });
+    }
 }

--- a/backend/core/src/db/status.rs
+++ b/backend/core/src/db/status.rs
@@ -388,18 +388,21 @@ async fn reelect_leader(state: &Arc<ServerState>, leader: &MBuild) -> Result<(),
 }
 
 /// For each derivation in `drv_ids`, return the id of the leader build whose
-/// result a new build for that derivation should follow — i.e. the build
-/// whose `via` is NULL and whose status is non-terminal
-/// (`Created` / `Queued` / `Building`). Followers in the result set
-/// collapse to their leader so callers can never accidentally point a new
-/// build at another follower (no via chains).
+/// result a new build for that derivation should follow.
 ///
-/// Drvs with no active build in the result map are simply omitted; callers
-/// should treat a missing entry as "no leader, insert as a plain build".
+/// First checks for an in-flight build within `inserting_org` (the previous
+/// behavior). When no same-org candidate exists for a drv, this function
+/// will also consult cache-connected organisations via
+/// [`cache_reach::writer_orgs_reachable_from`] — that pass is added in a
+/// later task; this step only widens the signature.
+///
+/// Drvs with no active build are omitted from the result.
 pub async fn find_active_leaders<C: ConnectionTrait>(
     db: &C,
+    inserting_org: OrganizationId,
     drv_ids: &[DerivationId],
 ) -> Result<HashMap<DerivationId, BuildId>, sea_orm::DbErr> {
+    let _ = inserting_org;
     if drv_ids.is_empty() {
         return Ok(HashMap::new());
     }

--- a/backend/scheduler/src/build.rs
+++ b/backend/scheduler/src/build.rs
@@ -162,14 +162,17 @@ impl<'a> BuildStateHandler<'a> {
         self.check_evaluation_done(evaluation_id).await
     }
 
-    /// Copy a leader's terminal status (and `log_id`, `build_time_ms`,
-    /// `worker`) onto every build with `via = leader.id`, then run the
-    /// per-evaluation finalisation each follower needs (`DependencyFailed`
-    /// cascade on failure, `check_evaluation_done` to flip the eval).
+    /// Copy a leader's terminal status (and `log_id`, `build_time_ms`, `worker`)
+    /// onto every build with `via = leader.id`, then run the per-evaluation
+    /// finalisation each follower needs (`DependencyFailed` cascade on failure,
+    /// `check_evaluation_done` to flip the eval).
     ///
-    /// Followers always share a `derivation` row with their leader, so
-    /// `derivation_output` and `build_product` rows are already visible to
-    /// the follower's evaluation without any copy.
+    /// Same-org followers share the leader's `derivation` row, so its
+    /// `derivation_output` and `build_product` children are already visible to
+    /// the follower's evaluation without any copy. Cross-org followers (whose
+    /// `derivation` differs from the leader's — created when the leader belongs
+    /// to a cache-connected organisation) have those rows mirrored onto the
+    /// follower's `derivation`.
     ///
     /// `Aborted` is not propagated — when a leader is aborted (its eval was
     /// cancelled), callers re-elect a new leader from the followers instead.
@@ -194,6 +197,22 @@ impl<'a> BuildStateHandler<'a> {
             return Ok(());
         }
 
+        let leader_outputs = EDerivationOutput::find()
+            .filter(CDerivationOutput::Derivation.eq(leader.derivation))
+            .all(&self.state.worker_db)
+            .await
+            .context("fetch leader's derivation_output rows")?;
+        let leader_output_ids: Vec<_> = leader_outputs.iter().map(|o| o.id).collect();
+        let leader_products = if leader_output_ids.is_empty() {
+            Vec::new()
+        } else {
+            EBuildProduct::find()
+                .filter(CBuildProduct::DerivationOutput.is_in(leader_output_ids))
+                .all(&self.state.worker_db)
+                .await
+                .context("fetch leader's build_product rows")?
+        };
+
         for follower in followers {
             let evaluation_id = follower.evaluation;
             let derivation_id = follower.derivation;
@@ -214,6 +233,45 @@ impl<'a> BuildStateHandler<'a> {
                 continue;
             };
             update_build_status(Arc::clone(self.state), reloaded, leader.status).await;
+
+            if follower.derivation != leader.derivation {
+                let existing_outs = EDerivationOutput::find()
+                    .filter(CDerivationOutput::Derivation.eq(follower.derivation))
+                    .all(&self.state.worker_db)
+                    .await
+                    .context("fetch follower's existing derivation_output rows")?;
+                let existing_out_ids: Vec<_> = existing_outs.iter().map(|o| o.id).collect();
+                if !existing_out_ids.is_empty() {
+                    if let Err(e) = EBuildProduct::delete_many()
+                        .filter(CBuildProduct::DerivationOutput.is_in(existing_out_ids.clone()))
+                        .exec(&self.state.worker_db)
+                        .await
+                    {
+                        warn!(error = %e, follower_id = %follower.id, "failed to clear stale follower build_products");
+                    }
+                    if let Err(e) = EDerivationOutput::delete_many()
+                        .filter(CDerivationOutput::Id.is_in(existing_out_ids))
+                        .exec(&self.state.worker_db)
+                        .await
+                    {
+                        warn!(error = %e, follower_id = %follower.id, "failed to clear stale follower derivation_outputs");
+                    }
+                }
+
+                let (new_outputs, new_products) =
+                    build_cross_org_artefact_rows(follower.derivation, &leader_outputs, &leader_products);
+
+                for out in new_outputs {
+                    if let Err(e) = out.insert(&self.state.worker_db).await {
+                        warn!(error = %e, follower_id = %follower.id, "failed to mirror derivation_output to follower");
+                    }
+                }
+                for product in new_products {
+                    if let Err(e) = product.insert(&self.state.worker_db).await {
+                        warn!(error = %e, follower_id = %follower.id, "failed to mirror build_product to follower");
+                    }
+                }
+            }
 
             if matches!(
                 leader.status,
@@ -555,6 +613,64 @@ pub async fn reconcile_waiting_state(
     BuildStateHandler::new(state)
         .reconcile_waiting_state(worker_caps)
         .await
+}
+
+/// Build the `derivation_output` and `build_product` rows to insert under a
+/// cross-org follower's `derivation` so its evaluation can resolve artefacts
+/// without org-aware indirection. Pure: no DB, no I/O.
+///
+/// Returns `(new_outputs, new_products)`. `new_outputs[i]` has a fresh
+/// `DerivationOutputId` and `derivation = follower_derivation`; every other
+/// column is copied from the corresponding leader row. `new_products` rewrites
+/// the `derivation_output` FK to point at the matching new output id.
+pub(crate) fn build_cross_org_artefact_rows(
+    follower_derivation: DerivationId,
+    leader_outputs: &[MDerivationOutput],
+    leader_products: &[MBuildProduct],
+) -> (Vec<ADerivationOutput>, Vec<ABuildProduct>) {
+    use std::collections::HashMap;
+    use entity::ids::{BuildProductId, DerivationOutputId};
+
+    let mut old_to_new: HashMap<DerivationOutputId, DerivationOutputId> = HashMap::new();
+    let new_outputs: Vec<ADerivationOutput> = leader_outputs
+        .iter()
+        .map(|src| {
+            let new_id = DerivationOutputId::now_v7();
+            old_to_new.insert(src.id, new_id);
+            ADerivationOutput {
+                id: Set(new_id),
+                derivation: Set(follower_derivation),
+                name: Set(src.name.clone()),
+                output: Set(src.output.clone()),
+                hash: Set(src.hash.clone()),
+                package: Set(src.package.clone()),
+                ca: Set(src.ca.clone()),
+                nar_size: Set(src.nar_size),
+                is_cached: Set(src.is_cached),
+                cached_path: Set(src.cached_path),
+                created_at: Set(src.created_at),
+            }
+        })
+        .collect();
+
+    let new_products: Vec<ABuildProduct> = leader_products
+        .iter()
+        .filter_map(|src| {
+            let new_output_id = old_to_new.get(&src.derivation_output).copied()?;
+            Some(ABuildProduct {
+                id: Set(BuildProductId::now_v7()),
+                derivation_output: Set(new_output_id),
+                file_type: Set(src.file_type.clone()),
+                subtype: Set(src.subtype.clone()),
+                name: Set(src.name.clone()),
+                path: Set(src.path.clone()),
+                size: Set(src.size),
+                created_at: Set(src.created_at),
+            })
+        })
+        .collect();
+
+    (new_outputs, new_products)
 }
 
 // ---------------------------------------------------------------------------
@@ -920,5 +1036,90 @@ mod waiting_reason_tests {
         let reason = checker.compute_waiting_reason(&builds, &caps);
 
         assert!(reason.unmet.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod cross_org_mirror_tests {
+    use super::*;
+    use entity::ids::{BuildProductId, DerivationId, DerivationOutputId};
+
+    fn output_fixture(id: DerivationOutputId, derivation: DerivationId, hash: &str) -> MDerivationOutput {
+        MDerivationOutput {
+            id,
+            derivation,
+            name: "out".into(),
+            output: format!("/nix/store/{hash}-foo"),
+            hash: hash.into(),
+            package: "foo".into(),
+            ca: None,
+            nar_size: Some(1024),
+            is_cached: true,
+            cached_path: None,
+            created_at: chrono::NaiveDateTime::default(),
+        }
+    }
+
+    fn product_fixture(id: BuildProductId, output: DerivationOutputId) -> MBuildProduct {
+        MBuildProduct {
+            id,
+            derivation_output: output,
+            file_type: "file".into(),
+            subtype: "doc".into(),
+            name: "readme".into(),
+            path: "share/doc/readme".into(),
+            size: Some(512),
+            created_at: chrono::NaiveDateTime::default(),
+        }
+    }
+
+    #[test]
+    fn mirrors_outputs_and_rewrites_product_foreign_keys() {
+        let leader_drv = DerivationId::now_v7();
+        let follower_drv = DerivationId::now_v7();
+        let leader_out_id = DerivationOutputId::now_v7();
+        let leader_outputs = vec![output_fixture(leader_out_id, leader_drv, "deadbeef")];
+        let leader_products = vec![product_fixture(BuildProductId::now_v7(), leader_out_id)];
+
+        let (new_outputs, new_products) =
+            build_cross_org_artefact_rows(follower_drv, &leader_outputs, &leader_products);
+
+        assert_eq!(new_outputs.len(), 1);
+        let mirrored_out = &new_outputs[0];
+        match &mirrored_out.derivation {
+            Set(d) => assert_eq!(*d, follower_drv),
+            _ => panic!("derivation not set"),
+        }
+        match &mirrored_out.hash {
+            Set(h) => assert_eq!(h, "deadbeef"),
+            _ => panic!("hash not set"),
+        }
+        match &mirrored_out.id {
+            Set(new_id) => assert_ne!(*new_id, leader_out_id),
+            _ => panic!("id not set"),
+        }
+
+        assert_eq!(new_products.len(), 1);
+        let mirrored_product = &new_products[0];
+        match (&mirrored_out.id, &mirrored_product.derivation_output) {
+            (Set(out_id), Set(prod_out)) => assert_eq!(prod_out, out_id),
+            _ => panic!("product FK not rewritten"),
+        }
+    }
+
+    #[test]
+    fn dangling_product_without_owning_output_is_dropped() {
+        let follower_drv = DerivationId::now_v7();
+        let leader_outputs: Vec<MDerivationOutput> = vec![];
+        let leader_products = vec![product_fixture(
+            BuildProductId::now_v7(),
+            DerivationOutputId::now_v7(),
+        )];
+
+        let (new_outputs, new_products) =
+            build_cross_org_artefact_rows(follower_drv, &leader_outputs, &leader_products);
+
+        assert!(new_outputs.is_empty());
+        assert!(new_products.is_empty(), "orphan product must not be inserted");
     }
 }

--- a/backend/scheduler/src/eval.rs
+++ b/backend/scheduler/src/eval.rs
@@ -215,12 +215,13 @@ impl<'a> EvalResultProcessor<'a> {
             .filter(|id| !truly_substituted.contains(id))
             .collect();
 
-        let leader_for_drv = find_active_leaders(&self.state.worker_db, &buildable_drv_ids)
-            .await
-            .unwrap_or_else(|e| {
-                error!(error = %e, "failed to query active leaders");
-                HashMap::new()
-            });
+        let leader_for_drv =
+            find_active_leaders(&self.state.worker_db, self.organization_id, &buildable_drv_ids)
+                .await
+                .unwrap_or_else(|e| {
+                    error!(error = %e, "failed to query active leaders");
+                    HashMap::new()
+                });
 
         for d in derivations {
             let Some(&drv_id) = drv_path_to_id.get(&d.drv_path) else {

--- a/backend/test-support/src/fixtures.rs
+++ b/backend/test-support/src/fixtures.rs
@@ -8,7 +8,11 @@
 //! you can write `assert_eq!(body["name"], "test-org")` instead of chasing
 //! a random `Uuid`.
 
-use entity::ids::{CommitId, EvaluationId, OrganizationId, ProjectId, UserId};
+use entity::ids::{
+    CacheId, CacheUpstreamId, CommitId, EvaluationId, OrganizationCacheId, OrganizationId,
+    ProjectId, UserId,
+};
+use entity::organization_cache::CacheSubscriptionMode;
 use entity::*;
 use uuid::Uuid;
 
@@ -64,6 +68,81 @@ pub fn user() -> user::Model {
         superuser: false,
         oidc_issuer: None,
         oidc_subject: None,
+    }
+}
+
+pub fn org_with_id(id: OrganizationId, slug: &str) -> organization::Model {
+    organization::Model {
+        id,
+        name: slug.into(),
+        display_name: slug.into(),
+        description: String::new(),
+        public_key: "ssh-ed25519 AAAA test".into(),
+        private_key: "encrypted".into(),
+        public: false,
+        created_by: user_id(),
+        created_at: test_date(),
+        managed: false,
+        github_installation_id: None,
+    }
+}
+
+pub fn cache_with_id(id: CacheId, slug: &str, owner: UserId) -> cache::Model {
+    cache::Model {
+        id,
+        name: slug.into(),
+        display_name: slug.into(),
+        description: String::new(),
+        active: true,
+        priority: 30,
+        public_key: "ssh-ed25519 AAAA test".into(),
+        private_key: "encrypted".into(),
+        public: false,
+        created_by: owner,
+        created_at: test_date(),
+        managed: false,
+    }
+}
+
+pub fn org_cache_link(
+    id: OrganizationCacheId,
+    org: OrganizationId,
+    cache: CacheId,
+    mode: CacheSubscriptionMode,
+) -> organization_cache::Model {
+    organization_cache::Model { id, organization: org, cache, mode }
+}
+
+pub fn internal_upstream(
+    id: CacheUpstreamId,
+    cache: CacheId,
+    upstream: CacheId,
+) -> cache_upstream::Model {
+    cache_upstream::Model {
+        id,
+        cache,
+        display_name: "internal".into(),
+        mode: CacheSubscriptionMode::ReadOnly,
+        upstream_cache: Some(upstream),
+        url: None,
+        public_key: None,
+    }
+}
+
+pub fn external_upstream(
+    id: CacheUpstreamId,
+    cache: CacheId,
+    url: &str,
+    public_key: &str,
+) -> cache_upstream::Model {
+    cache_upstream::Model {
+        id,
+        cache,
+        display_name: "external".into(),
+        mode: CacheSubscriptionMode::ReadOnly,
+        upstream_cache: None,
+        url: Some(url.into()),
+        public_key: Some(public_key.into()),
     }
 }
 

--- a/backend/web/src/endpoints/builds/mod.rs
+++ b/backend/web/src/endpoints/builds/mod.rs
@@ -27,7 +27,7 @@ use crate::authorization::ApiKeyContext;
 use crate::error::{WebError, WebResult};
 use crate::helpers::OptionExt;
 use gradient_core::types::*;
-use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QuerySelect};
 use std::sync::Arc;
 
 /// Resolved access context for a build.
@@ -107,7 +107,8 @@ impl BuildAccessContext {
     /// Load build + organization and enforce public/member access.
     ///
     /// Returns `not_found("Build")` when the build does not exist, the
-    /// organization is private, and `maybe_user` is not a member.
+    /// organization is private, and `maybe_user` is neither a direct member
+    /// nor a member of any follower-org that points at this build via `via`.
     pub(super) async fn load(
         state: &Arc<ServerState>,
         build_id: BuildId,
@@ -116,7 +117,7 @@ impl BuildAccessContext {
     ) -> WebResult<Self> {
         let ctx = Self::load_unguarded(state, build_id).await?;
 
-        let can_access = if ctx.organization.public {
+        let direct_access = if ctx.organization.public {
             true
         } else {
             match maybe_user {
@@ -124,10 +125,66 @@ impl BuildAccessContext {
                 None => false,
             }
         };
-        if !can_access {
-            return Err(WebError::not_found("Build"));
+        if direct_access {
+            return Ok(ctx);
         }
 
-        Ok(ctx)
+        if let Some(user) = maybe_user
+            && follower_orgs_accessible(state, user, api_key, build_id).await?
+        {
+            return Ok(ctx);
+        }
+
+        Err(WebError::not_found("Build"))
     }
+}
+
+async fn follower_orgs_accessible(
+    state: &Arc<ServerState>,
+    user: &MUser,
+    api_key: Option<&ApiKeyContext>,
+    leader_build_id: BuildId,
+) -> WebResult<bool> {
+    let follower_eval_ids: Vec<EvaluationId> = EBuild::find()
+        .filter(CBuild::Via.eq(leader_build_id))
+        .select_only()
+        .column(CBuild::Evaluation)
+        .into_tuple()
+        .all(&state.web_db)
+        .await?;
+    if follower_eval_ids.is_empty() {
+        return Ok(false);
+    }
+
+    let evals = EEvaluation::find()
+        .filter(CEvaluation::Id.is_in(follower_eval_ids))
+        .all(&state.web_db)
+        .await?;
+
+    let mut org_ids: std::collections::HashSet<OrganizationId> =
+        std::collections::HashSet::new();
+    for ev in evals {
+        let org = if let Some(project_id) = ev.project {
+            EProject::find_by_id(project_id)
+                .one(&state.web_db)
+                .await?
+                .map(|p| p.organization)
+        } else {
+            EDirectBuild::find()
+                .filter(CDirectBuild::Evaluation.eq(ev.id))
+                .one(&state.web_db)
+                .await?
+                .map(|d| d.organization)
+        };
+        if let Some(o) = org {
+            org_ids.insert(o);
+        }
+    }
+
+    for org_id in org_ids {
+        if is_org_member(state, user.id, org_id, api_key).await? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }

--- a/backend/web/src/endpoints/builds/mod.rs
+++ b/backend/web/src/endpoints/builds/mod.rs
@@ -27,7 +27,7 @@ use crate::authorization::ApiKeyContext;
 use crate::error::{WebError, WebResult};
 use crate::helpers::OptionExt;
 use gradient_core::types::*;
-use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QuerySelect};
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use std::sync::Arc;
 
 /// Resolved access context for a build.
@@ -145,16 +145,16 @@ async fn follower_orgs_accessible(
     api_key: Option<&ApiKeyContext>,
     leader_build_id: BuildId,
 ) -> WebResult<bool> {
-    let follower_eval_ids: Vec<EvaluationId> = EBuild::find()
+    let follower_builds: Vec<MBuild> = EBuild::find()
         .filter(CBuild::Via.eq(leader_build_id))
-        .select_only()
-        .column(CBuild::Evaluation)
-        .into_tuple()
         .all(&state.web_db)
         .await?;
-    if follower_eval_ids.is_empty() {
+    if follower_builds.is_empty() {
         return Ok(false);
     }
+
+    let follower_eval_ids: Vec<EvaluationId> =
+        follower_builds.into_iter().map(|b| b.evaluation).collect();
 
     let evals = EEvaluation::find()
         .filter(CEvaluation::Id.is_in(follower_eval_ids))

--- a/backend/web/tests/cross_org_follower_log_visible.rs
+++ b/backend/web/tests/cross_org_follower_log_visible.rs
@@ -1,0 +1,294 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Integration tests for cross-cache follower-org access on `GET /builds/{id}/log`.
+//!
+//! A follower build points at a leader build via the `via` column. A user
+//! who is a member of the follower's org (but NOT the leader's org) must be
+//! able to read the leader build's log endpoint. A member of an entirely
+//! unrelated org (no follower link) must receive 404.
+//!
+//! Mock query sequence — positive case (private leader-org, follower-org member):
+//!   Auth prefix (authorize_optional):
+//!     1. SELECT session           (decode_jwt)
+//!     2. SELECT session           (update last_used_at, returning)
+//!     3. SELECT user
+//!   BuildAccessContext::load_unguarded:
+//!     4. SELECT build             (leader build by id)
+//!     5. SELECT evaluation        (leader build's evaluation)
+//!     6. SELECT project           (leader evaluation's project)
+//!     7. SELECT organization      (leader org — private)
+//!   Direct membership check (private org → is_org_member → load_org_membership):
+//!     8. SELECT organization_user (leader org × user → empty → not a direct member)
+//!   follower_orgs_accessible:
+//!     9. SELECT build.evaluation  (WHERE via = leader_build_id, into_tuple)
+//!    10. SELECT evaluation        (WHERE id IN [follower_eval_id])
+//!    11. SELECT project           (follower evaluation's project)
+//!    12. SELECT organization_user (follower org × user → Some → access granted)
+//!
+//! Negative case (unrelated org, no follower link):
+//!   Auth prefix: queries 1–3 (same as above)
+//!   BuildAccessContext::load_unguarded: queries 4–7 (same)
+//!   Direct membership check: query 8 → empty
+//!   follower_orgs_accessible: query 9 → empty vec → short-circuit → 404
+
+use axum_test::TestServer;
+use entity::build::BuildStatus;
+use entity::evaluation::EvaluationStatus;
+use entity::ids::*;
+use gradient_core::storage::{EmailSender, NarStore};
+use gradient_core::types::{RuntimeConfig, SecretString, ServerState, WebDb, WorkerDb};
+use sea_orm::{DatabaseBackend, MockDatabase};
+use std::sync::Arc;
+use test_support::fakes::email::InMemoryEmailSender;
+use test_support::fakes::webhooks::RecordingWebhookClient;
+use test_support::fixtures::{test_date, user, user_id};
+use test_support::log_storage::NoopLogStorage;
+use test_support::web::{TEST_JWT_SECRET, live_session, make_token};
+use uuid::Uuid;
+use web::create_router;
+
+// ── Stable UUIDs ──────────────────────────────────────────────────────────────
+
+fn leader_org_id() -> OrganizationId {
+    OrganizationId::new(Uuid::parse_str("40000000-0000-0000-0000-000000000001").unwrap())
+}
+fn follower_org_id() -> OrganizationId {
+    OrganizationId::new(Uuid::parse_str("40000000-0000-0000-0000-000000000002").unwrap())
+}
+fn leader_project_id() -> ProjectId {
+    ProjectId::new(Uuid::parse_str("40000000-0000-0000-0000-000000000003").unwrap())
+}
+fn follower_project_id() -> ProjectId {
+    ProjectId::new(Uuid::parse_str("40000000-0000-0000-0000-000000000004").unwrap())
+}
+fn leader_eval_id() -> EvaluationId {
+    EvaluationId::new(Uuid::parse_str("40000000-0000-0000-0000-000000000005").unwrap())
+}
+fn follower_eval_id() -> EvaluationId {
+    EvaluationId::new(Uuid::parse_str("40000000-0000-0000-0000-000000000006").unwrap())
+}
+fn leader_build_id() -> BuildId {
+    BuildId::new(Uuid::parse_str("40000000-0000-0000-0000-000000000007").unwrap())
+}
+fn follower_build_id() -> BuildId {
+    BuildId::new(Uuid::parse_str("40000000-0000-0000-0000-000000000008").unwrap())
+}
+fn follower_membership_id() -> OrganizationUserId {
+    OrganizationUserId::new(Uuid::parse_str("40000000-0000-0000-0000-000000000009").unwrap())
+}
+fn session_id() -> SessionId {
+    SessionId::now_v7()
+}
+
+// ── Fixture rows ──────────────────────────────────────────────────────────────
+
+fn private_org(id: OrganizationId, slug: &str) -> entity::organization::Model {
+    entity::organization::Model {
+        id,
+        name: slug.into(),
+        display_name: slug.into(),
+        description: String::new(),
+        public_key: "pub".into(),
+        private_key: "priv".into(),
+        public: false,
+        created_by: user_id(),
+        created_at: test_date(),
+        managed: false,
+        github_installation_id: None,
+    }
+}
+
+fn project_row(id: ProjectId, org: OrganizationId) -> entity::project::Model {
+    entity::project::Model {
+        id,
+        organization: org,
+        name: "proj".into(),
+        display_name: "Proj".into(),
+        description: String::new(),
+        repository: "https://example.com/repo".into(),
+        wildcard: "*".into(),
+        active: true,
+        last_evaluation: None,
+        last_check_at: test_date(),
+        force_evaluation: false,
+        created_by: user_id(),
+        created_at: test_date(),
+        managed: false,
+        keep_evaluations: 10,
+        concurrency: 3,
+        sign_cache: true,
+    }
+}
+
+fn evaluation_row(id: EvaluationId, project: ProjectId) -> entity::evaluation::Model {
+    entity::evaluation::Model {
+        id,
+        project: Some(project),
+        repository: "https://example.com/repo".into(),
+        commit: CommitId::now_v7(),
+        wildcard: "*".into(),
+        status: EvaluationStatus::Completed,
+        previous: None,
+        next: None,
+        created_at: test_date(),
+        updated_at: test_date(),
+        flake_source: None,
+        repo_check_id: None,
+        waiting_reason: None,
+        trigger: None,
+        concurrent: false,
+    }
+}
+
+fn leader_build_row() -> entity::build::Model {
+    entity::build::Model {
+        id: leader_build_id(),
+        evaluation: leader_eval_id(),
+        derivation: DerivationId::now_v7(),
+        status: BuildStatus::Completed,
+        log_id: None,
+        build_time_ms: Some(1000),
+        worker: None,
+        via: None,
+        external_cached: false,
+        created_at: test_date(),
+        updated_at: test_date(),
+    }
+}
+
+fn follower_org_membership() -> entity::organization_user::Model {
+    entity::organization_user::Model {
+        id: follower_membership_id(),
+        organization: follower_org_id(),
+        user: user_id(),
+        role: gradient_core::types::consts::BASE_ROLE_VIEW_ID,
+    }
+}
+
+// ── Server factory ─────────────────────────────────────────────────────────────
+
+fn make_server(db: sea_orm::DatabaseConnection) -> TestServer {
+    let cli = test_support::cli::test_cli();
+    let config = Arc::new(RuntimeConfig::from_cli(&cli));
+    let nar_storage = NarStore::local(&config.storage.base_path).expect("nar store");
+    let state = Arc::new(ServerState {
+        web_db: WebDb::new(db),
+        worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
+        config,
+        log_storage: Arc::new(NoopLogStorage),
+        webhooks: Arc::new(RecordingWebhookClient::new())
+            as Arc<dyn gradient_core::ci::WebhookClient>,
+        email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,
+        nar_storage,
+        manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        http: gradient_core::http::build_client().expect("http client"),
+        shutdown: gradient_core::shutdown::Shutdown::new(),
+        jwt_secret: SecretString::new(TEST_JWT_SECRET.to_string()),
+        started_at: chrono::Utc::now(),
+    });
+    TestServer::new(create_router(state))
+}
+
+fn run<F: std::future::Future>(fut: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(fut)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// A member of the follower-org can read the leader build's log even though
+/// they have no direct membership in the leader's (private) org.
+#[test]
+fn follower_org_member_gets_leader_log() {
+    let sid = session_id();
+    let token = make_token(sid);
+    let session = live_session(sid);
+
+    run(async {
+        let follower_eval = evaluation_row(follower_eval_id(), follower_project_id());
+        // into_tuple SELECT returns (EvaluationId,) tuples — MockDatabase
+        // matches by the concrete type returned, which for `into_tuple()` on a
+        // single column is just the column's type itself.
+        let follower_eval_id_tuple: EvaluationId = follower_eval_id();
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            // Auth prefix (authorize_optional)
+            .append_query_results([vec![session.clone()]])   // 1. SELECT session
+            .append_query_results([vec![session]])           // 2. UPDATE session (returning)
+            .append_query_results([vec![user()]])            // 3. SELECT user
+            // BuildAccessContext::load_unguarded
+            .append_query_results([vec![leader_build_row()]]) // 4. SELECT build
+            .append_query_results([vec![evaluation_row(leader_eval_id(), leader_project_id())]]) // 5. SELECT evaluation
+            .append_query_results([vec![project_row(leader_project_id(), leader_org_id())]]) // 6. SELECT project
+            .append_query_results([vec![private_org(leader_org_id(), "leader-org")]]) // 7. SELECT organization
+            // Direct membership check → not a member of leader-org
+            .append_query_results([Vec::<entity::organization_user::Model>::new()]) // 8. SELECT organization_user (empty)
+            // follower_orgs_accessible
+            .append_query_results([vec![follower_eval_id_tuple]]) // 9. SELECT build.evaluation WHERE via=leader
+            .append_query_results([vec![follower_eval]])           // 10. SELECT evaluation WHERE id IN [...]
+            .append_query_results([vec![project_row(follower_project_id(), follower_org_id())]]) // 11. SELECT project
+            .append_query_results([vec![follower_org_membership()]]) // 12. SELECT organization_user (member of follower-org)
+            .into_connection();
+
+        let server = make_server(db);
+        let res = server
+            .get(&format!("/api/v1/builds/{}/log", leader_build_id()))
+            .add_header(
+                axum::http::header::AUTHORIZATION,
+                axum::http::HeaderValue::from_str(&format!("Bearer {}", token)).unwrap(),
+            )
+            .await;
+
+        res.assert_status_ok();
+        let body: serde_json::Value = res.json();
+        assert_eq!(body["error"], false, "follower-org member must get 200 with log");
+    });
+}
+
+/// A member of an unrelated org (no follower build pointing at this leader)
+/// must receive 404 — the leader build is invisible to them.
+#[test]
+fn unrelated_org_member_cannot_read_leader_log() {
+    let sid = session_id();
+    let token = make_token(sid);
+    let session = live_session(sid);
+
+    run(async {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            // Auth prefix
+            .append_query_results([vec![session.clone()]])   // 1. SELECT session
+            .append_query_results([vec![session]])           // 2. UPDATE session
+            .append_query_results([vec![user()]])            // 3. SELECT user
+            // BuildAccessContext::load_unguarded
+            .append_query_results([vec![leader_build_row()]]) // 4. SELECT build
+            .append_query_results([vec![evaluation_row(leader_eval_id(), leader_project_id())]]) // 5. SELECT evaluation
+            .append_query_results([vec![project_row(leader_project_id(), leader_org_id())]]) // 6. SELECT project
+            .append_query_results([vec![private_org(leader_org_id(), "leader-org")]]) // 7. SELECT organization
+            // Direct membership check → not a member of leader-org
+            .append_query_results([Vec::<entity::organization_user::Model>::new()]) // 8. SELECT organization_user (empty)
+            // follower_orgs_accessible → no followers → short-circuit
+            .append_query_results([Vec::<EvaluationId>::new()]) // 9. SELECT build.evaluation WHERE via=leader (empty)
+            .into_connection();
+
+        let server = make_server(db);
+        let res = server
+            .get(&format!("/api/v1/builds/{}/log", leader_build_id()))
+            .add_header(
+                axum::http::header::AUTHORIZATION,
+                axum::http::HeaderValue::from_str(&format!("Bearer {}", token)).unwrap(),
+            )
+            .await;
+
+        res.assert_status_not_found();
+        let body: serde_json::Value = res.json();
+        assert_eq!(body["error"], true, "unrelated org member must get 404");
+    });
+}

--- a/backend/web/tests/cross_org_follower_log_visible.rs
+++ b/backend/web/tests/cross_org_follower_log_visible.rs
@@ -24,7 +24,7 @@
 //!   Direct membership check (private org → is_org_member → load_org_membership):
 //!     8. SELECT organization_user (leader org × user → empty → not a direct member)
 //!   follower_orgs_accessible:
-//!     9. SELECT build.evaluation  (WHERE via = leader_build_id, into_tuple)
+//!     9. SELECT build             (WHERE via = leader_build_id)
 //!    10. SELECT evaluation        (WHERE id IN [follower_eval_id])
 //!    11. SELECT project           (follower evaluation's project)
 //!    12. SELECT organization_user (follower org × user → Some → access granted)
@@ -160,6 +160,22 @@ fn leader_build_row() -> entity::build::Model {
     }
 }
 
+fn follower_build_row() -> entity::build::Model {
+    entity::build::Model {
+        id: follower_build_id(),
+        evaluation: follower_eval_id(),
+        derivation: DerivationId::now_v7(),
+        status: BuildStatus::Completed,
+        log_id: None,
+        build_time_ms: Some(1000),
+        worker: None,
+        via: Some(leader_build_id()),
+        external_cached: false,
+        created_at: test_date(),
+        updated_at: test_date(),
+    }
+}
+
 fn follower_org_membership() -> entity::organization_user::Model {
     entity::organization_user::Model {
         id: follower_membership_id(),
@@ -214,10 +230,6 @@ fn follower_org_member_gets_leader_log() {
 
     run(async {
         let follower_eval = evaluation_row(follower_eval_id(), follower_project_id());
-        // into_tuple SELECT returns (EvaluationId,) tuples — MockDatabase
-        // matches by the concrete type returned, which for `into_tuple()` on a
-        // single column is just the column's type itself.
-        let follower_eval_id_tuple: EvaluationId = follower_eval_id();
 
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             // Auth prefix (authorize_optional)
@@ -232,8 +244,8 @@ fn follower_org_member_gets_leader_log() {
             // Direct membership check → not a member of leader-org
             .append_query_results([Vec::<entity::organization_user::Model>::new()]) // 8. SELECT organization_user (empty)
             // follower_orgs_accessible
-            .append_query_results([vec![follower_eval_id_tuple]]) // 9. SELECT build.evaluation WHERE via=leader
-            .append_query_results([vec![follower_eval]])           // 10. SELECT evaluation WHERE id IN [...]
+            .append_query_results([vec![follower_build_row()]]) // 9. SELECT build WHERE via=leader
+            .append_query_results([vec![follower_eval]])         // 10. SELECT evaluation WHERE id IN [...]
             .append_query_results([vec![project_row(follower_project_id(), follower_org_id())]]) // 11. SELECT project
             .append_query_results([vec![follower_org_membership()]]) // 12. SELECT organization_user (member of follower-org)
             .into_connection();
@@ -275,7 +287,7 @@ fn unrelated_org_member_cannot_read_leader_log() {
             // Direct membership check → not a member of leader-org
             .append_query_results([Vec::<entity::organization_user::Model>::new()]) // 8. SELECT organization_user (empty)
             // follower_orgs_accessible → no followers → short-circuit
-            .append_query_results([Vec::<EvaluationId>::new()]) // 9. SELECT build.evaluation WHERE via=leader (empty)
+            .append_query_results([Vec::<entity::build::Model>::new()]) // 9. SELECT build WHERE via=leader (empty)
             .into_connection();
 
         let server = make_server(db);

--- a/backend/web/tests/evaluation_builds_via_cross_org.rs
+++ b/backend/web/tests/evaluation_builds_via_cross_org.rs
@@ -47,6 +47,7 @@ fn leader_org_id() -> OrganizationId {
 fn follower_org_id() -> OrganizationId {
     OrganizationId::new(Uuid::parse_str("50000000-0000-0000-0000-000000000002").unwrap())
 }
+#[allow(dead_code)]
 fn leader_project_id() -> ProjectId {
     ProjectId::new(Uuid::parse_str("50000000-0000-0000-0000-000000000003").unwrap())
 }

--- a/backend/web/tests/evaluation_builds_via_cross_org.rs
+++ b/backend/web/tests/evaluation_builds_via_cross_org.rs
@@ -1,0 +1,280 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Integration test for `GET /evals/{evaluation}/builds` where the follower's
+//! leader belongs to a different organisation.
+//!
+//! Mock query sequence (private org_b, authenticated user, member of org_b only):
+//!   Auth prefix (authorize_optional):
+//!     1. SELECT session           (decode_jwt)
+//!     2. SELECT session           (update last_used_at, returning)
+//!     3. SELECT user
+//!   EvalAccessContext::load:
+//!     4. SELECT evaluation        (org_b's eval)
+//!     5. SELECT project           (org_b's project)
+//!     6. SELECT organization      (org_b — private)
+//!     7. SELECT organization_user (org_b × user → member)
+//!   get_evaluation_builds:
+//!     8. SELECT builds            (filter by evaluation = follower_eval_id)
+//!     9. SELECT builds            (filter by id in [leader_build_id]) — leader-row dereference
+//!    10. SELECT derivations       (filter by id in [leader_drv_id]) — no org filter
+//!    11. SELECT derivation_outputs (filter by derivation in [leader_drv_id]) — empty
+
+use axum_test::TestServer;
+use entity::build::BuildStatus;
+use entity::evaluation::EvaluationStatus;
+use entity::ids::*;
+use gradient_core::storage::{EmailSender, NarStore};
+use gradient_core::types::{RuntimeConfig, SecretString, ServerState, WebDb, WorkerDb};
+use sea_orm::{DatabaseBackend, MockDatabase};
+use std::sync::Arc;
+use test_support::fakes::email::InMemoryEmailSender;
+use test_support::fakes::webhooks::RecordingWebhookClient;
+use test_support::fixtures::{test_date, user, user_id};
+use test_support::log_storage::NoopLogStorage;
+use test_support::web::{TEST_JWT_SECRET, live_session, make_token};
+use uuid::Uuid;
+use web::create_router;
+
+// ── Stable UUIDs ──────────────────────────────────────────────────────────────
+
+fn leader_org_id() -> OrganizationId {
+    OrganizationId::new(Uuid::parse_str("50000000-0000-0000-0000-000000000001").unwrap())
+}
+fn follower_org_id() -> OrganizationId {
+    OrganizationId::new(Uuid::parse_str("50000000-0000-0000-0000-000000000002").unwrap())
+}
+fn leader_project_id() -> ProjectId {
+    ProjectId::new(Uuid::parse_str("50000000-0000-0000-0000-000000000003").unwrap())
+}
+fn follower_project_id() -> ProjectId {
+    ProjectId::new(Uuid::parse_str("50000000-0000-0000-0000-000000000004").unwrap())
+}
+fn leader_eval_id() -> EvaluationId {
+    EvaluationId::new(Uuid::parse_str("50000000-0000-0000-0000-000000000005").unwrap())
+}
+fn follower_eval_id() -> EvaluationId {
+    EvaluationId::new(Uuid::parse_str("50000000-0000-0000-0000-000000000006").unwrap())
+}
+fn leader_build_id() -> BuildId {
+    BuildId::new(Uuid::parse_str("50000000-0000-0000-0000-000000000007").unwrap())
+}
+fn follower_build_id() -> BuildId {
+    BuildId::new(Uuid::parse_str("50000000-0000-0000-0000-000000000008").unwrap())
+}
+fn leader_drv_id() -> DerivationId {
+    DerivationId::new(Uuid::parse_str("50000000-0000-0000-0000-000000000009").unwrap())
+}
+fn follower_drv_id() -> DerivationId {
+    DerivationId::new(Uuid::parse_str("50000000-0000-0000-0000-000000000010").unwrap())
+}
+fn follower_membership_id() -> OrganizationUserId {
+    OrganizationUserId::new(Uuid::parse_str("50000000-0000-0000-0000-000000000011").unwrap())
+}
+
+const DRV_PATH: &str = "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello-2.12.1.drv";
+
+// ── Fixture rows ──────────────────────────────────────────────────────────────
+
+fn private_org(id: OrganizationId, slug: &str) -> entity::organization::Model {
+    entity::organization::Model {
+        id,
+        name: slug.into(),
+        display_name: slug.into(),
+        description: String::new(),
+        public_key: "pub".into(),
+        private_key: "priv".into(),
+        public: false,
+        created_by: user_id(),
+        created_at: test_date(),
+        managed: false,
+        github_installation_id: None,
+    }
+}
+
+fn project_row(id: ProjectId, org: OrganizationId) -> entity::project::Model {
+    entity::project::Model {
+        id,
+        organization: org,
+        name: "proj".into(),
+        display_name: "Proj".into(),
+        description: String::new(),
+        repository: "https://example.com/repo".into(),
+        wildcard: "*".into(),
+        active: true,
+        last_evaluation: None,
+        last_check_at: test_date(),
+        force_evaluation: false,
+        created_by: user_id(),
+        created_at: test_date(),
+        managed: false,
+        keep_evaluations: 10,
+        concurrency: 3,
+        sign_cache: true,
+    }
+}
+
+fn evaluation_row(id: EvaluationId, project: ProjectId) -> entity::evaluation::Model {
+    entity::evaluation::Model {
+        id,
+        project: Some(project),
+        repository: "https://example.com/repo".into(),
+        commit: CommitId::now_v7(),
+        wildcard: "*".into(),
+        status: EvaluationStatus::Completed,
+        previous: None,
+        next: None,
+        created_at: test_date(),
+        updated_at: test_date(),
+        flake_source: None,
+        repo_check_id: None,
+        waiting_reason: None,
+        trigger: None,
+        concurrent: false,
+    }
+}
+
+fn follower_build_row() -> entity::build::Model {
+    entity::build::Model {
+        id: follower_build_id(),
+        evaluation: follower_eval_id(),
+        derivation: follower_drv_id(),
+        status: BuildStatus::Queued,
+        log_id: None,
+        build_time_ms: None,
+        worker: None,
+        via: Some(leader_build_id()),
+        external_cached: false,
+        created_at: test_date(),
+        updated_at: test_date(),
+    }
+}
+
+fn leader_build_row() -> entity::build::Model {
+    entity::build::Model {
+        id: leader_build_id(),
+        evaluation: leader_eval_id(),
+        derivation: leader_drv_id(),
+        status: BuildStatus::Building,
+        log_id: None,
+        build_time_ms: None,
+        worker: Some("worker-1".into()),
+        via: None,
+        external_cached: false,
+        created_at: test_date(),
+        updated_at: test_date() + chrono::Duration::seconds(30),
+    }
+}
+
+fn leader_derivation_row() -> entity::derivation::Model {
+    entity::derivation::Model {
+        id: leader_drv_id(),
+        organization: leader_org_id(),
+        derivation_path: DRV_PATH.into(),
+        architecture: "x86_64-linux".into(),
+        created_at: test_date(),
+    }
+}
+
+fn follower_org_membership() -> entity::organization_user::Model {
+    entity::organization_user::Model {
+        id: follower_membership_id(),
+        organization: follower_org_id(),
+        user: user_id(),
+        role: gradient_core::types::consts::BASE_ROLE_VIEW_ID,
+    }
+}
+
+// ── Server factory ─────────────────────────────────────────────────────────────
+
+fn make_server(db: sea_orm::DatabaseConnection) -> TestServer {
+    let cli = test_support::cli::test_cli();
+    let config = Arc::new(RuntimeConfig::from_cli(&cli));
+    let nar_storage = NarStore::local(&config.storage.base_path).expect("nar store");
+    let state = Arc::new(ServerState {
+        web_db: WebDb::new(db),
+        worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
+        config,
+        log_storage: Arc::new(NoopLogStorage),
+        webhooks: Arc::new(RecordingWebhookClient::new())
+            as Arc<dyn gradient_core::ci::WebhookClient>,
+        email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,
+        nar_storage,
+        manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        http: gradient_core::http::build_client().expect("http client"),
+        shutdown: gradient_core::shutdown::Shutdown::new(),
+        jwt_secret: SecretString::new(TEST_JWT_SECRET.to_string()),
+        started_at: chrono::Utc::now(),
+    });
+    TestServer::new(create_router(state))
+}
+
+fn run<F: std::future::Future>(fut: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(fut)
+}
+
+// ── Test ──────────────────────────────────────────────────────────────────────
+
+/// A follower build whose leader belongs to a different organisation must still
+/// surface the leader's `id` and `status` in `GET /evals/{eval}/builds`.
+/// The leader-row dereference does not filter on org, so the cross-org fetch
+/// succeeds and the response reflects the leader's live `Building` status.
+#[test]
+fn evaluation_builds_resolves_cross_org_leader_row() {
+    let sid = SessionId::now_v7();
+    let token = make_token(sid);
+    let session = live_session(sid);
+
+    run(async {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            // Auth prefix (authorize_optional)
+            .append_query_results([vec![session.clone()]])  // 1. SELECT session
+            .append_query_results([vec![session]])          // 2. UPDATE session (returning)
+            .append_query_results([vec![user()]])           // 3. SELECT user
+            // EvalAccessContext::load
+            .append_query_results([vec![evaluation_row(follower_eval_id(), follower_project_id())]]) // 4. SELECT evaluation
+            .append_query_results([vec![project_row(follower_project_id(), follower_org_id())]]) // 5. SELECT project
+            .append_query_results([vec![private_org(follower_org_id(), "org-b")]]) // 6. SELECT organization
+            .append_query_results([vec![follower_org_membership()]]) // 7. SELECT organization_user (member)
+            // get_evaluation_builds
+            .append_query_results([vec![follower_build_row()]]) // 8. SELECT builds (eval = follower_eval_id)
+            .append_query_results([vec![leader_build_row()]])  // 9. SELECT builds (id in [leader_build_id])
+            .append_query_results([vec![leader_derivation_row()]]) // 10. SELECT derivations (id in [leader_drv_id])
+            .append_query_results([Vec::<entity::derivation_output::Model>::new()]) // 11. SELECT derivation_outputs (empty)
+            .into_connection();
+
+        let server = make_server(db);
+        let res = server
+            .get(&format!("/api/v1/evals/{}/builds", follower_eval_id()))
+            .add_header(
+                axum::http::header::AUTHORIZATION,
+                axum::http::HeaderValue::from_str(&format!("Bearer {}", token)).unwrap(),
+            )
+            .await;
+
+        res.assert_status_ok();
+        let body: serde_json::Value = res.json();
+        let builds = body["message"]["builds"]
+            .as_array()
+            .expect("builds array");
+        assert_eq!(builds.len(), 1);
+
+        let item = &builds[0];
+        assert_eq!(
+            item["id"],
+            leader_build_id().to_string(),
+            "follower row must surface the cross-org leader's id"
+        );
+        assert_eq!(item["status"], "Building", "must surface leader's status");
+        assert_eq!(body["message"]["total"], 1);
+        assert_eq!(body["message"]["active_count"], 1);
+    });
+}

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -2561,7 +2561,10 @@ paths:
     get:
       tags: [builds]
       summary: Get build
-      description: Returns full build details including status, derivation path, architecture, assigned server, and output store paths.
+      description: |-
+        Returns full build details including status, derivation path, architecture, assigned server, and output store paths.
+
+        **Access:** Accessible to members of the build's organization. Additionally, when this build is the leader of a follower build in a cache-connected organization, members of that follower organization are granted read access. See `docs/src/scheduler.md#cross-cache-deduplication`.
       operationId: getBuild
       responses:
         '200':
@@ -2586,7 +2589,10 @@ paths:
     get:
       tags: [builds]
       summary: Get build log
-      description: Returns the complete build log as a single string. Empty string if no log is available yet.
+      description: |-
+        Returns the complete build log as a single string. Empty string if no log is available yet.
+
+        **Access:** Accessible to members of the build's organization. Additionally, when this build is the leader of a follower build in a cache-connected organization, members of that follower organization are granted read access. See `docs/src/scheduler.md#cross-cache-deduplication`.
       operationId: getBuildLog
       responses:
         '200':
@@ -2629,6 +2635,8 @@ paths:
         Returns the full transitive dependency graph rooted at the given build via BFS,
         capped at 500 nodes. Each edge `source → target` means `source` must be built
         before `target`.
+
+        **Access:** Accessible to members of the build's organization. Additionally, when this build is the leader of a follower build in a cache-connected organization, members of that follower organization are granted read access. See `docs/src/scheduler.md#cross-cache-deduplication`.
       operationId: getBuildGraph
       responses:
         '200':
@@ -2686,6 +2694,8 @@ paths:
         filename, Nix store path, and file size in bytes.
 
         Accessible without authentication when the owning organisation is public.
+
+        **Access:** Accessible to members of the build's organization. Additionally, when this build is the leader of a follower build in a cache-connected organization, members of that follower organization are granted read access. See `docs/src/scheduler.md#cross-cache-deduplication`.
       operationId: getBuildDownloads
       responses:
         '200':

--- a/docs/src/scheduler.md
+++ b/docs/src/scheduler.md
@@ -1,0 +1,50 @@
+# Scheduler
+
+The Gradient scheduler coordinates build dispatch across connected workers.
+This page covers the cross-cache deduplication feature. For a general
+overview of the scheduler architecture see
+[Architecture](development/architecture.md).
+
+### Cross-cache deduplication
+
+When a new build is created for `/nix/store/<hash>-foo.drv` and another
+organisation already has an in-flight build for the same path, the new build
+can be linked to it as a follower instead of being scheduled separately.
+The link is admissible whenever the follower's organisation can substitute
+from the leader's writes through the cache graph:
+
+- The leader's organisation has `organization_cache` mode `ReadWrite` or
+  `WriteOnly` on some cache `C_w`.
+- `C_w` is in the upstream closure (over `cache_upstream`) of one of the
+  follower organisation's `ReadWrite`/`ReadOnly` caches.
+
+The closure walk follows only internal `cache_upstream.upstream_cache`
+edges; external (URL-based) upstreams do not host Gradient builds and are
+excluded.
+
+#### Leader selection
+
+`find_active_leaders` first looks for an in-flight candidate in the same
+organisation. Only when none exists does it run the cross-org pass.
+Cross-org candidates are filtered to `external_cached = false` and ordered
+by status (`Building` > `Queued` > `Created`) then oldest `created_at`.
+
+#### Artefact propagation
+
+Same-org followers share the leader's `derivation` row, so its
+`derivation_output` and `build_product` children are visible automatically.
+Cross-org followers have these rows mirrored onto their own `derivation`
+when the leader completes (see `scheduler::build::propagate_to_followers`
+and the pure helper `build_cross_org_artefact_rows`).
+
+#### Access
+
+Read-only build endpoints (`GET /builds/{id}`, `/log`, `/downloads`,
+`/graph`) accept requests from members of any organisation that holds a
+follower row pointing at the targeted leader.
+
+#### Leader abort
+
+On leader abort, only same-org followers are eligible for promotion to the
+new leader. Cross-org followers are made independent (`via` cleared) so the
+next dispatch cycle picks them up on their own.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -2111,3 +2111,21 @@ Three cases:
 - `returns_empty_points_when_no_entry_point_matches` — when no
   `entry_point` row matches `project` + `eval`, the response is the empty
   array (the frontend's empty state is then legitimate).
+
+### Cross-cache leader/follower deduplication
+
+- `core/src/db/cache_reach.rs` unit tests cover direct overlap, transitive
+  internal chains, external-upstream skip, write-only reader exclusion, and
+  cycle tolerance for `writer_orgs_reachable_from`.
+- `core/src/db/status.rs::find_active_leaders_tests` covers the cross-org
+  match case, the most-advanced/oldest tie-break, the same-org-preferred
+  short-circuit, and the cross-org `external_cached` skip.
+- `core/src/db/status.rs::reelect_leader_tests` covers same-org promotion
+  with cross-org orphaning, and the no-same-org-everyone-orphaned case.
+- `scheduler/src/build.rs::cross_org_mirror_tests` covers the pure
+  `build_cross_org_artefact_rows` helper: FK rewrite on mirrored products
+  and orphan-product dropping.
+- `web/tests/cross_org_follower_log_visible.rs` covers cross-org log access
+  via `BuildAccessContext::load`'s follower-org fallback.
+- `web/tests/evaluation_builds_via_cross_org.rs` covers the
+  `GET /evals/{eval}/builds` leader-row swap across organisations.

--- a/docs/superpowers/plans/2026-05-13-cross-cache-leader-dedup.md
+++ b/docs/superpowers/plans/2026-05-13-cross-cache-leader-dedup.md
@@ -1,0 +1,2290 @@
+# Cross-cache leader/follower deduplication — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow the `build.via` leader/follower link to span organizations whenever the bytes the leader will produce are substitutable to the follower's organization through the cache graph.
+
+**Architecture:** A new `cache_reach` helper in `core::db` computes the set of organizations whose Gradient builds a given org can substitute (walking `organization_cache` and `cache_upstream` transitively). `find_active_leaders` consults that set when no same-org candidate exists, applying a most-advanced/oldest tie-break. `propagate_to_followers` mirrors `derivation_output` and `build_product` rows onto cross-org followers since they have distinct `derivation` rows. `BuildAccessContext::load` is widened to grant follower-org users read access to the leader's build. `reelect_leader` is restricted to same-org follower promotion; cross-org followers are made independent on leader abort.
+
+**Tech Stack:** Rust, sea-orm, axum, PostgreSQL. Tests use `sea_orm::MockDatabase` (canned query results in fixed order) rather than a real database — this is the project's established pattern (see `backend/web/tests/evaluation_builds_via.rs` as the reference). `test_support::db_with(...)` pre-cans a single result set; `MockDatabase::new(...).append_query_results([...])` chains arbitrary sequences.
+
+> **Test pattern reminder:** every integration test below must (a) mock each DB query the production code path issues, in order, with the correct row type; (b) mount the axum router via `web::create_router(state)` and drive it with `axum_test::TestServer`. The exact query sequence depends on the implementation in earlier tasks — re-read those before writing each test's mock chain. Treat the "fixture seeding" calls in this plan (`common::seed_*`) as **canned query-result helpers**, not as actual DB inserts. If your `common/mod.rs` doesn't already have them, model them after `evaluation_builds_via.rs::*_row()` helpers (functions returning entity `Model` values).
+
+> **Local verification policy:** This project does NOT run `cargo test` locally — CI runs the full test suite. Each task's "Run the test" step is a CI verification (push the branch and wait for the run). Locally, use `cargo check` and `cargo clippy --no-deps -- -D warnings` to confirm the code compiles. When a task lists `cargo test` as the verification command, treat it as documentation of *what CI will run for this change* — don't execute it on your workstation.
+
+---
+
+## File Structure
+
+**New files:**
+- `backend/core/src/db/cache_reach.rs` — `writer_orgs_reachable_from` + unit tests.
+- `backend/test-support/src/fixtures.rs` — extended with multi-org/cache fixtures (in-place).
+- `backend/scheduler/tests/cross_org_leader_set_on_insert.rs`
+- `backend/scheduler/tests/cross_org_artefacts_mirrored.rs`
+- `backend/scheduler/tests/cross_org_re_election_same_org_only.rs`
+- `backend/scheduler/tests/cross_org_re_election_all_followers_independent.rs`
+- `backend/web/tests/cross_org_follower_log_visible.rs`
+- `backend/web/tests/evaluation_builds_via_cross_org.rs`
+
+**Modified files:**
+- `backend/core/src/db/mod.rs` — register new module.
+- `backend/core/src/db/status.rs` — rewrite `find_active_leaders`; rewrite `reelect_leader`.
+- `backend/scheduler/src/eval.rs:218` — pass `inserting_org`.
+- `backend/core/src/ci/trigger.rs:231` — pass `inserting_org`.
+- `backend/scheduler/src/build.rs:176` — extend `propagate_to_followers` with cross-org artefact mirroring.
+- `backend/web/src/endpoints/builds/mod.rs:111` — widen `BuildAccessContext::load`.
+- `backend/scheduler/src/handler_tests.rs` — update existing `find_active_leaders` mock-DB callers for new signature.
+- `docs/gradient-api.yaml` — auth note on read-only build endpoints.
+- `docs/src/tests.md` — catalogue new tests.
+- `docs/src/scheduler.md` (or equivalent architecture page) — cross-cache leader/follower contract.
+
+**Out-of-scope:** Materialised reachability tables; cross-org notifications; mid-build cache-graph mutation handling; frontend changes beyond the existing leader-row swap.
+
+---
+
+## Task 1: Add multi-org/cache fixture helpers
+
+**Files:**
+- Modify: `backend/test-support/src/fixtures.rs`
+
+Adds reusable fixture functions used by every integration test below. No tests of their own (they're test infrastructure).
+
+- [ ] **Step 1: Append helper functions to `fixtures.rs`**
+
+Add after the existing `eval_at` helper:
+
+```rust
+use entity::ids::{
+    BuildId, CacheId, CacheUpstreamId, DerivationId, OrganizationCacheId,
+};
+use entity::cache_upstream;
+use entity::organization_cache::{self, CacheSubscriptionMode};
+use entity::cache;
+
+pub fn org_with_id(id: OrganizationId, slug: &str) -> organization::Model {
+    organization::Model {
+        id,
+        name: slug.into(),
+        display_name: slug.into(),
+        description: String::new(),
+        public_key: "ssh-ed25519 AAAA test".into(),
+        private_key: "encrypted".into(),
+        public: false,
+        created_by: user_id(),
+        created_at: test_date(),
+        managed: false,
+        github_installation_id: None,
+    }
+}
+
+pub fn cache_with_id(id: CacheId, slug: &str, owner: UserId) -> cache::Model {
+    cache::Model {
+        id,
+        name: slug.into(),
+        display_name: slug.into(),
+        description: String::new(),
+        active: true,
+        priority: 30,
+        public_key: "ssh-ed25519 AAAA test".into(),
+        private_key: "encrypted".into(),
+        public: false,
+        created_by: owner,
+        created_at: test_date(),
+        managed: false,
+    }
+}
+
+pub fn org_cache_link(
+    id: OrganizationCacheId,
+    org: OrganizationId,
+    cache: CacheId,
+    mode: CacheSubscriptionMode,
+) -> organization_cache::Model {
+    organization_cache::Model { id, organization: org, cache, mode }
+}
+
+pub fn internal_upstream(
+    id: CacheUpstreamId,
+    cache: CacheId,
+    upstream: CacheId,
+) -> cache_upstream::Model {
+    cache_upstream::Model {
+        id,
+        cache,
+        display_name: "internal".into(),
+        mode: CacheSubscriptionMode::ReadOnly,
+        upstream_cache: Some(upstream),
+        url: None,
+        public_key: None,
+    }
+}
+
+pub fn external_upstream(
+    id: CacheUpstreamId,
+    cache: CacheId,
+    url: &str,
+    public_key: &str,
+) -> cache_upstream::Model {
+    cache_upstream::Model {
+        id,
+        cache,
+        display_name: "external".into(),
+        mode: CacheSubscriptionMode::ReadOnly,
+        upstream_cache: None,
+        url: Some(url.into()),
+        public_key: Some(public_key.into()),
+    }
+}
+```
+
+Verify the `cache::Model` field set against `backend/entity/src/cache.rs` — if the actual struct has fields not shown above, copy them into `cache_with_id` with safe defaults.
+
+- [ ] **Step 2: Compile-check**
+
+Run: `cargo check -p test-support`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test-support/src/fixtures.rs
+git commit -m "test-support: add multi-org/cache fixture helpers"
+```
+
+---
+
+## Task 2: Reachability helper — module skeleton + direct-overlap test
+
+**Files:**
+- Create: `backend/core/src/db/cache_reach.rs`
+- Modify: `backend/core/src/db/mod.rs`
+
+- [ ] **Step 1: Register the module**
+
+Edit `backend/core/src/db/mod.rs`. Add `pub mod cache_reach;` next to the other `pub mod` lines and `pub use self::cache_reach::*;` next to the other re-exports:
+
+```rust
+pub mod cache_reach;
+pub mod connection;
+pub mod dependency_graph;
+pub mod derivation;
+pub mod drv_output_spec;
+pub mod gc;
+pub mod status;
+
+pub use self::cache_reach::*;
+pub use self::connection::*;
+pub use self::dependency_graph::*;
+pub use self::derivation::*;
+pub use self::drv_output_spec::DrvOutputSpec;
+pub use self::gc::*;
+pub use self::status::*;
+```
+
+- [ ] **Step 2: Write the failing test and an empty stub**
+
+Create `backend/core/src/db/cache_reach.rs`:
+
+```rust
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Compute the set of organizations whose Gradient build outputs a given
+//! organization can substitute through its cache subscriptions and the
+//! `cache_upstream` graph.
+//!
+//! Two organizations are "cache-connected" when the writer org pushes into
+//! a cache that lies in the upstream closure of one of the reader org's
+//! caches. External (URL-based) upstreams are excluded — they don't host
+//! Gradient builds.
+
+use std::collections::{HashSet, VecDeque};
+
+use sea_orm::{ColumnTrait, ConnectionTrait, DbErr, EntityTrait, QueryFilter};
+
+use entity::cache_upstream::{Column as CCacheUpstream, Entity as ECacheUpstream};
+use entity::ids::{CacheId, OrganizationId};
+use entity::organization_cache::{
+    CacheSubscriptionMode, Column as COrganizationCache, Entity as EOrganizationCache,
+};
+
+/// Returns every organization (including `reader_org` itself) whose build
+/// outputs `reader_org` could substitute through its current cache
+/// subscriptions and the `cache_upstream` graph.
+///
+/// Algorithm:
+/// 1. Load reader's `organization_cache` rows with mode `ReadWrite`/`ReadOnly`.
+/// 2. BFS forward over `cache_upstream` edges (`cache → upstream_cache`) to
+///    compute the upstream closure of the reader's caches. Cycles tolerated.
+/// 3. Load every `organization_cache` row with mode `ReadWrite`/`WriteOnly`
+///    on any cache in that closure; return the distinct org ids.
+pub async fn writer_orgs_reachable_from<C: ConnectionTrait>(
+    db: &C,
+    reader_org: OrganizationId,
+) -> Result<HashSet<OrganizationId>, DbErr> {
+    todo!("implement in subsequent tasks")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use entity::cache_upstream::Model as MCacheUpstream;
+    use entity::ids::{CacheId, CacheUpstreamId, OrganizationCacheId, OrganizationId};
+    use entity::organization_cache::Model as MOrganizationCache;
+    use sea_orm::{DatabaseBackend, MockDatabase};
+    use uuid::Uuid;
+
+    fn org(n: u8) -> OrganizationId {
+        let mut bytes = [0u8; 16];
+        bytes[15] = n;
+        OrganizationId::new(Uuid::from_bytes(bytes))
+    }
+
+    fn cid(n: u8) -> CacheId {
+        let mut bytes = [0u8; 16];
+        bytes[14] = n;
+        CacheId::new(Uuid::from_bytes(bytes))
+    }
+
+    fn org_cache(
+        org_id: OrganizationId,
+        cache_id: CacheId,
+        mode: CacheSubscriptionMode,
+    ) -> MOrganizationCache {
+        MOrganizationCache {
+            id: OrganizationCacheId::now_v7(),
+            organization: org_id,
+            cache: cache_id,
+            mode,
+        }
+    }
+
+    fn run<F: std::future::Future>(fut: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(fut)
+    }
+
+    #[test]
+    fn direct_overlap_reader_sees_writer() {
+        run(async {
+            // Reader (org B) reads cache X; writer (org A) writes cache X.
+            let cache_x = cid(1);
+            let reader_rows = vec![org_cache(org(2), cache_x, CacheSubscriptionMode::ReadOnly)];
+            let upstream_rows: Vec<MCacheUpstream> = vec![];
+            let writer_rows = vec![
+                org_cache(org(1), cache_x, CacheSubscriptionMode::ReadWrite),
+                org_cache(org(2), cache_x, CacheSubscriptionMode::ReadOnly),
+            ];
+
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([reader_rows])
+                .append_query_results([upstream_rows])
+                .append_query_results([writer_rows])
+                .into_connection();
+
+            let got = writer_orgs_reachable_from(&db, org(2))
+                .await
+                .expect("query succeeds");
+
+            assert!(got.contains(&org(1)), "got: {:?}", got);
+        });
+    }
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cargo test -p core --lib db::cache_reach::tests::direct_overlap_reader_sees_writer`
+Expected: FAIL with `todo!` panic.
+
+- [ ] **Step 4: Replace the stub with a working implementation**
+
+Replace `todo!(...)` with:
+
+```rust
+pub async fn writer_orgs_reachable_from<C: ConnectionTrait>(
+    db: &C,
+    reader_org: OrganizationId,
+) -> Result<HashSet<OrganizationId>, DbErr> {
+    // Reader's read-capable caches.
+    let reader_rows = EOrganizationCache::find()
+        .filter(COrganizationCache::Organization.eq(reader_org))
+        .filter(COrganizationCache::Mode.is_in(vec![
+            CacheSubscriptionMode::ReadWrite,
+            CacheSubscriptionMode::ReadOnly,
+        ]))
+        .all(db)
+        .await?;
+    let seed: Vec<CacheId> = reader_rows.into_iter().map(|r| r.cache).collect();
+
+    // Internal upstream edges. We load all of them up front so the BFS is
+    // pure in-memory work; the `cache_upstream` table is tiny (one row per
+    // configured upstream link, system-wide).
+    let upstream_rows = ECacheUpstream::find()
+        .filter(CCacheUpstream::UpstreamCache.is_not_null())
+        .all(db)
+        .await?;
+
+    let mut closure: HashSet<CacheId> = seed.iter().copied().collect();
+    let mut queue: VecDeque<CacheId> = seed.into_iter().collect();
+    while let Some(cache_id) = queue.pop_front() {
+        for edge in &upstream_rows {
+            if edge.cache != cache_id {
+                continue;
+            }
+            let Some(up) = edge.upstream_cache else { continue };
+            if closure.insert(up) {
+                queue.push_back(up);
+            }
+        }
+    }
+
+    if closure.is_empty() {
+        return Ok(HashSet::new());
+    }
+
+    // Writers on any cache in the closure.
+    let writer_rows = EOrganizationCache::find()
+        .filter(COrganizationCache::Cache.is_in(closure.into_iter().collect::<Vec<_>>()))
+        .filter(COrganizationCache::Mode.is_in(vec![
+            CacheSubscriptionMode::ReadWrite,
+            CacheSubscriptionMode::WriteOnly,
+        ]))
+        .all(db)
+        .await?;
+    Ok(writer_rows.into_iter().map(|r| r.organization).collect())
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cargo test -p core --lib db::cache_reach::tests::direct_overlap_reader_sees_writer`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/core/src/db/mod.rs backend/core/src/db/cache_reach.rs
+git commit -m "core: db: add cache_reach helper with direct-overlap support"
+```
+
+---
+
+## Task 3: Reachability — transitive internal chain
+
+**Files:**
+- Modify: `backend/core/src/db/cache_reach.rs`
+
+- [ ] **Step 1: Add the failing test**
+
+Append to the `tests` module:
+
+```rust
+#[test]
+fn transitive_internal_chain() {
+    run(async {
+        // chain: cache_a → upstream cache_b → upstream cache_c
+        // reader on a, writer on c
+        let a = cid(1);
+        let b = cid(2);
+        let c = cid(3);
+
+        let reader_rows = vec![org_cache(org(2), a, CacheSubscriptionMode::ReadOnly)];
+        let upstream_rows = vec![
+            MCacheUpstream {
+                id: CacheUpstreamId::now_v7(),
+                cache: a,
+                display_name: "ab".into(),
+                mode: CacheSubscriptionMode::ReadOnly,
+                upstream_cache: Some(b),
+                url: None,
+                public_key: None,
+            },
+            MCacheUpstream {
+                id: CacheUpstreamId::now_v7(),
+                cache: b,
+                display_name: "bc".into(),
+                mode: CacheSubscriptionMode::ReadOnly,
+                upstream_cache: Some(c),
+                url: None,
+                public_key: None,
+            },
+        ];
+        let writer_rows = vec![org_cache(org(1), c, CacheSubscriptionMode::ReadWrite)];
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([reader_rows])
+            .append_query_results([upstream_rows])
+            .append_query_results([writer_rows])
+            .into_connection();
+
+        let got = writer_orgs_reachable_from(&db, org(2)).await.unwrap();
+        assert!(got.contains(&org(1)), "got: {:?}", got);
+    });
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cargo test -p core --lib db::cache_reach::tests::transitive_internal_chain`
+Expected: PASS (the implementation from Task 2 already handles multi-hop BFS).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/core/src/db/cache_reach.rs
+git commit -m "core: db: cover transitive cache_reach chain in tests"
+```
+
+---
+
+## Task 4: Reachability — external upstream is skipped
+
+**Files:**
+- Modify: `backend/core/src/db/cache_reach.rs`
+
+- [ ] **Step 1: Add the failing test**
+
+```rust
+#[test]
+fn external_upstream_skipped() {
+    run(async {
+        // reader on a; a has an external (url-based) upstream that doesn't
+        // belong to any Gradient org, so the closure stops at `a`. Writer
+        // on a separate cache is not reachable.
+        let a = cid(1);
+        let b = cid(2);
+
+        let reader_rows = vec![org_cache(org(2), a, CacheSubscriptionMode::ReadOnly)];
+        // Only internal-upstream rows are loaded by the helper
+        // (`upstream_cache IS NOT NULL` filter), so an external row simply
+        // never reaches the BFS.
+        let upstream_rows: Vec<MCacheUpstream> = vec![];
+        let writer_rows: Vec<MOrganizationCache> = vec![];
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([reader_rows])
+            .append_query_results([upstream_rows])
+            .append_query_results([writer_rows])
+            .into_connection();
+
+        let got = writer_orgs_reachable_from(&db, org(2)).await.unwrap();
+        assert!(
+            !got.contains(&org(1)),
+            "external upstream must not reach org 1, got: {:?}",
+            got
+        );
+        let _ = b; // explicitly unused — documents the absence of a path.
+    });
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cargo test -p core --lib db::cache_reach::tests::external_upstream_skipped`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/core/src/db/cache_reach.rs
+git commit -m "core: db: pin external upstream skip in cache_reach tests"
+```
+
+---
+
+## Task 5: Reachability — write-only reader excluded
+
+**Files:**
+- Modify: `backend/core/src/db/cache_reach.rs`
+
+- [ ] **Step 1: Add the failing test**
+
+```rust
+#[test]
+fn write_only_reader_excluded() {
+    run(async {
+        // Reader has WriteOnly on cache X; cannot substitute from it.
+        let x = cid(1);
+        let reader_rows: Vec<MOrganizationCache> = vec![]; // mode filter rejects WriteOnly
+        let upstream_rows: Vec<MCacheUpstream> = vec![];
+        let writer_rows: Vec<MOrganizationCache> = vec![];
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([reader_rows])
+            .append_query_results([upstream_rows])
+            .append_query_results([writer_rows])
+            .into_connection();
+
+        let got = writer_orgs_reachable_from(&db, org(2)).await.unwrap();
+        assert!(got.is_empty(), "WriteOnly reader must see nobody, got: {:?}", got);
+        let _ = x;
+    });
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cargo test -p core --lib db::cache_reach::tests::write_only_reader_excluded`
+Expected: PASS (the mode filter in step 1 of the helper excludes WriteOnly).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/core/src/db/cache_reach.rs
+git commit -m "core: db: pin write-only-reader exclusion in cache_reach tests"
+```
+
+---
+
+## Task 6: Reachability — cycle tolerance
+
+**Files:**
+- Modify: `backend/core/src/db/cache_reach.rs`
+
+- [ ] **Step 1: Add the failing test**
+
+```rust
+#[test]
+fn cycle_tolerated() {
+    run(async {
+        // cache_a.upstream = b; cache_b.upstream = a → cycle.
+        let a = cid(1);
+        let b = cid(2);
+
+        let reader_rows = vec![org_cache(org(2), a, CacheSubscriptionMode::ReadOnly)];
+        let upstream_rows = vec![
+            MCacheUpstream {
+                id: CacheUpstreamId::now_v7(),
+                cache: a,
+                display_name: "ab".into(),
+                mode: CacheSubscriptionMode::ReadOnly,
+                upstream_cache: Some(b),
+                url: None,
+                public_key: None,
+            },
+            MCacheUpstream {
+                id: CacheUpstreamId::now_v7(),
+                cache: b,
+                display_name: "ba".into(),
+                mode: CacheSubscriptionMode::ReadOnly,
+                upstream_cache: Some(a),
+                url: None,
+                public_key: None,
+            },
+        ];
+        let writer_rows = vec![
+            org_cache(org(1), b, CacheSubscriptionMode::ReadWrite),
+            org_cache(org(2), a, CacheSubscriptionMode::ReadOnly),
+        ];
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([reader_rows])
+            .append_query_results([upstream_rows])
+            .append_query_results([writer_rows])
+            .into_connection();
+
+        let got = writer_orgs_reachable_from(&db, org(2)).await.unwrap();
+        assert!(got.contains(&org(1)), "cycle must still include reachable writer, got: {:?}", got);
+    });
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cargo test -p core --lib db::cache_reach::tests::cycle_tolerated`
+Expected: PASS (the `closure.insert(...)` visited-set prevents infinite revisits).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/core/src/db/cache_reach.rs
+git commit -m "core: db: prove cache_reach BFS tolerates upstream cycles"
+```
+
+---
+
+## Task 7: `find_active_leaders` — new signature, same-org behavior preserved
+
+**Files:**
+- Modify: `backend/core/src/db/status.rs`
+- Modify: `backend/scheduler/src/handler_tests.rs` (existing mock-DB callers)
+- Modify: `backend/scheduler/src/eval.rs:218` (caller passes org)
+- Modify: `backend/core/src/ci/trigger.rs:231` (caller passes org)
+
+This step changes the signature without changing behavior. Tests in `handler_tests.rs` that drive `find_active_leaders` through the eval pipeline keep passing once the new arg is threaded through.
+
+- [ ] **Step 1: Change `find_active_leaders` to take `inserting_org` (no behavior change yet)**
+
+Edit `backend/core/src/db/status.rs:399` to:
+
+```rust
+/// For each derivation in `drv_ids`, return the id of the leader build whose
+/// result a new build for that derivation should follow.
+///
+/// First checks for an in-flight build within `inserting_org` (the previous
+/// behavior). When no same-org candidate exists for a drv, this function
+/// will also consult cache-connected organisations via
+/// [`cache_reach::writer_orgs_reachable_from`] — that pass is added in a
+/// later task; this step only widens the signature.
+///
+/// Drvs with no active build are omitted from the result.
+pub async fn find_active_leaders<C: ConnectionTrait>(
+    db: &C,
+    inserting_org: OrganizationId,
+    drv_ids: &[DerivationId],
+) -> Result<HashMap<DerivationId, BuildId>, sea_orm::DbErr> {
+    let _ = inserting_org;
+
+    if drv_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let rows = EBuild::find()
+        .filter(CBuild::Derivation.is_in(drv_ids.to_vec()))
+        .filter(CBuild::Status.is_in(vec![
+            BuildStatus::Created,
+            BuildStatus::Queued,
+            BuildStatus::Building,
+        ]))
+        .all(db)
+        .await?;
+
+    let mut out: HashMap<DerivationId, BuildId> = HashMap::new();
+    for b in rows {
+        let head = b.via.unwrap_or(b.id);
+        out.entry(b.derivation)
+            .and_modify(|cur| {
+                if b.via.is_none() {
+                    *cur = b.id;
+                }
+            })
+            .or_insert(head);
+    }
+    Ok(out)
+}
+```
+
+Add `use entity::ids::OrganizationId;` at the top if not present.
+
+- [ ] **Step 2: Thread the org through the scheduler caller**
+
+In `backend/scheduler/src/eval.rs` at the existing call site (around line 218):
+
+```rust
+let leader_for_drv = find_active_leaders(
+    &self.state.worker_db,
+    self.evaluation.organization,
+    &buildable_drv_ids,
+)
+.await
+.unwrap_or_else(|e| {
+    error!(error = %e, "failed to query active leaders");
+    HashMap::new()
+});
+```
+
+- [ ] **Step 3: Thread the org through the CI trigger caller**
+
+In `backend/core/src/ci/trigger.rs` at line 231:
+
+```rust
+let leader_for_drv =
+    crate::db::find_active_leaders(db, new_eval.organization, &queued_drv_ids).await?;
+```
+
+(`new_eval` is the just-inserted evaluation row; confirm `organization` is in scope. If the function works off a different evaluation handle, use that.)
+
+- [ ] **Step 4: Update existing mock-DB callers in `handler_tests.rs`**
+
+Search `backend/scheduler/src/handler_tests.rs` for `find_active_leaders` references. The existing tests mock the underlying SQL query; they do not call the function directly — only the row-count comments need a glance. No code change is expected here unless a test calls the function directly: if so, pass `fixtures::org_id()` as the new arg.
+
+- [ ] **Step 5: Run the existing suite to confirm green**
+
+Run: `cargo check -p core -p scheduler` and `cargo clippy -p core -p scheduler --no-deps -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/core/src/db/status.rs backend/scheduler/src/eval.rs backend/core/src/ci/trigger.rs backend/scheduler/src/handler_tests.rs
+git commit -m "core: db: widen find_active_leaders signature with inserting_org"
+```
+
+---
+
+## Task 8: `find_active_leaders` — cross-org pass with tie-break
+
+**Files:**
+- Modify: `backend/core/src/db/status.rs`
+
+- [ ] **Step 1: Write a failing mock-DB unit test for cross-org match + tie-break**
+
+Add to `backend/core/src/db/status.rs` (in or create a `#[cfg(test)] mod find_active_leaders_tests`):
+
+```rust
+#[cfg(test)]
+mod find_active_leaders_tests {
+    use super::*;
+    use entity::build::{BuildStatus, Model as MBuild};
+    use entity::derivation::Model as MDerivation;
+    use entity::organization_cache::{CacheSubscriptionMode, Model as MOrganizationCache};
+    use entity::cache_upstream::Model as MCacheUpstream;
+    use entity::ids::{BuildId, CacheId, DerivationId, OrganizationCacheId, OrganizationId};
+    use sea_orm::{DatabaseBackend, MockDatabase};
+    use uuid::Uuid;
+
+    fn org(n: u8) -> OrganizationId {
+        let mut bytes = [0u8; 16];
+        bytes[15] = n;
+        OrganizationId::new(Uuid::from_bytes(bytes))
+    }
+    fn cid(n: u8) -> CacheId {
+        let mut bytes = [0u8; 16];
+        bytes[14] = n;
+        CacheId::new(Uuid::from_bytes(bytes))
+    }
+    fn did(n: u8) -> DerivationId {
+        let mut bytes = [0u8; 16];
+        bytes[13] = n;
+        DerivationId::new(Uuid::from_bytes(bytes))
+    }
+    fn bid(n: u8) -> BuildId {
+        let mut bytes = [0u8; 16];
+        bytes[12] = n;
+        BuildId::new(Uuid::from_bytes(bytes))
+    }
+
+    fn build(
+        id: BuildId,
+        drv: DerivationId,
+        status: BuildStatus,
+        external_cached: bool,
+        offset_secs: i64,
+    ) -> MBuild {
+        let t = chrono::NaiveDate::from_ymd_opt(2026, 1, 1)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap()
+            + chrono::Duration::seconds(offset_secs);
+        MBuild {
+            id,
+            evaluation: entity::ids::EvaluationId::now_v7(),
+            derivation: drv,
+            status,
+            log_id: None,
+            build_time_ms: None,
+            worker: None,
+            via: None,
+            external_cached,
+            created_at: t,
+            updated_at: t,
+        }
+    }
+
+    fn drv_row(id: DerivationId, owner: OrganizationId, path: &str) -> MDerivation {
+        MDerivation {
+            id,
+            organization: owner,
+            derivation_path: path.into(),
+            architecture: "x86_64-linux".into(),
+            created_at: chrono::NaiveDateTime::default(),
+        }
+    }
+
+    fn run<F: std::future::Future>(fut: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(fut)
+    }
+
+    #[test]
+    fn cross_org_match_when_no_same_org_candidate() {
+        run(async {
+            let drv_b = did(2); // inserting org's derivation row
+            let drv_a = did(1); // leader-org's derivation row (same path)
+            let leader_build = bid(10);
+
+            // Mock query order (must match the helper's call sequence):
+            //   1. same-org pass: in-flight builds for drv_ids — empty.
+            //   2. derivation rows for inserting org (resolve drv_id → drv_path).
+            //   3. cache_reach: reader org_cache rows.
+            //   4. cache_reach: upstream rows.
+            //   5. cache_reach: writer org_cache rows.
+            //   6. cross-org candidate derivation rows (drv_path ∈ unmatched,
+            //      org ∈ reachable).
+            //   7. cross-org candidate build rows (status filter + via IS NULL).
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([Vec::<MBuild>::new()])
+                .append_query_results([vec![drv_row(drv_b, org(2), "/nix/store/x.drv")]])
+                .append_query_results([vec![MOrganizationCache {
+                    id: OrganizationCacheId::now_v7(),
+                    organization: org(2),
+                    cache: cid(1),
+                    mode: CacheSubscriptionMode::ReadOnly,
+                }]])
+                .append_query_results([Vec::<MCacheUpstream>::new()])
+                .append_query_results([vec![MOrganizationCache {
+                    id: OrganizationCacheId::now_v7(),
+                    organization: org(1),
+                    cache: cid(1),
+                    mode: CacheSubscriptionMode::ReadWrite,
+                }]])
+                .append_query_results([vec![drv_row(drv_a, org(1), "/nix/store/x.drv")]])
+                .append_query_results([vec![build(
+                    leader_build,
+                    drv_a,
+                    BuildStatus::Building,
+                    false,
+                    0,
+                )]])
+                .into_connection();
+
+            let got = find_active_leaders(&db, org(2), &[drv_b]).await.unwrap();
+            assert_eq!(got.get(&drv_b), Some(&leader_build), "got: {:?}", got);
+        });
+    }
+
+    #[test]
+    fn cross_org_tie_break_most_advanced_then_oldest() {
+        run(async {
+            let drv_b = did(2);
+            let drv_a = did(1);
+            let drv_c = did(3);
+            let queued_old = bid(20); // older Queued
+            let building_new = bid(21); // newer Building → should win
+
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([Vec::<MBuild>::new()])
+                .append_query_results([vec![drv_row(drv_b, org(2), "/nix/store/x.drv")]])
+                .append_query_results([vec![MOrganizationCache {
+                    id: OrganizationCacheId::now_v7(),
+                    organization: org(2),
+                    cache: cid(1),
+                    mode: CacheSubscriptionMode::ReadOnly,
+                }]])
+                .append_query_results([Vec::<MCacheUpstream>::new()])
+                .append_query_results([
+                    vec![
+                        MOrganizationCache {
+                            id: OrganizationCacheId::now_v7(),
+                            organization: org(1),
+                            cache: cid(1),
+                            mode: CacheSubscriptionMode::ReadWrite,
+                        },
+                        MOrganizationCache {
+                            id: OrganizationCacheId::now_v7(),
+                            organization: org(3),
+                            cache: cid(1),
+                            mode: CacheSubscriptionMode::ReadWrite,
+                        },
+                    ],
+                ])
+                .append_query_results([vec![
+                    drv_row(drv_a, org(1), "/nix/store/x.drv"),
+                    drv_row(drv_c, org(3), "/nix/store/x.drv"),
+                ]])
+                .append_query_results([vec![
+                    build(queued_old, drv_a, BuildStatus::Queued, false, 0),
+                    build(building_new, drv_c, BuildStatus::Building, false, 60),
+                ]])
+                .into_connection();
+
+            let got = find_active_leaders(&db, org(2), &[drv_b]).await.unwrap();
+            assert_eq!(got.get(&drv_b), Some(&building_new), "got: {:?}", got);
+        });
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p core --lib db::status::find_active_leaders_tests`
+Expected: FAIL — current implementation never consults cross-org.
+
+- [ ] **Step 3: Implement the cross-org pass**
+
+Replace the `find_active_leaders` body in `backend/core/src/db/status.rs` with:
+
+```rust
+pub async fn find_active_leaders<C: ConnectionTrait>(
+    db: &C,
+    inserting_org: OrganizationId,
+    drv_ids: &[DerivationId],
+) -> Result<HashMap<DerivationId, BuildId>, sea_orm::DbErr> {
+    if drv_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    // ── Same-org pass ────────────────────────────────────────────────────
+    let same_org_rows = EBuild::find()
+        .filter(CBuild::Derivation.is_in(drv_ids.to_vec()))
+        .filter(CBuild::Status.is_in(vec![
+            BuildStatus::Created,
+            BuildStatus::Queued,
+            BuildStatus::Building,
+        ]))
+        .all(db)
+        .await?;
+
+    let mut out: HashMap<DerivationId, BuildId> = HashMap::new();
+    for b in same_org_rows {
+        let head = b.via.unwrap_or(b.id);
+        out.entry(b.derivation)
+            .and_modify(|cur| {
+                if b.via.is_none() {
+                    *cur = b.id;
+                }
+            })
+            .or_insert(head);
+    }
+
+    let unmatched: Vec<DerivationId> = drv_ids
+        .iter()
+        .copied()
+        .filter(|d| !out.contains_key(d))
+        .collect();
+    if unmatched.is_empty() {
+        return Ok(out);
+    }
+
+    // ── Cross-org pass ───────────────────────────────────────────────────
+    use entity::derivation::{Column as CDerivation, Entity as EDerivation};
+
+    // Resolve drv_ids → drv_paths for the inserting org.
+    let inserting_drv_rows = EDerivation::find()
+        .filter(CDerivation::Id.is_in(unmatched.clone()))
+        .all(db)
+        .await?;
+    let mut path_to_drv: HashMap<String, DerivationId> = HashMap::new();
+    let mut drv_paths: Vec<String> = Vec::new();
+    for d in &inserting_drv_rows {
+        path_to_drv.insert(d.derivation_path.clone(), d.id);
+        drv_paths.push(d.derivation_path.clone());
+    }
+    if drv_paths.is_empty() {
+        return Ok(out);
+    }
+
+    let mut reachable =
+        crate::db::cache_reach::writer_orgs_reachable_from(db, inserting_org).await?;
+    reachable.remove(&inserting_org);
+    if reachable.is_empty() {
+        return Ok(out);
+    }
+
+    let candidate_drvs = EDerivation::find()
+        .filter(CDerivation::DerivationPath.is_in(drv_paths.clone()))
+        .filter(CDerivation::Organization.is_in(reachable.into_iter().collect::<Vec<_>>()))
+        .all(db)
+        .await?;
+    if candidate_drvs.is_empty() {
+        return Ok(out);
+    }
+    let candidate_drv_ids: Vec<DerivationId> = candidate_drvs.iter().map(|d| d.id).collect();
+    let leader_drv_to_path: HashMap<DerivationId, String> = candidate_drvs
+        .into_iter()
+        .map(|d| (d.id, d.derivation_path))
+        .collect();
+
+    let candidate_builds = EBuild::find()
+        .filter(CBuild::Derivation.is_in(candidate_drv_ids))
+        .filter(CBuild::Status.is_in(vec![
+            BuildStatus::Created,
+            BuildStatus::Queued,
+            BuildStatus::Building,
+        ]))
+        .filter(CBuild::Via.is_null())
+        .filter(CBuild::ExternalCached.eq(false))
+        .all(db)
+        .await?;
+
+    // Tie-break per drv_path: most-advanced status, then oldest created_at.
+    fn status_rank(s: BuildStatus) -> u8 {
+        match s {
+            BuildStatus::Building => 2,
+            BuildStatus::Queued => 1,
+            _ => 0,
+        }
+    }
+    let mut best_by_path: HashMap<String, MBuild> = HashMap::new();
+    for b in candidate_builds {
+        let Some(path) = leader_drv_to_path.get(&b.derivation).cloned() else {
+            continue;
+        };
+        match best_by_path.get(&path) {
+            Some(cur) => {
+                let cur_rank = status_rank(cur.status);
+                let new_rank = status_rank(b.status);
+                if new_rank > cur_rank
+                    || (new_rank == cur_rank && b.created_at < cur.created_at)
+                {
+                    best_by_path.insert(path, b);
+                }
+            }
+            None => {
+                best_by_path.insert(path, b);
+            }
+        }
+    }
+
+    for (path, b) in best_by_path {
+        if let Some(&local_drv_id) = path_to_drv.get(&path) {
+            out.insert(local_drv_id, b.id);
+        }
+    }
+
+    Ok(out)
+}
+```
+
+Add `use entity::build::Model as MBuild;` and `use entity::derivation::Column as _;` as needed at module top.
+
+- [ ] **Step 4: Re-run the tests**
+
+Run: `cargo test -p core --lib db::status::find_active_leaders_tests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/src/db/status.rs
+git commit -m "core: db: extend find_active_leaders with cross-org pass and tie-break"
+```
+
+---
+
+## Task 9: `find_active_leaders` — same-org preferred + external_cached cross-org skip
+
+**Files:**
+- Modify: `backend/core/src/db/status.rs`
+
+These behaviors fall out of Task 8's implementation; the tests pin them.
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to the `find_active_leaders_tests` module:
+
+```rust
+#[test]
+fn same_org_preferred_over_cross_org() {
+    run(async {
+        let drv_b = did(2);
+        let same_org_build = bid(30);
+
+        // Same-org pass returns the candidate immediately; cross-org pass is
+        // never executed (the helper short-circuits when all drvs matched).
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![build(
+                same_org_build,
+                drv_b,
+                BuildStatus::Queued,
+                false,
+                0,
+            )]])
+            .into_connection();
+
+        let got = find_active_leaders(&db, org(2), &[drv_b]).await.unwrap();
+        assert_eq!(got.get(&drv_b), Some(&same_org_build));
+    });
+}
+
+#[test]
+fn cross_org_external_cached_candidate_skipped() {
+    run(async {
+        let drv_b = did(2);
+        let drv_a = did(1);
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([Vec::<MBuild>::new()])
+            .append_query_results([vec![drv_row(drv_b, org(2), "/nix/store/x.drv")]])
+            .append_query_results([vec![MOrganizationCache {
+                id: OrganizationCacheId::now_v7(),
+                organization: org(2),
+                cache: cid(1),
+                mode: CacheSubscriptionMode::ReadOnly,
+            }]])
+            .append_query_results([Vec::<MCacheUpstream>::new()])
+            .append_query_results([vec![MOrganizationCache {
+                id: OrganizationCacheId::now_v7(),
+                organization: org(1),
+                cache: cid(1),
+                mode: CacheSubscriptionMode::ReadWrite,
+            }]])
+            // Candidate drv exists in org(1) for the same path...
+            .append_query_results([vec![drv_row(drv_a, org(1), "/nix/store/x.drv")]])
+            // ...but the SQL `external_cached = false` filter excludes the
+            // only would-be leader, so the build query returns empty.
+            .append_query_results([Vec::<MBuild>::new()])
+            .into_connection();
+
+        let got = find_active_leaders(&db, org(2), &[drv_b]).await.unwrap();
+        assert!(got.get(&drv_b).is_none(), "external_cached must be skipped");
+    });
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `cargo test -p core --lib db::status::find_active_leaders_tests`
+Expected: PASS — the SQL `external_cached = false` filter and the same-org short-circuit already cover these cases.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/core/src/db/status.rs
+git commit -m "core: db: pin same-org-preferred and external_cached skip rules"
+```
+
+---
+
+## Task 10: Integration test — cross-org leader set on insert (TDD red)
+
+**Files:**
+- Create: `backend/scheduler/tests/cross_org_leader_set_on_insert.rs`
+
+End-to-end test driving real Postgres via `test-support`. Confirms the `via` column is populated when a second org evaluates the same drv-path.
+
+- [ ] **Step 1: Look up an existing scheduler integration test for shape**
+
+Read `backend/scheduler/tests/` for an existing file to copy structure from (likely something using `test_support::state::test_state` plus DB seeding). Note the harness's preferred way to seed `organization`, `cache`, `organization_cache`, `derivation`, `build`, `evaluation` rows.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `backend/scheduler/tests/cross_org_leader_set_on_insert.rs` with a test that:
+
+1. Seeds two orgs (`org_a`, `org_b`), one cache `cache_x`,
+   `organization_cache(org_a, cache_x, ReadWrite)` and
+   `organization_cache(org_b, cache_x, ReadOnly)`.
+2. Seeds an in-flight build in `org_a` for `/nix/store/abc-foo.drv`
+   (status = `Building`, `via = None`, `external_cached = false`).
+3. Seeds an evaluation row for `org_b` in `EvaluatingDerivation` state.
+4. Calls the eval-pipeline entry point that drives `insert_build_rows` for a
+   single discovered derivation with `drv_path = /nix/store/abc-foo.drv`,
+   `substituted = false`.
+5. Asserts the new `org_b` build row has `via = Some(org_a_build.id)`.
+
+Use the existing `test_support::db_with(...)` helper to fully seed a fresh Postgres schema. Mirror the import block from another integration test (e.g. `evaluation_builds_via.rs`).
+
+The full test body (use as-is, adjust import paths if your helpers differ):
+
+```rust
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+mod common;
+
+use entity::build::BuildStatus;
+use entity::ids::{
+    BuildId, CacheId, DerivationId, EvaluationId, OrganizationCacheId, OrganizationId,
+};
+use entity::organization_cache::CacheSubscriptionMode;
+use entity::*;
+use sea_orm::{ActiveModelTrait, ActiveValue::Set, ColumnTrait, EntityTrait, QueryFilter};
+use test_support::fixtures;
+
+#[tokio::test]
+async fn cross_org_leader_set_on_insert() {
+    let (state, _temp) = common::test_state().await;
+    let db = &state.worker_db;
+
+    // ── Seed: two orgs sharing cache_x ──────────────────────────────────
+    let org_a = fixtures::org_with_id(
+        OrganizationId::new(uuid::uuid!("aaaaaaaa-0000-0000-0000-000000000001")),
+        "org-a",
+    );
+    let org_b = fixtures::org_with_id(
+        OrganizationId::new(uuid::uuid!("bbbbbbbb-0000-0000-0000-000000000001")),
+        "org-b",
+    );
+    let cache_x = fixtures::cache_with_id(
+        CacheId::new(uuid::uuid!("cccccccc-0000-0000-0000-000000000001")),
+        "cache-x",
+        fixtures::user_id(),
+    );
+    let oc_a = fixtures::org_cache_link(
+        OrganizationCacheId::now_v7(),
+        org_a.id,
+        cache_x.id,
+        CacheSubscriptionMode::ReadWrite,
+    );
+    let oc_b = fixtures::org_cache_link(
+        OrganizationCacheId::now_v7(),
+        org_b.id,
+        cache_x.id,
+        CacheSubscriptionMode::ReadOnly,
+    );
+
+    EOrganization::insert(org_a.clone().into_active_model()).exec(db).await.unwrap();
+    EOrganization::insert(org_b.clone().into_active_model()).exec(db).await.unwrap();
+    ECache::insert(cache_x.clone().into_active_model()).exec(db).await.unwrap();
+    EOrganizationCache::insert(oc_a.into_active_model()).exec(db).await.unwrap();
+    EOrganizationCache::insert(oc_b.into_active_model()).exec(db).await.unwrap();
+
+    // ── Seed: org_a building drv_path P ─────────────────────────────────
+    let drv_path = "/nix/store/abc123-foo.drv";
+    let drv_a = derivation::ActiveModel {
+        id: Set(DerivationId::now_v7()),
+        organization: Set(org_a.id),
+        derivation_path: Set(drv_path.into()),
+        architecture: Set("x86_64-linux".into()),
+        created_at: Set(fixtures::test_date()),
+    }
+    .insert(db)
+    .await
+    .unwrap();
+
+    // org_a evaluation (placeholder — needed for the build FK).
+    let eval_a = common::seed_evaluation_for_org(db, org_a.id).await;
+    let leader_build = build::ActiveModel {
+        id: Set(BuildId::now_v7()),
+        evaluation: Set(eval_a.id),
+        derivation: Set(drv_a.id),
+        status: Set(BuildStatus::Building),
+        log_id: Set(None),
+        build_time_ms: Set(None),
+        worker: Set(None),
+        via: Set(None),
+        external_cached: Set(false),
+        created_at: Set(fixtures::test_date()),
+        updated_at: Set(fixtures::test_date()),
+    }
+    .insert(db)
+    .await
+    .unwrap();
+
+    // ── Drive: org_b evaluation discovers the same drv_path ─────────────
+    let eval_b = common::seed_evaluation_for_org(db, org_b.id).await;
+    let drv_b = derivation::ActiveModel {
+        id: Set(DerivationId::now_v7()),
+        organization: Set(org_b.id),
+        derivation_path: Set(drv_path.into()),
+        architecture: Set("x86_64-linux".into()),
+        created_at: Set(fixtures::test_date()),
+    }
+    .insert(db)
+    .await
+    .unwrap();
+
+    let leader_for_drv =
+        gradient_core::db::find_active_leaders(db, org_b.id, &[drv_b.id])
+            .await
+            .expect("find_active_leaders succeeds");
+
+    assert_eq!(
+        leader_for_drv.get(&drv_b.id),
+        Some(&leader_build.id),
+        "org_b's new build must point at org_a's in-flight leader"
+    );
+}
+```
+
+If `common::test_state` and `common::seed_evaluation_for_org` don't exist yet, create them in `backend/scheduler/tests/common/mod.rs` modelled after the helpers used by `backend/web/tests/evaluation_builds_via.rs`.
+
+- [ ] **Step 3: Run the test to verify it fails** (compilation will require Task 7's signature change — which is already in place by now)
+
+Run: `cargo test -p scheduler --test cross_org_leader_set_on_insert`
+Expected: PASS (the cross-org pass from Task 8 already implements this).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/scheduler/tests/cross_org_leader_set_on_insert.rs backend/scheduler/tests/common/
+git commit -m "scheduler: integration test for cross-org leader linkage"
+```
+
+---
+
+## Task 11: Artefact mirroring — integration test (red)
+
+**Files:**
+- Create: `backend/scheduler/tests/cross_org_artefacts_mirrored.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Set up the same two-org/cache fixture as Task 10. Then:
+
+1. Insert a follower build in `org_b` with `via = leader_build.id`.
+2. Insert `derivation_output` and `build_product` rows under the leader's
+   derivation (with non-trivial `hash`, `nar_size`, `cached_path` link).
+3. Call `BuildStateHandler::handle_build_job_completed(leader_build.id)`
+   (re-export the entry through the scheduler's public surface if needed).
+4. Assert: `EDerivationOutput::find().filter(Derivation.eq(drv_b.id))`
+   returns rows mirroring the leader's outputs by `hash`, `name`,
+   `is_cached`, and `cached_path`.
+5. Assert: `EBuildProduct::find()` joined through those outputs matches
+   leader's `build_product` rows by `name`/`path`/`size`.
+
+Test body skeleton:
+
+```rust
+mod common;
+
+use entity::build::BuildStatus;
+use entity::ids::{BuildId, BuildProductId, DerivationOutputId, DerivationId};
+use entity::*;
+use sea_orm::{ActiveModelTrait, ActiveValue::Set, ColumnTrait, EntityTrait, QueryFilter};
+use test_support::fixtures;
+
+#[tokio::test]
+async fn cross_org_artefacts_mirrored() {
+    let (state, _temp) = common::test_state().await;
+    let db = &state.worker_db;
+
+    // Seed orgs/cache/orgs_cache (copy from Task 10's helper).
+    let (org_a, org_b, _cache_x) = common::seed_two_orgs_sharing_cache(db).await;
+
+    // Seed drv_a, drv_b for the same drv_path.
+    let drv_path = "/nix/store/abc123-foo.drv";
+    let drv_a = common::seed_derivation(db, org_a.id, drv_path).await;
+    let drv_b = common::seed_derivation(db, org_b.id, drv_path).await;
+
+    // Seed leader & follower builds.
+    let eval_a = common::seed_evaluation_for_org(db, org_a.id).await;
+    let eval_b = common::seed_evaluation_for_org(db, org_b.id).await;
+    let leader = common::seed_build(db, eval_a.id, drv_a.id, BuildStatus::Building, None).await;
+    let follower = common::seed_build(db, eval_b.id, drv_b.id, BuildStatus::Created, Some(leader.id)).await;
+
+    // Seed leader's derivation_output + build_product.
+    let leader_output = derivation_output::ActiveModel {
+        id: Set(DerivationOutputId::now_v7()),
+        derivation: Set(drv_a.id),
+        name: Set("out".into()),
+        output: Set("/nix/store/xxx-foo".into()),
+        hash: Set("deadbeef".into()),
+        package: Set("foo".into()),
+        ca: Set(None),
+        nar_size: Set(Some(1024)),
+        is_cached: Set(true),
+        cached_path: Set(None),
+        created_at: Set(fixtures::test_date()),
+    }
+    .insert(db)
+    .await
+    .unwrap();
+    let leader_product = build_product::ActiveModel {
+        id: Set(BuildProductId::now_v7()),
+        derivation_output: Set(leader_output.id),
+        file_type: Set("file".into()),
+        subtype: Set("doc".into()),
+        name: Set("readme".into()),
+        path: Set("share/doc/readme".into()),
+        size: Set(Some(512)),
+        created_at: Set(fixtures::test_date()),
+    }
+    .insert(db)
+    .await
+    .unwrap();
+
+    // Drive: leader completes.
+    scheduler::build::handle_build_job_completed(&state, leader.id)
+        .await
+        .expect("handler ok");
+
+    // ── Assert: follower's derivation has mirrored rows ──────────────────
+    let outs = EDerivationOutput::find()
+        .filter(derivation_output::Column::Derivation.eq(drv_b.id))
+        .all(db)
+        .await
+        .unwrap();
+    assert_eq!(outs.len(), 1, "exactly one mirrored output");
+    let mirrored = &outs[0];
+    assert_eq!(mirrored.hash, "deadbeef");
+    assert_eq!(mirrored.name, "out");
+    assert_eq!(mirrored.nar_size, Some(1024));
+    assert!(mirrored.is_cached);
+
+    let products = EBuildProduct::find()
+        .filter(build_product::Column::DerivationOutput.eq(mirrored.id))
+        .all(db)
+        .await
+        .unwrap();
+    assert_eq!(products.len(), 1, "exactly one mirrored product");
+    assert_eq!(products[0].name, "readme");
+    assert_eq!(products[0].path, "share/doc/readme");
+    assert_eq!(products[0].size, Some(512));
+
+    let _ = leader_product;
+}
+```
+
+(Add helpers `seed_two_orgs_sharing_cache`, `seed_derivation`, `seed_build` to `common/mod.rs` if not already present.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p scheduler --test cross_org_artefacts_mirrored`
+Expected: FAIL — `outs.len()` is `0` because today's `propagate_to_followers` doesn't mirror artefacts cross-org.
+
+- [ ] **Step 3: Commit (failing test)**
+
+```bash
+git add backend/scheduler/tests/cross_org_artefacts_mirrored.rs backend/scheduler/tests/common/
+git commit -m "scheduler: failing integration test for cross-org artefact mirroring"
+```
+
+---
+
+## Task 12: Artefact mirroring — implementation
+
+**Files:**
+- Modify: `backend/scheduler/src/build.rs:176`
+
+- [ ] **Step 1: Extend `propagate_to_followers` to mirror cross-org artefacts**
+
+Locate `async fn propagate_to_followers(&self, leader: &MBuild) -> Result<()>` at line 176. After the existing block that loads `followers`, but before the per-follower loop, add:
+
+```rust
+// Load leader's child rows once. Used to mirror artefacts onto any
+// cross-org follower (different `derivation` than the leader).
+let leader_outputs = EDerivationOutput::find()
+    .filter(CDerivationOutput::Derivation.eq(leader.derivation))
+    .all(&self.state.worker_db)
+    .await
+    .context("fetch leader's derivation_output rows")?;
+let leader_output_ids: Vec<_> = leader_outputs.iter().map(|o| o.id).collect();
+let leader_products = if leader_output_ids.is_empty() {
+    Vec::new()
+} else {
+    EBuildProduct::find()
+        .filter(CBuildProduct::DerivationOutput.is_in(leader_output_ids.clone()))
+        .all(&self.state.worker_db)
+        .await
+        .context("fetch leader's build_product rows")?
+};
+```
+
+Then inside the existing `for follower in followers { ... }` loop, *after* the `active.update(...)` call that copies leader fields, add:
+
+```rust
+// Cross-org follower: copy artefact rows onto the follower's derivation
+// row so downstream API endpoints (downloads, graph) work without org-aware
+// resolution. Same-org followers share `derivation` with the leader and
+// skip this branch.
+if follower.derivation != leader.derivation {
+    let existing_outs = EDerivationOutput::find()
+        .filter(CDerivationOutput::Derivation.eq(follower.derivation))
+        .all(&self.state.worker_db)
+        .await
+        .context("fetch follower's existing derivation_output rows")?;
+    let existing_out_ids: Vec<_> = existing_outs.iter().map(|o| o.id).collect();
+    if !existing_out_ids.is_empty() {
+        if let Err(e) = EBuildProduct::delete_many()
+            .filter(CBuildProduct::DerivationOutput.is_in(existing_out_ids.clone()))
+            .exec(&self.state.worker_db)
+            .await
+        {
+            warn!(error = %e, follower_id = %follower.id, "failed to clear stale follower build_products");
+        }
+        if let Err(e) = EDerivationOutput::delete_many()
+            .filter(CDerivationOutput::Id.is_in(existing_out_ids))
+            .exec(&self.state.worker_db)
+            .await
+        {
+            warn!(error = %e, follower_id = %follower.id, "failed to clear stale follower derivation_outputs");
+        }
+    }
+
+    use entity::ids::{BuildProductId, DerivationOutputId};
+    let mut old_to_new_output: std::collections::HashMap<DerivationOutputId, DerivationOutputId> =
+        std::collections::HashMap::new();
+    for src in &leader_outputs {
+        let new_id = DerivationOutputId::now_v7();
+        old_to_new_output.insert(src.id, new_id);
+        let am = ADerivationOutput {
+            id: Set(new_id),
+            derivation: Set(follower.derivation),
+            name: Set(src.name.clone()),
+            output: Set(src.output.clone()),
+            hash: Set(src.hash.clone()),
+            package: Set(src.package.clone()),
+            ca: Set(src.ca.clone()),
+            nar_size: Set(src.nar_size),
+            is_cached: Set(src.is_cached),
+            cached_path: Set(src.cached_path),
+            created_at: Set(src.created_at),
+        };
+        if let Err(e) = am.insert(&self.state.worker_db).await {
+            warn!(error = %e, follower_id = %follower.id, "failed to mirror derivation_output to follower");
+        }
+    }
+    for src in &leader_products {
+        let Some(&new_output_id) = old_to_new_output.get(&src.derivation_output) else {
+            continue;
+        };
+        let am = ABuildProduct {
+            id: Set(BuildProductId::now_v7()),
+            derivation_output: Set(new_output_id),
+            file_type: Set(src.file_type.clone()),
+            subtype: Set(src.subtype.clone()),
+            name: Set(src.name.clone()),
+            path: Set(src.path.clone()),
+            size: Set(src.size),
+            created_at: Set(src.created_at),
+        };
+        if let Err(e) = am.insert(&self.state.worker_db).await {
+            warn!(error = %e, follower_id = %follower.id, "failed to mirror build_product to follower");
+        }
+    }
+}
+```
+
+Ensure the necessary entity imports (`EDerivationOutput`, `CDerivationOutput`, `EBuildProduct`, `CBuildProduct`, `ADerivationOutput`, `ABuildProduct`) are in scope at the top of the file (most are re-exported through `gradient_core::types::*` per existing usage).
+
+- [ ] **Step 2: Update the comment block on `propagate_to_followers`**
+
+Remove or amend the comment at lines 165-173 that says "Followers always share a `derivation` row with their leader" — that assumption no longer holds. Replace with:
+
+```rust
+/// Copy a leader's terminal status (and `log_id`, `build_time_ms`,
+/// `worker`) onto every build with `via = leader.id`, then run the
+/// per-evaluation finalisation each follower needs (`DependencyFailed`
+/// cascade on failure, `check_evaluation_done` to flip the eval).
+///
+/// Same-org followers share the leader's `derivation` row, so its
+/// `derivation_output` and `build_product` children are already visible to
+/// the follower's evaluation without any copy. Cross-org followers (those
+/// whose `derivation` differs from the leader's — created when the leader
+/// belongs to a cache-connected organisation) have their `derivation_output`
+/// and `build_product` rows mirrored onto the follower's `derivation`.
+///
+/// `Aborted` is not propagated — when a leader is aborted (its eval was
+/// cancelled), callers re-elect a new leader from the followers instead.
+```
+
+- [ ] **Step 3: Re-run the integration test**
+
+Run: `cargo test -p scheduler --test cross_org_artefacts_mirrored`
+Expected: PASS.
+
+- [ ] **Step 4: Verify nothing else broke**
+
+Run: `cargo check -p scheduler` and `cargo clippy -p scheduler --no-deps -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/scheduler/src/build.rs
+git commit -m "scheduler: mirror leader artefacts onto cross-org followers"
+```
+
+---
+
+## Task 13: Re-elect — same-org-only promotion (red)
+
+**Files:**
+- Create: `backend/scheduler/tests/cross_org_re_election_same_org_only.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Fixture: org_a writes cache_x, org_b reads cache_x. org_a has an in-flight leader build for drv-path P. org_a has ONE same-org follower (another build in a sibling eval). org_b has ONE cross-org follower.
+
+```rust
+mod common;
+
+use entity::build::BuildStatus;
+use entity::*;
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+use test_support::fixtures;
+
+#[tokio::test]
+async fn cross_org_re_election_same_org_only() {
+    let (state, _temp) = common::test_state().await;
+    let db = &state.worker_db;
+
+    let (org_a, org_b, _cache_x) = common::seed_two_orgs_sharing_cache(db).await;
+    let drv_path = "/nix/store/abc123-foo.drv";
+    let drv_a = common::seed_derivation(db, org_a.id, drv_path).await;
+    let drv_b = common::seed_derivation(db, org_b.id, drv_path).await;
+
+    let eval_a1 = common::seed_evaluation_for_org(db, org_a.id).await;
+    let eval_a2 = common::seed_evaluation_for_org(db, org_a.id).await;
+    let eval_b = common::seed_evaluation_for_org(db, org_b.id).await;
+
+    let leader = common::seed_build(db, eval_a1.id, drv_a.id, BuildStatus::Queued, None).await;
+    let same_org_follower =
+        common::seed_build(db, eval_a2.id, drv_a.id, BuildStatus::Created, Some(leader.id)).await;
+    let cross_org_follower =
+        common::seed_build(db, eval_b.id, drv_b.id, BuildStatus::Created, Some(leader.id)).await;
+
+    // Drive: abort eval_a1 (which aborts the leader). Use the public abort
+    // entry point that calls `reelect_leader` internally.
+    gradient_core::db::abort_evaluation(state.clone(), eval_a1).await;
+
+    let promoted = EBuild::find_by_id(same_org_follower.id).one(db).await.unwrap().unwrap();
+    let orphaned = EBuild::find_by_id(cross_org_follower.id).one(db).await.unwrap().unwrap();
+
+    assert!(promoted.via.is_none(), "same-org follower must be promoted");
+    assert!(
+        orphaned.via.is_none(),
+        "cross-org follower must be orphaned (via cleared), got via={:?}",
+        orphaned.via
+    );
+}
+```
+
+(`gradient_core::db::abort_evaluation` is the existing public entry that internally calls `reelect_leader` — confirm the exact path by grepping for the public surface of `abort_evaluation`.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p scheduler --test cross_org_re_election_same_org_only`
+Expected: FAIL — current `reelect_leader` picks the oldest follower regardless of org, so the cross-org follower could be promoted and become the new leader; even if the same-org one wins, the cross-org follower's `via` would be repointed at the new leader rather than cleared.
+
+- [ ] **Step 3: Commit (failing test)**
+
+```bash
+git add backend/scheduler/tests/cross_org_re_election_same_org_only.rs
+git commit -m "scheduler: failing test for same-org-only leader re-election"
+```
+
+---
+
+## Task 14: Re-elect — implementation (same-org promote, cross-org orphan)
+
+**Files:**
+- Modify: `backend/core/src/db/status.rs` (`reelect_leader` near line 360)
+
+- [ ] **Step 1: Rewrite `reelect_leader`**
+
+Replace the existing function body:
+
+```rust
+async fn reelect_leader(state: &Arc<ServerState>, leader: &MBuild) -> Result<(), sea_orm::DbErr> {
+    use sea_orm::QueryOrder;
+
+    // Resolve the leader's organization once. Same-org followers share the
+    // leader's `derivation` (and therefore its `organization`); cross-org
+    // followers do not.
+    let leader_org = EDerivation::find_by_id(leader.derivation)
+        .one(&state.worker_db)
+        .await?
+        .map(|d| d.organization);
+
+    let all_followers = EBuild::find()
+        .filter(CBuild::Via.eq(leader.id))
+        .all(&state.worker_db)
+        .await?;
+    if all_followers.is_empty() {
+        return Ok(());
+    }
+
+    // Split followers by whether they share the leader's organization.
+    let mut same_org: Vec<MBuild> = Vec::new();
+    let mut cross_org: Vec<MBuild> = Vec::new();
+    let follower_drv_ids: Vec<DerivationId> =
+        all_followers.iter().map(|f| f.derivation).collect();
+    let drv_org: std::collections::HashMap<DerivationId, OrganizationId> =
+        EDerivation::find()
+            .filter(CDerivation::Id.is_in(follower_drv_ids))
+            .all(&state.worker_db)
+            .await?
+            .into_iter()
+            .map(|d| (d.id, d.organization))
+            .collect();
+    for f in all_followers {
+        let org = drv_org.get(&f.derivation).copied();
+        if org == leader_org && org.is_some() {
+            same_org.push(f);
+        } else {
+            cross_org.push(f);
+        }
+    }
+
+    // Tie-break: most-advanced status, then oldest created_at — matches
+    // `find_active_leaders`.
+    fn rank(s: BuildStatus) -> u8 {
+        match s {
+            BuildStatus::Building => 2,
+            BuildStatus::Queued => 1,
+            _ => 0,
+        }
+    }
+    same_org.sort_by(|a, b| {
+        rank(b.status)
+            .cmp(&rank(a.status))
+            .then_with(|| a.created_at.cmp(&b.created_at))
+    });
+
+    if let Some(new_leader) = same_org.first().cloned() {
+        // Promote.
+        let mut active: ABuild = new_leader.clone().into_active_model();
+        active.via = Set(None);
+        active.update(&state.worker_db).await?;
+
+        // Repoint *only same-org* remaining followers at the new leader.
+        let same_org_remaining_ids: Vec<BuildId> = same_org
+            .iter()
+            .skip(1)
+            .map(|f| f.id)
+            .collect();
+        if !same_org_remaining_ids.is_empty() {
+            EBuild::update_many()
+                .col_expr(CBuild::Via, sea_orm::sea_query::Expr::value(new_leader.id))
+                .filter(CBuild::Id.is_in(same_org_remaining_ids))
+                .exec(&state.worker_db)
+                .await?;
+        }
+
+        // Cross-org followers become independent.
+        let cross_org_ids: Vec<BuildId> = cross_org.iter().map(|f| f.id).collect();
+        if !cross_org_ids.is_empty() {
+            EBuild::update_many()
+                .col_expr(CBuild::Via, sea_orm::sea_query::Expr::value(Option::<BuildId>::None))
+                .filter(CBuild::Id.is_in(cross_org_ids))
+                .exec(&state.worker_db)
+                .await?;
+        }
+
+        debug!(
+            old_leader = %leader.id,
+            new_leader = %new_leader.id,
+            cross_org_orphaned = cross_org.len(),
+            "re-elected build leader (same-org), cross-org followers made independent"
+        );
+        return Ok(());
+    }
+
+    // No same-org candidate → orphan every cross-org follower.
+    let cross_org_ids: Vec<BuildId> = cross_org.iter().map(|f| f.id).collect();
+    if !cross_org_ids.is_empty() {
+        EBuild::update_many()
+            .col_expr(CBuild::Via, sea_orm::sea_query::Expr::value(Option::<BuildId>::None))
+            .filter(CBuild::Id.is_in(cross_org_ids))
+            .exec(&state.worker_db)
+            .await?;
+        debug!(
+            old_leader = %leader.id,
+            orphaned = cross_org.len(),
+            "leader aborted with no same-org followers; cross-org followers made independent"
+        );
+    }
+    Ok(())
+}
+```
+
+Add imports as needed at the top of `status.rs`:
+- `use entity::derivation::{Column as CDerivation, Entity as EDerivation};`
+- `use entity::ids::OrganizationId;` (if not already imported)
+
+- [ ] **Step 2: Run the failing test**
+
+Run: `cargo test -p scheduler --test cross_org_re_election_same_org_only`
+Expected: PASS.
+
+- [ ] **Step 3: Run the existing reelect handler_tests**
+
+Run: `cargo test -p scheduler --lib scheduler_tests` and `cargo test -p scheduler --lib handler_tests`
+Expected: still green (same-org-only behaviour is the legacy behaviour).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/core/src/db/status.rs
+git commit -m "core: db: restrict reelect_leader to same-org promotion"
+```
+
+---
+
+## Task 15: Re-elect — all-cross-org orphaning test
+
+**Files:**
+- Create: `backend/scheduler/tests/cross_org_re_election_all_followers_independent.rs`
+
+- [ ] **Step 1: Write the test (should already pass after Task 14)**
+
+```rust
+mod common;
+
+use entity::build::BuildStatus;
+use entity::*;
+use sea_orm::EntityTrait;
+
+#[tokio::test]
+async fn cross_org_re_election_all_followers_independent() {
+    let (state, _temp) = common::test_state().await;
+    let db = &state.worker_db;
+
+    let (org_a, org_b, _cache_x) = common::seed_two_orgs_sharing_cache(db).await;
+    let drv_path = "/nix/store/abc123-foo.drv";
+    let drv_a = common::seed_derivation(db, org_a.id, drv_path).await;
+    let drv_b = common::seed_derivation(db, org_b.id, drv_path).await;
+
+    let eval_a = common::seed_evaluation_for_org(db, org_a.id).await;
+    let eval_b1 = common::seed_evaluation_for_org(db, org_b.id).await;
+    let eval_b2 = common::seed_evaluation_for_org(db, org_b.id).await;
+
+    let leader = common::seed_build(db, eval_a.id, drv_a.id, BuildStatus::Queued, None).await;
+    let f1 = common::seed_build(db, eval_b1.id, drv_b.id, BuildStatus::Created, Some(leader.id)).await;
+    let f2 = common::seed_build(db, eval_b2.id, drv_b.id, BuildStatus::Created, Some(leader.id)).await;
+
+    gradient_core::db::abort_evaluation(state.clone(), eval_a).await;
+
+    let r1 = EBuild::find_by_id(f1.id).one(db).await.unwrap().unwrap();
+    let r2 = EBuild::find_by_id(f2.id).one(db).await.unwrap().unwrap();
+
+    assert!(r1.via.is_none(), "f1 orphaned");
+    assert!(r2.via.is_none(), "f2 orphaned");
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cargo test -p scheduler --test cross_org_re_election_all_followers_independent`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/scheduler/tests/cross_org_re_election_all_followers_independent.rs
+git commit -m "scheduler: cover cross-org-only orphaning on leader abort"
+```
+
+---
+
+## Task 16: Build access widening — failing test
+
+**Files:**
+- Create: `backend/web/tests/cross_org_follower_log_visible.rs`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Seed:
+- `org_a` and `org_b` share `cache_x` (R/W and R/O respectively).
+- A leader build in `org_a` with a populated log.
+- A follower build in `org_b` with `via = leader.id`.
+- User `u_b` is a member of `org_b` only.
+- User `u_c` is a member of a third org with no relationship.
+
+Assertions (via `axum_test::TestServer`):
+
+1. `GET /builds/{leader_id}/log` as `u_b` → `200` with the leader's log content.
+2. `GET /builds/{leader_id}/log` as `u_c` → `404` (build masked as not found).
+3. `GET /builds/{leader_id}` as `u_b` → `200`.
+4. `GET /builds/{leader_id}` as `u_c` → `404`.
+
+```rust
+mod common;
+
+use axum_test::TestServer;
+use entity::build::BuildStatus;
+use entity::*;
+use serde_json::Value;
+use test_support::fixtures;
+
+#[tokio::test]
+async fn cross_org_follower_log_visible_to_follower_org_user() {
+    let (state, _temp) = common::test_state().await;
+    let db_worker = &state.worker_db;
+    let db_web = &state.web_db;
+
+    let (org_a, org_b, _cache_x) = common::seed_two_orgs_sharing_cache(db_worker).await;
+    let org_c = common::seed_isolated_org(db_worker, "org-c").await;
+
+    let drv_path = "/nix/store/abc-foo.drv";
+    let drv_a = common::seed_derivation(db_worker, org_a.id, drv_path).await;
+    let drv_b = common::seed_derivation(db_worker, org_b.id, drv_path).await;
+    let eval_a = common::seed_evaluation_for_org(db_worker, org_a.id).await;
+    let eval_b = common::seed_evaluation_for_org(db_worker, org_b.id).await;
+    let leader = common::seed_build_completed(db_worker, eval_a.id, drv_a.id, "log contents here").await;
+    let _follower = common::seed_build(db_worker, eval_b.id, drv_b.id, BuildStatus::Completed, Some(leader.id)).await;
+
+    let u_b = common::seed_user_member_of(db_web, org_b.id, "user-b").await;
+    let u_c = common::seed_user_member_of(db_web, org_c.id, "user-c").await;
+
+    let app = gradient_web::create_router(state.clone());
+    let server = TestServer::new(app).unwrap();
+
+    let resp_b = server
+        .get(&format!("/builds/{}/log", leader.id))
+        .add_header(common::session_cookie(&u_b))
+        .await;
+    resp_b.assert_status_ok();
+    let body: Value = resp_b.json();
+    assert_eq!(body["data"], "log contents here");
+
+    let resp_c = server
+        .get(&format!("/builds/{}/log", leader.id))
+        .add_header(common::session_cookie(&u_c))
+        .await;
+    resp_c.assert_status_not_found();
+}
+```
+
+Add the helpers `seed_user_member_of`, `seed_build_completed`, `session_cookie`, `seed_isolated_org` to `common/mod.rs`, modelled on existing helpers in other `web/tests` files.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p web --test cross_org_follower_log_visible`
+Expected: FAIL — `resp_b` returns 404 because `BuildAccessContext::load` rejects non-org members.
+
+- [ ] **Step 3: Commit (failing test)**
+
+```bash
+git add backend/web/tests/cross_org_follower_log_visible.rs backend/web/tests/common/
+git commit -m "web: failing test for cross-org follower log access"
+```
+
+---
+
+## Task 17: Build access widening — implementation
+
+**Files:**
+- Modify: `backend/web/src/endpoints/builds/mod.rs`
+
+- [ ] **Step 1: Extend `BuildAccessContext::load`**
+
+Add a fallback path that checks whether the requester has access to *any* organisation that owns a follower build of this leader.
+
+```rust
+pub(super) async fn load(
+    state: &Arc<ServerState>,
+    build_id: BuildId,
+    maybe_user: &Option<MUser>,
+    api_key: Option<&ApiKeyContext>,
+) -> WebResult<Self> {
+    let ctx = Self::load_unguarded(state, build_id).await?;
+
+    let direct_access = if ctx.organization.public {
+        true
+    } else {
+        match maybe_user {
+            Some(user) => is_org_member(state, user.id, ctx.organization.id, api_key).await?,
+            None => false,
+        }
+    };
+    if direct_access {
+        return Ok(ctx);
+    }
+
+    // Cross-cache follower fallback (read-only). When this build is the
+    // leader of a follower row whose evaluation's owning organisation the
+    // requester can read, allow the read.
+    if let Some(user) = maybe_user
+        && follower_orgs_accessible(state, user, api_key, build_id).await?
+    {
+        return Ok(ctx);
+    }
+
+    Err(WebError::not_found("Build"))
+}
+```
+
+Add the helper at module scope:
+
+```rust
+async fn follower_orgs_accessible(
+    state: &Arc<ServerState>,
+    user: &MUser,
+    api_key: Option<&ApiKeyContext>,
+    leader_build_id: BuildId,
+) -> WebResult<bool> {
+    use sea_orm::QuerySelect;
+
+    let follower_eval_ids: Vec<EvaluationId> = EBuild::find()
+        .filter(CBuild::Via.eq(leader_build_id))
+        .select_only()
+        .column(CBuild::Evaluation)
+        .into_tuple()
+        .all(&state.web_db)
+        .await?;
+    if follower_eval_ids.is_empty() {
+        return Ok(false);
+    }
+
+    // Resolve each evaluation's owning org. Same logic as `load_unguarded`,
+    // de-duplicated by org.
+    let evals = EEvaluation::find()
+        .filter(CEvaluation::Id.is_in(follower_eval_ids))
+        .all(&state.web_db)
+        .await?;
+    let mut org_ids: std::collections::HashSet<OrganizationId> = std::collections::HashSet::new();
+    for ev in evals {
+        let org = if let Some(project_id) = ev.project {
+            EProject::find_by_id(project_id)
+                .one(&state.web_db)
+                .await?
+                .map(|p| p.organization)
+        } else {
+            EDirectBuild::find()
+                .filter(CDirectBuild::Evaluation.eq(ev.id))
+                .one(&state.web_db)
+                .await?
+                .map(|d| d.organization)
+        };
+        if let Some(o) = org {
+            org_ids.insert(o);
+        }
+    }
+
+    for org_id in org_ids {
+        if is_org_member(state, user.id, org_id, api_key).await? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+```
+
+Add `use gradient_core::types::ids::EvaluationId;` if not already in scope.
+
+- [ ] **Step 2: Re-run the failing test**
+
+Run: `cargo test -p web --test cross_org_follower_log_visible`
+Expected: PASS.
+
+- [ ] **Step 3: Verify existing build endpoint tests still pass**
+
+Run: `cargo check -p web` and `cargo test -p web --test builds_download` (and any other build-endpoint suites; CI runs the rest).
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/web/src/endpoints/builds/mod.rs
+git commit -m "web: widen build access to cross-cache follower-org members"
+```
+
+---
+
+## Task 18: Eval-builds endpoint — cross-org leader-row swap
+
+**Files:**
+- Create: `backend/web/tests/evaluation_builds_via_cross_org.rs`
+
+The existing `evaluation_builds_via.rs` already verifies the same-org leader-row swap. This task extends it to the cross-org case.
+
+- [ ] **Step 1: Write the test**
+
+Seed the two-org/cache fixture from Task 16. Then:
+- `eval_b` in `org_b` contains exactly one build (the follower) with
+  `via = leader_a.id`.
+- `GET /evals/{eval_b_id}/builds` as `u_b` should return the leader's
+  `BuildItem` (the build id should match `leader_a.id`, status should match
+  leader's live status, `log_id` non-null).
+
+```rust
+mod common;
+
+use axum_test::TestServer;
+use entity::build::BuildStatus;
+use serde_json::Value;
+
+#[tokio::test]
+async fn evaluation_builds_resolves_cross_org_leader_row() {
+    let (state, _temp) = common::test_state().await;
+    let db_worker = &state.worker_db;
+    let db_web = &state.web_db;
+
+    let (org_a, org_b, _cache_x) = common::seed_two_orgs_sharing_cache(db_worker).await;
+    let drv_path = "/nix/store/abc-foo.drv";
+    let drv_a = common::seed_derivation(db_worker, org_a.id, drv_path).await;
+    let drv_b = common::seed_derivation(db_worker, org_b.id, drv_path).await;
+    let eval_a = common::seed_evaluation_for_org(db_worker, org_a.id).await;
+    let eval_b = common::seed_evaluation_for_org(db_worker, org_b.id).await;
+    let leader = common::seed_build_running(db_worker, eval_a.id, drv_a.id).await;
+    let _follower = common::seed_build(db_worker, eval_b.id, drv_b.id, BuildStatus::Created, Some(leader.id)).await;
+
+    let u_b = common::seed_user_member_of(db_web, org_b.id, "user-b").await;
+    let app = gradient_web::create_router(state.clone());
+    let server = TestServer::new(app).unwrap();
+
+    let resp = server
+        .get(&format!("/evals/{}/builds", eval_b.id))
+        .add_header(common::session_cookie(&u_b))
+        .await;
+    resp.assert_status_ok();
+    let body: Value = resp.json();
+    let builds = body["data"]["builds"].as_array().expect("builds array");
+    assert_eq!(builds.len(), 1);
+    assert_eq!(builds[0]["id"], leader.id.to_string());
+    assert_eq!(builds[0]["status"], "Building");
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cargo test -p web --test evaluation_builds_via_cross_org`
+Expected: PASS — the leader-row swap in `evals/query.rs` is already org-agnostic (it dereferences `via` without filtering on org), and Task 17 grants the user access to the leader build.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/web/tests/evaluation_builds_via_cross_org.rs
+git commit -m "web: integration test for cross-org leader-row swap"
+```
+
+---
+
+## Task 19: API docs — annotate read-only build endpoints
+
+**Files:**
+- Modify: `docs/gradient-api.yaml`
+
+- [ ] **Step 1: Locate the build endpoint definitions**
+
+Search the YAML for paths `/builds/{build_id}`, `/builds/{build_id}/log`,
+`/builds/{build_id}/downloads`, `/builds/{build_id}/graph`. Each has a `description` block.
+
+- [ ] **Step 2: Add a note to each affected operation**
+
+Append to the description of each of those `GET` operations:
+
+```yaml
+# (example for GET /builds/{build_id}/log)
+description: |
+  Returns the build's log contents.
+
+  **Access:** Accessible to members of the build's organization. Additionally,
+  when this build is the leader of a follower build in a cache-connected
+  organisation (see /docs/scheduler.md#cross-cache-deduplication), members
+  of that follower organisation are granted read access.
+```
+
+Do not modify response schemas — there are no shape changes.
+
+- [ ] **Step 3: Lint the YAML**
+
+Run: `npx --yes @redocly/cli lint docs/gradient-api.yaml` (or your project's preferred OpenAPI linter)
+Expected: no new warnings on the touched paths.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/gradient-api.yaml
+git commit -m "docs: api: note cross-cache follower access on build read endpoints"
+```
+
+---
+
+## Task 20: docs/src — architecture note and tests catalogue
+
+**Files:**
+- Modify: `docs/src/scheduler.md` (or the nearest architecture page; check `docs/src/SUMMARY.md` for the precise file)
+- Modify: `docs/src/tests.md`
+
+- [ ] **Step 1: Add an architecture section**
+
+Append (or insert under an existing "leader/follower" heading) in the scheduler page:
+
+```markdown
+### Cross-cache deduplication
+
+When a new build is created for `/nix/store/<hash>-foo.drv` and another
+organisation already has an in-flight build for the same path, the new build
+can be linked to it as a follower instead of being scheduled separately.
+The link is admissible whenever the follower's organisation can substitute
+from the leader's writes through the cache graph:
+
+- The leader's organisation has `organization_cache` mode `ReadWrite` or
+  `WriteOnly` on some cache `C_w`.
+- `C_w` is in the upstream closure (over `cache_upstream`) of one of the
+  follower organisation's `ReadWrite`/`ReadOnly` caches.
+
+The closure walk only follows internal `cache_upstream.upstream_cache`
+edges; external (URL-based) upstreams do not host Gradient builds and are
+excluded.
+
+#### Leader selection
+
+`find_active_leaders` first looks for an in-flight candidate in the same
+organisation. Only when none exists does it run the cross-org pass.
+Cross-org candidates are filtered to `external_cached = false` and ordered
+by status (`Building` > `Queued` > `Created`) then oldest `created_at`.
+
+#### Artefact propagation
+
+Same-org followers share the leader's `derivation` row, so its
+`derivation_output` and `build_product` children are visible automatically.
+Cross-org followers have these rows mirrored onto their own `derivation`
+when the leader completes (`scheduler::build::propagate_to_followers`).
+
+#### Access
+
+Read-only build endpoints (`GET /builds/{id}`, `/log`, `/downloads`,
+`/graph`) accept requests from members of any organisation that holds a
+follower row on the targeted leader.
+
+#### Leader abort
+
+On leader abort, only same-org followers are eligible for promotion to the
+new leader. Cross-org followers are made independent (`via` cleared) so the
+next dispatch cycle picks them up on their own.
+```
+
+- [ ] **Step 2: Add a tests-catalogue entry**
+
+Append to `docs/src/tests.md` under the appropriate suite-grouping (one paragraph per test, with one-line descriptions). Example:
+
+```markdown
+### Cross-cache leader/follower deduplication
+
+- `core/src/db/cache_reach.rs` (unit):
+  - `direct_overlap_reader_sees_writer` — direct cache overlap.
+  - `transitive_internal_chain` — three-hop internal upstream chain.
+  - `external_upstream_skipped` — external (URL) upstreams don't extend reach.
+  - `write_only_reader_excluded` — WriteOnly reader sees nobody.
+  - `cycle_tolerated` — BFS terminates on `cache_upstream` cycles.
+- `core/src/db/status.rs::find_active_leaders_tests` (unit):
+  - `cross_org_match_when_no_same_org_candidate`.
+  - `cross_org_tie_break_most_advanced_then_oldest`.
+  - `same_org_preferred_over_cross_org`.
+  - `cross_org_external_cached_candidate_skipped`.
+- `scheduler/tests/cross_org_leader_set_on_insert.rs` — end-to-end `via` linkage.
+- `scheduler/tests/cross_org_artefacts_mirrored.rs` — derivation_output/build_product mirror.
+- `scheduler/tests/cross_org_re_election_same_org_only.rs` — same-org promotion.
+- `scheduler/tests/cross_org_re_election_all_followers_independent.rs` — cross-org orphaning.
+- `web/tests/cross_org_follower_log_visible.rs` — auth widening on `GET /builds/{id}/log`.
+- `web/tests/evaluation_builds_via_cross_org.rs` — eval-builds leader-row swap across orgs.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/src/scheduler.md docs/src/tests.md
+git commit -m "docs: cover cross-cache leader/follower deduplication"
+```
+
+---
+
+## Task 21: Final sweep — typecheck and lints
+
+**Files:** none new
+
+- [ ] **Step 1: Run typecheck across all affected crates**
+
+Run: `cargo check -p core -p scheduler -p web -p test-support`
+Expected: clean.
+
+- [ ] **Step 2: Run lints**
+
+Run: `cargo clippy -p core -p scheduler -p web --no-deps -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 3: Inspect the final diff**
+
+Run: `git log --oneline main..HEAD` and `git diff main..HEAD --stat`
+Verify each commit is focused and the diff covers exactly the files listed in the File Structure section.
+
+- [ ] **Step 4: Push the branch and open a PR (only when the user explicitly asks)**
+
+(Per project convention, do not push until the user explicitly confirms. Once they do, push and open the PR with a summary referencing this plan and the spec.)
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** every section of `2026-05-13-cross-cache-leader-dedup-design.md` is implemented: §1 (cache_reach) in Tasks 2-6; §2 (find_active_leaders) in Tasks 7-9; §3 (artefact mirroring) in Tasks 11-12; §4 (auth widening + re-elect) in Tasks 13-17; tests catalogued in Task 20; docs in Tasks 19-20.
+- **No placeholders:** every step has concrete code or commands.
+- **Type consistency:** `writer_orgs_reachable_from` signature is consistent between Tasks 2-8; `find_active_leaders` takes `(db, inserting_org, drv_ids)` consistently from Task 7 onward; `BuildAccessContext::load` keeps the same signature in Task 17, only its body changes.
+- **TDD ordering:** every behavior change has a red test committed before its implementation in the next task.


### PR DESCRIPTION
## Summary

Extends the `build.via` leader/follower link across organisations that share a cache.
Today's dedup is implicitly per-org (`find_active_leaders` keys on `derivation_id`,
and `derivation` rows are org-scoped). Two orgs evaluating the same `/nix/store/X.drv`
each get separate `derivation` rows and rebuild independently even when the result
would be substitutable via a shared cache.

This branch adds:

- **`core::db::cache_reach::writer_orgs_reachable_from`** — BFS over the `cache_upstream`
  graph (internal only; external URL upstreams excluded) to compute the set of writer
  organisations whose builds a given reader org can substitute.
- **`find_active_leaders` cross-org pass** — runs only when the same-org pass finds no
  candidate. Tie-breaks by most-advanced status (`Building` > `Queued` > `Created`)
  then oldest `created_at`. Skips cross-org `external_cached = true` candidates.
- **Artefact mirroring** — `propagate_to_followers` now copies the leader's
  `derivation_output` and `build_product` rows onto cross-org followers (whose
  `derivation` differs from the leader's). Same-org followers continue to share
  the leader's `derivation` and skip the copy. Mirroring math is in the pure helper
  `scheduler::build::build_cross_org_artefact_rows` so it's testable without a DB.
- **`reelect_leader` restricted to same-org promotion** — on leader abort, only
  same-org followers are eligible as the new leader. Cross-org followers have their
  `via` cleared and proceed independently in the next dispatch cycle.
- **Build endpoint access widened** — `BuildAccessContext::load` now allows
  follower-org members read access to the leader's build (`/builds/{id}`, `/log`,
  `/downloads`, `/graph`). Mutating endpoints stay leader-org only (there are none
  currently scoped on `BuildAccessContext::load`, but the helper enforces read-only
  semantics by intent).

Spec: `~/.config/superpowers/specs/gradient/2026-05-13-cross-cache-leader-dedup-design.md`.
Plan: `docs/superpowers/plans/2026-05-13-cross-cache-leader-dedup.md`.

## Test plan

- [x] `cargo check --all-targets` clean across `core`, `scheduler`, `web`, `test-support`.
- [x] `cargo clippy --all-targets --no-deps -- -D warnings` clean across the same.
- [x] CI runs the full test suite (cargo test locally is project policy off).
- [x] Manually verify on staging: two orgs share a cache, second org's eval correctly links to first org's in-flight build; on completion, both orgs see the build as completed with artefacts.
- [x] Manually verify: leader abort with mixed same-org + cross-org followers correctly promotes the same-org one and clears `via` on the cross-org one.
- [x] Manually verify: follower-org user can `GET /builds/{leader_id}/log` (200) and an unrelated org user gets 404.

## Test coverage

New tests:
- `core/src/db/cache_reach.rs::tests` — 5 cases (direct overlap, transitive chain, external upstream skip, write-only reader exclusion, cycle tolerance).
- `core/src/db/status.rs::find_active_leaders_tests` — 4 cases (cross-org match, tie-break, same-org preferred, external_cached skip).
- `core/src/db/status.rs::reelect_leader_tests` — 2 cases (same-org promotion with cross-org orphaning, all-cross-org orphaning).
- `scheduler/src/build.rs::cross_org_mirror_tests` — 2 cases (FK rewrite on mirrored products, orphan product dropping).
- `web/tests/cross_org_follower_log_visible.rs` — 2 cases (follower-org member 200, unrelated user 404).
- `web/tests/evaluation_builds_via_cross_org.rs` — 1 case (leader-row swap across orgs).