### PR TITLE
worker: pin active build inputs and outputs as GC roots (#245)

### DIFF
--- a/backend/worker/src/config.rs
+++ b/backend/worker/src/config.rs
@@ -54,6 +54,18 @@ pub struct WorkerConfig {
     #[arg(long, env = "GRADIENT_BINPATH_SSH", default_value = "ssh")]
     pub binpath_ssh: String,
 
+    /// Directory under which worker-held indirect GC roots are written.
+    /// One symlink per active build (drv + outputs) pins inputs and
+    /// outputs through the daemon while the build runs. Empty string
+    /// disables GC root pinning (build still works, but a concurrent
+    /// `nix-collect-garbage` may race the build).
+    #[arg(
+        long,
+        env = "GRADIENT_WORKER_GCROOTS_DIR",
+        default_value = "/nix/var/nix/gcroots/gradient"
+    )]
+    pub gcroots_dir: String,
+
     /// Re-exec as a Nix evaluator subprocess (internal — do not set manually).
     #[arg(long, env = "GRADIENT_EVAL_WORKER", hide = true)]
     pub eval_worker: bool,
@@ -282,6 +294,7 @@ mod tests {
             worker_id: None,
             binpath_nix: "nix".to_owned(),
             binpath_ssh: "ssh".to_owned(),
+            gcroots_dir: String::new(),
             eval_worker: false,
             eval_workers: 1,
             max_evals_per_worker: 1,
@@ -359,6 +372,7 @@ mod tests {
             worker_id: None,
             binpath_nix: "nix".to_owned(),
             binpath_ssh: "ssh".to_owned(),
+            gcroots_dir: String::new(),
             eval_worker: false,
             eval_workers: 1,
             max_evals_per_worker: 1,
@@ -420,6 +434,7 @@ mod tests {
             worker_id: None,
             binpath_nix: "nix".to_owned(),
             binpath_ssh: "ssh".to_owned(),
+            gcroots_dir: String::new(),
             eval_worker: false,
             eval_workers: 1,
             max_evals_per_worker: 1,

--- a/backend/worker/src/executor/mod.rs
+++ b/backend/worker/src/executor/mod.rs
@@ -24,6 +24,7 @@ use tracing::instrument;
 use gradient_core::types::CachedPathInfo;
 use proto::messages::QueryMode;
 
+use crate::nix::gcroots::{GcRootHandle, GcRootKeeper};
 use crate::nix::store::LocalNixStore;
 use crate::proto::{credentials::CredentialStore, job::JobUpdater, nar};
 use proto::messages::CachedPath;
@@ -155,6 +156,7 @@ async fn push_one_fetched_nar(updater: &mut JobUpdater, cp: &CachedPath, store: 
 pub struct JobExecutor {
     pub(crate) store: Arc<LocalNixStore>,
     pub(crate) evaluator: Arc<WorkerEvaluator>,
+    pub(crate) gcroots: GcRootKeeper,
     pub(crate) binpath_nix: String,
     pub(crate) binpath_ssh: String,
 }
@@ -163,12 +165,14 @@ impl JobExecutor {
     pub fn new(
         store: LocalNixStore,
         evaluator: WorkerEvaluator,
+        gcroots: GcRootKeeper,
         binpath_nix: String,
         binpath_ssh: String,
     ) -> Self {
         Self {
             store: Arc::new(store),
             evaluator: Arc::new(evaluator),
+            gcroots,
             binpath_nix,
             binpath_ssh,
         }
@@ -265,6 +269,7 @@ impl JobExecutor {
         mut abort: watch::Receiver<bool>,
     ) -> Result<()> {
         let mut all_output_paths: Vec<String> = Vec::new();
+        let mut gc_handles: Vec<GcRootHandle> = Vec::new();
         for (index, build_task) in job.builds.iter().enumerate() {
             check_abort(&mut abort)?;
             // Move the build to `Building` on the server *before* anything
@@ -275,6 +280,12 @@ impl JobExecutor {
             // still `Queued`, the transition would be rejected, and the UI
             // would show the build hanging in `Queued` forever.
             updater.report_building(build_task.build_id.clone())?;
+
+            // Pin the .drv as an indirect GC root before prefetching its
+            // inputs. Nix's reachability walks .drv references
+            // (input_drvs + input_sources), so one root covers the entire
+            // build-time closure.
+            gc_handles.push(self.gcroots.add(&build_task.drv_path).await);
 
             if build_task.external_cached {
                 // Optimistic path: the worker reported the outputs as
@@ -308,6 +319,9 @@ impl JobExecutor {
                             });
                         }
                         updater.report_build_output(build_task.build_id.clone(), reported)?;
+                        for (_, p) in &outputs {
+                            gc_handles.push(self.gcroots.add(p).await);
+                        }
                         all_output_paths.extend(outputs.into_iter().map(|(_, p)| p));
                         continue;
                     }
@@ -339,6 +353,9 @@ impl JobExecutor {
                 })?;
             let outputs =
                 build::build_derivation(&self.store, build_task, index as u32, updater).await?;
+            for o in &outputs {
+                gc_handles.push(self.gcroots.add(&o.store_path).await);
+            }
             all_output_paths.extend(outputs.into_iter().map(|o| o.store_path));
         }
 
@@ -351,6 +368,9 @@ impl JobExecutor {
         compress::compress_and_push_paths(&self.store, &all_output_paths, updater, &mut abort)
             .await?;
 
+        // Release every indirect GC root for this job; symlinks are removed
+        // and the daemon's next GC walk is free to delete unreachable paths.
+        drop(gc_handles);
         Ok(())
     }
 }

--- a/backend/worker/src/nix/gcroots.rs
+++ b/backend/worker/src/nix/gcroots.rs
@@ -1,0 +1,241 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Indirect GC roots for active builds.
+//!
+//! Concurrent `nix-collect-garbage` on the worker would otherwise be free to
+//! delete a derivation's inputs (or its just-built outputs before
+//! compress+push uploads them). `GcRootKeeper` pins the .drv and each
+//! realised output via harmonia's `add_indirect_root` for the duration of
+//! the build job. Symlinks live under `gcroots_dir` (default
+//! `/nix/var/nix/gcroots/gradient`) and are removed on handle drop. The
+//! keeper purges leftovers at worker startup — anything still in the dir
+//! came from a prior worker that crashed before its handles ran.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use tokio::fs;
+use tracing::{debug, warn};
+
+use crate::nix::store::LocalNixStore;
+
+/// Manages the on-disk gcroots directory and hands out RAII handles that
+/// register / release indirect GC roots through the local nix-daemon.
+#[derive(Clone)]
+pub struct GcRootKeeper {
+    inner: Arc<KeeperInner>,
+}
+
+struct KeeperInner {
+    dir: Option<PathBuf>,
+    store: Arc<LocalNixStore>,
+}
+
+impl GcRootKeeper {
+    /// Construct a keeper. An empty `gcroots_dir` disables the feature.
+    pub fn new(gcroots_dir: &str, store: Arc<LocalNixStore>) -> Self {
+        let dir = if gcroots_dir.is_empty() {
+            None
+        } else {
+            Some(PathBuf::from(gcroots_dir))
+        };
+        Self {
+            inner: Arc::new(KeeperInner { dir, store }),
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.inner.dir.is_some()
+    }
+
+    /// Remove every entry under the gcroots dir and recreate the dir if it
+    /// doesn't exist. Stale leftovers came from a prior crashed worker.
+    pub async fn purge_all(&self) -> Result<()> {
+        let Some(dir) = self.inner.dir.as_ref() else {
+            return Ok(());
+        };
+        fs::create_dir_all(dir)
+            .await
+            .with_context(|| format!("create gcroots dir {}", dir.display()))?;
+
+        let mut entries = fs::read_dir(dir)
+            .await
+            .with_context(|| format!("read gcroots dir {}", dir.display()))?;
+        let mut removed = 0u32;
+        while let Some(entry) = entries
+            .next_entry()
+            .await
+            .with_context(|| format!("iterate gcroots dir {}", dir.display()))?
+        {
+            let path = entry.path();
+            if let Err(e) = fs::remove_file(&path).await {
+                warn!(path = %path.display(), error = %e, "purge_all: skipping unreadable entry");
+            } else {
+                removed += 1;
+            }
+        }
+        debug!(dir = %dir.display(), removed, "purged stale gcroots");
+        Ok(())
+    }
+
+    /// Add an indirect GC root for `store_path` (e.g.
+    /// `/nix/store/<hash>-<name>` or `/nix/store/<hash>-<name>.drv`).
+    /// The returned handle removes the symlink on drop.
+    ///
+    /// Returns an inert handle when the keeper is disabled. Errors creating
+    /// the symlink or registering with the daemon are logged and the
+    /// inert handle is returned — bookkeeping failures never fail a build.
+    pub async fn add(&self, store_path: &str) -> GcRootHandle {
+        let Some(dir) = self.inner.dir.as_ref() else {
+            return GcRootHandle::inert();
+        };
+        let hash_name = store_path
+            .strip_prefix("/nix/store/")
+            .unwrap_or(store_path);
+        let symlink = dir.join(hash_name);
+
+        if let Err(e) = create_symlink_idempotent(&symlink, store_path).await {
+            warn!(path = %store_path, error = %e, "gcroot: symlink create failed; build proceeds unpinned");
+            return GcRootHandle::inert();
+        }
+
+        if let Err(e) = self.inner.store.add_indirect_root(&symlink).await {
+            warn!(path = %store_path, error = %e, "gcroot: add_indirect_root failed; removing symlink");
+            let _ = fs::remove_file(&symlink).await;
+            return GcRootHandle::inert();
+        }
+
+        GcRootHandle {
+            symlink: Some(symlink),
+        }
+    }
+}
+
+async fn create_symlink_idempotent(symlink: &Path, target: &str) -> Result<()> {
+    match fs::symlink_metadata(symlink).await {
+        Ok(_) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => fs::symlink(target, symlink)
+            .await
+            .with_context(|| format!("symlink {} -> {target}", symlink.display())),
+        Err(e) => Err(anyhow::anyhow!("stat {}: {e}", symlink.display())),
+    }
+}
+
+/// RAII guard for a single indirect GC root. Removes its symlink on drop.
+pub struct GcRootHandle {
+    symlink: Option<PathBuf>,
+}
+
+impl GcRootHandle {
+    fn inert() -> Self {
+        Self { symlink: None }
+    }
+}
+
+impl Drop for GcRootHandle {
+    fn drop(&mut self) {
+        if let Some(symlink) = self.symlink.take()
+            && let Err(e) = std::fs::remove_file(&symlink)
+            && e.kind() != std::io::ErrorKind::NotFound
+        {
+            warn!(symlink = %symlink.display(), error = %e, "gcroot: failed to remove symlink on drop");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn disabled_keeper() -> GcRootKeeper {
+        GcRootKeeper::new(
+            "",
+            Arc::new(
+                LocalNixStore::connect_at("/var/empty/gradient-nonexistent.sock", 1).unwrap(),
+            ),
+        )
+    }
+
+    #[tokio::test]
+    async fn disabled_keeper_purge_is_noop() {
+        let keeper = disabled_keeper();
+        keeper.purge_all().await.unwrap();
+        assert!(!keeper.is_enabled());
+    }
+
+    #[tokio::test]
+    async fn disabled_keeper_add_returns_inert_handle() {
+        let keeper = disabled_keeper();
+        let handle = keeper.add("/nix/store/abc-foo").await;
+        assert!(handle.symlink.is_none());
+    }
+
+    #[tokio::test]
+    async fn purge_all_removes_existing_entries_and_creates_missing_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("gcroots");
+        tokio::fs::create_dir(&dir).await.unwrap();
+        tokio::fs::write(dir.join("stale-1"), b"").await.unwrap();
+        tokio::fs::symlink("/nix/store/abc-foo", dir.join("stale-2"))
+            .await
+            .unwrap();
+
+        let keeper = GcRootKeeper::new(
+            dir.to_str().unwrap(),
+            Arc::new(
+                LocalNixStore::connect_at("/var/empty/gradient-nonexistent.sock", 1).unwrap(),
+            ),
+        );
+        keeper.purge_all().await.unwrap();
+
+        let mut entries = tokio::fs::read_dir(&dir).await.unwrap();
+        assert!(entries.next_entry().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn purge_all_creates_missing_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("not-yet-created");
+        let keeper = GcRootKeeper::new(
+            dir.to_str().unwrap(),
+            Arc::new(
+                LocalNixStore::connect_at("/var/empty/gradient-nonexistent.sock", 1).unwrap(),
+            ),
+        );
+        keeper.purge_all().await.unwrap();
+        assert!(dir.is_dir());
+    }
+
+    #[tokio::test]
+    async fn drop_removes_symlink() {
+        let tmp = tempfile::tempdir().unwrap();
+        let symlink = tmp.path().join("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-foo");
+        tokio::fs::symlink("/nix/store/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-foo", &symlink)
+            .await
+            .unwrap();
+        let handle = GcRootHandle {
+            symlink: Some(symlink.clone()),
+        };
+        drop(handle);
+        assert!(symlink.symlink_metadata().is_err());
+    }
+
+    #[tokio::test]
+    async fn create_symlink_idempotent_skips_existing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let symlink = tmp.path().join("link");
+        tokio::fs::symlink("/nix/store/existing", &symlink)
+            .await
+            .unwrap();
+        create_symlink_idempotent(&symlink, "/nix/store/other")
+            .await
+            .unwrap();
+        let target = tokio::fs::read_link(&symlink).await.unwrap();
+        assert_eq!(target, std::path::PathBuf::from("/nix/store/existing"));
+    }
+}

--- a/backend/worker/src/nix/mod.rs
+++ b/backend/worker/src/nix/mod.rs
@@ -8,5 +8,6 @@
 
 pub mod eval_worker;
 pub mod flake;
+pub mod gcroots;
 pub mod nix_eval;
 pub mod store;

--- a/backend/worker/src/nix/store.rs
+++ b/backend/worker/src/nix/store.rs
@@ -170,6 +170,28 @@ impl LocalNixStore {
     /// Paths that fail individual `query_references` calls (e.g. removed
     /// between calls) are logged and skipped — the walk continues so the
     /// caller still gets a best-effort closure for the remaining paths.
+    /// Register `gcroot_symlink` as an indirect GC root with the daemon.
+    ///
+    /// The caller must have already created the symlink on disk; the daemon
+    /// records the link and treats its target as alive for GC purposes
+    /// until the link is removed.
+    pub async fn add_indirect_root(&self, gcroot_symlink: &std::path::Path) -> Result<()> {
+        let bytes =
+            bytes::Bytes::copy_from_slice(gcroot_symlink.as_os_str().as_encoded_bytes());
+
+        let mut guard = self.scoped().await?;
+        match guard.client().add_indirect_root(&bytes).await {
+            Ok(()) => {
+                guard.mark_ok();
+                Ok(())
+            }
+            Err(e) => Err(anyhow::anyhow!(
+                "add_indirect_root failed for {}: {e}",
+                gcroot_symlink.display()
+            )),
+        }
+    }
+
     pub async fn collect_runtime_closure(&self, seeds: &[String]) -> HashSet<String> {
         let mut visited: HashSet<String> = HashSet::new();
         let mut queue: VecDeque<String> = VecDeque::new();

--- a/backend/worker/src/worker/mod.rs
+++ b/backend/worker/src/worker/mod.rs
@@ -248,9 +248,17 @@ impl Worker<Connected> {
     async fn build_executor(config: &WorkerConfig) -> Result<(JobExecutor, JobScorer)> {
         let store = LocalNixStore::connect(config.max_nixdaemon_connections)?;
         let evaluator = WorkerEvaluator::new(config.eval_workers, config.max_evals_per_worker);
+        let gcroots = crate::nix::gcroots::GcRootKeeper::new(
+            &config.gcroots_dir,
+            std::sync::Arc::new(store.clone()),
+        );
+        if let Err(e) = gcroots.purge_all().await {
+            tracing::warn!(error = %e, "gcroot purge failed at startup; continuing");
+        }
         let executor = JobExecutor::new(
             store,
             evaluator,
+            gcroots,
             config.binpath_nix.clone(),
             config.binpath_ssh.clone(),
         );

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -294,6 +294,7 @@ The token must be the 48-byte random secret returned by the registration API (ge
 | `settings.maxEvaluationsPerWorker` | `20` | Recycle evaluator subprocess after N jobs (0 = never) |
 | `settings.maxNixdaemonConnections` | `32` | Worker's local nix-daemon connection pool size. Each in-flight NAR import holds one connection; size for `maxConcurrentBuilds * 8` plus headroom |
 | `settings.maxProtoConnections` | `16` | Max simultaneous WebSocket connections (for discoverable mode) |
+| `settings.gcrootsDir` | `/nix/var/nix/gcroots/gradient` | Directory for worker-held indirect GC roots. One symlink per active build (drv + outputs) pins inputs and just-built outputs through the daemon so a concurrent `nix-collect-garbage` cannot race the build. Empty string disables |
 | `settings.logLevel.default` | `info` | Worker log level |
 | `settings.logLevel.eval` | null | Evaluator log level override |
 | `settings.logLevel.build` | null | Builder log level override |

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -2304,3 +2304,30 @@ plain_build_returns_own_row_without_extra_query}` and
 `evaluation_builds_via_cross_org.rs` pin the new query sequence; the
 behavioural regression for the overflow is verified at code-review time
 (every `is_in(...)` site on this hot path is now chunked).
+
+## Worker indirect GC roots for active builds (#245)
+
+Concurrent `nix-collect-garbage` on a worker can otherwise delete a
+derivation's inputs (or its just-built outputs before compress+push
+uploads them). `GcRootKeeper` (`worker/src/nix/gcroots.rs`) writes one
+indirect-root symlink per active build to `GRADIENT_WORKER_GCROOTS_DIR`
+(default `/nix/var/nix/gcroots/gradient`); handles remove the symlinks on
+drop and the keeper purges the dir at startup to clean up after a
+crashed prior worker.
+
+### `gradient_worker::nix::gcroots::tests`
+
+- `disabled_keeper_purge_is_noop` — empty `gcroots_dir` skips startup
+  cleanup and never touches the filesystem.
+- `disabled_keeper_add_returns_inert_handle` — disabled keeper returns
+  a handle that owns no symlink.
+- `purge_all_removes_existing_entries_and_creates_missing_dir` —
+  startup wipes regular files and symlinks left by a prior crashed
+  worker.
+- `purge_all_creates_missing_dir` — first-run startup with no dir
+  present creates it instead of failing.
+- `drop_removes_symlink` — `GcRootHandle::Drop` releases the indirect
+  root by removing its symlink.
+- `create_symlink_idempotent_skips_existing` — re-adding a root for an
+  existing symlink is a no-op (handles cross-build re-entry without
+  clobbering the daemon's existing root).

--- a/nix/modules/gradient-worker.nix
+++ b/nix/modules/gradient-worker.nix
@@ -205,6 +205,23 @@ in {
         default = 1;
       };
 
+      gcrootsDir = lib.mkOption {
+        description = ''
+          Directory under which the worker writes one indirect GC root
+          symlink per active build (drv + outputs). Pins inputs and
+          just-built outputs through the local nix-daemon so a concurrent
+          <literal>nix-collect-garbage</literal> cannot delete them
+          mid-build. A systemd-tmpfiles rule creates the directory under
+          the worker user and adds it to the unit's
+          <literal>ReadWritePaths</literal>.
+
+          Set to an empty string to disable GC root pinning (the worker
+          still builds, but a concurrent GC may race the build).
+        '';
+        type = lib.types.str;
+        default = "/nix/var/nix/gcroots/gradient";
+      };
+
       logLevel = lib.mkOption {
         default = { };
         description = ''
@@ -256,10 +273,12 @@ in {
     ];
 
     systemd = {
-      tmpfiles.settings."10-gradient"."/nix/var/nix/gcroots/gradient".d = {
-        user = "gradient-worker";
-        group = "gradient-worker";
-        mode = "0755";
+      tmpfiles.settings = lib.mkIf (cfg.settings.gcrootsDir != "") {
+        "10-gradient".${cfg.settings.gcrootsDir}.d = {
+          user = "gradient-worker";
+          group = "gradient-worker";
+          mode = "0755";
+        };
       };
 
       services.gradient-worker = {
@@ -284,7 +303,7 @@ in {
           ProtectKernelTunables = true;
           ProtectProc = "invisible";
           ProtectSystem = "strict";
-          ReadWritePaths = [ "/nix/var/nix/gcroots/gradient" ];
+          ReadWritePaths = lib.optionals (cfg.settings.gcrootsDir != "") [ cfg.settings.gcrootsDir ];
           Restart = "on-failure";
           RestartSec = 10;
           KillMode = "mixed";
@@ -321,6 +340,7 @@ in {
           GRADIENT_WORKER_EVAL_WORKERS                = toString cfg.settings.evalWorkers;
           GRADIENT_MAX_EVALUATIONS_PER_WORKER         = toString cfg.settings.maxEvaluationsPerWorker;
           GRADIENT_MAX_PROTO_CONNECTIONS              = toString cfg.settings.maxProtoConnections;
+          GRADIENT_WORKER_GCROOTS_DIR                 = cfg.settings.gcrootsDir;
         } // lib.optionalAttrs (cfg.settings.architectures != []) {
           GRADIENT_WORKER_ARCHITECTURES = lib.concatStringsSep "," cfg.settings.architectures;
         } // lib.optionalAttrs (cfg.settings.systemFeatures != []) {


### PR DESCRIPTION
## Summary
- Adds `GcRootKeeper` to the worker: per-build indirect GC roots on each `.drv` (before prefetch) and on each realised output (after build), via harmonia's `add_indirect_root`.
- `GcRootHandle::Drop` removes the symlink, so any error / cancel / panic between add and explicit release still cleans up.
- Purges leftover symlinks at worker startup — anything still there is from a prior crashed worker.
- New `services.gradient.worker.settings.gcrootsDir` (default `/nix/var/nix/gcroots/gradient`) drives the tmpfiles rule, `ReadWritePaths`, and `GRADIENT_WORKER_GCROOTS_DIR`. Empty string disables.

Closes #245.

## Test plan
- [x] CI green on `gradient_worker::nix::gcroots::tests` (disabled keeper no-ops, `purge_all` clears stale roots and creates missing dir, handle drop removes symlink, idempotent re-add).
- [x] Manual: trigger a long build, run `nix-collect-garbage -d` on the worker mid-build; build completes without `1 dependency failed` and `gcrootsDir` empties after the job.
- [x] Manual: kill the worker mid-build, restart, confirm `gcrootsDir` is empty on first dispatch.