### PR TITLE
worker: install rustls crypto provider before TLS handshake (#232)

### DIFF
--- a/backend/core/src/http.rs
+++ b/backend/core/src/http.rs
@@ -23,8 +23,20 @@ pub fn user_agent() -> String {
     )
 }
 
-fn rustls_config() -> rustls::ClientConfig {
+/// Install the process-wide rustls `CryptoProvider`.
+///
+/// rustls 0.23 refuses to auto-pick a provider when zero or multiple are
+/// enabled via crate features; any TLS handshake started before a provider is
+/// installed panics. Binaries must call this **before** any code path opens a
+/// TLS connection (e.g. `tokio_tungstenite::connect_async` for `wss://`,
+/// `reqwest` HTTPS, sea-orm postgres TLS). The call is idempotent — the second
+/// install attempt returns `Err`, which we deliberately ignore.
+pub fn init_crypto_provider() {
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+}
+
+fn rustls_config() -> rustls::ClientConfig {
+    init_crypto_provider();
     let mut roots = rustls::RootCertStore::empty();
     roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
     rustls::ClientConfig::builder()
@@ -48,6 +60,22 @@ mod tests {
     #[test]
     fn build_client_succeeds() {
         let _ = build_client().expect("client builds with defaults");
+    }
+
+    /// Regression test for issue #232: without an installed `CryptoProvider`,
+    /// rustls panics inside `ClientConfig::builder()` when feature
+    /// auto-detection fails. `init_crypto_provider` must be idempotent and
+    /// must make subsequent rustls config construction succeed.
+    #[test]
+    fn init_crypto_provider_is_idempotent_and_enables_tls() {
+        init_crypto_provider();
+        init_crypto_provider();
+
+        let mut roots = rustls::RootCertStore::empty();
+        roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+        let _ = rustls::ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_no_client_auth();
     }
 
     #[test]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -53,6 +53,10 @@ fn init_logging(logging: &LoggingArgs) {
 }
 
 pub fn main() -> std::io::Result<()> {
+    // Install rustls provider before any TLS handshake (postgres TLS, outbound
+    // HTTPS, …) — rustls 0.23 panics otherwise. See issue #232.
+    gradient_core::http::init_crypto_provider();
+
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .thread_stack_size(8 * 1024 * 1024)

--- a/backend/worker/src/main.rs
+++ b/backend/worker/src/main.rs
@@ -51,6 +51,11 @@ fn main() -> Result<()> {
         return nix::eval_worker::run_eval_worker().map_err(anyhow::Error::from);
     }
 
+    // Must precede the first TLS handshake — `connect_async` for `wss://` is
+    // the first thing the runtime does and rustls 0.23 panics if no provider
+    // is installed (see issue #232).
+    gradient_core::http::init_crypto_provider();
+
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async move {
         info!(server_url = %config.server_url, "gradient-worker starting");

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -1102,6 +1102,14 @@ Unit tests in `backend/core/src/http.rs`:
   can identify and contact-trace outbound calls (`#205`).
 - `user_agent_does_not_use_lowercase_brand` — regression guard against
   the previous lowercase `gradient/` format (`#205`).
+- `init_crypto_provider_is_idempotent_and_enables_tls` — regression
+  guard for `#232`: `init_crypto_provider` installs the rustls
+  `aws-lc-rs` provider, may be called repeatedly, and unblocks
+  `rustls::ClientConfig::builder()` (which otherwise panics when the
+  process-level provider has not been chosen). Worker (`worker::main`)
+  and server (`backend::main`) call it before any TLS handshake so
+  `wss://` connections through `tokio_tungstenite::connect_async`
+  succeed under TLS.
 
 ## Graceful shutdown (`#72`)
 


### PR DESCRIPTION
Fixes #232.

`tokio_tungstenite::connect_async` for `wss://` is the first thing the
worker does after parsing config. rustls 0.23 panics there if no
process-level `CryptoProvider` is installed and crate-feature
auto-detection finds zero-or-many providers — exactly the state in this
workspace (`aws-lc-rs` enabled on the direct `rustls` dep,
`rustls-platform-verifier` pulled in transitively by `reqwest 0.13`).

`core::http::rustls_config` already installs the provider, but only
lazily through `build_client()` (called on first NAR upload), so the
worker hits the websocket handshake first and panics.

Make the install explicit: export `core::http::init_crypto_provider`
(idempotent, calls `aws_lc_rs::default_provider().install_default()`)
and call it at the top of both `worker::main` and `backend::main`,
before any runtime starts a TLS connection.