### PR TITLE
Make dashboard stats navigation items

### DIFF
--- a/frontend/src/app/features/dashboard/dashboard.component.html
+++ b/frontend/src/app/features/dashboard/dashboard.component.html
@@ -15,16 +15,30 @@
   } @else {
     <!-- Stats Overview -->
     <div class="dashboard-stats">
-      <app-stat-card
-        icon="corporate_fare"
-        [value]="organizations().length"
-        label="Organizations"
-      />
-      <app-stat-card
-        icon="inventory_2"
-        [value]="caches().length"
-        label="Caches"
-      />
+      <a routerLink="/organizations" class="card">
+        <div class="card-icon">
+          <span class="material-symbols-outlined">corporate_fare</span>
+        </div>
+        <div class="card-content">
+          <h3>{{ organizations().length }}</h3>
+          <p class="text-secondary">Organizations</p>
+        </div>
+        <div class="card-arrow">
+          <span class="material-symbols-outlined">arrow_forward</span>
+        </div>
+      </a>
+      <a routerLink="/caches" class="card">
+        <div class="card-icon">
+          <span class="material-symbols-outlined">inventory_2</span>
+        </div>
+        <div class="card-content">
+          <h3>{{ caches().length }}</h3>
+          <p class="text-secondary">Caches</p>
+        </div>
+        <div class="card-arrow">
+          <span class="material-symbols-outlined">arrow_forward</span>
+        </div>
+      </a>
     </div>
 
     <!-- Recent Organizations -->

--- a/frontend/src/app/features/dashboard/dashboard.component.ts
+++ b/frontend/src/app/features/dashboard/dashboard.component.ts
@@ -10,7 +10,6 @@ import { RouterModule } from '@angular/router';
 import { forkJoin } from 'rxjs';
 import { OrganizationsService } from '@core/services/organizations.service';
 import { CachesService } from '@core/services/caches.service';
-import { StatCardComponent } from '@shared/components/stat-card/stat-card.component';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { EmptyStateComponent } from '@shared/components/empty-state/empty-state.component';
 import { Organization, Cache } from '@core/models';
@@ -21,7 +20,6 @@ import { Organization, Cache } from '@core/models';
   imports: [
     CommonModule,
     RouterModule,
-    StatCardComponent,
     LoadingSpinnerComponent,
     EmptyStateComponent,
   ],


### PR DESCRIPTION
This implements the original #236 

The evaluation cards mentioned in [this comment](https://github.com/wavelens/gradient/issues/236#issuecomment-4486102527) are not implemented yet, but I would like to implement them in a later PR.