### PR TITLE
fix SPA loading with caddy reverseproxy

### DIFF
--- a/nix/modules/gradient.nix
+++ b/nix/modules/gradient.nix
@@ -629,16 +629,24 @@ in {
         virtualHosts."${if cfg.useTls then "" else "http://"}${cfg.domain}" = {
           inherit (cfg.reverseProxy.caddy) useACMEHost;
           extraConfig = ''
-            @backend {
-              path_regexp api ^/(api|proto|cache)(/.*)?$
+            handle /api/* {
+              reverse_proxy http://${cfg.listenAddr}:${toString cfg.port}
             }
-            reverse_proxy @backend http://${cfg.listenAddr}:${toString cfg.port}
+            handle /cache/* {
+              reverse_proxy http://${cfg.listenAddr}:${toString cfg.port}
+            }
+            handle /proto {
+              reverse_proxy http://${cfg.listenAddr}:${toString cfg.port}
+            }
 
             ${
               if cfg.frontend.enable then
                 ''
-                  root ${cfg.packages.frontend}/share/gradient-frontend
-                  file_server
+                  handle {
+                    root ${cfg.packages.frontend}/share/gradient-frontend
+                    try_files {path} index.html
+                    file_server
+                  }
                 ''
               else
                 ""


### PR DESCRIPTION
This PR fixes the SPA loading logic when using caddy as a reverse proxy.

The current behavior:

- `GET / --> index.html`
- `GET /api/* --> redirect to API`
- `GET /organizations --> 404` (this should be 404)

The navigation only worked when already on the page, but not when reloading.
This is fixed no with the usage of `try_files {path} index.html`

- `GET / --> index.html`
- `GET /api/* --> redirect to API`
- `GET /organizations --> index.html` 