### PR TITLE
fix: surface entity name in title, align eval duration, disable PrimeNG inputs (#229)

### DIFF
--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -2103,7 +2103,13 @@ The primitives:
   `[appManagedDisable]` attribute directive. Adds `disabled` and a tooltip
   when `managed || !canEdit`. Tests cover all four flag combinations,
   tooltip text, and that the directive correctly clears its own state when
-  access becomes writable.
+  access becomes writable. The directive also propagates the disabled state
+  through `NgControl.valueAccessor.setDisabledState`, so PrimeNG controls
+  (`p-select`, `p-checkbox`, `p-autoComplete`, …) — which only honor the
+  ControlValueAccessor hook, not raw DOM `disabled` — actually become
+  read-only when the user has no write access. A `FakePrimeNgInputDirective`
+  in the spec stands in for any `ControlValueAccessor` host and asserts the
+  propagation (issue #229).
 - `frontend/src/app/core/resolvers/project-access.resolver.ts` and
   `cache-access.resolver.ts` — fetch the parent entity once, expose
   `{ entity, access }` on `route.parent.data`. Children consume via
@@ -2331,6 +2337,47 @@ crashed prior worker.
 - `create_symlink_idempotent_skips_existing` — re-adding a root for an
   existing symlink is a no-op (handles cross-build re-entry without
   clobbering the daemon's existing root).
+
+## Frontend titles surface the entity name (issue #229)
+
+`frontend/src/app/core/title/gradient-title-strategy.ts` walks the
+`RouterStateSnapshot` for resolved `projectAccess` / `cacheAccess` /
+`organizationAccess` data and composes a title of the form
+`<entity display_name> · <route title> · Gradient`, falling back to
+`<entity> · Gradient` for the root detail pages whose static route title
+is implied by the entity itself (`Project`, `Cache`, `Organization`). The
+spec at `gradient-title-strategy.spec.ts` covers the four combinations
+(both, entity-only, route-only, neither) and the entity-not-found
+fallback that keeps the title strategy a noop when an
+`organizationAccess` resolver returns `null`.
+
+A companion `organizationAccessResolver`
+(`frontend/src/app/core/resolvers/organization-access.resolver.ts`)
+fetches the organization for every `/organization/:org/*` route that
+doesn't already have a parent resolver. The spec covers the happy path,
+the no-param case, and the network-error fallback (resolver must not
+fail navigation just because the org fetch errored).
+
+## Evaluation duration parity between project page and log page (issue #229)
+
+`frontend/src/app/shared/evaluation/duration.ts` is the single source of
+truth for "how long has this evaluation been running?". Both
+`project-detail` and `evaluation-log` now use
+`evaluationDuration(evaluation, now)` and `formatEvaluationDuration(ms)`
+so the same evaluation row shows the same `Xh Ym Zs` figure on both
+pages. The regression that motivated this — the log page kept growing
+its duration after the evaluation finished because it used
+`Date.now()` instead of `updated_at` — is covered by
+`duration.spec.ts`:
+
+- `isRunningEvaluationStatus` — the six in-flight statuses return true,
+  the three terminal statuses return false.
+- `formatEvaluationDuration` — sub-minute / sub-hour / multi-hour
+  rendering, plus the negative-clock-skew clamp.
+- `parseUtcTimestamp` — backend timestamps with explicit zone and the
+  naive form that gets treated as UTC.
+- `evaluationDuration` — terminal evaluations stop at `updated_at`;
+  running evaluations track the current time.
 
 ## Connector + CLI JSON
 

--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -4,9 +4,8 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { ApplicationConfig, APP_INITIALIZER, provideBrowserGlobalErrorListeners, inject, Injectable } from '@angular/core';
-import { provideRouter, TitleStrategy, RouterStateSnapshot, withRouterConfig } from '@angular/router';
-import { Title } from '@angular/platform-browser';
+import { ApplicationConfig, APP_INITIALIZER, provideBrowserGlobalErrorListeners, inject } from '@angular/core';
+import { provideRouter, TitleStrategy, withRouterConfig } from '@angular/router';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { providePrimeNG } from 'primeng/config';
@@ -16,16 +15,7 @@ import { routes } from './app.routes';
 import { authInterceptor } from '@core/interceptors/auth.interceptor';
 import { errorInterceptor } from '@core/interceptors/error.interceptor';
 import { ConfigService } from '@core/services/config.service';
-
-@Injectable({ providedIn: 'root' })
-class GradientTitleStrategy extends TitleStrategy {
-  constructor(private readonly title: Title) { super(); }
-
-  override updateTitle(state: RouterStateSnapshot): void {
-    const routeTitle = this.buildTitle(state);
-    this.title.setTitle(routeTitle ? `${routeTitle} · Gradient` : 'Gradient');
-  }
-}
+import { GradientTitleStrategy } from '@core/title/gradient-title-strategy';
 
 export const appConfig: ApplicationConfig = {
   providers: [

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -9,6 +9,7 @@ import { authGuard } from '@core/guards/auth.guard';
 import { adminGuard } from '@core/guards/admin.guard';
 import { projectAccessResolver } from '@core/resolvers/project-access.resolver';
 import { cacheAccessResolver } from '@core/resolvers/cache-access.resolver';
+import { organizationAccessResolver } from '@core/resolvers/organization-access.resolver';
 
 export const routes: Routes = [
   // Authentication routes (public)
@@ -41,6 +42,7 @@ export const routes: Routes = [
   {
     path: 'organization/:org',
     title: 'Organization',
+    resolve: { organizationAccess: organizationAccessResolver },
     loadComponent: () =>
       import('./features/organizations/organization-detail/organization-detail.component').then(
         (m) => m.OrganizationDetailComponent
@@ -214,6 +216,7 @@ export const routes: Routes = [
       {
         path: 'organization/:org/settings',
         title: 'Organization Settings',
+        resolve: { organizationAccess: organizationAccessResolver },
         loadComponent: () =>
           import('./features/organizations/organization-settings/organization-settings.component').then(
             (m) => m.OrganizationSettingsComponent
@@ -222,6 +225,7 @@ export const routes: Routes = [
       {
         path: 'organization/:org/members',
         title: 'Members & Roles',
+        resolve: { organizationAccess: organizationAccessResolver },
         loadComponent: () =>
           import('./features/organizations/members-roles/members-roles.component').then(
             (m) => m.MembersRolesComponent
@@ -232,6 +236,7 @@ export const routes: Routes = [
       {
         path: 'organization/:org/workers',
         title: 'Workers',
+        resolve: { organizationAccess: organizationAccessResolver },
         loadComponent: () =>
           import('./features/organizations/workers/workers.component').then(
             (m) => m.WorkersComponent
@@ -242,6 +247,7 @@ export const routes: Routes = [
       {
         path: 'organization/:org/integrations',
         title: 'Integrations',
+        resolve: { organizationAccess: organizationAccessResolver },
         loadComponent: () =>
           import('./features/organizations/integrations/integrations.component').then(
             (m) => m.IntegrationsComponent
@@ -252,6 +258,7 @@ export const routes: Routes = [
       {
         path: 'organization/:org/caches',
         title: 'Cache Subscriptions',
+        resolve: { organizationAccess: organizationAccessResolver },
         loadComponent: () =>
           import('./features/organizations/cache-subscriptions/cache-subscriptions.component').then(
             (m) => m.CacheSubscriptionsComponent

--- a/frontend/src/app/core/models/project.model.ts
+++ b/frontend/src/app/core/models/project.model.ts
@@ -94,6 +94,7 @@ export interface Evaluation {
   previous?: string;
   next?: string;
   created_at: string;
+  updated_at: string;
   error_count: number;
   warning_count: number;
   waiting_reason?: WaitingReason;

--- a/frontend/src/app/core/resolvers/cache-access.resolver.spec.ts
+++ b/frontend/src/app/core/resolvers/cache-access.resolver.spec.ts
@@ -34,6 +34,7 @@ describe('cacheAccessResolver', () => {
     description: '',
     active: true,
     priority: 10,
+    local_priority: null,
     public: false,
     managed: false,
     can_edit: true,

--- a/frontend/src/app/core/resolvers/organization-access.resolver.spec.ts
+++ b/frontend/src/app/core/resolvers/organization-access.resolver.spec.ts
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, convertToParamMap } from '@angular/router';
+import { Observable, firstValueFrom, of, throwError } from 'rxjs';
+import { OrganizationsService } from '@core/services/organizations.service';
+import { organizationAccessResolver, OrganizationAccessData } from './organization-access.resolver';
+import { Organization } from '@core/models';
+
+function snap(params: Record<string, string>): ActivatedRouteSnapshot {
+  return { paramMap: convertToParamMap(params) } as ActivatedRouteSnapshot;
+}
+
+function runResolver(route: ActivatedRouteSnapshot): Promise<OrganizationAccessData> {
+  const result = TestBed.runInInjectionContext(() =>
+    organizationAccessResolver(route, {} as never),
+  ) as Observable<OrganizationAccessData>;
+  return firstValueFrom(result);
+}
+
+describe('organizationAccessResolver', () => {
+  let getOrganization: ReturnType<typeof vi.fn>;
+
+  const baseOrg: Organization = {
+    id: 'o1',
+    name: 'wavelens',
+    display_name: 'Wavelens',
+    description: '',
+    public: true,
+    hide_build_requests: false,
+    managed: false,
+  };
+
+  beforeEach(() => {
+    getOrganization = vi.fn(() => of(baseOrg));
+    TestBed.configureTestingModule({
+      providers: [{ provide: OrganizationsService, useValue: { getOrganization } }],
+    });
+  });
+
+  it('fetches the organization by route param', async () => {
+    const data = await runResolver(snap({ org: 'wavelens' }));
+    expect(getOrganization).toHaveBeenCalledWith('wavelens');
+    expect(data.organization).toBe(baseOrg);
+  });
+
+  it('returns null when the org param is missing', async () => {
+    const data = await runResolver(snap({}));
+    expect(getOrganization).not.toHaveBeenCalled();
+    expect(data.organization).toBeNull();
+  });
+
+  it('falls back to null when the fetch errors so navigation still proceeds', async () => {
+    getOrganization.mockReturnValue(throwError(() => new Error('boom')));
+    const data = await runResolver(snap({ org: 'missing' }));
+    expect(data.organization).toBeNull();
+  });
+});

--- a/frontend/src/app/core/resolvers/organization-access.resolver.ts
+++ b/frontend/src/app/core/resolvers/organization-access.resolver.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { inject } from '@angular/core';
+import { ResolveFn } from '@angular/router';
+import { catchError, map, of } from 'rxjs';
+import { OrganizationsService } from '@core/services/organizations.service';
+import { Organization } from '@core/models';
+
+export interface OrganizationAccessData {
+  organization: Organization | null;
+}
+
+export const organizationAccessResolver: ResolveFn<OrganizationAccessData> = (route) => {
+  const orgs = inject(OrganizationsService);
+  const name = route.paramMap.get('org') ?? '';
+  if (!name) return of({ organization: null });
+  return orgs.getOrganization(name).pipe(
+    map((organization) => ({ organization })),
+    catchError(() => of({ organization: null })),
+  );
+};

--- a/frontend/src/app/core/services/org-access.service.spec.ts
+++ b/frontend/src/app/core/services/org-access.service.spec.ts
@@ -17,6 +17,7 @@ function org(partial: Partial<Organization> = {}): Organization {
     display_name: 'Acme',
     description: '',
     public: false,
+    hide_build_requests: false,
     managed: false,
     ...partial,
   };

--- a/frontend/src/app/core/title/gradient-title-strategy.spec.ts
+++ b/frontend/src/app/core/title/gradient-title-strategy.spec.ts
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { ActivatedRouteSnapshot } from '@angular/router';
+import { composeTitle, findEntityName } from './gradient-title-strategy';
+
+interface FakeSnapshot {
+  data: Record<string, unknown>;
+  children: FakeSnapshot[];
+}
+
+function snap(data: Record<string, unknown> = {}, children: FakeSnapshot[] = []): FakeSnapshot {
+  return { data, children };
+}
+
+function find(s: FakeSnapshot): string | undefined {
+  return findEntityName(s as unknown as ActivatedRouteSnapshot);
+}
+
+describe('composeTitle', () => {
+  it('uses entity + page + brand when both are present', () => {
+    expect(composeTitle('Demo', 'Project Settings')).toBe('Demo · Project Settings · Gradient');
+  });
+
+  it('collapses redundant entity-only page titles', () => {
+    // The detail page's static title ("Project"/"Cache"/"Organization") is implied
+    // by the entity name itself, so it drops out to avoid "Demo · Project · Gradient".
+    expect(composeTitle('Demo', 'Project')).toBe('Demo · Gradient');
+    expect(composeTitle('Demo', 'Cache')).toBe('Demo · Gradient');
+    expect(composeTitle('Demo', 'Organization')).toBe('Demo · Gradient');
+  });
+
+  it('falls back to page + brand when no entity is in the tree', () => {
+    expect(composeTitle(undefined, 'Sign In')).toBe('Sign In · Gradient');
+  });
+
+  it('falls back to brand alone when there is nothing else', () => {
+    expect(composeTitle(undefined, undefined)).toBe('Gradient');
+  });
+});
+
+describe('findEntityName', () => {
+  it('returns the project display_name from resolved data', () => {
+    const tree = snap({}, [
+      snap({ projectAccess: { project: { display_name: 'Test Gradient' } } }),
+    ]);
+    expect(find(tree)).toBe('Test Gradient');
+  });
+
+  it('returns the cache display_name from resolved data', () => {
+    const tree = snap({}, [
+      snap({ cacheAccess: { cache: { display_name: 'main' } } }),
+    ]);
+    expect(find(tree)).toBe('main');
+  });
+
+  it('returns the organization display_name from resolved data', () => {
+    const tree = snap({ organizationAccess: { organization: { display_name: 'Wavelens' } } });
+    expect(find(tree)).toBe('Wavelens');
+  });
+
+  it('returns undefined when no entity data is in the tree', () => {
+    expect(find(snap())).toBeUndefined();
+  });
+
+  it('returns undefined when an organizationAccess resolves to null (404)', () => {
+    const tree = snap({ organizationAccess: { organization: null } });
+    expect(find(tree)).toBeUndefined();
+  });
+});

--- a/frontend/src/app/core/title/gradient-title-strategy.ts
+++ b/frontend/src/app/core/title/gradient-title-strategy.ts
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Injectable, inject } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+import { ActivatedRouteSnapshot, RouterStateSnapshot, TitleStrategy } from '@angular/router';
+import { ProjectAccessData } from '@core/resolvers/project-access.resolver';
+import { CacheAccessData } from '@core/resolvers/cache-access.resolver';
+import { OrganizationAccessData } from '@core/resolvers/organization-access.resolver';
+
+const BRAND = 'Gradient';
+const ENTITY_ONLY_ROUTE_TITLES = new Set(['Organization', 'Project', 'Cache']);
+
+@Injectable({ providedIn: 'root' })
+export class GradientTitleStrategy extends TitleStrategy {
+  private readonly title = inject(Title);
+
+  override updateTitle(state: RouterStateSnapshot): void {
+    const routeTitle = this.buildTitle(state);
+    const entity = findEntityName(state.root);
+    this.title.setTitle(composeTitle(entity, routeTitle));
+  }
+}
+
+export function composeTitle(entity: string | undefined, routeTitle: string | undefined): string {
+  if (entity && routeTitle && !ENTITY_ONLY_ROUTE_TITLES.has(routeTitle)) {
+    return `${entity} · ${routeTitle} · ${BRAND}`;
+  }
+  if (entity) return `${entity} · ${BRAND}`;
+  if (routeTitle) return `${routeTitle} · ${BRAND}`;
+  return BRAND;
+}
+
+export function findEntityName(snapshot: ActivatedRouteSnapshot): string | undefined {
+  const visit = (s: ActivatedRouteSnapshot): string | undefined => {
+    const data = s.data as {
+      projectAccess?: ProjectAccessData;
+      cacheAccess?: CacheAccessData;
+      organizationAccess?: OrganizationAccessData;
+    };
+    const name =
+      data.projectAccess?.project.display_name ??
+      data.cacheAccess?.cache.display_name ??
+      data.organizationAccess?.organization?.display_name;
+    if (name) return name;
+    for (const child of s.children) {
+      const found = visit(child);
+      if (found) return found;
+    }
+    return undefined;
+  };
+  return visit(snapshot);
+}

--- a/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.ts
+++ b/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.ts
@@ -23,9 +23,10 @@ import { switchMap } from 'rxjs/operators';
 import { CdkVirtualScrollViewport, ScrollingModule } from '@angular/cdk/scrolling';
 import { EvaluationsService, BuildItem } from '@core/services/evaluations.service';
 import { OrganizationsService } from '@core/services/organizations.service';
-import { Evaluation, EvaluationMessage, WaitingReason, TriggerType } from '@core/models';
+import { Evaluation, EvaluationMessage, EvaluationStatus, WaitingReason, TriggerType } from '@core/models';
 import { AuthService } from '@core/services/auth.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
+import { formatEvaluationDuration, isRunningEvaluationStatus, parseUtcTimestamp } from '@shared/evaluation';
 import { ButtonModule } from 'primeng/button';
 import { environment } from '@environments/environment';
 
@@ -59,7 +60,7 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
   aborting = signal(false);
   autoScroll = signal(true);
   showScrollBtn = signal(false);
-  duration = signal('0:00');
+  duration = signal('0s');
   totalBuildsCount = signal(0);
   activeBuildsCount = signal(0);
   private tick = signal(0);
@@ -347,10 +348,9 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
     });
   }
 
-  startPollingIfRunning(status: string): void {
+  startPollingIfRunning(status: EvaluationStatus): void {
     this.stopPolling();
-    const running = ['Queued', 'Fetching', 'EvaluatingFlake', 'EvaluatingDerivation', 'Building', 'Waiting'];
-    if (!running.includes(status)) return;
+    if (!this.isRunningStatus(status)) return;
 
     this.pollSub = interval(5000)
       .pipe(switchMap(() => this.evalService.getEvaluation(this.evaluationId)))
@@ -358,8 +358,9 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
         next: (evaluation) => {
           this.evaluation.set(evaluation);
           this.loadBuilds();
-          if (!running.includes(evaluation.status)) {
+          if (!this.isRunningStatus(evaluation.status)) {
             this.stopPolling();
+            this.updateDuration(evaluation);
             this.stopDurationTimer();
             this.loadBuilds(); // final update
             this.loadMessages(); // pick up any messages recorded during eval
@@ -688,8 +689,7 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
     this.stopDurationTimer();
     this.updateDuration(evaluation);
 
-    const running = ['Queued', 'Fetching', 'EvaluatingFlake', 'EvaluatingDerivation', 'Building', 'Waiting'];
-    if (!running.includes(evaluation.status)) return;
+    if (!this.isRunningStatus(evaluation.status)) return;
 
     this.durationInterval = setInterval(() => {
       const ev = this.evaluation();
@@ -706,21 +706,15 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
   }
 
   private updateDuration(evaluation: Evaluation): void {
-    const ts = evaluation.created_at;
-    const start = new Date(
-      ts.includes('Z') || ts.includes('+') ? ts : ts + 'Z'
-    );
-    const ms = Math.max(0, new Date().getTime() - start.getTime());
-    const totalSecs = Math.floor(ms / 1000);
-    const h = Math.floor(totalSecs / 3600);
-    const m = Math.floor((totalSecs % 3600) / 60);
-    const s = totalSecs % 60;
+    const start = parseUtcTimestamp(evaluation.created_at);
+    const end = this.isRunningStatus(evaluation.status)
+      ? Date.now()
+      : parseUtcTimestamp(evaluation.updated_at);
+    this.duration.set(formatEvaluationDuration(end - start));
+  }
 
-    this.duration.set(
-      h > 0
-        ? `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
-        : `${m}:${String(s).padStart(2, '0')}`
-    );
+  isRunningStatus(status: EvaluationStatus): boolean {
+    return isRunningEvaluationStatus(status);
   }
 
   // ── Abort ───────────────────────────────────────────────────────────────────

--- a/frontend/src/app/features/organizations/organization-settings/organization-settings.component.spec.ts
+++ b/frontend/src/app/features/organizations/organization-settings/organization-settings.component.spec.ts
@@ -22,6 +22,7 @@ function orgFor(access: AccessState): Organization {
     display_name: 'Acme',
     description: '',
     public: false,
+    hide_build_requests: false,
     managed: access.managed,
     role: access.canEdit ? 'Admin' : 'View',
   };

--- a/frontend/src/app/features/projects/project-detail/project-detail.component.ts
+++ b/frontend/src/app/features/projects/project-detail/project-detail.component.ts
@@ -17,6 +17,7 @@ import { EmptyStateComponent } from '@shared/components/empty-state/empty-state.
 import { AccessService, WritableDirective } from '@shared/access';
 import { injectProjectAccess } from '@core/resolvers/inject-access';
 import { ProjectDetail, EvaluationSummary, EvaluationStatus, EntryPointSummary, BuildStatus, TriggerType } from '@core/models';
+import { formatEvaluationDuration, isRunningEvaluationStatus, parseUtcTimestamp } from '@shared/evaluation';
 
 @Component({
   selector: 'app-project-detail',
@@ -181,7 +182,7 @@ export class ProjectDetailComponent implements OnInit, OnDestroy {
   }
 
   isRunningStatus(status: EvaluationStatus): boolean {
-    return status === 'Queued' || status === 'Fetching' || status === 'EvaluatingFlake' || status === 'EvaluatingDerivation' || status === 'Building' || status === 'Waiting';
+    return isRunningEvaluationStatus(status);
   }
 
   isBuildRunning(status: BuildStatus): boolean {
@@ -214,22 +215,11 @@ export class ProjectDetailComponent implements OnInit, OnDestroy {
   }
 
   getEvaluationDuration(evaluation: EvaluationSummary): string {
-    const toUtc = (s: string) => new Date(s.includes('Z') || s.includes('+') ? s : s + 'Z').getTime();
-    const start = toUtc(evaluation.created_at);
+    const start = parseUtcTimestamp(evaluation.created_at);
     const end = this.isRunningStatus(evaluation.status)
       ? this.tick()
-      : toUtc(evaluation.updated_at);
-    return this.formatDuration(end - start);
-  }
-
-  private formatDuration(ms: number): string {
-    const totalSeconds = Math.max(0, Math.floor(ms / 1000));
-    const h = Math.floor(totalSeconds / 3600);
-    const m = Math.floor((totalSeconds % 3600) / 60);
-    const s = totalSeconds % 60;
-    if (h > 0) return `${h}h ${m}m ${s}s`;
-    if (m > 0) return `${m}m ${s}s`;
-    return `${s}s`;
+      : parseUtcTimestamp(evaluation.updated_at);
+    return formatEvaluationDuration(end - start);
   }
 
   formatArchitecture(arch: string | undefined): string {

--- a/frontend/src/app/shared/access/managed-disable.directive.spec.ts
+++ b/frontend/src/app/shared/access/managed-disable.directive.spec.ts
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, signal } from '@angular/core';
+import { Component, Directive, forwardRef, signal } from '@angular/core';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ManagedDisableDirective } from './managed-disable.directive';
 import { AccessState } from '@core/models/access.model';
 
@@ -16,6 +17,38 @@ import { AccessState } from '@core/models/access.model';
   template: `<input [appManagedDisable]="access()" />`,
 })
 class HostComponent {
+  access = signal<AccessState>({ managed: false, canEdit: true, canTrigger: true });
+}
+
+// Mirrors how PrimeNG inputs implement ControlValueAccessor — the directive
+// must call `setDisabledState` on them, since setting the DOM `disabled`
+// property on a component host element does not flow into the component's
+// internal state.
+@Directive({
+  selector: 'fake-primeng-input',
+  standalone: true,
+  providers: [
+    { provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => FakePrimeNgInputDirective), multi: true },
+  ],
+})
+class FakePrimeNgInputDirective implements ControlValueAccessor {
+  isDisabled = false;
+  writeValue(): void {}
+  registerOnChange(): void {}
+  registerOnTouched(): void {}
+  setDisabledState(disabled: boolean): void {
+    this.isDisabled = disabled;
+  }
+}
+
+@Component({
+  selector: 'cva-host',
+  standalone: true,
+  imports: [FormsModule, ManagedDisableDirective, FakePrimeNgInputDirective],
+  template: `<fake-primeng-input [(ngModel)]="value" [appManagedDisable]="access()"></fake-primeng-input>`,
+})
+class CvaHostComponent {
+  value = '';
   access = signal<AccessState>({ managed: false, canEdit: true, canTrigger: true });
 }
 
@@ -76,5 +109,35 @@ describe('ManagedDisableDirective ([appManagedDisable])', () => {
     fixture.detectChanges();
     expect(input().disabled).toBe(false);
     expect(input().title).toBe('');
+  });
+});
+
+describe('ManagedDisableDirective with a ControlValueAccessor (PrimeNG-like)', () => {
+  let fixture: ComponentFixture<CvaHostComponent>;
+
+  function cvaInstance(): FakePrimeNgInputDirective {
+    const debugEl = fixture.debugElement.children[0];
+    return debugEl.injector.get(FakePrimeNgInputDirective);
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [CvaHostComponent] });
+    fixture = TestBed.createComponent(CvaHostComponent);
+  });
+
+  it('propagates the disabled state via setDisabledState', () => {
+    fixture.componentInstance.access.set({ managed: false, canEdit: false, canTrigger: false });
+    fixture.detectChanges();
+    expect(cvaInstance().isDisabled).toBe(true);
+  });
+
+  it('lifts the disabled state when access becomes writable again', () => {
+    fixture.componentInstance.access.set({ managed: true, canEdit: true, canTrigger: true });
+    fixture.detectChanges();
+    expect(cvaInstance().isDisabled).toBe(true);
+
+    fixture.componentInstance.access.set({ managed: false, canEdit: true, canTrigger: true });
+    fixture.detectChanges();
+    expect(cvaInstance().isDisabled).toBe(false);
   });
 });

--- a/frontend/src/app/shared/access/managed-disable.directive.ts
+++ b/frontend/src/app/shared/access/managed-disable.directive.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Directive, ElementRef, Input, Renderer2, inject } from '@angular/core';
+import { Directive, ElementRef, Input, OnInit, Renderer2, inject } from '@angular/core';
+import { NgControl } from '@angular/forms';
 import { AccessState } from '@core/models/access.model';
 import { AccessService } from './access.service';
 
@@ -12,26 +13,36 @@ import { AccessService } from './access.service';
   selector: '[appManagedDisable]',
   standalone: true,
 })
-export class ManagedDisableDirective {
+export class ManagedDisableDirective implements OnInit {
   private el = inject(ElementRef<HTMLElement>);
   private renderer = inject(Renderer2);
   private access = inject(AccessService);
+  private ngControl = inject(NgControl, { optional: true, self: true });
+  private state: AccessState | null | undefined;
+  private initialized = false;
 
   @Input({ required: true }) set appManagedDisable(state: AccessState | null | undefined) {
-    this.apply(state);
+    this.state = state;
+    if (this.initialized) this.apply();
   }
 
-  private apply(state: AccessState | null | undefined): void {
+  ngOnInit(): void {
+    this.initialized = true;
+    this.apply();
+  }
+
+  private apply(): void {
     const node = this.el.nativeElement;
-    if (state && this.access.shouldDisableInput(state)) {
-      this.renderer.setProperty(node, 'disabled', true);
+    const disable = !!this.state && this.access.shouldDisableInput(this.state);
+    this.renderer.setProperty(node, 'disabled', disable);
+    if (disable) {
       this.renderer.setAttribute(node, 'aria-disabled', 'true');
-      this.renderer.setAttribute(node, 'title', this.tooltip(state));
+      this.renderer.setAttribute(node, 'title', this.tooltip(this.state!));
     } else {
-      this.renderer.setProperty(node, 'disabled', false);
       this.renderer.removeAttribute(node, 'aria-disabled');
       this.renderer.removeAttribute(node, 'title');
     }
+    this.ngControl?.valueAccessor?.setDisabledState?.(disable);
   }
 
   private tooltip(state: AccessState): string {

--- a/frontend/src/app/shared/evaluation/duration.spec.ts
+++ b/frontend/src/app/shared/evaluation/duration.spec.ts
@@ -1,0 +1,82 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import {
+  evaluationDuration,
+  formatEvaluationDuration,
+  isRunningEvaluationStatus,
+  parseUtcTimestamp,
+} from './duration';
+
+describe('isRunningEvaluationStatus', () => {
+  it('returns true for in-flight statuses', () => {
+    expect(isRunningEvaluationStatus('Queued')).toBe(true);
+    expect(isRunningEvaluationStatus('Fetching')).toBe(true);
+    expect(isRunningEvaluationStatus('EvaluatingFlake')).toBe(true);
+    expect(isRunningEvaluationStatus('EvaluatingDerivation')).toBe(true);
+    expect(isRunningEvaluationStatus('Building')).toBe(true);
+    expect(isRunningEvaluationStatus('Waiting')).toBe(true);
+  });
+
+  it('returns false for terminal statuses', () => {
+    expect(isRunningEvaluationStatus('Completed')).toBe(false);
+    expect(isRunningEvaluationStatus('Failed')).toBe(false);
+    expect(isRunningEvaluationStatus('Aborted')).toBe(false);
+  });
+});
+
+describe('formatEvaluationDuration', () => {
+  it('shows seconds only when sub-minute', () => {
+    expect(formatEvaluationDuration(5_000)).toBe('5s');
+  });
+
+  it('shows minutes + seconds when sub-hour', () => {
+    expect(formatEvaluationDuration(125_000)).toBe('2m 5s');
+  });
+
+  it('shows hours + minutes + seconds when long-running', () => {
+    expect(formatEvaluationDuration(3_725_000)).toBe('1h 2m 5s');
+  });
+
+  it('clamps negative durations (clock skew) to 0s', () => {
+    expect(formatEvaluationDuration(-1_000)).toBe('0s');
+  });
+});
+
+describe('parseUtcTimestamp', () => {
+  it('parses ISO strings with explicit zone', () => {
+    expect(parseUtcTimestamp('2026-05-20T12:00:00Z')).toBe(Date.UTC(2026, 4, 20, 12, 0, 0));
+    expect(parseUtcTimestamp('2026-05-20T14:00:00+02:00')).toBe(Date.UTC(2026, 4, 20, 12, 0, 0));
+  });
+
+  it('defaults to UTC when the timestamp omits a zone', () => {
+    // Backend frequently emits naive timestamps; we treat them as UTC so durations
+    // are not skewed by the viewer's local offset.
+    expect(parseUtcTimestamp('2026-05-20T12:00:00')).toBe(Date.UTC(2026, 4, 20, 12, 0, 0));
+  });
+});
+
+describe('evaluationDuration', () => {
+  const created = '2026-05-20T12:00:00Z';
+  const updated = '2026-05-20T12:01:30Z';
+  const now = Date.UTC(2026, 4, 20, 12, 5, 0);
+
+  it('uses updated_at for terminal evaluations so the duration stops growing', () => {
+    const ms = evaluationDuration(
+      { status: 'Completed', created_at: created, updated_at: updated },
+      now,
+    );
+    expect(ms).toBe(90_000);
+  });
+
+  it('uses the current time for running evaluations', () => {
+    const ms = evaluationDuration(
+      { status: 'Building', created_at: created, updated_at: updated },
+      now,
+    );
+    expect(ms).toBe(5 * 60 * 1000);
+  });
+});

--- a/frontend/src/app/shared/evaluation/duration.ts
+++ b/frontend/src/app/shared/evaluation/duration.ts
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { EvaluationStatus } from '@core/models';
+
+const RUNNING_STATUSES: ReadonlySet<EvaluationStatus> = new Set([
+  'Queued',
+  'Fetching',
+  'EvaluatingFlake',
+  'EvaluatingDerivation',
+  'Building',
+  'Waiting',
+]);
+
+export function isRunningEvaluationStatus(status: EvaluationStatus): boolean {
+  return RUNNING_STATUSES.has(status);
+}
+
+export function formatEvaluationDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const s = totalSeconds % 60;
+  if (h > 0) return `${h}h ${m}m ${s}s`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
+export function parseUtcTimestamp(ts: string): number {
+  return new Date(ts.includes('Z') || ts.includes('+') ? ts : ts + 'Z').getTime();
+}
+
+export function evaluationDuration(
+  evaluation: { status: EvaluationStatus; created_at: string; updated_at: string },
+  nowMs: number,
+): number {
+  const start = parseUtcTimestamp(evaluation.created_at);
+  const end = isRunningEvaluationStatus(evaluation.status) ? nowMs : parseUtcTimestamp(evaluation.updated_at);
+  return end - start;
+}

--- a/frontend/src/app/shared/evaluation/index.ts
+++ b/frontend/src/app/shared/evaluation/index.ts
@@ -1,0 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export * from './duration';


### PR DESCRIPTION
Closes #229.

## Summary

- **Browser title now leads with the entity name.** `GradientTitleStrategy` walks the route snapshot tree for resolved `projectAccess` / `cacheAccess` / `organizationAccess` data and composes `<entity> · <page> · Gradient` (e.g. `Test Gradient · Project Settings · Gradient`). On a detail page whose route title is implied by the entity itself (`Project`, `Cache`, `Organization`), the static title drops out, so a project detail page becomes `Test Gradient · Gradient`. A new `organizationAccessResolver` provides the org `display_name` for the org-scoped pages that didn't have a parent resolver.
- **Evaluation duration is consistent between the project page and the log page.** The log page was using `Date.now()` as the end time even for terminal evaluations, so the duration kept growing after the eval finished. The fix moves the duration math (start = `created_at`, end = `Date.now()` while running else `updated_at`, format `Xh Ym Zs`) into a shared helper (`shared/evaluation/duration.ts`) used by both `project-detail` and `evaluation-log`.
- **`[appManagedDisable]` actually disables PrimeNG inputs now.** The directive used to call `Renderer2.setProperty(node, 'disabled', true)` only, which silently no-ops on `<p-select>`, `<p-checkbox>`, `<p-autoComplete>` — those components only honor the `ControlValueAccessor.setDisabledState` hook. The directive now also propagates through `NgControl.valueAccessor.setDisabledState`, deferred to `ngOnInit` so `NgModel`'s own initial `setDisabledState(false)` doesn't clobber us. Settings forms are now genuinely read-only for users without write access.

## Test plan

- [x] `pnpm -C frontend test --watch=false` — 115/115 passing.
- [x] `pnpm -C frontend exec ng build` — production build succeeds.
- [x] Manual check: open `/organization/<org>/project/<proj>/settings` as a read-only user, confirm the concurrency dropdown, sign-cache checkbox, and outbound-integration dropdown are all disabled.
- [x] Manual check: open an evaluation log for a `Completed` evaluation, confirm the duration stops at the eval's actual runtime and matches the project page.
- [x] Manual check: open `/organization/wavelens/project/gradient/settings`, confirm the browser tab reads `<display_name> · Project Settings · Gradient`.