### PR TITLE
Restore MockConnectInfo fallback for nix_cache_info

### DIFF
--- a/backend/web/src/endpoints/caches/narinfo.rs
+++ b/backend/web/src/endpoints/caches/narinfo.rs
@@ -6,15 +6,41 @@
 
 use super::helpers::{CacheContext, JsonFlag, get_nar_by_hash};
 use crate::error::{WebError, WebResult};
-use axum::extract::{ConnectInfo, Extension, Path, Query, State};
+use axum::extract::connect_info::MockConnectInfo;
+use axum::extract::{ConnectInfo, FromRequestParts, Path, Query, State};
+use axum::http::request::Parts;
 use axum::http::{HeaderMap, HeaderValue, header};
 use axum::response::{IntoResponse, Response};
 use gradient_core::sources::{get_hash_from_url, verify_narinfo_signature};
 use gradient_core::types::*;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tracing::warn;
+
+/// Optional peer address — mirrors `ConnectInfo`'s real / `MockConnectInfo`
+/// fallback, but yields `None` instead of 500 when the runtime wired neither
+/// (`axum_test::TestServer` without `MockConnectInfo`, ad-hoc tower stacks).
+pub struct OptionalPeer(pub Option<SocketAddr>);
+
+impl<S: Send + Sync> FromRequestParts<S> for OptionalPeer {
+    type Rejection = Infallible;
+
+    async fn from_request_parts(parts: &mut Parts, _: &S) -> Result<Self, Self::Rejection> {
+        let addr = parts
+            .extensions
+            .get::<ConnectInfo<SocketAddr>>()
+            .map(|c| c.0)
+            .or_else(|| {
+                parts
+                    .extensions
+                    .get::<MockConnectInfo<SocketAddr>>()
+                    .map(|m| m.0)
+            });
+        Ok(OptionalPeer(addr))
+    }
+}
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -29,15 +55,15 @@ fn text_response(content_type: &'static str, body: String) -> WebResult<Response
 
 pub async fn nix_cache_info(
     state: State<Arc<ServerState>>,
-    connect_info: Option<Extension<ConnectInfo<SocketAddr>>>,
+    OptionalPeer(peer): OptionalPeer,
     headers: HeaderMap,
     Path(cache): Path<String>,
     Query(flag): Query<JsonFlag>,
 ) -> WebResult<Response> {
     let ctx = CacheContext::load(&state, &headers, cache).await?;
 
-    let priority = match (ctx.cache.local_priority, connect_info) {
-        (Some(p), Some(Extension(ConnectInfo(addr)))) if p != 0 => {
+    let priority = match (ctx.cache.local_priority, peer) {
+        (Some(p), Some(addr)) if p != 0 => {
             let client_ip = crate::client_ip::resolve_client_ip(
                 &headers,
                 addr.ip(),


### PR DESCRIPTION
## Summary
Fixes `local_priority_swapped_when_xff_in_local_ips` (and any future test using `MockConnectInfo`) on `main`.

PR #227 swapped `nix_cache_info`'s mandatory `ConnectInfo<SocketAddr>` extractor for `Option<Extension<ConnectInfo<SocketAddr>>>` to avoid 500s when no connect-info layer is wired. That works for `TestServer::new(...)` (no extension at all) but silently breaks `MockConnectInfo`: per axum 0.8 (`extract/connect_info.rs:223-232`), `MockConnectInfo<T>` inserts itself as `MockConnectInfo<T>`, not `ConnectInfo<T>`. The real `ConnectInfo` extractor has a built-in fallback to look up `MockConnectInfo<T>`; an `Extension<ConnectInfo<T>>` does not.

The result was that `local_priority_swapped_when_xff_in_local_ips` returned `Priority: 40` (default) instead of `10` (local override) because the `Some(Extension(ConnectInfo(addr)))` arm never matched.

## Fix
Introduce a tiny `OptionalPeer` extractor in `narinfo.rs` that mirrors `ConnectInfo`'s real-then-mock lookup pattern and yields `Option<SocketAddr>`. Handler signature becomes `OptionalPeer(peer): OptionalPeer`; match arm simplifies to `(Some(p), Some(addr))`. Behavior:
- Production (`into_make_service_with_connect_info`): finds `ConnectInfo<SocketAddr>` → `Some(addr)`.
- Tests using `MockConnectInfo`: falls back to `MockConnectInfo<SocketAddr>` → `Some(addr)`.
- Tests / setups with neither: `None` → uses default cache priority (no 500).

## Test plan
- [x] CI green on `web::tests::cache_local_priority::*` (was failing on main).
- [x] CI green on `web::tests::cache_json::nix_cache_info_*` (originally fixed by PR #227, still passing).