### PR TITLE
backend: fix Postgres parameter overflow on /evals/{eval}/builds

### DIFF
--- a/backend/core/src/ci/webhook.rs
+++ b/backend/core/src/ci/webhook.rs
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-use crate::executer::nix_store_path;
 use crate::types::input::load_secret_bytes;
 use crate::types::*;
 use anyhow::Result;
@@ -308,7 +307,7 @@ pub async fn fire_build_webhook(state: Arc<ServerState>, build: MBuild, status: 
         .await
         .ok()
         .flatten()
-        .map(|d| nix_store_path(&d.derivation_path));
+        .map(|d| d.store_path());
 
     let payload = serde_json::json!({
         "build_id": build.id,

--- a/backend/core/src/db/status.rs
+++ b/backend/core/src/db/status.rs
@@ -524,12 +524,12 @@ pub async fn find_active_leaders<C: ConnectionTrait>(
         .all(db)
         .await?;
     let mut path_to_drv: HashMap<String, DerivationId> = HashMap::new();
-    let mut drv_paths: Vec<String> = Vec::new();
+    let mut drv_hashes: Vec<String> = Vec::new();
     for d in &inserting_drv_rows {
-        path_to_drv.insert(d.derivation_path.clone(), d.id);
-        drv_paths.push(d.derivation_path.clone());
+        path_to_drv.insert(d.drv_path(), d.id);
+        drv_hashes.push(d.hash.clone());
     }
-    if drv_paths.is_empty() {
+    if drv_hashes.is_empty() {
         return Ok(out);
     }
 
@@ -541,7 +541,7 @@ pub async fn find_active_leaders<C: ConnectionTrait>(
     }
 
     let candidate_drvs = EDerivation::find()
-        .filter(CDerivation::DerivationPath.is_in(drv_paths.clone()))
+        .filter(CDerivation::Hash.is_in(drv_hashes))
         .filter(CDerivation::Organization.is_in(reachable.into_iter().collect::<Vec<_>>()))
         .all(db)
         .await?;
@@ -551,7 +551,7 @@ pub async fn find_active_leaders<C: ConnectionTrait>(
     let candidate_drv_ids: Vec<DerivationId> = candidate_drvs.iter().map(|d| d.id).collect();
     let leader_drv_to_path: HashMap<DerivationId, String> = candidate_drvs
         .into_iter()
-        .map(|d| (d.id, d.derivation_path))
+        .map(|d| (d.id, d.drv_path()))
         .collect();
 
     let candidate_builds = EBuild::find()
@@ -645,7 +645,8 @@ mod reelect_leader_tests {
         MDerivation {
             id,
             organization: owner,
-            derivation_path: "/nix/store/x.drv".into(),
+            hash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
+            name: "x".into(),
             architecture: "x86_64-linux".into(),
             created_at: chrono::NaiveDateTime::default(),
         }
@@ -870,11 +871,12 @@ mod find_active_leaders_tests {
         }
     }
 
-    fn drv_row(id: DerivationId, owner: OrganizationId, path: &str) -> MDerivation {
+    fn drv_row(id: DerivationId, owner: OrganizationId, _path: &str) -> MDerivation {
         MDerivation {
             id,
             organization: owner,
-            derivation_path: path.into(),
+            hash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
+            name: "x".into(),
             architecture: "x86_64-linux".into(),
             created_at: chrono::NaiveDateTime::default(),
         }

--- a/backend/core/src/executer/path_utils.rs
+++ b/backend/core/src/executer/path_utils.rs
@@ -26,8 +26,5 @@ pub fn strip_store_prefix(path: &str) -> &str {
 }
 
 pub fn get_derivation_paths(derivations: &[MDerivation]) -> Vec<String> {
-    derivations
-        .iter()
-        .map(|d| nix_store_path(&d.derivation_path))
-        .collect()
+    derivations.iter().map(|d| d.store_path()).collect()
 }

--- a/backend/core/src/repo/derivation.rs
+++ b/backend/core/src/repo/derivation.rs
@@ -95,10 +95,15 @@ impl<'db> DerivationRepo<'db> {
         Ok(outputs)
     }
 
-    /// Find all outputs by store path.
+    /// Find an output by its `/nix/store/<hash>-<package>` path.
     pub async fn find_output_by_path(&self, store_path: &str) -> Result<Option<MDerivationOutput>> {
+        let bare = store_path.strip_prefix("/nix/store/").unwrap_or(store_path);
+        let Some((hash, package)) = bare.split_once('-') else {
+            return Ok(None);
+        };
         let output = EDerivationOutput::find()
-            .filter(CDerivationOutput::Output.eq(store_path))
+            .filter(CDerivationOutput::Hash.eq(hash))
+            .filter(CDerivationOutput::Package.eq(package))
             .one(self.db)
             .await?;
         Ok(output)

--- a/backend/core/src/sources/nar_path.rs
+++ b/backend/core/src/sources/nar_path.rs
@@ -58,6 +58,19 @@ pub fn get_path_from_derivation_output(output: MDerivationOutput) -> String {
     format!("/nix/store/{}-{}", output.hash, output.package)
 }
 
+/// Parses a bare `<hash>-<name>.drv` (no `/nix/store/` prefix) into its hash
+/// and name components. `name` includes everything after the first `-` minus
+/// the trailing `.drv` suffix. Returns `InvalidPath` when the input is not in
+/// `<hash>-<name>.drv` form.
+pub fn parse_drv_hash_name(drv_path: &str) -> Result<(String, String), SourceError> {
+    let (hash, rest) = drv_path.split_once('-').ok_or(SourceError::InvalidPath)?;
+    let name = rest.strip_suffix(".drv").ok_or(SourceError::InvalidPath)?;
+    if hash.is_empty() || name.is_empty() {
+        return Err(SourceError::InvalidPath);
+    }
+    Ok((hash.to_string(), name.to_string()))
+}
+
 pub fn get_cache_nar_location(base_path: String, hash: String) -> Result<String, SourceError> {
     let hash_hex = hash.as_str();
     std::fs::create_dir_all(format!("{}/nars/{}", base_path, &hash_hex[0..2])).map_err(|e| {
@@ -93,4 +106,33 @@ pub fn get_cache_nar_compressed_location(
         &hash_hex[0..2],
         &hash_hex[2..],
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_canonical_drv_form() {
+        let (h, n) =
+            parse_drv_hash_name("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello-2.12.1.drv").unwrap();
+        assert_eq!(h, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        assert_eq!(n, "hello-2.12.1");
+    }
+
+    #[test]
+    fn rejects_missing_drv_suffix() {
+        assert!(parse_drv_hash_name("abc-foo").is_err());
+    }
+
+    #[test]
+    fn rejects_missing_hash_or_name() {
+        assert!(parse_drv_hash_name("-foo.drv").is_err());
+        assert!(parse_drv_hash_name("abc-.drv").is_err());
+    }
+
+    #[test]
+    fn rejects_missing_dash() {
+        assert!(parse_drv_hash_name("abcfoo.drv").is_err());
+    }
 }

--- a/backend/entity/src/derivation.rs
+++ b/backend/entity/src/derivation.rs
@@ -16,9 +16,24 @@ pub struct Model {
     #[sea_orm(primary_key)]
     pub id: DerivationId,
     pub organization: OrganizationId,
-    pub derivation_path: String,
+    pub hash: String,
+    pub name: String,
     pub architecture: super::server::Architecture,
     pub created_at: NaiveDateTime,
+}
+
+impl Model {
+    /// Canonical `<hash>-<name>.drv` form (no `/nix/store/` prefix), matching
+    /// the wire shape used by workers and the cache narinfo `References:`
+    /// convention.
+    pub fn drv_path(&self) -> String {
+        format!("{}-{}.drv", self.hash, self.name)
+    }
+
+    /// Full `/nix/store/<hash>-<name>.drv` path for display + dispatch.
+    pub fn store_path(&self) -> String {
+        format!("/nix/store/{}-{}.drv", self.hash, self.name)
+    }
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/backend/entity/src/derivation_output.rs
+++ b/backend/entity/src/derivation_output.rs
@@ -17,15 +17,11 @@ pub struct Model {
     pub id: DerivationOutputId,
     pub derivation: DerivationId,
     pub name: String,
-    pub output: String,
     pub hash: String,
     pub package: String,
     pub ca: Option<String>,
     pub nar_size: Option<i64>,
     pub is_cached: bool,
-    /// Link to the `cached_path` row when this output is cached.
-    /// Replaces the old `derivation_output_signature` join — the signature
-    /// lives on `cached_path` directly.
     pub cached_path: Option<CachedPathId>,
     pub created_at: NaiveDateTime,
 }

--- a/backend/migration/src/lib.rs
+++ b/backend/migration/src/lib.rs
@@ -99,6 +99,7 @@ mod m20260510_000001_api_key_options;
 mod m20260510_000002_add_managed_to_role;
 mod m20260511_000000_strip_derivation_path_prefix;
 mod m20260513_000000_add_local_priority_to_cache;
+mod m20260519_000000_normalize_derivation_columns;
 
 pub struct Migrator;
 
@@ -199,6 +200,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260510_000002_add_managed_to_role::Migration),
             Box::new(m20260511_000000_strip_derivation_path_prefix::Migration),
             Box::new(m20260513_000000_add_local_priority_to_cache::Migration),
+            Box::new(m20260519_000000_normalize_derivation_columns::Migration),
         ]
     }
 }

--- a/backend/migration/src/m20260519_000000_normalize_derivation_columns.rs
+++ b/backend/migration/src/m20260519_000000_normalize_derivation_columns.rs
@@ -1,0 +1,214 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Split `derivation.derivation_path` into structured `hash` + `name`
+//! columns and drop the redundant `derivation_output.output` (the full
+//! `/nix/store/<hash>-<package>` path, reconstructed on read from
+//! `hash` + `package`).
+//!
+//! The old schema stored each `<hash>-<name>.drv` derivation path as a
+//! single string and re-parsed it on every read to display a build's name.
+//! When an evaluation contained tens of thousands of builds, the
+//! `GET /evals/{eval}/builds` endpoint hydrated derivations via
+//! `WHERE id IN ($1, $2, ..., $N)`, which overflowed Postgres' 65 535
+//! parameter limit (issue #237). Structured columns let the endpoint sort
+//! by `derivation.name` directly and read the display name without
+//! per-row parsing.
+
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::{ConnectionTrait, Statement};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Derivation::Table)
+                    .add_column(ColumnDef::new(Derivation::Hash).text().null())
+                    .add_column(ColumnDef::new(Derivation::Name).text().null())
+                    .to_owned(),
+            )
+            .await?;
+
+        let db = manager.get_connection();
+        let backend = db.get_database_backend();
+
+        db.execute(Statement::from_string(
+            backend,
+            "UPDATE derivation \
+             SET hash = split_part(derivation_path, '-', 1), \
+                 name = regexp_replace( \
+                     substring(derivation_path FROM position('-' IN derivation_path) + 1), \
+                     '\\.drv$', '' \
+                 ) \
+             WHERE derivation_path LIKE '%-%'",
+        ))
+        .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Derivation::Table)
+                    .modify_column(ColumnDef::new(Derivation::Hash).text().not_null())
+                    .modify_column(ColumnDef::new(Derivation::Name).text().not_null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx-derivation-org-path")
+                    .table(Derivation::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx-derivation-org-hash-name")
+                    .table(Derivation::Table)
+                    .col(Derivation::Organization)
+                    .col(Derivation::Hash)
+                    .col(Derivation::Name)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Derivation::Table)
+                    .drop_column(Derivation::DerivationPath)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(DerivationOutput::Table)
+                    .drop_column(DerivationOutput::Output)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+        let backend = db.get_database_backend();
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(DerivationOutput::Table)
+                    .add_column(ColumnDef::new(DerivationOutput::Output).text().null())
+                    .to_owned(),
+            )
+            .await?;
+
+        db.execute(Statement::from_string(
+            backend,
+            "UPDATE derivation_output \
+             SET output = '/nix/store/' || hash || '-' || package",
+        ))
+        .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(DerivationOutput::Table)
+                    .modify_column(ColumnDef::new(DerivationOutput::Output).text().not_null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Derivation::Table)
+                    .add_column(ColumnDef::new(Derivation::DerivationPath).text().null())
+                    .to_owned(),
+            )
+            .await?;
+
+        db.execute(Statement::from_string(
+            backend,
+            "UPDATE derivation SET derivation_path = hash || '-' || name || '.drv'",
+        ))
+        .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Derivation::Table)
+                    .modify_column(
+                        ColumnDef::new(Derivation::DerivationPath)
+                            .text()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx-derivation-org-hash-name")
+                    .table(Derivation::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx-derivation-org-path")
+                    .table(Derivation::Table)
+                    .col(Derivation::Organization)
+                    .col(Derivation::DerivationPath)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Derivation::Table)
+                    .drop_column(Derivation::Hash)
+                    .drop_column(Derivation::Name)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+#[allow(clippy::enum_variant_names)]
+enum Derivation {
+    Table,
+    Organization,
+    DerivationPath,
+    Hash,
+    Name,
+}
+
+#[derive(DeriveIden)]
+enum DerivationOutput {
+    Table,
+    Output,
+}

--- a/backend/proto/src/handler/dispatch.rs
+++ b/backend/proto/src/handler/dispatch.rs
@@ -9,7 +9,7 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 
-use gradient_core::executer::{nix_store_path, strip_nix_store_prefix};
+use gradient_core::executer::strip_nix_store_prefix;
 use gradient_core::types::ids::{DerivationId, OrganizationId};
 use gradient_core::types::*;
 use tokio::sync::Semaphore;
@@ -761,6 +761,12 @@ impl<'a> DispatchContext<'a> {
     async fn on_query_known_derivations(&mut self, job_id: String, drv_paths: Vec<String>) -> bool {
         debug!(peer_id = %self.peer_id, %job_id, count = drv_paths.len(), "QueryKnownDerivations");
         let stripped: Vec<String> = drv_paths.iter().map(|p| strip_nix_store_prefix(p)).collect();
+        let hashes: Vec<String> = stripped
+            .iter()
+            .filter_map(|p| gradient_core::sources::parse_drv_hash_name(p).ok().map(|(h, _)| h))
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
         let known = match self.scheduler.peer_id_for_job(&job_id).await {
             Some(org_id) => {
                 use entity::build::BuildStatus;
@@ -769,7 +775,7 @@ impl<'a> DispatchContext<'a> {
                 // First: find derivations that exist for this org.
                 let candidates = EDerivation::find()
                     .filter(CDerivation::Organization.eq(org_id))
-                    .filter(CDerivation::DerivationPath.is_in(stripped))
+                    .filter(CDerivation::Hash.is_in(hashes))
                     .all(&self.state.worker_db)
                     .await
                     .unwrap_or_default();
@@ -797,7 +803,7 @@ impl<'a> DispatchContext<'a> {
                     candidates
                         .into_iter()
                         .filter(|d| built.contains(&d.id))
-                        .map(|d| nix_store_path(&d.derivation_path))
+                        .map(|d| d.store_path())
                         .collect()
                 }
             }

--- a/backend/scheduler/src/build.rs
+++ b/backend/scheduler/src/build.rs
@@ -133,7 +133,7 @@ impl<'a> BuildStateHandler<'a> {
                     .one(&state.worker_db)
                     .await
                 {
-                    Ok(Some(d)) => d.derivation_path,
+                    Ok(Some(d)) => d.drv_path(),
                     Ok(None) => {
                         warn!(%leader_id, %derivation_id, "substitute_log: derivation row missing");
                         return;
@@ -672,7 +672,6 @@ pub(crate) fn build_cross_org_artefact_rows(
                 id: Set(new_id),
                 derivation: Set(follower_derivation),
                 name: Set(src.name.clone()),
-                output: Set(src.output.clone()),
                 hash: Set(src.hash.clone()),
                 package: Set(src.package.clone()),
                 ca: Set(src.ca.clone()),
@@ -869,7 +868,8 @@ mod waiting_reason_tests {
         entity::derivation::Model {
             id,
             organization: OrganizationId::nil(),
-            derivation_path: "/nix/store/x.drv".into(),
+            hash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
+            name: "x".into(),
             architecture: arch.into(),
             created_at: chrono::NaiveDateTime::default(),
         }
@@ -1080,7 +1080,6 @@ mod cross_org_mirror_tests {
             id,
             derivation,
             name: "out".into(),
-            output: format!("/nix/store/{hash}-foo"),
             hash: hash.into(),
             package: "foo".into(),
             ca: None,

--- a/backend/scheduler/src/dispatch.rs
+++ b/backend/scheduler/src/dispatch.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 
 use entity::build::BuildStatus;
 use entity::evaluation::EvaluationStatus;
-use gradient_core::executer::nix_store_path;
+use gradient_core::sources::get_path_from_derivation_output;
 use gradient_core::types::input::vec_to_hex;
 use gradient_core::types::wildcard::Wildcard;
 use gradient_core::types::*;
@@ -368,7 +368,7 @@ impl BuildDispatchMaps {
                 for o in outputs {
                     let cache_info = cache_info_by_hash.get(&o.hash).cloned();
                     paths.push(RequiredPath {
-                        path: o.output.clone(),
+                        path: get_path_from_derivation_output(o.clone()),
                         cache_info,
                     });
                 }
@@ -432,7 +432,7 @@ impl BuildDispatchMaps {
         let build_job = BuildJob {
             builds: vec![BuildTask {
                 build_id: build.id.to_string(),
-                drv_path: nix_store_path(&derivation.derivation_path),
+                drv_path: derivation.store_path(),
                 external_cached: build.external_cached,
             }],
         };

--- a/backend/scheduler/src/dispatch_tests.rs
+++ b/backend/scheduler/src/dispatch_tests.rs
@@ -129,10 +129,14 @@ fn make_build_queued(id: BuildId, eval_id: EvaluationId, drv_id: DerivationId) -
 }
 
 fn make_derivation(id: DerivationId, org_id: OrganizationId, path: &str) -> MDerivation {
+    let stripped = gradient_core::executer::strip_nix_store_prefix(path);
+    let (hash, name) = gradient_core::sources::parse_drv_hash_name(&stripped)
+        .unwrap_or_else(|_| ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(), "x".into()));
     entity::derivation::Model {
         id,
         organization: org_id,
-        derivation_path: path.to_string(),
+        hash,
+        name,
         architecture: "x86_64-linux".into(),
         created_at: test_date(),
     }

--- a/backend/scheduler/src/eval.rs
+++ b/backend/scheduler/src/eval.rs
@@ -18,7 +18,7 @@ use gradient_core::db::{
     update_evaluation_status_with_error,
 };
 use gradient_core::executer::strip_nix_store_prefix;
-use gradient_core::sources::get_hash_from_path;
+use gradient_core::sources::{get_hash_from_path, parse_drv_hash_name};
 use gradient_core::types::*;
 use sea_orm::{ActiveValue::Set, ColumnTrait, EntityTrait, QueryFilter};
 use tracing::{debug, error, info};
@@ -50,7 +50,7 @@ impl DerivationInsertBatch {
     ) -> Self {
         let mut drv_path_to_id: HashMap<String, DerivationId> = existing
             .iter()
-            .map(|d| (strip_nix_store_prefix(&d.derivation_path), d.id))
+            .map(|d| (d.drv_path(), d.id))
             .collect();
 
         let now = gradient_core::types::now();
@@ -63,10 +63,13 @@ impl DerivationInsertBatch {
             }
             let id = DerivationId::now_v7();
             drv_path_to_id.insert(d.drv_path.clone(), id);
+            let (drv_hash, drv_name) = parse_drv_hash_name(&d.drv_path)
+                .unwrap_or_else(|_| ("unknown".to_owned(), d.drv_path.clone()));
             new_derivations.push(ADerivation {
                 id: Set(id),
                 organization: Set(organization_id),
-                derivation_path: Set(d.drv_path.clone()),
+                hash: Set(drv_hash),
+                name: Set(drv_name),
                 architecture: Set(d.architecture.clone()),
                 created_at: Set(now),
             });
@@ -77,7 +80,6 @@ impl DerivationInsertBatch {
                     id: Set(DerivationOutputId::now_v7()),
                     derivation: Set(id),
                     name: Set(output.name.clone()),
-                    output: Set(output.path.clone()),
                     hash: Set(hash),
                     package: Set(package),
                     ca: Set(None),
@@ -167,17 +169,26 @@ impl<'a> EvalResultProcessor<'a> {
     }
 
     /// Load derivations that already exist in the DB so we don't re-insert them.
+    ///
+    /// Filters by `hash` only (Nix store hashes are content-addressed, so
+    /// `(organization, hash)` is unique in practice) to keep the IN clause
+    /// bounded by the number of distinct hashes rather than full drv paths.
     async fn load_existing_derivations(
         &self,
         derivations: &[DiscoveredDerivation],
     ) -> Result<Vec<MDerivation>> {
-        let paths: Vec<String> = derivations.iter().map(|d| d.drv_path.clone()).collect();
-        if paths.is_empty() {
+        let hashes: Vec<String> = derivations
+            .iter()
+            .filter_map(|d| parse_drv_hash_name(&d.drv_path).ok().map(|(h, _)| h))
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
+        if hashes.is_empty() {
             return Ok(vec![]);
         }
         EDerivation::find()
             .filter(CDerivation::Organization.eq(self.organization_id))
-            .filter(CDerivation::DerivationPath.is_in(paths))
+            .filter(CDerivation::Hash.is_in(hashes))
             .all(&self.state.worker_db)
             .await
             .context("query existing derivations")
@@ -622,7 +633,7 @@ async fn expand_substituted_closure(
         {
             Ok(rows) => rows
                 .into_iter()
-                .map(|d| (d.id, d.derivation_path))
+                .map(|d| (d.id, d.drv_path()))
                 .collect::<std::collections::HashMap<_, _>>(),
             Err(e) => {
                 error!(%evaluation_id, error = %e, "expand_substituted_closure: drv path lookup failed");
@@ -794,27 +805,32 @@ pub async fn flush_deferred_deps(
         return Ok(());
     }
 
-    // Collect every unique drv_path mentioned (both as source and as dep).
-    let all_paths: Vec<String> = {
-        let mut set = std::collections::HashSet::new();
-        for (src, deps) in &deferred {
-            set.insert(src.clone());
-            for d in deps {
-                set.insert(d.clone());
-            }
+    // Collect every unique drv_path mentioned (both as source and as dep), and
+    // derive the unique hash set we'll filter the DB on. Hashes are
+    // content-addressed (32-char nix32) so filtering by hash alone is enough to
+    // pin a row down within an organization.
+    let mut all_paths: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for (src, deps) in &deferred {
+        all_paths.insert(src.clone());
+        for d in deps {
+            all_paths.insert(d.clone());
         }
-        set.into_iter().collect()
-    };
+    }
+    let all_hashes: Vec<String> = all_paths
+        .iter()
+        .filter_map(|p| parse_drv_hash_name(p).ok().map(|(h, _)| h))
+        .collect::<std::collections::HashSet<_>>()
+        .into_iter()
+        .collect();
 
-    // Single query to map drv_path → UUID.
     let drv_path_to_id: std::collections::HashMap<String, DerivationId> = EDerivation::find()
         .filter(CDerivation::Organization.eq(organization_id))
-        .filter(CDerivation::DerivationPath.is_in(all_paths))
+        .filter(CDerivation::Hash.is_in(all_hashes))
         .all(&state.worker_db)
         .await
         .context("flush_deferred_deps: query derivations")?
         .into_iter()
-        .map(|d| (d.derivation_path, d.id))
+        .map(|d| (d.drv_path(), d.id))
         .collect();
 
     let mut edges: Vec<ADerivationDependency> = Vec::new();

--- a/backend/scheduler/src/handler_tests.rs
+++ b/backend/scheduler/src/handler_tests.rs
@@ -91,10 +91,14 @@ fn make_build(
 }
 
 fn make_derivation(id: DerivationId, org_id: OrganizationId, path: &str) -> MDerivation {
+    let stripped = gradient_core::executer::strip_nix_store_prefix(path);
+    let (hash, name) = gradient_core::sources::parse_drv_hash_name(&stripped)
+        .unwrap_or_else(|_| ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(), "x".into()));
     entity::derivation::Model {
         id,
         organization: org_id,
-        derivation_path: path.to_string(),
+        hash,
+        name,
         architecture: "x86_64-linux".into(),
         created_at: test_date(),
     }
@@ -115,7 +119,6 @@ fn make_drv_output(
         id,
         derivation: drv_id,
         name: name.to_string(),
-        output: path.to_string(),
         hash,
         package: name.to_string(),
         ca: None,

--- a/backend/scheduler/src/log_substitution.rs
+++ b/backend/scheduler/src/log_substitution.rs
@@ -353,10 +353,14 @@ mod tests {
     }
 
     fn make_derivation(drv_id: DerivationId, org: OrganizationId, drv_path: String) -> entity::derivation::Model {
+        let stripped = gradient_core::executer::strip_nix_store_prefix(&drv_path);
+        let (hash, name) = gradient_core::sources::parse_drv_hash_name(&stripped)
+            .unwrap_or_else(|_| ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(), "x".into()));
         entity::derivation::Model {
             id: drv_id,
             organization: org,
-            derivation_path: drv_path,
+            hash,
+            name,
             architecture: "x86_64-linux".to_string(),
             created_at: gradient_core::types::now(),
         }

--- a/backend/test-support/src/cache_fixture.rs
+++ b/backend/test-support/src/cache_fixture.rs
@@ -87,7 +87,6 @@ pub async fn public_cache_with_narinfo() -> Arc<ServerState> {
         id: drv_output_id(),
         derivation: deriv_id(),
         name: "out".into(),
-        output: format!("/nix/store/{}-hello", FIXTURE_PATH_HASH),
         hash: FIXTURE_PATH_HASH.into(),
         package: "hello".into(),
         ca: None,
@@ -100,7 +99,8 @@ pub async fn public_cache_with_narinfo() -> Arc<ServerState> {
     let deriv_row = entity::derivation::Model {
         id: deriv_id(),
         organization: org_id(),
-        derivation_path: format!("/nix/store/{}-hello.drv", FIXTURE_PATH_HASH),
+        hash: FIXTURE_PATH_HASH.into(),
+        name: "hello".into(),
         architecture: "x86_64-linux".into(),
         created_at: test_date(),
     };
@@ -309,7 +309,8 @@ fn derivation_row() -> entity::derivation::Model {
     entity::derivation::Model {
         id: deriv_id(),
         organization: org_id(),
-        derivation_path: format!("/nix/store/{}", FIXTURE_DRV_FILENAME),
+        hash: FIXTURE_PATH_HASH.into(),
+        name: "hello".into(),
         architecture: "x86_64-linux".into(),
         created_at: test_date(),
     }

--- a/backend/web/src/endpoints/builds/downloads.rs
+++ b/backend/web/src/endpoints/builds/downloads.rs
@@ -11,6 +11,7 @@ use axum::extract::{Path, Query, State};
 use axum::http::{StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use axum::{Extension, Json};
+use gradient_core::sources::get_path_from_derivation_output;
 use gradient_core::storage::nar_extract::{ExtractError, Extracted, extract_path_from_nar_bytes};
 use gradient_core::types::*;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
@@ -120,15 +121,15 @@ async fn find_and_serve_file(
             .iter()
             .find(|o| o.id == product.derivation_output);
         let output_root = match output {
-            Some(o) => &o.output,
+            Some(o) => get_path_from_derivation_output(o.clone()),
             None => {
                 tracing::warn!(%build_id, %filename, "build_product references unknown output");
                 continue;
             }
         };
 
-        let hash = store_path_hash(output_root);
-        let rel = relative_in_output(&product.path, output_root);
+        let hash = store_path_hash(&output_root);
+        let rel = relative_in_output(&product.path, &output_root);
 
         let compressed = match state.nar_storage.get(hash).await {
             Ok(Some(b)) => b,

--- a/backend/web/src/endpoints/builds/graph.rs
+++ b/backend/web/src/endpoints/builds/graph.rs
@@ -9,7 +9,6 @@ use crate::error::WebResult;
 use crate::helpers::{OptionExt, ok_json};
 use axum::extract::{Path, State};
 use axum::{Extension, Json};
-use gradient_core::executer::nix_store_path;
 use gradient_core::types::*;
 use sea_orm::EntityTrait;
 use sea_orm::{ColumnTrait, QueryFilter};
@@ -20,13 +19,6 @@ use std::sync::Arc;
 use super::BuildAccessContext;
 
 // ── Dependency graph helpers ──────────────────────────────────────────────────
-
-pub(super) fn extract_drv_name(path: &str) -> String {
-    let filename = path.split('/').next_back().unwrap_or(path);
-    // Strip the nix store hash prefix (e.g. "abc123xyz-name.drv" → "name")
-    let without_hash = filename.split_once('-').map(|x| x.1).unwrap_or(filename);
-    without_hash.trim_end_matches(".drv").to_string()
-}
 
 pub(super) async fn authorize_build_opt(
     state: &Arc<ServerState>,
@@ -99,8 +91,8 @@ async fn process_graph_wave(
         if let Some(drv) = drv_by_id.get(&build.derivation) {
             nodes.push(DependencyNode {
                 id: build.id,
-                name: extract_drv_name(&drv.derivation_path),
-                path: nix_store_path(&drv.derivation_path),
+                name: drv.name.clone(),
+                path: drv.store_path(),
                 status: format!("{:?}", build.status),
                 created_at: build.created_at,
                 updated_at: build.updated_at,
@@ -197,8 +189,8 @@ pub async fn get_build_dependencies(
             if let Some(drv) = drv_by_id.get(&b.derivation) {
                 nodes.push(DependencyNode {
                     id: b.id,
-                    name: extract_drv_name(&drv.derivation_path),
-                    path: nix_store_path(&drv.derivation_path),
+                    name: drv.name.clone(),
+                    path: drv.store_path(),
                     status: format!("{:?}", b.status),
                     created_at: b.created_at,
                     updated_at: b.updated_at,

--- a/backend/web/src/endpoints/builds/query.rs
+++ b/backend/web/src/endpoints/builds/query.rs
@@ -9,7 +9,7 @@ use crate::error::{WebError, WebResult};
 use crate::helpers::ok_json;
 use axum::extract::{Path, State};
 use axum::{Extension, Json};
-use gradient_core::executer::nix_store_path;
+use gradient_core::sources::get_path_from_derivation_output;
 use gradient_core::types::*;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use serde::{Deserialize, Serialize};
@@ -65,14 +65,15 @@ pub async fn get_build(
 
     let mut outputs = HashMap::new();
     for output in derivation_outputs {
-        outputs.insert(output.name, output.output);
+        let path = get_path_from_derivation_output(output.clone());
+        outputs.insert(output.name, path);
     }
 
     let build_with_outputs = BuildWithOutputs {
         id: build.id,
         evaluation: build.evaluation,
         status: build.status.for_api(),
-        derivation_path: nix_store_path(&derivation.derivation_path),
+        derivation_path: derivation.store_path(),
         architecture: derivation.architecture,
         worker: build.worker,
         via: build.via,

--- a/backend/web/src/endpoints/caches/build_log.rs
+++ b/backend/web/src/endpoints/caches/build_log.rs
@@ -10,6 +10,7 @@ use axum::extract::{Path, State};
 use axum::http::{HeaderMap, HeaderValue, header};
 use axum::response::Response;
 use entity::build::BuildStatus;
+use gradient_core::sources::parse_drv_hash_name;
 use gradient_core::types::*;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder};
 use std::sync::Arc;
@@ -21,14 +22,13 @@ pub async fn log(
 ) -> WebResult<Response> {
     let ctx = CacheContext::load(&state, &headers, cache).await?;
 
-    if !drv.ends_with(".drv") {
+    let Ok((drv_hash, drv_name)) = parse_drv_hash_name(&drv) else {
         return Err(WebError::not_found("Log"));
-    }
-
-    let derivation_path = format!("/nix/store/{}", drv);
+    };
 
     let Some(derivation_row) = EDerivation::find()
-        .filter(CDerivation::DerivationPath.eq(derivation_path))
+        .filter(CDerivation::Hash.eq(drv_hash))
+        .filter(CDerivation::Name.eq(drv_name))
         .one(&state.web_db)
         .await?
     else {

--- a/backend/web/src/endpoints/evals/log.rs
+++ b/backend/web/src/endpoints/evals/log.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 use tracing::error;
 
 use super::EvalAccessContext;
-use super::types::drv_display_name;
 
 pub async fn post_evaluation_builds(
     state: State<Arc<ServerState>>,
@@ -56,11 +55,10 @@ pub async fn post_evaluation_builds(
         };
 
         for build in past_builds {
-            let drv_path = match EDerivation::find_by_id(build.derivation).one(&state.web_db).await {
-                Ok(Some(d)) => d.derivation_path,
+            let name = match EDerivation::find_by_id(build.derivation).one(&state.web_db).await {
+                Ok(Some(d)) => d.name,
                 _ => String::new(),
             };
-            let name = drv_display_name(&drv_path);
             let log = state.log_storage.read(build.log_id.unwrap_or(build.id)).await.unwrap_or_default();
             last_logs.insert(build.id, log.len());
 
@@ -114,11 +112,10 @@ pub async fn post_evaluation_builds(
             }
 
             for build in builds {
-                let drv_path = match EDerivation::find_by_id(build.derivation).one(&state.web_db).await {
-                    Ok(Some(d)) => d.derivation_path,
+                let name = match EDerivation::find_by_id(build.derivation).one(&state.web_db).await {
+                    Ok(Some(d)) => d.name,
                     _ => String::new(),
                 };
-                let name = drv_display_name(&drv_path);
                 let log = state.log_storage.read(build.log_id.unwrap_or(build.id)).await.unwrap_or_default();
                 let last_offset = *last_logs.get(&build.id).unwrap_or(&0);
                 let log_new = log[last_offset..].to_string();

--- a/backend/web/src/endpoints/evals/query.rs
+++ b/backend/web/src/endpoints/evals/query.rs
@@ -9,11 +9,10 @@ use crate::error::WebResult;
 use crate::helpers::ok_json;
 use axum::extract::{Path, Query, State};
 use axum::{Extension, Json};
-use gradient_core::executer::nix_store_path;
 use gradient_core::types::input::vec_to_hex;
 use gradient_core::types::*;
 use sea_orm::{ColumnTrait, EntityTrait, Order, QueryFilter, QueryOrder};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use super::EvalAccessContext;
@@ -141,6 +140,23 @@ pub async fn get_evaluation(
     Ok(Json(res))
 }
 
+/// Maximum number of values per `IN (...)` parameter list. Postgres' wire
+/// protocol limits any query to 65 535 bind parameters; 10 000 leaves room
+/// for additional filters/joins and avoids overflowing on evaluations with
+/// tens of thousands of builds (issue #237).
+const IS_IN_CHUNK: usize = 10_000;
+
+fn status_rank(status: entity::build::BuildStatus) -> u32 {
+    use entity::build::BuildStatus::*;
+    match status {
+        Building => 0,
+        Created | Queued => 1,
+        Failed => 2,
+        Aborted | DependencyFailed => 3,
+        Completed | Substituted => 4,
+    }
+}
+
 pub async fn get_evaluation_builds(
     state: State<Arc<ServerState>>,
     Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
@@ -163,18 +179,22 @@ pub async fn get_evaluation_builds(
     // frontend renders the live build and log endpoints resolve to the right
     // build id. Same-org invariant (see `entity::build::Model::via`) means no
     // cross-org leak.
-    let leader_ids: Vec<BuildId> = raw_builds.iter().filter_map(|b| b.via).collect();
-    let leaders: HashMap<BuildId, MBuild> = if leader_ids.is_empty() {
-        HashMap::new()
-    } else {
-        EBuild::find()
-            .filter(CBuild::Id.is_in(leader_ids))
+    let leader_ids: Vec<BuildId> = raw_builds
+        .iter()
+        .filter_map(|b| b.via)
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+    let mut leaders: HashMap<BuildId, MBuild> = HashMap::new();
+    for chunk in leader_ids.chunks(IS_IN_CHUNK) {
+        let rows = EBuild::find()
+            .filter(CBuild::Id.is_in(chunk.to_vec()))
             .all(&state.web_db)
-            .await?
-            .into_iter()
-            .map(|b| (b.id, b))
-            .collect()
-    };
+            .await?;
+        for row in rows {
+            leaders.insert(row.id, row);
+        }
+    }
     let builds: Vec<MBuild> = raw_builds
         .into_iter()
         .map(|b| match b.via.and_then(|id| leaders.get(&id)) {
@@ -183,94 +203,92 @@ pub async fn get_evaluation_builds(
         })
         .collect();
 
-    let drv_ids: Vec<DerivationId> = builds.iter().map(|b| b.derivation).collect();
+    // Distinct derivations referenced by builds. Deduping cuts the IN-list down
+    // by the leader/follower factor (often 2–10x in large evals).
+    let drv_ids: Vec<DerivationId> = builds
+        .iter()
+        .map(|b| b.derivation)
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
 
-    let derivations: HashMap<DerivationId, MDerivation> = if drv_ids.is_empty() {
-        HashMap::new()
-    } else {
-        EDerivation::find()
-            .filter(CDerivation::Id.is_in(drv_ids.clone()))
-            .all(&state.web_db)
-            .await?
-            .into_iter()
-            .map(|d| (d.id, d))
-            .collect()
-    };
-
-    // has_artefacts is per-derivation: any output of the derivation has build_product rows.
-    let has_artefacts_map: HashMap<DerivationId, bool> = if drv_ids.is_empty() {
-        HashMap::new()
-    } else {
-        let outputs = EDerivationOutput::find()
-            .filter(CDerivationOutput::Derivation.is_in(drv_ids))
+    let mut derivations: HashMap<DerivationId, MDerivation> = HashMap::new();
+    for chunk in drv_ids.chunks(IS_IN_CHUNK) {
+        let rows = EDerivation::find()
+            .filter(CDerivation::Id.is_in(chunk.to_vec()))
             .all(&state.web_db)
             .await?;
-        let output_ids: Vec<DerivationOutputId> = outputs.iter().map(|o| o.id).collect();
-        let mut m: HashMap<DerivationId, bool> = HashMap::new();
-        if !output_ids.is_empty() {
-            for bp in EBuildProduct::find()
-                .filter(CBuildProduct::DerivationOutput.is_in(output_ids))
-                .all(&state.web_db)
-                .await?
-            {
-                if let Some(output) = outputs.iter().find(|o| o.id == bp.derivation_output) {
-                    m.insert(output.derivation, true);
-                }
-            }
+        for row in rows {
+            derivations.insert(row.id, row);
         }
-        m
-    };
+    }
 
-    let mut builds: Vec<BuildItem> = builds
+    // Sort by status (Building → Queued → Failed → Aborted/DependencyFailed →
+    // Completed/Substituted), then by derivation name. Mirrors the client-side
+    // ordering in `evaluation-log.component.ts::buildStatusOrder`.
+    let mut sorted: Vec<(u32, &str, &MBuild)> = builds
         .iter()
         .filter_map(|b| {
             let drv = derivations.get(&b.derivation)?;
-            if !drv.derivation_path.ends_with(".drv") {
-                return None;
-            }
-            Some(BuildItem {
-                id: b.id,
-                name: nix_store_path(&drv.derivation_path),
-                status: format!("{:?}", b.status.for_api()),
-                has_artefacts: *has_artefacts_map.get(&b.derivation).unwrap_or(&false),
-                updated_at: b.updated_at,
-                build_time_ms: b.build_time_ms,
-            })
+            Some((status_rank(b.status.for_api()), drv.name.as_str(), b))
         })
         .collect();
+    sorted.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(b.1)));
 
-    // Sort by status (Building → Queued → Failed → Aborted/DependencyFailed →
-    // Completed/Substituted), then by display name. Must match the client-side
-    // ordering in `evaluation-log.component.ts::buildStatusOrder`.
-    fn status_rank(status: &str) -> u32 {
-        match status {
-            "Building" => 0,
-            "Queued" => 1,
-            "Failed" => 2,
-            "Aborted" | "DependencyFailed" => 3,
-            "Completed" | "Substituted" => 4,
-            _ => 99,
+    let total = sorted.len();
+    let active_count = sorted.iter().filter(|(rank, _, _)| *rank < 4).count();
+
+    let offset = query.offset.unwrap_or(0).min(total);
+    let limit = query.limit.unwrap_or(total.saturating_sub(offset));
+    let page_slice: Vec<&(u32, &str, &MBuild)> =
+        sorted.iter().skip(offset).take(limit).collect();
+
+    // Hydrate `has_artefacts` only for the page. Bounded by `limit`, so the
+    // `IN` clause is safe regardless of evaluation size.
+    let page_drv_ids: Vec<DerivationId> = page_slice
+        .iter()
+        .map(|(_, _, b)| b.derivation)
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+    let mut has_artefacts: HashSet<DerivationId> = HashSet::new();
+    if !page_drv_ids.is_empty() {
+        let outputs = EDerivationOutput::find()
+            .filter(CDerivationOutput::Derivation.is_in(page_drv_ids.clone()))
+            .all(&state.web_db)
+            .await?;
+        let output_to_drv: HashMap<DerivationOutputId, DerivationId> =
+            outputs.iter().map(|o| (o.id, o.derivation)).collect();
+        let output_ids: Vec<DerivationOutputId> = outputs.iter().map(|o| o.id).collect();
+        for chunk in output_ids.chunks(IS_IN_CHUNK) {
+            let products = EBuildProduct::find()
+                .filter(CBuildProduct::DerivationOutput.is_in(chunk.to_vec()))
+                .all(&state.web_db)
+                .await?;
+            for bp in products {
+                if let Some(&drv) = output_to_drv.get(&bp.derivation_output) {
+                    has_artefacts.insert(drv);
+                }
+            }
         }
     }
-    fn display_name(path: &str) -> &str {
-        let filename = path.rsplit('/').next().unwrap_or(path);
-        let stripped = filename.strip_suffix(".drv").unwrap_or(filename);
-        stripped
-            .split_once('-')
-            .map(|(_, rest)| rest)
-            .unwrap_or(stripped)
-    }
-    builds.sort_by(|a, b| {
-        status_rank(&a.status)
-            .cmp(&status_rank(&b.status))
-            .then_with(|| display_name(&a.name).cmp(display_name(&b.name)))
-    });
 
-    let total = builds.len();
-    let active_count = builds.iter().filter(|b| status_rank(&b.status) < 4).count();
-    let offset = query.offset.unwrap_or(0).min(total);
-    let limit = query.limit.unwrap_or(total);
-    let page = builds.into_iter().skip(offset).take(limit).collect();
+    let page: Vec<BuildItem> = page_slice
+        .into_iter()
+        .map(|(_, _, b)| {
+            let drv = derivations
+                .get(&b.derivation)
+                .expect("derivation hydrated above");
+            BuildItem {
+                id: b.id,
+                name: drv.store_path(),
+                status: format!("{:?}", b.status.for_api()),
+                has_artefacts: has_artefacts.contains(&b.derivation),
+                updated_at: b.updated_at,
+                build_time_ms: b.build_time_ms,
+            }
+        })
+        .collect();
 
     let res = BaseResponse {
         error: false,

--- a/backend/web/src/endpoints/evals/types.rs
+++ b/backend/web/src/endpoints/evals/types.rs
@@ -98,12 +98,3 @@ pub struct EvaluationMessageResponse {
     pub entry_points: Vec<EntryPointId>,
 }
 
-/// `/nix/store/hash-name-version.drv` → `name-version`
-pub fn drv_display_name(path: &str) -> String {
-    let filename = path.rsplit('/').next().unwrap_or(path);
-    let after_hash = filename.split_once('-').map(|x| x.1).unwrap_or(filename);
-    after_hash
-        .strip_suffix(".drv")
-        .unwrap_or(after_hash)
-        .to_string()
-}

--- a/backend/web/src/endpoints/projects/evaluations.rs
+++ b/backend/web/src/endpoints/projects/evaluations.rs
@@ -20,8 +20,7 @@ use axum::{Extension, Json};
 use entity::build::BuildStatus;
 use entity::evaluation::EvaluationStatus;
 use gradient_core::db::get_any_organization_by_name;
-use gradient_core::executer::nix_store_path;
-use gradient_core::sources::check_project_updates;
+use gradient_core::sources::{check_project_updates, get_path_from_derivation_output};
 use gradient_core::storage::nar_extract::{ExtractError, Extracted, extract_path_from_nar_bytes};
 use gradient_core::types::input::vec_to_hex;
 use gradient_core::types::*;
@@ -483,7 +482,7 @@ impl EntryPointRelatedData {
             summaries.push(EntryPointSummary {
                 id: ep.id,
                 build_id: build.id,
-                derivation_path: nix_store_path(&drv.derivation_path),
+                derivation_path: drv.store_path(),
                 eval: ep.eval.clone(),
                 build_status: build.status.for_api(),
                 has_artefacts: *self.has_products.get(&build.derivation).unwrap_or(&false),
@@ -552,18 +551,15 @@ async fn serve_hydra_artifact(
             .iter()
             .find(|o| o.id == product.derivation_output);
         let output_root = match output {
-            Some(o) => &o.output,
+            Some(o) => get_path_from_derivation_output(o.clone()),
             None => {
                 tracing::warn!(%filename, "build_product references unknown output");
                 continue;
             }
         };
 
-        let hash = output_root
-            .strip_prefix("/nix/store/")
-            .unwrap_or(output_root)
-            .split('-')
-            .next()
+        let hash = output
+            .map(|o| o.hash.as_str())
             .unwrap_or("");
         if hash.is_empty() {
             continue;

--- a/backend/web/src/endpoints/projects/metrics.rs
+++ b/backend/web/src/endpoints/projects/metrics.rs
@@ -327,7 +327,6 @@ mod tests {
             id: DerivationOutputId::now_v7(),
             derivation,
             name: "out".into(),
-            output: format!("/nix/store/{hash}-foo"),
             hash: hash.into(),
             package: "foo".into(),
             ca: None,

--- a/backend/web/tests/builds_download.rs
+++ b/backend/web/tests/builds_download.rs
@@ -187,7 +187,6 @@ fn drv_output_row() -> entity::derivation_output::Model {
         id: drv_output_id(),
         derivation: derivation_id(),
         name: "out".into(),
-        output: STORE_PATH.into(),
         hash: FIXTURE_HASH.into(),
         package: "pkg".into(),
         ca: None,

--- a/backend/web/tests/evaluation_builds_via.rs
+++ b/backend/web/tests/evaluation_builds_via.rs
@@ -134,7 +134,8 @@ fn derivation_row() -> entity::derivation::Model {
     entity::derivation::Model {
         id: derivation_id(),
         organization: org_id(),
-        derivation_path: DRV_PATH.into(),
+        hash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
+        name: "hello-2.12.1".into(),
         architecture: "x86_64-linux".into(),
         created_at: test_date(),
     }

--- a/backend/web/tests/evaluation_builds_via_cross_org.rs
+++ b/backend/web/tests/evaluation_builds_via_cross_org.rs
@@ -76,8 +76,6 @@ fn follower_membership_id() -> OrganizationUserId {
     OrganizationUserId::new(Uuid::parse_str("50000000-0000-0000-0000-000000000011").unwrap())
 }
 
-const DRV_PATH: &str = "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello-2.12.1.drv";
-
 // ── Fixture rows ──────────────────────────────────────────────────────────────
 
 fn private_org(id: OrganizationId, slug: &str) -> entity::organization::Model {
@@ -174,7 +172,8 @@ fn leader_derivation_row() -> entity::derivation::Model {
     entity::derivation::Model {
         id: leader_drv_id(),
         organization: leader_org_id(),
-        derivation_path: DRV_PATH.into(),
+        hash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
+        name: "hello-2.12.1".into(),
         architecture: "x86_64-linux".into(),
         created_at: test_date(),
     }

--- a/backend/web/tests/narinfo.rs
+++ b/backend/web/tests/narinfo.rs
@@ -97,7 +97,6 @@ async fn narinfo_served_from_db_inner() {
         id: drv_output_id(),
         derivation: deriv_id(),
         name: "out".into(),
-        output: format!("/nix/store/{}-hello", FIXTURE_HASH),
         hash: FIXTURE_HASH.into(),
         package: "hello".into(),
         ca: None,
@@ -111,7 +110,8 @@ async fn narinfo_served_from_db_inner() {
     let deriv_row = entity::derivation::Model {
         id: deriv_id(),
         organization: org_id(),
-        derivation_path: format!("/nix/store/{}-hello.drv", FIXTURE_HASH),
+        hash: FIXTURE_HASH.into(),
+        name: "hello".into(),
         architecture: "x86_64-linux".into(),
         created_at: test_date(),
     };
@@ -251,7 +251,6 @@ async fn narinfo_unsigned_inner() {
         id: drv_output_id(),
         derivation: deriv_id(),
         name: "out".into(),
-        output: format!("/nix/store/{}-hello", FIXTURE_HASH),
         hash: FIXTURE_HASH.into(),
         package: "hello".into(),
         ca: None,
@@ -264,7 +263,8 @@ async fn narinfo_unsigned_inner() {
     let deriv_row = entity::derivation::Model {
         id: deriv_id(),
         organization: org_id(),
-        derivation_path: format!("/nix/store/{}-hello.drv", FIXTURE_HASH),
+        hash: FIXTURE_HASH.into(),
+        name: "hello".into(),
         architecture: "x86_64-linux".into(),
         created_at: test_date(),
     };

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -2216,3 +2216,33 @@ Tests for when a derivation's outputs are pulled from an upstream cache, Gradien
 
 - `returns_urls_from_subscribed_caches` — shared upstream-URL helper.
 - `empty_when_no_org_caches` — empty result when org has no caches.
+
+## Derivation path parsing (`core/src/sources/nar_path.rs`)
+
+Unit tests covering `parse_drv_hash_name`, used at scheduler insert time and
+on the `/log/{drv}` cache endpoint to split bare `<hash>-<name>.drv` strings
+into the `hash` and `name` columns now stored on `derivation` (issue #237):
+
+- `parses_canonical_drv_form` — `aaaa…aa-hello-2.12.1.drv` → (`aaaa…aa`, `hello-2.12.1`).
+- `rejects_missing_drv_suffix` — input without `.drv` returns `InvalidPath`.
+- `rejects_missing_hash_or_name` — empty hash or empty name returns `InvalidPath`.
+- `rejects_missing_dash` — input without `-` returns `InvalidPath`.
+
+## `GET /evals/{eval}/builds` parameter overflow on large evaluations (#237)
+
+The endpoint previously fetched every build in the evaluation and hydrated
+display data via `WHERE id IN ($1, …, $N)` against `derivation`,
+`derivation_output`, and `build_product`. With ~28 000 builds the combined
+parameter count reached 84 560 — over Postgres' 65 535 wire-protocol limit —
+and the endpoint returned `500`.
+
+`backend/web/src/endpoints/evals/query.rs::get_evaluation_builds` now chunks
+every `IN (…)` lookup at `IS_IN_CHUNK = 10 000` after deduplicating leader IDs
+and derivation IDs, and hydrates `has_artefacts` only for the page's
+derivations, so the largest single query is bounded by the request `limit`
+rather than the evaluation size. The existing mock-DB integration tests
+`evaluation_builds_via.rs::{follower_build_is_replaced_with_leader_row,
+plain_build_returns_own_row_without_extra_query}` and
+`evaluation_builds_via_cross_org.rs` pin the new query sequence; the
+behavioural regression for the overflow is verified at code-review time
+(every `is_in(...)` site on this hot path is now chunked).


### PR DESCRIPTION
## Summary

- Replace `derivation.derivation_path` with structured `hash` + `name` columns and drop the redundant `derivation_output.output`; downstream readers reconstruct `/nix/store/<hash>-<name>.drv` via the new `MDerivation::store_path()` / `drv_path()` helpers and the existing `get_path_from_derivation_output`.
- Rewrite `get_evaluation_builds` to deduplicate leader/derivation IDs and chunk every `IN (...)` lookup at 10 000, hydrating `has_artefacts` only for the requested page. Largest query is now bounded by `limit` rather than the evaluation size.
- Audit and convert the remaining `is_in(derivation_path)` sites in scheduler/proto/core to hash-based filters so the same overflow can't recur there.

## Why

On a ~28 000-build evaluation the endpoint hydrated builds → derivations → outputs → products via `WHERE id IN (...)`, binding 84 560 parameters — past Postgres' 65 535 wire-protocol limit — and returned `500`. Issue posted by @knownasred, assigned to me.

## Test plan

- [x] `cargo check --workspace --tests`
- [x] `cargo clippy --workspace --tests --no-deps -- -D warnings`
- [x] CI runs the full test suite
- [x] Existing mock-DB integration tests (`evaluation_builds_via*`, `narinfo`, `builds_download`, etc.) keep passing through the new query sequence
- [x] Manual: hit `/api/v1/evals/{id}/builds` against a production-sized evaluation post-deploy

closes #237