### PR TITLE
fix: add overlays also on standalone workers

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -106,7 +106,7 @@
       deploy = ./nix/modules/gradient-deploy.nix;
       gradient = { config, lib, ... }: {
         imports = [ ./nix/modules/gradient.nix ];
-        nixpkgs.overlays = lib.mkIf config.services.gradient.enable [
+        nixpkgs.overlays = lib.mkIf (config.services.gradient.enable || config.services.gradient.worker.enable) [
           self.overlays.default
         ];
       };


### PR DESCRIPTION
Currently the package overlays (needed for `pkgs.gradient`) is only added when `services.gradient.enable` is set to true (so when the frontend / server is running on the host.

This PR also adds the overlay when only `services.gradient.worker.enable` is set to true, which is the case on a host only running the gradient server (which also relys on `pkgs.gradient`)

This fixes this evaluation error which would occur otherwise:
``` 
```
error:
       … while calling the 'head' builtin
         at «github:nixos/nixpkgs/15f4ee454b1dce334612fa6843b3e05cf546efab?narHash=sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM%2BZ4%3D»/lib/attrsets.nix:1712:13:
         1711|           if length values == 1 || pred here (elemAt values 1) (head values) then
         1712|             head values
             |             ^
         1713|           else

       … while evaluating the attribute 'value'
         at «github:nixos/nixpkgs/15f4ee454b1dce334612fa6843b3e05cf546efab?narHash=sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM%2BZ4%3D»/lib/modules.nix:1166:7:
         1165|     // {
         1166|       value = addErrorContext "while evaluating the option `${showOption loc}':" value;
             |       ^
         1167|       inherit (res.defsFinal') highestPrio;

       … while evaluating the option `system.build.toplevel':

       … while evaluating definitions from `/nix/store/wjfxdzblindbl9sp2hbwhi4iyh5jh348-source/nixos/modules/system/activation/top-level.nix':

       … while evaluating the option `warnings':

       … while evaluating definitions from `/nix/store/wjfxdzblindbl9sp2hbwhi4iyh5jh348-source/nixos/modules/system/boot/systemd.nix':

       … while evaluating the option `systemd.services.gradient-worker.serviceConfig':

       … while evaluating definitions from `/nix/store/pa5dvnrhxqsh9r8p2rfm9viv82w2qmpm-source/nix/modules/gradient-worker.nix':

       … while evaluating the option `services.gradient.worker.packages.gradient':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: gradient cannot be found in pkgs
```  