### PR TITLE
Gate untrusted PR builds on maintainer approval (#247)

### DIFF
--- a/backend/core/src/ci/apply.rs
+++ b/backend/core/src/ci/apply.rs
@@ -10,11 +10,14 @@
 
 use super::abort::{AbortKind, abort_evaluation};
 use super::trigger::{TriggerError, trigger_evaluation};
+use crate::db::org_has_writable_cache;
 use crate::types::triggers::{ConcurrencyPolicy, TriggerType};
+use crate::types::waiting_reason::WaitingReason;
 use crate::types::*;
 
 use entity::evaluation::EvaluationStatus;
-use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
+use sea_orm::ActiveValue::Set;
+use sea_orm::{ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
 
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
@@ -140,6 +143,8 @@ pub async fn apply_trigger<C: ConnectionTrait>(
         }
         Err(e) => return Err(e.into()),
     };
+
+    let eval = park_if_no_cache(db, eval, project.organization).await?;
     Ok(ApplyOutcome::Created {
         evaluation: eval,
         aborted_evaluation,
@@ -147,9 +152,33 @@ pub async fn apply_trigger<C: ConnectionTrait>(
     })
 }
 
+/// Move a freshly-created `Queued` evaluation into `Waiting` with
+/// `WaitingReason::NoCache` if the project's organisation lacks a writable
+/// cache subscription. Returns the evaluation unchanged when at least one
+/// ReadWrite/WriteOnly cache is present.
+///
+/// Callers that go through [`apply_trigger`] get this automatically; the
+/// manual `/projects/{org}/{project}/evaluate` endpoint applies it directly
+/// after calling [`trigger_evaluation`].
+pub async fn park_if_no_cache<C: ConnectionTrait>(
+    db: &C,
+    eval: MEvaluation,
+    organization: OrganizationId,
+) -> Result<MEvaluation, sea_orm::DbErr> {
+    if org_has_writable_cache(db, organization).await? {
+        return Ok(eval);
+    }
+    let mut ae: AEvaluation = eval.into();
+    ae.status = Set(EvaluationStatus::Waiting);
+    ae.waiting_reason = Set(Some(WaitingReason::NoCache.to_json()));
+    ae.updated_at = Set(crate::types::now());
+    ae.update(db).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::ids::{CacheId, OrganizationCacheId, UserId};
     use chrono::NaiveDateTime;
     use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
     use uuid::Uuid;
@@ -231,6 +260,41 @@ mod tests {
         }
     }
 
+    fn cache_row(active: bool) -> entity::cache::Model {
+        entity::cache::Model {
+            id: CacheId::now_v7(),
+            name: "cache".into(),
+            display_name: "Cache".into(),
+            description: String::new(),
+            active,
+            priority: 10,
+            local_priority: None,
+            public_key: String::new(),
+            private_key: String::new(),
+            public: false,
+            created_by: UserId::nil(),
+            created_at: NaiveDateTime::default(),
+            managed: false,
+        }
+    }
+
+    fn org_cache_row(cache: CacheId) -> entity::organization_cache::Model {
+        entity::organization_cache::Model {
+            id: OrganizationCacheId::now_v7(),
+            organization: OrganizationId::nil(),
+            cache,
+            mode: entity::organization_cache::CacheSubscriptionMode::ReadWrite,
+        }
+    }
+
+    /// Append the two queries `org_has_writable_cache` issues for the
+    /// "writable cache exists" path.
+    fn with_writable_cache(db: MockDatabase) -> MockDatabase {
+        let cache = cache_row(true);
+        db.append_query_results([vec![org_cache_row(cache.id)]])
+            .append_query_results([vec![cache]])
+    }
+
     #[tokio::test]
     async fn skips_when_same_commit_as_last_eval() {
         let prev_eval_id = EvaluationId::now_v7();
@@ -302,8 +366,8 @@ mod tests {
             .append_exec_results([MockExecResult {
                 last_insert_id: 0,
                 rows_affected: 1,
-            }])
-            .into_connection();
+            }]);
+        let db = with_writable_cache(db).into_connection();
 
         let res = apply_trigger(
             &db,
@@ -419,8 +483,8 @@ mod tests {
             .append_exec_results([MockExecResult {
                 last_insert_id: 0,
                 rows_affected: 1,
-            }])
-            .into_connection();
+            }]);
+        let db = with_writable_cache(db).into_connection();
 
         let res = apply_trigger(
             &db,
@@ -513,8 +577,8 @@ mod tests {
             .append_exec_results([MockExecResult {
                 last_insert_id: 0,
                 rows_affected: 1,
-            }])
-            .into_connection();
+            }]);
+        let db = with_writable_cache(db).into_connection();
 
         let res = apply_trigger(
             &db,
@@ -599,8 +663,8 @@ mod tests {
             .append_exec_results([MockExecResult {
                 last_insert_id: 0,
                 rows_affected: 1,
-            }])
-            .into_connection();
+            }]);
+        let db = with_writable_cache(db).into_connection();
 
         let res = apply_trigger(
             &db,
@@ -621,5 +685,84 @@ mod tests {
         assert_eq!(evaluation.id, new_eval_id);
         assert_eq!(aborted_evaluation, Some(running_eval_id));
         assert_eq!(aborted_builds, vec![active_build_id]);
+    }
+
+    /// When the project's organisation has no writable cache subscription, a
+    /// freshly-created evaluation is parked in `Waiting` with the `NoCache`
+    /// reason — no jobs are spawned and the scheduler's reconciler must leave
+    /// the row alone until the cache-create endpoint re-queues it.
+    #[tokio::test]
+    async fn no_writable_cache_parks_evaluation_in_waiting_no_cache() {
+        use crate::types::waiting_reason::WaitingReason;
+        let project = make_project_with_last_eval(None);
+        let new_eval_id = EvaluationId::now_v7();
+        let new_commit_id = CommitId::now_v7();
+        let trig = ProjectTriggerId::now_v7();
+        let new_hash = vec![1u8; 20];
+
+        let parked_eval = {
+            let mut m = make_eval(
+                new_eval_id,
+                project.id,
+                new_commit_id,
+                EvaluationStatus::Waiting,
+            );
+            m.trigger = Some(trig);
+            m.waiting_reason = Some(WaitingReason::NoCache.to_json());
+            m
+        };
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            // Concurrency check: no in-flight
+            .append_query_results([Vec::<entity::evaluation::Model>::new()])
+            // trigger_evaluation: in-progress guard
+            .append_query_results([Vec::<entity::evaluation::Model>::new()])
+            // trigger_evaluation: commit insert
+            .append_query_results([vec![make_commit(new_commit_id, new_hash.clone())]])
+            // trigger_evaluation: eval insert (initially Queued)
+            .append_query_results([vec![{
+                let mut m = make_eval(
+                    new_eval_id,
+                    project.id,
+                    new_commit_id,
+                    EvaluationStatus::Queued,
+                );
+                m.trigger = Some(trig);
+                m
+            }]])
+            // trigger_evaluation: project update read-back + exec
+            .append_query_results([vec![project.clone()]])
+            .append_exec_results([MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }])
+            // org_has_writable_cache: no organization_cache rows → returns false
+            .append_query_results([Vec::<entity::organization_cache::Model>::new()])
+            // Park: update eval read-back + exec, returns the parked row
+            .append_query_results([vec![parked_eval.clone()]])
+            .append_exec_results([MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }])
+            .into_connection();
+
+        let res = apply_trigger(
+            &db,
+            &project,
+            input(trig, TriggerType::Polling, new_hash, false),
+        )
+        .await
+        .unwrap();
+
+        let ApplyOutcome::Created { evaluation, .. } = res else {
+            panic!("expected Created, got {res:?}");
+        };
+        assert_eq!(evaluation.status, EvaluationStatus::Waiting);
+        let reason = evaluation
+            .waiting_reason
+            .as_ref()
+            .and_then(WaitingReason::from_json)
+            .expect("waiting_reason must be set");
+        assert!(matches!(reason, WaitingReason::NoCache));
     }
 }

--- a/backend/core/src/ci/apply.rs
+++ b/backend/core/src/ci/apply.rs
@@ -53,6 +53,19 @@ pub struct ApplyInput {
     /// Set true for manual UI re-runs and `/triggers/{id}/test` calls.
     /// Bypasses the same-commit dedup check.
     pub manual: bool,
+    /// Set by the PR webhook layer when the caller has determined the PR
+    /// requires maintainer approval (untrusted contributor on a require_approval
+    /// trigger). `apply_trigger` parks the resulting evaluation in
+    /// `Waiting + WaitingReason::Approval` instead of `Queued`.
+    pub gate_approval: Option<ApprovalInfo>,
+}
+
+/// Identification of the pull request a maintainer must approve before the
+/// evaluation runs. Persisted on `evaluation.waiting_reason`.
+#[derive(Debug, Clone)]
+pub struct ApprovalInfo {
+    pub pr_number: u64,
+    pub pr_author: String,
 }
 
 pub async fn apply_trigger<C: ConnectionTrait>(
@@ -144,12 +157,36 @@ pub async fn apply_trigger<C: ConnectionTrait>(
         Err(e) => return Err(e.into()),
     };
 
+    let eval = park_if_pending_approval(db, eval, input.gate_approval.as_ref()).await?;
     let eval = park_if_no_cache(db, eval, project.organization).await?;
     Ok(ApplyOutcome::Created {
         evaluation: eval,
         aborted_evaluation,
         aborted_builds,
     })
+}
+
+/// Move a freshly-created `Queued` evaluation into `Waiting` with
+/// `WaitingReason::Approval` when the caller has flagged it as gated. No-op
+/// when `info` is `None` or the evaluation is already parked.
+pub async fn park_if_pending_approval<C: ConnectionTrait>(
+    db: &C,
+    eval: MEvaluation,
+    info: Option<&ApprovalInfo>,
+) -> Result<MEvaluation, sea_orm::DbErr> {
+    let Some(info) = info else {
+        return Ok(eval);
+    };
+    if eval.status != EvaluationStatus::Queued {
+        return Ok(eval);
+    }
+    let mut ae: AEvaluation = eval.into();
+    ae.status = Set(EvaluationStatus::Waiting);
+    ae.waiting_reason = Set(Some(
+        WaitingReason::approval(info.pr_number, info.pr_author.clone()).to_json(),
+    ));
+    ae.updated_at = Set(crate::types::now());
+    ae.update(db).await
 }
 
 /// Move a freshly-created `Queued` evaluation into `Waiting` with
@@ -165,6 +202,9 @@ pub async fn park_if_no_cache<C: ConnectionTrait>(
     eval: MEvaluation,
     organization: OrganizationId,
 ) -> Result<MEvaluation, sea_orm::DbErr> {
+    if eval.status != EvaluationStatus::Queued {
+        return Ok(eval);
+    }
     if org_has_writable_cache(db, organization).await? {
         return Ok(eval);
     }
@@ -257,6 +297,7 @@ mod tests {
             commit_message: None,
             author_name: None,
             manual,
+            gate_approval: None,
         }
     }
 
@@ -685,6 +726,93 @@ mod tests {
         assert_eq!(evaluation.id, new_eval_id);
         assert_eq!(aborted_evaluation, Some(running_eval_id));
         assert_eq!(aborted_builds, vec![active_build_id]);
+    }
+
+    /// When the PR webhook layer flags a freshly-created evaluation as needing
+    /// maintainer approval, `apply_trigger` parks it in `Waiting + Approval`
+    /// before checking the cache gate. The NoCache check then early-returns
+    /// because the eval is no longer in `Queued` status.
+    #[tokio::test]
+    async fn gate_approval_parks_pr_evaluation_in_waiting_approval() {
+        use crate::types::waiting_reason::WaitingReason;
+        let project = make_project_with_last_eval(None);
+        let new_eval_id = EvaluationId::now_v7();
+        let new_commit_id = CommitId::now_v7();
+        let trig = ProjectTriggerId::now_v7();
+        let new_hash = vec![1u8; 20];
+
+        let parked_eval = {
+            let mut m = make_eval(
+                new_eval_id,
+                project.id,
+                new_commit_id,
+                EvaluationStatus::Waiting,
+            );
+            m.trigger = Some(trig);
+            m.waiting_reason = Some(WaitingReason::approval(42, "external-contrib").to_json());
+            m
+        };
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([Vec::<entity::evaluation::Model>::new()])
+            .append_query_results([Vec::<entity::evaluation::Model>::new()])
+            .append_query_results([vec![make_commit(new_commit_id, new_hash.clone())]])
+            .append_query_results([vec![{
+                let mut m = make_eval(
+                    new_eval_id,
+                    project.id,
+                    new_commit_id,
+                    EvaluationStatus::Queued,
+                );
+                m.trigger = Some(trig);
+                m
+            }]])
+            .append_query_results([vec![project.clone()]])
+            .append_exec_results([MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }])
+            // park_if_pending_approval: update returns the parked row
+            .append_query_results([vec![parked_eval.clone()]])
+            .append_exec_results([MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }])
+            .into_connection();
+
+        let applied = ApplyInput {
+            trigger_id: trig,
+            trigger_type: TriggerType::ReporterPullRequest,
+            commit_hash: new_hash,
+            commit_message: None,
+            author_name: None,
+            manual: false,
+            gate_approval: Some(ApprovalInfo {
+                pr_number: 42,
+                pr_author: "external-contrib".into(),
+            }),
+        };
+        let res = apply_trigger(&db, &project, applied).await.unwrap();
+
+        let ApplyOutcome::Created { evaluation, .. } = res else {
+            panic!("expected Created, got {res:?}");
+        };
+        assert_eq!(evaluation.status, EvaluationStatus::Waiting);
+        let reason = evaluation
+            .waiting_reason
+            .as_ref()
+            .and_then(WaitingReason::from_json)
+            .expect("waiting_reason must be set");
+        match reason {
+            WaitingReason::Approval {
+                pr_number,
+                pr_author,
+            } => {
+                assert_eq!(pr_number, 42);
+                assert_eq!(pr_author, "external-contrib");
+            }
+            other => panic!("expected Approval, got {other:?}"),
+        }
     }
 
     /// When the project's organisation has no writable cache subscription, a

--- a/backend/core/src/ci/mod.rs
+++ b/backend/core/src/ci/mod.rs
@@ -13,13 +13,15 @@ pub mod manifest_state;
 pub mod reporter;
 pub mod reporting;
 pub mod trigger;
+pub mod unpark;
 pub mod webhook;
 
 pub use self::abort::{AbortKind, abort_evaluation};
-pub use self::apply::{ApplyError, ApplyInput, ApplyOutcome, apply_trigger};
+pub use self::apply::{ApplyError, ApplyInput, ApplyOutcome, apply_trigger, park_if_no_cache};
 pub use self::github_app::*;
 pub use self::integration_lookup::*;
 pub use self::reporter::*;
 pub use self::reporting::*;
 pub use self::trigger::*;
+pub use self::unpark::unpark_no_cache_for_org;
 pub use self::webhook::*;

--- a/backend/core/src/ci/mod.rs
+++ b/backend/core/src/ci/mod.rs
@@ -17,11 +17,14 @@ pub mod unpark;
 pub mod webhook;
 
 pub use self::abort::{AbortKind, abort_evaluation};
-pub use self::apply::{ApplyError, ApplyInput, ApplyOutcome, apply_trigger, park_if_no_cache};
+pub use self::apply::{
+    ApplyError, ApplyInput, ApplyOutcome, ApprovalInfo, apply_trigger, park_if_no_cache,
+    park_if_pending_approval,
+};
 pub use self::github_app::*;
 pub use self::integration_lookup::*;
 pub use self::reporter::*;
 pub use self::reporting::*;
 pub use self::trigger::*;
-pub use self::unpark::unpark_no_cache_for_org;
+pub use self::unpark::{find_approval_gated_eval, unpark_approval, unpark_no_cache_for_org};
 pub use self::webhook::*;

--- a/backend/core/src/ci/reporter.rs
+++ b/backend/core/src/ci/reporter.rs
@@ -36,7 +36,26 @@ pub enum CiStatus {
     Failure,
     /// Completed with an infrastructure or unexpected error.
     Error,
+    /// Awaiting a maintainer action (PR approval gate). On GitHub Apps this
+    /// surfaces as the native `action_required` conclusion with a
+    /// `requested_actions` button; other forges report it as `Pending` with
+    /// the description spelling out what the maintainer needs to do.
+    ActionRequired,
 }
+
+/// A button shown on a GitHub Check Run that the maintainer clicks to fire a
+/// `check_run.requested_action` webhook back to Gradient. Only consumed by
+/// [`GithubAppReporter`]; other reporters ignore the field.
+#[derive(Debug, Clone, Serialize)]
+pub struct RequestedAction {
+    pub identifier: String,
+    pub label: String,
+    pub description: String,
+}
+
+/// Identifier we send for the "approve untrusted PR" button — and pattern-match
+/// on when the forge echoes it back via `check_run.requested_action`.
+pub const APPROVAL_ACTION_ID: &str = "approve-and-run";
 
 /// All parameters needed to report a CI status to an external provider.
 #[derive(Debug, Clone)]
@@ -60,6 +79,11 @@ pub struct CiReport {
     /// GitHub `check_run` id when an existing check run should be updated.
     /// Only used by [`GithubAppReporter`]; ignored by all other reporters.
     pub existing_check_id: Option<i64>,
+    /// `requested_actions` to attach to a GitHub Check Run. Only emitted by
+    /// [`GithubAppReporter`] when `status == ActionRequired`. Empty for
+    /// every other reporter; other forges express the same intent through
+    /// `description`.
+    pub requested_actions: Vec<RequestedAction>,
 }
 
 /// Abstraction over external CI status providers.
@@ -84,6 +108,22 @@ pub trait CiReporter: Send + Sync + std::fmt::Debug + 'static {
     /// whose id the caller should persist for future updates. All other
     /// reporters (and PATCHes against an existing check run) return `Ok(None)`.
     async fn report(&self, report: &CiReport) -> Result<Option<i64>>;
+
+    /// Returns `true` iff `username` has push (write) or admin permission on
+    /// `owner/repo`. Used by the PR approval gate to skip the maintainer-
+    /// approval requirement for trusted contributors.
+    ///
+    /// Default impl returns `Ok(false)`: implementations that cannot probe
+    /// the forge for permissions should fail closed so untrusted PRs are
+    /// always parked for approval.
+    async fn is_repo_writer(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _username: &str,
+    ) -> Result<bool> {
+        Ok(false)
+    }
 }
 
 // ── NoopCiReporter ────────────────────────────────────────────────────────────
@@ -144,7 +184,7 @@ enum GiteaState {
 impl From<&CiStatus> for GiteaState {
     fn from(s: &CiStatus) -> Self {
         match s {
-            CiStatus::Pending | CiStatus::Running => GiteaState::Pending,
+            CiStatus::Pending | CiStatus::Running | CiStatus::ActionRequired => GiteaState::Pending,
             CiStatus::Success => GiteaState::Success,
             CiStatus::Failure => GiteaState::Failure,
             CiStatus::Error => GiteaState::Error,
@@ -201,6 +241,45 @@ impl CiReporter for GiteaReporter {
 
         Ok(None)
     }
+
+    async fn is_repo_writer(
+        &self,
+        owner: &str,
+        repo: &str,
+        username: &str,
+    ) -> Result<bool> {
+        let url = format!(
+            "{}/api/v1/repos/{}/{}/collaborators/{}/permission",
+            self.base_url, owner, repo, username
+        );
+        let resp = self
+            .client
+            .get(&url)
+            .header("Authorization", format!("token {}", self.token))
+            .send()
+            .await
+            .context("Failed to query Gitea collaborator permission")?;
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(false);
+        }
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("Gitea permission query returned {}: {}", status, body);
+        }
+        #[derive(Deserialize)]
+        struct PermissionResponse {
+            permission: String,
+        }
+        let parsed: PermissionResponse = resp
+            .json()
+            .await
+            .context("Failed to parse Gitea permission response")?;
+        Ok(matches!(
+            parsed.permission.as_str(),
+            "admin" | "owner" | "write"
+        ))
+    }
 }
 
 // ── GitlabReporter ────────────────────────────────────────────────────────────
@@ -253,7 +332,7 @@ enum GitlabState {
 impl From<&CiStatus> for GitlabState {
     fn from(s: &CiStatus) -> Self {
         match s {
-            CiStatus::Pending => GitlabState::Pending,
+            CiStatus::Pending | CiStatus::ActionRequired => GitlabState::Pending,
             CiStatus::Running => GitlabState::Running,
             CiStatus::Success => GitlabState::Success,
             CiStatus::Failure => GitlabState::Failed,
@@ -320,6 +399,45 @@ impl CiReporter for GitlabReporter {
 
         Ok(None)
     }
+
+    async fn is_repo_writer(
+        &self,
+        owner: &str,
+        repo: &str,
+        username: &str,
+    ) -> Result<bool> {
+        let project_id = gitlab_project_id(owner, repo);
+        let encoded_username: String =
+            url::form_urlencoded::byte_serialize(username.as_bytes()).collect();
+        let url = format!(
+            "{}/api/v4/projects/{}/members/all?query={}",
+            self.base_url, project_id, encoded_username
+        );
+        let resp = self
+            .client
+            .get(&url)
+            .header("PRIVATE-TOKEN", &self.token)
+            .send()
+            .await
+            .context("Failed to query GitLab member access level")?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("GitLab members query returned {}: {}", status, body);
+        }
+        #[derive(Deserialize)]
+        struct Member {
+            username: String,
+            access_level: i32,
+        }
+        let members: Vec<Member> = resp
+            .json()
+            .await
+            .context("Failed to parse GitLab members response")?;
+        Ok(members
+            .iter()
+            .any(|m| m.username.eq_ignore_ascii_case(username) && m.access_level >= 30))
+    }
 }
 
 // ── GithubReporter ────────────────────────────────────────────────────────────
@@ -379,7 +497,9 @@ enum GithubState {
 impl From<&CiStatus> for GithubState {
     fn from(s: &CiStatus) -> Self {
         match s {
-            CiStatus::Pending | CiStatus::Running => GithubState::Pending,
+            CiStatus::Pending | CiStatus::Running | CiStatus::ActionRequired => {
+                GithubState::Pending
+            }
             CiStatus::Success => GithubState::Success,
             CiStatus::Failure => GithubState::Failure,
             CiStatus::Error => GithubState::Error,
@@ -437,6 +557,45 @@ impl CiReporter for GithubReporter {
 
         Ok(None)
     }
+
+    async fn is_repo_writer(
+        &self,
+        owner: &str,
+        repo: &str,
+        username: &str,
+    ) -> Result<bool> {
+        let url = format!(
+            "{}/repos/{}/{}/collaborators/{}/permission",
+            self.base_url, owner, repo, username
+        );
+        let resp = self
+            .client
+            .get(&url)
+            .header("Authorization", format!("Bearer {}", self.token))
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .send()
+            .await
+            .context("Failed to query GitHub collaborator permission")?;
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(false);
+        }
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("GitHub permission query returned {}: {}", status, body);
+        }
+        let parsed: GithubPermissionResponse = resp
+            .json()
+            .await
+            .context("Failed to parse GitHub permission response")?;
+        Ok(matches!(parsed.permission.as_str(), "admin" | "write"))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubPermissionResponse {
+    permission: String,
 }
 
 // ── GithubAppReporter ────────────────────────────────────────────────────────
@@ -524,7 +683,7 @@ fn map_ci_status(status: &CiStatus) -> (CheckRunStatus, Option<CheckRunConclusio
         CiStatus::Running => (CheckRunStatus::InProgress, None),
         CiStatus::Success => (CheckRunStatus::Completed, Some(CheckRunConclusion::Success)),
         CiStatus::Failure => (CheckRunStatus::Completed, Some(CheckRunConclusion::Failure)),
-        CiStatus::Error => (
+        CiStatus::Error | CiStatus::ActionRequired => (
             CheckRunStatus::Completed,
             Some(CheckRunConclusion::ActionRequired),
         ),
@@ -548,6 +707,8 @@ struct CreateCheckRunPayload<'a> {
     details_url: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     output: Option<CheckRunOutput<'a>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    actions: Vec<&'a RequestedAction>,
 }
 
 #[derive(Debug, Serialize)]
@@ -559,6 +720,8 @@ struct UpdateCheckRunPayload<'a> {
     details_url: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     output: Option<CheckRunOutput<'a>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    actions: Vec<&'a RequestedAction>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -594,6 +757,7 @@ impl CiReporter for GithubAppReporter {
                 conclusion,
                 details_url: report.details_url.as_deref(),
                 output,
+                actions: report.requested_actions.iter().collect(),
             };
             let resp = self
                 .client
@@ -630,6 +794,7 @@ impl CiReporter for GithubAppReporter {
                 conclusion,
                 details_url: report.details_url.as_deref(),
                 output,
+                actions: report.requested_actions.iter().collect(),
             };
             let resp = self
                 .client
@@ -659,6 +824,53 @@ impl CiReporter for GithubAppReporter {
                 .context("Failed to parse GitHub check-run create response")?;
             Ok(Some(parsed.id))
         }
+    }
+
+    async fn is_repo_writer(
+        &self,
+        owner: &str,
+        repo: &str,
+        username: &str,
+    ) -> Result<bool> {
+        let token = crate::ci::github_app::get_installation_token(
+            &self.client,
+            self.app_id,
+            &self.private_key_pem,
+            self.installation_id,
+        )
+        .await
+        .context("Failed to mint GitHub App installation token")?;
+
+        let url = format!(
+            "{}/repos/{}/{}/collaborators/{}/permission",
+            self.api_base_url, owner, repo, username
+        );
+        let resp = self
+            .client
+            .get(&url)
+            .header("Authorization", format!("Bearer {}", token))
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .send()
+            .await
+            .context("Failed to query GitHub collaborator permission")?;
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(false);
+        }
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "GitHub App permission query returned {}: {}",
+                status,
+                body
+            );
+        }
+        let parsed: GithubPermissionResponse = resp
+            .json()
+            .await
+            .context("Failed to parse GitHub permission response")?;
+        Ok(matches!(parsed.permission.as_str(), "admin" | "write"))
     }
 }
 

--- a/backend/core/src/ci/reporting.rs
+++ b/backend/core/src/ci/reporting.rs
@@ -176,6 +176,7 @@ pub async fn report_build_ci(state: Arc<ServerState>, build: MBuild, status: CiS
             description: None,
             details_url: details_url.clone(),
             existing_check_id: ep.repo_check_id,
+            requested_actions: Vec::new(),
         };
         match reporter.report(&report).await {
             Ok(Some(new_id)) => {
@@ -278,6 +279,7 @@ pub async fn report_evaluation_ci(
         description: None,
         details_url,
         existing_check_id: evaluation.repo_check_id,
+        requested_actions: Vec::new(),
     };
 
     match reporter.report(&report).await {

--- a/backend/core/src/ci/unpark.rs
+++ b/backend/core/src/ci/unpark.rs
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Side-effect helpers that flip parked evaluations back to `Queued` once
+//! the external condition they were waiting on clears.
+//!
+//! `NoCache` parks: triggered when the project's organisation had no writable
+//! cache subscription. Caller (`orgs/settings.rs::subscribe_cache`) invokes
+//! [`unpark_no_cache_for_org`] right after inserting the subscription row;
+//! the caller is also responsible for re-emitting the `Pending` CI status
+//! for each unparked evaluation.
+
+use crate::types::ids::OrganizationId;
+use crate::types::waiting_reason::WaitingReason;
+use crate::types::*;
+
+use entity::evaluation::EvaluationStatus;
+use sea_orm::ActiveValue::Set;
+use sea_orm::{ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
+
+/// Flip every evaluation parked with `WaitingReason::NoCache` for projects in
+/// `organization` back to `Queued`. Returns the updated rows so the caller
+/// can re-emit pending CI checks.
+pub async fn unpark_no_cache_for_org<C: ConnectionTrait>(
+    db: &C,
+    organization: OrganizationId,
+) -> Result<Vec<MEvaluation>, sea_orm::DbErr> {
+    let project_ids: Vec<ProjectId> = EProject::find()
+        .filter(CProject::Organization.eq(organization))
+        .all(db)
+        .await?
+        .into_iter()
+        .map(|p| p.id)
+        .collect();
+
+    if project_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let parked = EEvaluation::find()
+        .filter(CEvaluation::Project.is_in(project_ids))
+        .filter(CEvaluation::Status.eq(EvaluationStatus::Waiting))
+        .all(db)
+        .await?;
+
+    let candidates: Vec<MEvaluation> = parked
+        .into_iter()
+        .filter(|e| {
+            e.waiting_reason
+                .as_ref()
+                .and_then(WaitingReason::from_json)
+                .is_some_and(|r| matches!(r, WaitingReason::NoCache))
+        })
+        .collect();
+
+    let mut unparked = Vec::with_capacity(candidates.len());
+    for eval in candidates {
+        let mut ae: AEvaluation = eval.into();
+        ae.status = Set(EvaluationStatus::Queued);
+        ae.waiting_reason = Set(None);
+        ae.updated_at = Set(crate::types::now());
+        unparked.push(ae.update(db).await?);
+    }
+    Ok(unparked)
+}

--- a/backend/core/src/ci/unpark.rs
+++ b/backend/core/src/ci/unpark.rs
@@ -66,3 +66,110 @@ pub async fn unpark_no_cache_for_org<C: ConnectionTrait>(
     }
     Ok(unparked)
 }
+
+/// Transition a single evaluation parked in `Waiting + Approval` back to
+/// `Queued`. Returns `Ok(None)` when the row isn't parked-Approval (already
+/// unparked, never parked, status drifted) so the caller can decide whether
+/// to log or ignore.
+pub async fn unpark_approval(
+    db: &impl ConnectionTrait,
+    evaluation_id: EvaluationId,
+) -> Result<Option<MEvaluation>, sea_orm::DbErr> {
+    let Some(eval) = EEvaluation::find_by_id(evaluation_id).one(db).await? else {
+        return Ok(None);
+    };
+    if eval.status != EvaluationStatus::Waiting {
+        return Ok(None);
+    }
+    let is_approval = eval
+        .waiting_reason
+        .as_ref()
+        .and_then(WaitingReason::from_json)
+        .is_some_and(|r| matches!(r, WaitingReason::Approval { .. }));
+    if !is_approval {
+        return Ok(None);
+    }
+    let mut ae: AEvaluation = eval.into();
+    ae.status = Set(EvaluationStatus::Queued);
+    ae.waiting_reason = Set(None);
+    ae.updated_at = Set(crate::types::now());
+    Ok(Some(ae.update(db).await?))
+}
+
+/// Find the evaluation that is parked in `Waiting + Approval` for the given
+/// project + PR number combination. Used by the comment-based unpark path
+/// where the webhook only carries the PR number, not the eval id.
+pub async fn find_approval_gated_eval(
+    db: &impl ConnectionTrait,
+    project: ProjectId,
+    pr_number: u64,
+) -> Result<Option<MEvaluation>, sea_orm::DbErr> {
+    let parked = EEvaluation::find()
+        .filter(CEvaluation::Project.eq(project))
+        .filter(CEvaluation::Status.eq(EvaluationStatus::Waiting))
+        .all(db)
+        .await?;
+    Ok(parked.into_iter().find(|e| {
+        e.waiting_reason
+            .as_ref()
+            .and_then(WaitingReason::from_json)
+            .is_some_and(|r| matches!(r, WaitingReason::Approval { pr_number: n, .. } if n == pr_number))
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveDateTime;
+    use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
+
+    fn waiting_eval(reason: WaitingReason) -> MEvaluation {
+        entity::evaluation::Model {
+            id: EvaluationId::now_v7(),
+            project: Some(ProjectId::now_v7()),
+            repository: String::new(),
+            commit: CommitId::now_v7(),
+            wildcard: "*".into(),
+            status: EvaluationStatus::Waiting,
+            previous: None,
+            next: None,
+            created_at: NaiveDateTime::default(),
+            updated_at: NaiveDateTime::default(),
+            flake_source: None,
+            repo_check_id: None,
+            waiting_reason: Some(reason.to_json()),
+            trigger: None,
+            concurrent: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn unpark_approval_requeues_waiting_approval_row() {
+        let parked = waiting_eval(WaitingReason::approval(7, "octocat"));
+        let mut requeued = parked.clone();
+        requeued.status = EvaluationStatus::Queued;
+        requeued.waiting_reason = None;
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![parked.clone()]])
+            .append_query_results([vec![requeued.clone()]])
+            .append_exec_results([MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }])
+            .into_connection();
+
+        let out = unpark_approval(&db, parked.id).await.unwrap().unwrap();
+        assert_eq!(out.status, EvaluationStatus::Queued);
+        assert!(out.waiting_reason.is_none());
+    }
+
+    #[tokio::test]
+    async fn unpark_approval_no_op_for_non_approval_reason() {
+        let parked = waiting_eval(WaitingReason::NoCache);
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![parked.clone()]])
+            .into_connection();
+        assert!(unpark_approval(&db, parked.id).await.unwrap().is_none());
+    }
+}

--- a/backend/core/src/db/mod.rs
+++ b/backend/core/src/db/mod.rs
@@ -11,6 +11,7 @@ pub mod dependency_graph;
 pub mod derivation;
 pub mod drv_output_spec;
 pub mod gc;
+pub mod org_cache;
 pub mod status;
 
 pub use self::cache_reach::*;
@@ -20,4 +21,5 @@ pub use self::dependency_graph::*;
 pub use self::derivation::*;
 pub use self::drv_output_spec::DrvOutputSpec;
 pub use self::gc::*;
+pub use self::org_cache::org_has_writable_cache;
 pub use self::status::*;

--- a/backend/core/src/db/org_cache.rs
+++ b/backend/core/src/db/org_cache.rs
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Organisation ↔ cache subscription helpers consumed by the trigger
+//! pipeline (no-cache gate) and the cache-create reconcile path.
+
+use crate::types::ids::OrganizationId;
+use entity::organization_cache::CacheSubscriptionMode;
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
+
+/// Returns `true` when the organisation has at least one active cache
+/// subscription that can receive build outputs (ReadWrite or WriteOnly).
+///
+/// ReadOnly subscriptions are excluded — they let the org pull but not push,
+/// so a build would have nowhere to land.
+pub async fn org_has_writable_cache<C: ConnectionTrait>(
+    db: &C,
+    organization: OrganizationId,
+) -> Result<bool, sea_orm::DbErr> {
+    use entity::cache::{Column as CCache, Entity as ECache};
+    use entity::ids::CacheId;
+    use entity::organization_cache::{Column as COC, Entity as EOC};
+
+    let cache_ids: Vec<CacheId> = EOC::find()
+        .filter(COC::Organization.eq(organization))
+        .filter(COC::Mode.is_in([
+            CacheSubscriptionMode::ReadWrite,
+            CacheSubscriptionMode::WriteOnly,
+        ]))
+        .all(db)
+        .await?
+        .into_iter()
+        .map(|r| r.cache)
+        .collect();
+
+    if cache_ids.is_empty() {
+        return Ok(false);
+    }
+
+    let row = ECache::find()
+        .filter(CCache::Id.is_in(cache_ids))
+        .filter(CCache::Active.eq(true))
+        .one(db)
+        .await?;
+    Ok(row.is_some())
+}

--- a/backend/core/src/state/provisioning.rs
+++ b/backend/core/src/state/provisioning.rs
@@ -1360,6 +1360,11 @@ fn build_trigger_config(
                         .unwrap_or_else(|| {
                             vec!["opened".into(), "synchronize".into(), "reopened".into()]
                         }),
+                    require_approval: t
+                        .config
+                        .get("require_approval")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(true),
                 }
             }
         }

--- a/backend/core/src/types/triggers.rs
+++ b/backend/core/src/types/triggers.rs
@@ -63,6 +63,13 @@ pub enum TriggerConfig {
         branches: Vec<String>,
         #[serde(default = "default_pr_actions")]
         actions: Vec<String>,
+        /// When true (default, secure-by-default), PRs from contributors who
+        /// are not repo writers on the forge are parked in
+        /// `WaitingReason::Approval` until a maintainer either clicks the
+        /// "Approve and Run" check-run action (GitHub) or comments `/ci run`
+        /// (Gitea/Forgejo/GitLab).
+        #[serde(default = "default_require_approval")]
+        require_approval: bool,
     },
     Time {
         cron: String,
@@ -71,6 +78,10 @@ pub enum TriggerConfig {
 
 fn default_pr_actions() -> Vec<String> {
     vec!["opened".into(), "synchronize".into(), "reopened".into()]
+}
+
+fn default_require_approval() -> bool {
+    true
 }
 
 #[derive(Debug, Error)]
@@ -243,6 +254,26 @@ mod tests {
             assert_eq!(TriggerType::try_from(n), Ok(t));
         }
         assert!(TriggerType::try_from(99).is_err());
+    }
+
+    #[test]
+    fn reporter_pull_request_require_approval_defaults_true_for_legacy_rows() {
+        // Pre-#247 rows lack `require_approval` in the stored JSON. The serde
+        // default must produce `true` on read so secure-by-default applies
+        // without a backfill migration on existing trigger rows.
+        let legacy_db = serde_json::json!({
+            "integration_id": IntegrationId::nil(),
+            "branches": [],
+            "actions": ["opened"],
+        });
+        let parsed = TriggerConfig::parse_row(2, &legacy_db).unwrap();
+        let TriggerConfig::ReporterPullRequest {
+            require_approval, ..
+        } = parsed
+        else {
+            panic!("expected ReporterPullRequest");
+        };
+        assert!(require_approval, "missing field must default to true");
     }
 
     #[test]

--- a/backend/core/src/types/waiting_reason.rs
+++ b/backend/core/src/types/waiting_reason.rs
@@ -6,18 +6,33 @@
 
 //! Structured "why is this evaluation waiting?" payload.
 //!
-//! Persisted on `evaluation.waiting_reason` (JSON) by the scheduler whenever it
-//! reconciles an evaluation against the connected worker pool, returned by the
-//! `GET /evals/{evaluation}` endpoint, and rendered by the frontend's
-//! "Waiting for Workers" panel.
+//! Persisted on `evaluation.waiting_reason` (JSON) by the scheduler and the
+//! trigger pipeline, returned by `GET /evals/{evaluation}`, rendered by the
+//! frontend's waiting panel.
+//!
+//! Three reasons:
+//! - `Workers` — no connected worker can satisfy the pending builds' arch /
+//!   required-feature combo (legacy reason; persisted under JSON `kind=workers`).
+//! - `Approval` — pull-request evaluation from a contributor who is not a
+//!   forge writer on the repo, gated until a maintainer approves.
+//! - `NoCache` — the project's organisation has no active cache configured,
+//!   so the build outputs would have nowhere to land.
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct WaitingReason {
-    pub unmet: Vec<UnmetRequirement>,
-    pub connected_workers: u32,
-    pub available_architectures: Vec<String>,
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WaitingReason {
+    Workers {
+        unmet: Vec<UnmetRequirement>,
+        connected_workers: u32,
+        available_architectures: Vec<String>,
+    },
+    Approval {
+        pr_number: u64,
+        pr_author: String,
+    },
+    NoCache,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -32,7 +47,100 @@ impl WaitingReason {
         serde_json::to_value(self).unwrap_or(serde_json::Value::Null)
     }
 
+    /// Tolerant of legacy rows written before the `kind` discriminator existed
+    /// — those decode as `Workers { .. }`.
     pub fn from_json(value: &serde_json::Value) -> Option<Self> {
-        serde_json::from_value(value.clone()).ok()
+        if let Ok(parsed) = serde_json::from_value::<Self>(value.clone()) {
+            return Some(parsed);
+        }
+        if value.is_object() && value.get("kind").is_none() {
+            let mut patched = value.clone();
+            if let serde_json::Value::Object(ref mut m) = patched {
+                m.insert("kind".into(), serde_json::Value::String("workers".into()));
+            }
+            return serde_json::from_value::<Self>(patched).ok();
+        }
+        None
+    }
+
+    pub fn workers(
+        unmet: Vec<UnmetRequirement>,
+        connected_workers: u32,
+        available_architectures: Vec<String>,
+    ) -> Self {
+        Self::Workers {
+            unmet,
+            connected_workers,
+            available_architectures,
+        }
+    }
+
+    pub fn approval(pr_number: u64, pr_author: impl Into<String>) -> Self {
+        Self::Approval {
+            pr_number,
+            pr_author: pr_author.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workers_round_trip_carries_kind_tag() {
+        let r = WaitingReason::workers(
+            vec![UnmetRequirement {
+                architecture: "x86_64-linux".into(),
+                required_features: vec!["kvm".into()],
+                build_count: 2,
+            }],
+            1,
+            vec!["aarch64-linux".into()],
+        );
+        let v = r.to_json();
+        assert_eq!(v["kind"], "workers");
+        assert_eq!(WaitingReason::from_json(&v).unwrap(), r);
+    }
+
+    #[test]
+    fn approval_round_trip() {
+        let r = WaitingReason::approval(42, "octocat");
+        let v = r.to_json();
+        assert_eq!(v["kind"], "approval");
+        assert_eq!(v["pr_number"], 42);
+        assert_eq!(v["pr_author"], "octocat");
+        assert_eq!(WaitingReason::from_json(&v).unwrap(), r);
+    }
+
+    #[test]
+    fn no_cache_round_trip() {
+        let r = WaitingReason::NoCache;
+        let v = r.to_json();
+        assert_eq!(v["kind"], "no_cache");
+        assert_eq!(WaitingReason::from_json(&v).unwrap(), r);
+    }
+
+    /// Legacy rows persisted before the `kind` tag existed must still
+    /// decode — they all represent the workers-capacity reason.
+    #[test]
+    fn legacy_untagged_workers_row_decodes() {
+        let legacy = serde_json::json!({
+            "unmet": [],
+            "connected_workers": 3,
+            "available_architectures": ["x86_64-linux"],
+        });
+        let decoded = WaitingReason::from_json(&legacy).expect("legacy row decodes");
+        match decoded {
+            WaitingReason::Workers {
+                connected_workers,
+                available_architectures,
+                ..
+            } => {
+                assert_eq!(connected_workers, 3);
+                assert_eq!(available_architectures, vec!["x86_64-linux"]);
+            }
+            other => panic!("expected Workers, got {other:?}"),
+        }
     }
 }

--- a/backend/migration/src/lib.rs
+++ b/backend/migration/src/lib.rs
@@ -104,6 +104,7 @@ mod m20260519_000001_create_build_request_blob;
 mod m20260519_000002_create_upload_session;
 mod m20260519_000003_add_organization_hide_build_requests;
 mod m20260519_000004_drop_direct_build;
+mod m20260521_000000_tag_waiting_reason_kind;
 
 pub struct Migrator;
 
@@ -209,6 +210,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260519_000002_create_upload_session::Migration),
             Box::new(m20260519_000003_add_organization_hide_build_requests::Migration),
             Box::new(m20260519_000004_drop_direct_build::Migration),
+            Box::new(m20260521_000000_tag_waiting_reason_kind::Migration),
         ]
     }
 }

--- a/backend/migration/src/m20260521_000000_tag_waiting_reason_kind.rs
+++ b/backend/migration/src/m20260521_000000_tag_waiting_reason_kind.rs
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Tag every legacy `evaluation.waiting_reason` row with `kind = "workers"`.
+//!
+//! `WaitingReason` was a flat struct (`unmet`, `connected_workers`,
+//! `available_architectures`) and is now a `#[serde(tag = "kind")]` enum with
+//! `Workers`, `Approval`, `NoCache` variants. Existing rows lack the `kind`
+//! discriminator; they all represent the historical workers-capacity reason,
+//! so we add it in-place. The application's `WaitingReason::from_json` is
+//! tolerant of untagged legacy rows, but the migration backfills the tag so
+//! every row matches the canonical shape going forward.
+
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::{ConnectionTrait, Statement};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+        let backend = db.get_database_backend();
+
+        db.execute(Statement::from_string(
+            backend,
+            "UPDATE evaluation \
+             SET waiting_reason = jsonb_set(waiting_reason, '{kind}', '\"workers\"'::jsonb) \
+             WHERE waiting_reason IS NOT NULL \
+               AND waiting_reason ? 'unmet' \
+               AND NOT (waiting_reason ? 'kind')",
+        ))
+        .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+        let backend = db.get_database_backend();
+
+        db.execute(Statement::from_string(
+            backend,
+            "UPDATE evaluation \
+             SET waiting_reason = waiting_reason - 'kind' \
+             WHERE waiting_reason IS NOT NULL \
+               AND waiting_reason->>'kind' = 'workers'",
+        ))
+        .await?;
+        Ok(())
+    }
+}

--- a/backend/scheduler/src/build.rs
+++ b/backend/scheduler/src/build.rs
@@ -541,7 +541,7 @@ fn decide_pre_build_target(
     let stall = || {
         (
             EvaluationStatus::Waiting,
-            Some(WaitingReason {
+            Some(WaitingReason::Workers {
                 unmet: Vec::new(),
                 connected_workers: 0,
                 available_architectures: Vec::new(),
@@ -852,7 +852,7 @@ impl BuildabilityChecker {
         available_architectures.sort_unstable();
         available_architectures.dedup();
 
-        WaitingReason {
+        WaitingReason::Workers {
             unmet,
             connected_workers: worker_caps.len() as u32,
             available_architectures,
@@ -863,6 +863,17 @@ impl BuildabilityChecker {
 #[cfg(test)]
 mod waiting_reason_tests {
     use super::*;
+
+    fn workers_view(r: &WaitingReason) -> (&[UnmetRequirement], u32, &[String]) {
+        match r {
+            WaitingReason::Workers {
+                unmet,
+                connected_workers,
+                available_architectures,
+            } => (unmet, *connected_workers, available_architectures),
+            other => panic!("expected Workers variant, got {other:?}"),
+        }
+    }
 
     fn drv(id: DerivationId, arch: &str) -> MDerivation {
         entity::derivation::Model {
@@ -918,19 +929,18 @@ mod waiting_reason_tests {
         let checker = checker_with(vec![d1, d2], vec![]);
 
         let reason = checker.compute_waiting_reason(&builds, &[]);
+        let (unmet, connected_workers, available_architectures) = workers_view(&reason);
 
-        assert_eq!(reason.connected_workers, 0);
-        assert!(reason.available_architectures.is_empty());
-        assert_eq!(reason.unmet.len(), 2);
+        assert_eq!(connected_workers, 0);
+        assert!(available_architectures.is_empty());
+        assert_eq!(unmet.len(), 2);
         assert!(
-            reason
-                .unmet
+            unmet
                 .iter()
                 .any(|u| u.architecture == "aarch64-linux" && u.build_count == 1)
         );
         assert!(
-            reason
-                .unmet
+            unmet
                 .iter()
                 .any(|u| u.architecture == "x86_64-linux" && u.build_count == 1)
         );
@@ -946,12 +956,13 @@ mod waiting_reason_tests {
 
         let caps: Vec<(Vec<String>, Vec<String>)> = vec![(vec!["x86_64-linux".into()], vec![])];
         let reason = checker.compute_waiting_reason(&builds, &caps);
+        let (unmet, connected_workers, available_architectures) = workers_view(&reason);
 
-        assert_eq!(reason.connected_workers, 1);
-        assert_eq!(reason.available_architectures, vec!["x86_64-linux"]);
-        assert_eq!(reason.unmet.len(), 1);
-        assert_eq!(reason.unmet[0].architecture, "aarch64-linux");
-        assert_eq!(reason.unmet[0].build_count, 1);
+        assert_eq!(connected_workers, 1);
+        assert_eq!(available_architectures, ["x86_64-linux"]);
+        assert_eq!(unmet.len(), 1);
+        assert_eq!(unmet[0].architecture, "aarch64-linux");
+        assert_eq!(unmet[0].build_count, 1);
     }
 
     #[test]
@@ -965,11 +976,12 @@ mod waiting_reason_tests {
 
         let caps: Vec<(Vec<String>, Vec<String>)> = vec![(vec!["x86_64-linux".into()], vec![])];
         let reason = checker.compute_waiting_reason(&builds, &caps);
+        let (unmet, _, _) = workers_view(&reason);
 
-        assert_eq!(reason.unmet.len(), 1);
-        assert_eq!(reason.unmet[0].architecture, "x86_64-linux");
-        assert_eq!(reason.unmet[0].required_features, vec!["kvm".to_string()]);
-        assert_eq!(reason.unmet[0].build_count, 1);
+        assert_eq!(unmet.len(), 1);
+        assert_eq!(unmet[0].architecture, "x86_64-linux");
+        assert_eq!(unmet[0].required_features, vec!["kvm".to_string()]);
+        assert_eq!(unmet[0].build_count, 1);
     }
 
     #[test]
@@ -986,10 +998,11 @@ mod waiting_reason_tests {
         let checker = checker_with(vec![d1, d2, d3], vec![]);
 
         let reason = checker.compute_waiting_reason(&builds, &[]);
+        let (unmet, _, _) = workers_view(&reason);
 
-        assert_eq!(reason.unmet.len(), 1);
-        assert_eq!(reason.unmet[0].architecture, "aarch64-linux");
-        assert_eq!(reason.unmet[0].build_count, 3);
+        assert_eq!(unmet.len(), 1);
+        assert_eq!(unmet[0].architecture, "aarch64-linux");
+        assert_eq!(unmet[0].build_count, 3);
     }
 
     #[test]
@@ -998,9 +1011,10 @@ mod waiting_reason_tests {
             .expect("stall must produce a transition");
         assert_eq!(target, EvaluationStatus::Waiting);
         let reason = reason.expect("stall target must carry a reason");
-        assert_eq!(reason.connected_workers, 0);
-        assert!(reason.unmet.is_empty());
-        assert!(reason.available_architectures.is_empty());
+        let (unmet, connected_workers, available_architectures) = workers_view(&reason);
+        assert_eq!(connected_workers, 0);
+        assert!(unmet.is_empty());
+        assert!(available_architectures.is_empty());
     }
 
     #[test]
@@ -1065,8 +1079,9 @@ mod waiting_reason_tests {
 
         let caps: Vec<(Vec<String>, Vec<String>)> = vec![(vec!["x86_64-linux".into()], vec![])];
         let reason = checker.compute_waiting_reason(&builds, &caps);
+        let (unmet, _, _) = workers_view(&reason);
 
-        assert!(reason.unmet.is_empty());
+        assert!(unmet.is_empty());
     }
 }
 

--- a/backend/scheduler/src/build.rs
+++ b/backend/scheduler/src/build.rs
@@ -446,6 +446,19 @@ impl<'a> BuildStateHandler<'a> {
         }
 
         for eval in evals {
+            // Approval and no-cache parks are owned by webhook + cache-create
+            // hooks. The reconciler must not unpark them just because workers
+            // showed up.
+            if eval.status == EvaluationStatus::Waiting
+                && eval
+                    .waiting_reason
+                    .as_ref()
+                    .and_then(WaitingReason::from_json)
+                    .is_some_and(|r| !matches!(r, WaitingReason::Workers { .. }))
+            {
+                continue;
+            }
+
             let pending_builds = EBuild::find()
                 .filter(CBuild::Evaluation.eq(eval.id))
                 .filter(CBuild::Status.is_in(vec![

--- a/backend/scheduler/src/ci.rs
+++ b/backend/scheduler/src/ci.rs
@@ -5,9 +5,11 @@
  */
 
 use gradient_core::ci::{
-    CiReport, CiStatus, build_check_context, ci_status_for_build, evaluation_check_context,
-    format_check_scope, parse_owner_repo, resolve_outbound_reporter_for_project,
+    APPROVAL_ACTION_ID, CiReport, CiStatus, RequestedAction, build_check_context,
+    ci_status_for_build, evaluation_check_context, format_check_scope, parse_owner_repo,
+    resolve_outbound_reporter_for_project,
 };
+use gradient_core::types::waiting_reason::WaitingReason;
 use gradient_core::types::*;
 use sea_orm::ActiveValue::Set;
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter};
@@ -134,6 +136,7 @@ pub async fn report_ci_for_entry_points(
             description: None,
             details_url: details_url.clone(),
             existing_check_id: ep.repo_check_id,
+            requested_actions: Vec::new(),
         };
 
         match reporter.report(&report).await {
@@ -171,18 +174,164 @@ pub fn spawn_pending_ci_for_eval(state: Arc<ServerState>, eval: &MEvaluation) {
     let repo = eval.repository.clone();
     let commit_id = eval.commit;
     let evaluation_id = eval.id;
+
+    let approval_info = eval
+        .waiting_reason
+        .as_ref()
+        .and_then(WaitingReason::from_json)
+        .and_then(|r| match r {
+            WaitingReason::Approval {
+                pr_number,
+                pr_author,
+            } => Some((pr_number, pr_author)),
+            _ => None,
+        });
+
     let s = Arc::clone(&state);
     state.shutdown.spawn(async move {
-        report_ci_for_evaluation(
-            s,
-            project_id,
-            commit_id,
-            &repo,
-            evaluation_id,
-            CiStatus::Pending,
-        )
-        .await;
+        if let Some((pr_number, pr_author)) = approval_info {
+            report_awaiting_approval_ci(
+                s,
+                project_id,
+                commit_id,
+                &repo,
+                evaluation_id,
+                pr_number,
+                &pr_author,
+            )
+            .await;
+        } else {
+            report_ci_for_evaluation(
+                s,
+                project_id,
+                commit_id,
+                &repo,
+                evaluation_id,
+                CiStatus::Pending,
+            )
+            .await;
+        }
     });
+}
+
+/// Posts the per-evaluation CI check in `ActionRequired` state with an
+/// "Approve and run" button (GitHub Apps) or a pending status whose
+/// description tells the maintainer to comment `/ci run` (other forges).
+///
+/// Mirrors [`report_ci_for_evaluation`] but with approval-specific framing.
+pub async fn report_awaiting_approval_ci(
+    state: Arc<ServerState>,
+    project_id: ProjectId,
+    commit_id: CommitId,
+    repository_url: &str,
+    evaluation_id: EvaluationId,
+    pr_number: u64,
+    pr_author: &str,
+) {
+    let project = match EProject::find_by_id(project_id).one(&state.worker_db).await {
+        Ok(Some(p)) => p,
+        Ok(None) => {
+            warn!(%project_id, "Project not found for approval-gate CI report");
+            return;
+        }
+        Err(e) => {
+            error!(error = %e, %project_id, "Failed to query project for approval-gate CI report");
+            return;
+        }
+    };
+
+    let reporter = resolve_outbound_reporter_for_project(&state, project_id).await;
+
+    let commit = match ECommit::find_by_id(commit_id).one(&state.worker_db).await {
+        Ok(Some(c)) => c,
+        Ok(None) => {
+            warn!(%commit_id, "Commit not found for approval-gate CI report");
+            return;
+        }
+        Err(e) => {
+            error!(error = %e, %commit_id, "Failed to query commit for approval-gate CI report");
+            return;
+        }
+    };
+
+    let sha = gradient_core::types::input::vec_to_hex(&commit.hash);
+
+    let (owner, repo) = match parse_owner_repo(repository_url) {
+        Some(pair) => pair,
+        None => {
+            warn!(
+                repository_url,
+                "Could not parse owner/repo for approval-gate CI report"
+            );
+            return;
+        }
+    };
+
+    let org_name = match EOrganization::find_by_id(project.organization)
+        .one(&state.worker_db)
+        .await
+    {
+        Ok(Some(org)) => Some(org.name),
+        _ => None,
+    };
+
+    let scope = format_check_scope(org_name.as_deref(), &project.name);
+    let details_url = org_name.as_ref().map(|org| {
+        format!(
+            "{}/organization/{}/log/{}",
+            state.config.server.frontend_url, org, evaluation_id
+        )
+    });
+
+    let description = format!(
+        "Awaiting maintainer approval for PR #{} by {} — click \"Approve and run\" or comment /ci run.",
+        pr_number, pr_author
+    );
+
+    let evaluation = match EEvaluation::find_by_id(evaluation_id)
+        .one(&state.worker_db)
+        .await
+    {
+        Ok(Some(e)) => e,
+        Ok(None) => {
+            warn!(%evaluation_id, "Evaluation not found for approval-gate CI report");
+            return;
+        }
+        Err(e) => {
+            error!(error = %e, %evaluation_id, "Failed to query evaluation for approval-gate CI report");
+            return;
+        }
+    };
+
+    let report = CiReport {
+        owner,
+        repo,
+        sha,
+        context: evaluation_check_context(&scope),
+        status: CiStatus::ActionRequired,
+        description: Some(description),
+        details_url,
+        existing_check_id: evaluation.repo_check_id,
+        requested_actions: vec![RequestedAction {
+            identifier: APPROVAL_ACTION_ID.to_string(),
+            label: "Approve and run".to_string(),
+            description: "Run CI for this PR from an external contributor.".to_string(),
+        }],
+    };
+
+    match reporter.report(&report).await {
+        Ok(Some(new_id)) => {
+            let mut a = evaluation.into_active_model();
+            a.repo_check_id = Set(Some(new_id));
+            if let Err(e) = a.update(&state.worker_db).await {
+                warn!(error = %e, %evaluation_id, "Failed to persist approval-gate check_run id");
+            }
+        }
+        Ok(None) => {}
+        Err(e) => {
+            warn!(error = format!("{e:#}"), %evaluation_id, "Approval-gate CI report failed");
+        }
+    }
 }
 
 /// Reports a single `"gradient"` top-level CI status for the whole evaluation.
@@ -281,6 +430,7 @@ pub async fn report_ci_for_evaluation(
         description: None,
         details_url,
         existing_check_id: evaluation.repo_check_id,
+        requested_actions: Vec::new(),
     };
 
     match reporter.report(&report).await {

--- a/backend/scheduler/src/trigger_dispatch.rs
+++ b/backend/scheduler/src/trigger_dispatch.rs
@@ -217,6 +217,7 @@ pub(crate) async fn dispatch_once(scheduler: &Scheduler) -> anyhow::Result<()> {
                 commit_message: Some(msg),
                 author_name: Some(author),
                 manual: false,
+                gate_approval: None,
             },
         )
         .await

--- a/backend/web/src/endpoints/forge_hooks/events.rs
+++ b/backend/web/src/endpoints/forge_hooks/events.rs
@@ -23,6 +23,8 @@ pub(super) struct GitHubPushPayload {
 pub(super) struct GitHubRepository {
     pub clone_url: String,
     pub ssh_url: String,
+    #[serde(default)]
+    pub full_name: Option<String>,
 }
 
 // ── Gitea/Forgejo push payload ─────────────────────────────────────────────
@@ -39,6 +41,8 @@ pub(super) struct GiteaPushPayload {
 pub(super) struct GiteaRepository {
     pub clone_url: String,
     pub ssh_url: Option<String>,
+    #[serde(default)]
+    pub full_name: Option<String>,
 }
 
 // ── GitLab push payload ────────────────────────────────────────────────────
@@ -55,6 +59,8 @@ pub(super) struct GitLabPushPayload {
 pub(super) struct GitLabProject {
     pub http_url: String,
     pub ssh_url: Option<String>,
+    #[serde(default)]
+    pub path_with_namespace: Option<String>,
 }
 
 // ── GitHub PR payload ──────────────────────────────────────────────────────
@@ -69,6 +75,12 @@ pub(super) struct GitHubPullRequestPayload {
 #[derive(Deserialize)]
 pub(super) struct GitHubPullRequest {
     pub head: GitHubPRRef,
+    #[serde(default)]
+    pub base: Option<GitHubPRRef>,
+    #[serde(default)]
+    pub number: Option<u64>,
+    #[serde(default)]
+    pub user: Option<GitHubUser>,
 }
 
 #[derive(Deserialize)]
@@ -76,6 +88,20 @@ pub(super) struct GitHubPRRef {
     pub sha: String,
     #[serde(rename = "ref")]
     pub branch: String,
+    #[serde(default)]
+    pub repo: Option<GitHubRepoStub>,
+}
+
+#[derive(Deserialize)]
+pub(super) struct GitHubRepoStub {
+    #[serde(default)]
+    pub full_name: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub(super) struct GitHubUser {
+    #[serde(default)]
+    pub login: Option<String>,
 }
 
 // ── GitHub release payload ─────────────────────────────────────────────────
@@ -104,6 +130,12 @@ pub(super) struct GiteaPullRequestPayload {
 #[derive(Deserialize)]
 pub(super) struct GiteaPullRequest {
     pub head: GiteaPRRef,
+    #[serde(default)]
+    pub base: Option<GiteaPRRef>,
+    #[serde(default)]
+    pub number: Option<u64>,
+    #[serde(default)]
+    pub user: Option<GiteaUser>,
 }
 
 #[derive(Deserialize)]
@@ -112,6 +144,22 @@ pub(super) struct GiteaPRRef {
     #[serde(rename = "ref")]
     pub branch: Option<String>,
     pub name: Option<String>,
+    #[serde(default)]
+    pub repo: Option<GiteaRepoStub>,
+}
+
+#[derive(Deserialize)]
+pub(super) struct GiteaRepoStub {
+    #[serde(default)]
+    pub full_name: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub(super) struct GiteaUser {
+    #[serde(default)]
+    pub username: Option<String>,
+    #[serde(default)]
+    pub login: Option<String>,
 }
 
 // ── Gitea/Forgejo release payload ─────────────────────────────────────────
@@ -135,6 +183,8 @@ pub(super) struct GiteaRelease {
 pub(super) struct GitLabMergeRequestPayload {
     pub object_attributes: GitLabMRAttributes,
     pub project: GitLabProject,
+    #[serde(default)]
+    pub user: Option<GitLabUser>,
 }
 
 #[derive(Deserialize)]
@@ -142,6 +192,18 @@ pub(super) struct GitLabMRAttributes {
     pub action: String,
     pub source_branch: String,
     pub last_commit: GitLabCommit,
+    #[serde(default)]
+    pub iid: Option<u64>,
+    #[serde(default)]
+    pub source_project_id: Option<u64>,
+    #[serde(default)]
+    pub target_project_id: Option<u64>,
+}
+
+#[derive(Deserialize)]
+pub(super) struct GitLabUser {
+    #[serde(default)]
+    pub username: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -182,6 +244,20 @@ pub(super) struct ParsedPullRequestEvent {
     pub action: String,
     /// PR head branch name (without `refs/heads/` prefix), if available.
     pub branch: Option<String>,
+    /// PR / MR number as the forge knows it (GitHub `pull_request.number`,
+    /// Gitea/Forgejo `pull_request.number`, GitLab `object_attributes.iid`).
+    /// `None` when the payload omits it.
+    pub pr_number: Option<u64>,
+    /// Login/username of the PR author.
+    pub pr_author: Option<String>,
+    /// `true` when the head repo is not the base repo (i.e. the PR comes
+    /// from a fork). `false` when same-repo. `None` when the payload lacks
+    /// enough information to decide — callers should treat as untrusted.
+    pub is_fork: Option<bool>,
+    /// Owner segment of the base repository's `full_name` (`owner/repo`).
+    pub base_owner: Option<String>,
+    /// Repo segment of the base repository's `full_name`.
+    pub base_repo: Option<String>,
 }
 
 /// Release/tag event. `commit_hash` is the SHA the tag points at.
@@ -271,6 +347,16 @@ fn gitlab_project_urls(project: &GitLabProject) -> Vec<String> {
     urls
 }
 
+/// Splits `"owner/repo"` (or `"group/subgroup/repo"` for GitLab) into
+/// `(owner_path, repo)`. Returns `None` if the string lacks a `/`.
+fn split_full_name(full_name: &str) -> Option<(String, String)> {
+    let (owner, repo) = full_name.rsplit_once('/')?;
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    Some((owner.to_string(), repo.to_string()))
+}
+
 // ── ParsedPushEvent impl ───────────────────────────────────────────────────
 
 impl ParsedPushEvent {
@@ -356,11 +442,46 @@ impl ParsedPullRequestEvent {
             "github",
             "pull_request.head.sha",
         )?;
+        let base_full = payload
+            .pull_request
+            .base
+            .as_ref()
+            .and_then(|b| b.repo.as_ref())
+            .and_then(|r| r.full_name.clone())
+            .or_else(|| payload.repository.full_name.clone());
+        let head_full = payload
+            .pull_request
+            .head
+            .repo
+            .as_ref()
+            .and_then(|r| r.full_name.clone());
+        let is_fork = match (head_full.as_deref(), base_full.as_deref()) {
+            (Some(h), Some(b)) => Some(h != b),
+            _ => None,
+        };
+        let (base_owner, base_repo) = base_full
+            .as_deref()
+            .and_then(split_full_name)
+            .map(|(o, r)| (Some(o), Some(r)))
+            .unwrap_or((None, None));
+        let pr_author = payload
+            .pull_request
+            .user
+            .as_ref()
+            .and_then(|u| u.login.clone());
         Some(Self {
             commit_hash,
-            repository_urls: vec![payload.repository.clone_url, payload.repository.ssh_url],
+            repository_urls: vec![
+                payload.repository.clone_url,
+                payload.repository.ssh_url,
+            ],
             action: payload.action,
             branch: Some(payload.pull_request.head.branch),
+            pr_number: payload.pull_request.number,
+            pr_author,
+            is_fork,
+            base_owner,
+            base_repo,
         })
     }
 
@@ -381,12 +502,45 @@ impl ParsedPullRequestEvent {
             .pull_request
             .head
             .branch
-            .or(payload.pull_request.head.name);
+            .clone()
+            .or(payload.pull_request.head.name.clone());
+        let base_full = payload
+            .pull_request
+            .base
+            .as_ref()
+            .and_then(|b| b.repo.as_ref())
+            .and_then(|r| r.full_name.clone())
+            .or_else(|| payload.repository.full_name.clone());
+        let head_full = payload
+            .pull_request
+            .head
+            .repo
+            .as_ref()
+            .and_then(|r| r.full_name.clone());
+        let is_fork = match (head_full.as_deref(), base_full.as_deref()) {
+            (Some(h), Some(b)) => Some(h != b),
+            _ => None,
+        };
+        let (base_owner, base_repo) = base_full
+            .as_deref()
+            .and_then(split_full_name)
+            .map(|(o, r)| (Some(o), Some(r)))
+            .unwrap_or((None, None));
+        let pr_author = payload
+            .pull_request
+            .user
+            .as_ref()
+            .and_then(|u| u.username.clone().or_else(|| u.login.clone()));
         Some(Self {
             commit_hash,
             repository_urls: gitea_repo_urls(&payload.repository),
             action: payload.action,
             branch,
+            pr_number: payload.pull_request.number,
+            pr_author,
+            is_fork,
+            base_owner,
+            base_repo,
         })
     }
 
@@ -404,11 +558,31 @@ impl ParsedPullRequestEvent {
             "object_attributes.last_commit.id",
         )?;
         let action = normalise_gitlab_mr_action(&payload.object_attributes.action);
+        let is_fork = match (
+            payload.object_attributes.source_project_id,
+            payload.object_attributes.target_project_id,
+        ) {
+            (Some(src), Some(tgt)) => Some(src != tgt),
+            _ => None,
+        };
+        let (base_owner, base_repo) = payload
+            .project
+            .path_with_namespace
+            .as_deref()
+            .and_then(split_full_name)
+            .map(|(o, r)| (Some(o), Some(r)))
+            .unwrap_or((None, None));
+        let pr_author = payload.user.as_ref().and_then(|u| u.username.clone());
         Some(Self {
             commit_hash,
             repository_urls: gitlab_project_urls(&payload.project),
             action,
             branch: Some(payload.object_attributes.source_branch),
+            pr_number: payload.object_attributes.iid,
+            pr_author,
+            is_fork,
+            base_owner,
+            base_repo,
         })
     }
 }
@@ -547,6 +721,98 @@ mod tests {
         assert_eq!(ev.branch, Some("feature-x".to_string()));
         assert_eq!(ev.commit_hash, hex::decode(VALID_SHA).unwrap());
         assert_eq!(ev.repository_urls.len(), 2);
+    }
+
+    #[test]
+    fn github_pr_from_fork_marks_is_fork_and_extracts_metadata() {
+        let body = format!(
+            r#"{{
+                "action": "opened",
+                "pull_request": {{
+                    "number": 42,
+                    "user": {{ "login": "external-contrib" }},
+                    "head": {{
+                        "sha": "{VALID_SHA}",
+                        "ref": "patch-1",
+                        "repo": {{ "full_name": "external-contrib/repo" }}
+                    }},
+                    "base": {{
+                        "sha": "0000000000000000000000000000000000000000",
+                        "ref": "main",
+                        "repo": {{ "full_name": "org/repo" }}
+                    }}
+                }},
+                "repository": {{
+                    "clone_url": "https://github.com/org/repo.git",
+                    "ssh_url": "git@github.com:org/repo.git",
+                    "full_name": "org/repo"
+                }}
+            }}"#
+        );
+        let ev = ParsedPullRequestEvent::from_github(body.as_bytes()).unwrap();
+        assert_eq!(ev.pr_number, Some(42));
+        assert_eq!(ev.pr_author.as_deref(), Some("external-contrib"));
+        assert_eq!(ev.is_fork, Some(true));
+        assert_eq!(ev.base_owner.as_deref(), Some("org"));
+        assert_eq!(ev.base_repo.as_deref(), Some("repo"));
+    }
+
+    #[test]
+    fn github_pr_same_repo_is_not_fork() {
+        let body = format!(
+            r#"{{
+                "action": "synchronize",
+                "pull_request": {{
+                    "number": 7,
+                    "user": {{ "login": "maintainer" }},
+                    "head": {{
+                        "sha": "{VALID_SHA}",
+                        "ref": "feature",
+                        "repo": {{ "full_name": "org/repo" }}
+                    }},
+                    "base": {{
+                        "sha": "0000000000000000000000000000000000000000",
+                        "ref": "main",
+                        "repo": {{ "full_name": "org/repo" }}
+                    }}
+                }},
+                "repository": {{
+                    "clone_url": "https://github.com/org/repo.git",
+                    "ssh_url": "git@github.com:org/repo.git",
+                    "full_name": "org/repo"
+                }}
+            }}"#
+        );
+        let ev = ParsedPullRequestEvent::from_github(body.as_bytes()).unwrap();
+        assert_eq!(ev.is_fork, Some(false));
+    }
+
+    #[test]
+    fn gitlab_mr_different_projects_marks_is_fork() {
+        let body = format!(
+            r#"{{
+                "object_attributes": {{
+                    "action": "open",
+                    "iid": 11,
+                    "source_branch": "feat",
+                    "source_project_id": 99,
+                    "target_project_id": 1,
+                    "last_commit": {{ "id": "{VALID_SHA}" }}
+                }},
+                "project": {{
+                    "http_url": "https://gitlab.example.com/group/repo.git",
+                    "ssh_url": "git@gitlab.example.com:group/repo.git",
+                    "path_with_namespace": "group/repo"
+                }},
+                "user": {{ "username": "external" }}
+            }}"#
+        );
+        let ev = ParsedPullRequestEvent::from_gitlab(body.as_bytes()).unwrap();
+        assert_eq!(ev.pr_number, Some(11));
+        assert_eq!(ev.pr_author.as_deref(), Some("external"));
+        assert_eq!(ev.is_fork, Some(true));
+        assert_eq!(ev.base_owner.as_deref(), Some("group"));
+        assert_eq!(ev.base_repo.as_deref(), Some("repo"));
     }
 
     #[test]

--- a/backend/web/src/endpoints/forge_hooks/mod.rs
+++ b/backend/web/src/endpoints/forge_hooks/mod.rs
@@ -138,6 +138,21 @@ pub async fn github_app_webhook(
             handle_github_installation(&state, &body).await;
             WebhookResponse::empty(&event)
         }
+        "check_run" => {
+            trigger::handle_github_check_run(&state, &scheduler, &body).await;
+            WebhookResponse::empty(&event)
+        }
+        "issue_comment" => {
+            trigger::handle_issue_comment(
+                &state,
+                &scheduler,
+                ForgeType::GitHub,
+                None,
+                &body,
+            )
+            .await;
+            WebhookResponse::empty(&event)
+        }
         other => WebhookResponse::empty(other),
     };
 
@@ -215,6 +230,7 @@ async fn dispatch_github_app_pr(
         );
         return WebhookTriggerOutcome::default();
     };
+    let approval_ctx = approval_context_from(&parsed);
     trigger_pr_for_integration(
         state,
         scheduler,
@@ -224,8 +240,19 @@ async fn dispatch_github_app_pr(
         parsed.commit_hash,
         None,
         None,
+        approval_ctx,
     )
     .await
+}
+
+fn approval_context_from(parsed: &ParsedPullRequestEvent) -> trigger::PullRequestApprovalContext {
+    trigger::PullRequestApprovalContext {
+        pr_number: parsed.pr_number,
+        pr_author: parsed.pr_author.clone(),
+        is_fork: parsed.is_fork,
+        base_owner: parsed.base_owner.clone(),
+        base_repo: parsed.base_repo.clone(),
+    }
 }
 
 async fn dispatch_github_app_release(
@@ -371,6 +398,7 @@ pub async fn forge_webhook(
                 return Err(WebError::bad_request("malformed webhook payload"));
             };
             let urls = parsed.repository_urls.clone();
+            let approval_ctx = approval_context_from(&parsed);
             let outcome = trigger_pr_for_integration(
                 &state,
                 &scheduler,
@@ -380,6 +408,7 @@ pub async fn forge_webhook(
                 parsed.commit_hash,
                 None,
                 None,
+                approval_ctx,
             )
             .await;
             WebhookResponse {
@@ -418,6 +447,17 @@ pub async fn forge_webhook(
                 skipped: outcome.skipped,
             }
         }
+        ForgeEvent::Comment => {
+            trigger::handle_issue_comment(
+                &state,
+                &scheduler,
+                forge_type,
+                Some(integration_id),
+                &body,
+            )
+            .await;
+            WebhookResponse::empty("comment")
+        }
         ForgeEvent::Unknown(name) => WebhookResponse::empty(&name),
     };
 
@@ -430,6 +470,7 @@ enum ForgeEvent {
     Push,
     PullRequest,
     Release,
+    Comment,
     Unknown(String),
 }
 
@@ -445,6 +486,7 @@ fn forge_event_type(forge: ForgeType, headers: &HeaderMap) -> ForgeEvent {
                 "push" => ForgeEvent::Push,
                 "pull_request" => ForgeEvent::PullRequest,
                 "release" => ForgeEvent::Release,
+                "issue_comment" | "pull_request_comment" => ForgeEvent::Comment,
                 other => ForgeEvent::Unknown(other.to_string()),
             }
         }
@@ -457,6 +499,7 @@ fn forge_event_type(forge: ForgeType, headers: &HeaderMap) -> ForgeEvent {
                 "Push Hook" | "Tag Push Hook" => ForgeEvent::Push,
                 "Merge Request Hook" => ForgeEvent::PullRequest,
                 "Release Hook" => ForgeEvent::Release,
+                "Note Hook" => ForgeEvent::Comment,
                 other => ForgeEvent::Unknown(other.to_string()),
             }
         }

--- a/backend/web/src/endpoints/forge_hooks/trigger.rs
+++ b/backend/web/src/endpoints/forge_hooks/trigger.rs
@@ -8,18 +8,32 @@
 
 use super::response::{QueuedEvaluation, SkippedProject, WebhookTriggerOutcome};
 use entity::project_trigger as ept;
-use gradient_core::ci::{ApplyInput, ApplyOutcome, apply_trigger};
+use gradient_core::ci::{
+    APPROVAL_ACTION_ID, ApplyInput, ApplyOutcome, ApprovalInfo, ForgeType, apply_trigger,
+    find_approval_gated_eval, resolve_outbound_reporter_for_project, unpark_approval,
+};
 use gradient_core::types::triggers::{TriggerConfig, TriggerType};
 use gradient_core::types::*;
 use scheduler::Scheduler;
 use sea_orm::ActiveValue::Set;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, DbBackend, EntityTrait, IntoActiveModel, QueryFilter, Statement,
-    Value,
+    ActiveModelTrait, ColumnTrait, DbBackend, EntityTrait, FromQueryResult, IntoActiveModel,
+    QueryFilter, Statement, Value,
 };
 use serde::Deserialize;
 use std::sync::Arc;
 use tracing::{info, warn};
+
+/// PR metadata extracted from the forge webhook payload, used by the approval
+/// gate to decide whether to park the evaluation pending maintainer approval.
+#[derive(Debug, Clone, Default)]
+pub(super) struct PullRequestApprovalContext {
+    pub pr_number: Option<u64>,
+    pub pr_author: Option<String>,
+    pub is_fork: Option<bool>,
+    pub base_owner: Option<String>,
+    pub base_repo: Option<String>,
+}
 
 // ── GitHub installation payload ────────────────────────────────────────────
 
@@ -201,6 +215,7 @@ pub(super) async fn trigger_push_for_integration(
             }
             _ => FilterResult::Skip,
         },
+        None,
     )
     .await
 }
@@ -215,7 +230,10 @@ pub(super) async fn trigger_pr_for_integration(
     commit_hash: Vec<u8>,
     commit_message: Option<String>,
     author_name: Option<String>,
+    approval_ctx: PullRequestApprovalContext,
 ) -> WebhookTriggerOutcome {
+    let action_owned = action.to_string();
+    let branch_owned = branch.map(str::to_string);
     fan_out_triggers(
         state,
         scheduler,
@@ -226,23 +244,28 @@ pub(super) async fn trigger_pr_for_integration(
         author_name,
         |cfg| match cfg {
             TriggerConfig::ReporterPullRequest {
-                branches, actions, ..
+                branches,
+                actions,
+                require_approval,
+                ..
             } => {
-                if !actions.iter().any(|a| a == action) {
+                if !actions.iter().any(|a| a == &action_owned) {
                     return FilterResult::SkipFilter;
                 }
-                let matches = match branch {
+                let matches = match branch_owned.as_deref() {
                     Some(b) => glob_matches(branches, b),
                     None => branches.is_empty(),
                 };
-                if matches {
-                    FilterResult::Fire
-                } else {
-                    FilterResult::SkipFilter
+                if !matches {
+                    return FilterResult::SkipFilter;
+                }
+                FilterResult::FirePr {
+                    require_approval: *require_approval,
                 }
             }
             _ => FilterResult::Skip,
         },
+        Some(approval_ctx),
     )
     .await
 }
@@ -285,6 +308,7 @@ pub(super) async fn trigger_release_for_integration(
             }
             _ => FilterResult::Skip,
         },
+        None,
     )
     .await
 }
@@ -292,8 +316,11 @@ pub(super) async fn trigger_release_for_integration(
 // ── Generic fan-out engine ─────────────────────────────────────────────────
 
 enum FilterResult {
-    /// Proceed to fire `apply_trigger`.
+    /// Proceed to fire `apply_trigger` (push / release / time / polling).
     Fire,
+    /// PR trigger matched; whether the approval gate engages depends on the
+    /// PR being from a fork and the contributor failing the writer-trust probe.
+    FirePr { require_approval: bool },
     /// Config filter did not match — add to skipped with reason "filter".
     SkipFilter,
     /// This trigger type / config shape doesn't apply at all — silently ignore.
@@ -310,6 +337,7 @@ async fn fan_out_triggers<F>(
     commit_message: Option<String>,
     author_name: Option<String>,
     filter: F,
+    approval_ctx: Option<PullRequestApprovalContext>,
 ) -> WebhookTriggerOutcome
 where
     F: Fn(&TriggerConfig) -> FilterResult,
@@ -333,7 +361,7 @@ where
             }
         };
 
-        match filter(&cfg) {
+        let pr_require_approval = match filter(&cfg) {
             FilterResult::Skip => continue,
             FilterResult::SkipFilter => {
                 let (project_name, organization) = project_identity(state, trig.project).await;
@@ -345,8 +373,9 @@ where
                 });
                 continue;
             }
-            FilterResult::Fire => {}
-        }
+            FilterResult::Fire => false,
+            FilterResult::FirePr { require_approval } => require_approval,
+        };
 
         let project = match EProject::find_by_id(trig.project).one(&state.web_db).await {
             Ok(Some(p)) => p,
@@ -365,6 +394,12 @@ where
             .await
             .unwrap_or_default();
 
+        let gate_approval = if pr_require_approval {
+            decide_pr_gate(state, project.id, approval_ctx.as_ref()).await
+        } else {
+            None
+        };
+
         match apply_trigger(
             &state.web_db,
             &project,
@@ -375,6 +410,7 @@ where
                 commit_message: commit_message.clone(),
                 author_name: author_name.clone(),
                 manual: false,
+                gate_approval,
             },
         )
         .await
@@ -430,6 +466,56 @@ where
         }
     }
     outcome
+}
+
+/// Resolves whether a PR webhook fire should be gated on maintainer approval.
+///
+/// Returns `Some(ApprovalInfo)` when the evaluation must be parked in
+/// `Waiting + Approval`; `None` when the PR can proceed immediately (same-repo
+/// PR, or the contributor is a confirmed repo writer).
+///
+/// Fail-closed semantics: when `is_fork` is unknown (the payload didn't carry
+/// enough information) or the trust probe errors / can't run for lack of
+/// metadata, the gate engages. Maintainers who hit a false positive can still
+/// approve via the forge UI / `/ci run` comment.
+async fn decide_pr_gate(
+    state: &Arc<ServerState>,
+    project_id: ProjectId,
+    ctx: Option<&PullRequestApprovalContext>,
+) -> Option<ApprovalInfo> {
+    let ctx = ctx?;
+    if matches!(ctx.is_fork, Some(false)) {
+        return None;
+    }
+    let pr_number = ctx.pr_number.unwrap_or(0);
+    let pr_author = ctx.pr_author.clone().unwrap_or_default();
+
+    if let (Some(owner), Some(repo), Some(author)) = (
+        ctx.base_owner.as_deref(),
+        ctx.base_repo.as_deref(),
+        ctx.pr_author.as_deref(),
+    ) && !author.is_empty()
+    {
+        let reporter = resolve_outbound_reporter_for_project(state, project_id).await;
+        match reporter.is_repo_writer(owner, repo, author).await {
+            Ok(true) => return None,
+            Ok(false) => {}
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    %project_id,
+                    pr_number,
+                    %author,
+                    "PR trust probe failed — parking pending approval"
+                );
+            }
+        }
+    }
+
+    Some(ApprovalInfo {
+        pr_number,
+        pr_author,
+    })
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -528,10 +614,458 @@ async fn org_name_for(state: &Arc<ServerState>, org_id: OrganizationId) -> Optio
         .map(|o| o.name)
 }
 
+// ── Approval unpark: GitHub `check_run.requested_action` ───────────────────
+
+#[derive(Deserialize)]
+struct GithubCheckRunRequestedAction<'a> {
+    action: &'a str,
+    requested_action: Option<GithubRequestedAction<'a>>,
+    check_run: GithubCheckRunRef<'a>,
+    repository: GithubRepoFull<'a>,
+    sender: Option<GithubSender<'a>>,
+}
+
+#[derive(Deserialize)]
+struct GithubRequestedAction<'a> {
+    identifier: &'a str,
+}
+
+#[derive(Deserialize)]
+struct GithubCheckRunRef<'a> {
+    id: i64,
+    #[serde(rename = "pull_requests", default)]
+    _pull_requests: Vec<serde_json::Value>,
+    #[serde(default)]
+    _name: Option<&'a str>,
+}
+
+#[derive(Deserialize)]
+struct GithubRepoFull<'a> {
+    full_name: Option<&'a str>,
+}
+
+#[derive(Deserialize)]
+struct GithubSender<'a> {
+    login: &'a str,
+}
+
+/// Handle a GitHub App `check_run.requested_action` event. Verifies the sender
+/// is a repo writer via the project's reporter, then re-queues the
+/// approval-gated evaluation matched by `check_run.id` and fires a fresh
+/// pending check.
+pub(super) async fn handle_github_check_run(
+    state: &Arc<ServerState>,
+    _scheduler: &Arc<Scheduler>,
+    body: &[u8],
+) {
+    let payload: GithubCheckRunRequestedAction = match serde_json::from_slice(body) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(error = %e, "GitHub check_run: failed to parse payload");
+            return;
+        }
+    };
+    if payload.action != "requested_action" {
+        return;
+    }
+    let Some(action) = payload.requested_action else {
+        return;
+    };
+    if action.identifier != APPROVAL_ACTION_ID {
+        return;
+    }
+    let Some(sender) = payload.sender else {
+        warn!("GitHub check_run.requested_action: missing sender");
+        return;
+    };
+    let Some(full_name) = payload.repository.full_name else {
+        warn!("GitHub check_run.requested_action: missing repository.full_name");
+        return;
+    };
+    let Some((owner, repo)) = full_name.split_once('/') else {
+        warn!(full_name, "GitHub check_run.requested_action: malformed repo full_name");
+        return;
+    };
+
+    let check_id = payload.check_run.id;
+    let Some(eval) = find_eval_by_check_id(state, check_id).await else {
+        warn!(
+            check_run_id = check_id,
+            "GitHub check_run.requested_action: no evaluation with matching repo_check_id"
+        );
+        return;
+    };
+    let Some(project_id) = eval.project else {
+        return;
+    };
+
+    if !sender_is_trusted(state, project_id, owner, repo, sender.login).await {
+        warn!(
+            evaluation_id = %eval.id,
+            sender = %sender.login,
+            "Rejecting approval click — sender is not a repo writer"
+        );
+        return;
+    }
+
+    match unpark_approval(&state.web_db, eval.id).await {
+        Ok(Some(unparked)) => {
+            info!(
+                evaluation_id = %eval.id,
+                sender = %sender.login,
+                "PR approval gate cleared via GitHub action"
+            );
+            scheduler::ci::spawn_pending_ci_for_eval(Arc::clone(state), &unparked);
+        }
+        Ok(None) => {
+            warn!(
+                evaluation_id = %eval.id,
+                "Approval click but evaluation no longer in Waiting+Approval state"
+            );
+        }
+        Err(e) => warn!(error = %e, evaluation_id = %eval.id, "Failed to unpark approval gate"),
+    }
+}
+
+async fn find_eval_by_check_id(
+    state: &Arc<ServerState>,
+    check_id: i64,
+) -> Option<MEvaluation> {
+    EEvaluation::find()
+        .filter(CEvaluation::RepoCheckId.eq(check_id))
+        .one(&state.web_db)
+        .await
+        .ok()
+        .flatten()
+}
+
+async fn sender_is_trusted(
+    state: &Arc<ServerState>,
+    project_id: ProjectId,
+    owner: &str,
+    repo: &str,
+    sender: &str,
+) -> bool {
+    let reporter = resolve_outbound_reporter_for_project(state, project_id).await;
+    match reporter.is_repo_writer(owner, repo, sender).await {
+        Ok(b) => b,
+        Err(e) => {
+            warn!(
+                error = %e,
+                %project_id,
+                sender,
+                "is_repo_writer probe failed during approval unpark"
+            );
+            false
+        }
+    }
+}
+
+// ── Approval unpark: `/ci run` comment on Gitea/Forgejo/GitLab + GitHub ────
+
+#[derive(Deserialize)]
+struct CommentPayload {
+    #[serde(default)]
+    action: Option<String>,
+    #[serde(default)]
+    comment: Option<CommentBody>,
+    #[serde(default)]
+    issue: Option<CommentIssue>,
+    #[serde(default)]
+    pull_request: Option<CommentIssue>,
+    #[serde(default)]
+    sender: Option<CommentSender>,
+    #[serde(default)]
+    repository: Option<CommentRepo>,
+    /// GitLab Note Hook fields.
+    #[serde(default)]
+    object_attributes: Option<GitlabNoteAttrs>,
+    #[serde(default)]
+    user: Option<CommentSender>,
+    #[serde(default)]
+    project: Option<GitlabNoteProject>,
+    #[serde(default)]
+    merge_request: Option<GitlabNoteMr>,
+}
+
+#[derive(Deserialize, Default)]
+struct CommentBody {
+    body: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct CommentIssue {
+    number: Option<u64>,
+}
+
+#[derive(Deserialize, Default)]
+struct CommentSender {
+    #[serde(default)]
+    login: Option<String>,
+    #[serde(default)]
+    username: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct CommentRepo {
+    #[serde(default)]
+    full_name: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct GitlabNoteAttrs {
+    #[serde(default)]
+    note: Option<String>,
+    #[serde(default)]
+    noteable_type: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct GitlabNoteProject {
+    #[serde(default)]
+    path_with_namespace: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct GitlabNoteMr {
+    #[serde(default)]
+    iid: Option<u64>,
+}
+
+/// Handle a `/ci run` comment on a PR. Re-queues the approval-gated
+/// evaluation when the commenter passes the writer-trust probe.
+///
+/// `integration_id` is `Some` for per-integration webhook routes (Gitea /
+/// Forgejo / GitLab) and `None` for the shared GitHub App route — for the
+/// latter we resolve the integration from `installation.id` in the body.
+pub(super) async fn handle_issue_comment(
+    state: &Arc<ServerState>,
+    _scheduler: &Arc<Scheduler>,
+    forge: ForgeType,
+    integration_id: Option<IntegrationId>,
+    body: &[u8],
+) {
+    let payload: CommentPayload = match serde_json::from_slice(body) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(error = %e, "comment webhook: failed to parse payload");
+            return;
+        }
+    };
+
+    let (comment_body, pr_number, sender_login, owner_repo) = match forge {
+        ForgeType::GitLab => {
+            let Some(attrs) = payload.object_attributes else {
+                return;
+            };
+            if attrs.noteable_type.as_deref() != Some("MergeRequest") {
+                return;
+            }
+            let comment_body = attrs.note.unwrap_or_default();
+            let pr_number = payload.merge_request.and_then(|m| m.iid);
+            let sender = payload.user.and_then(|u| u.username.or(u.login));
+            let owner_repo = payload
+                .project
+                .and_then(|p| p.path_with_namespace);
+            (comment_body, pr_number, sender, owner_repo)
+        }
+        _ => {
+            // GitHub uses `action == "created"`; Gitea uses
+            // `action == "created"` too.
+            if payload.action.as_deref() != Some("created") {
+                return;
+            }
+            let comment_body = payload
+                .comment
+                .and_then(|c| c.body)
+                .unwrap_or_default();
+            let pr_number = payload
+                .pull_request
+                .or(payload.issue)
+                .and_then(|i| i.number);
+            let sender = payload.sender.and_then(|s| s.login.or(s.username));
+            let owner_repo = payload.repository.and_then(|r| r.full_name);
+            (comment_body, pr_number, sender, owner_repo)
+        }
+    };
+
+    if !is_ci_run_command(&comment_body) {
+        return;
+    }
+    let Some(pr_number) = pr_number else {
+        warn!("comment webhook: /ci run but no PR number");
+        return;
+    };
+    let Some(sender) = sender_login else {
+        warn!("comment webhook: /ci run but no sender");
+        return;
+    };
+    let Some(owner_repo) = owner_repo else {
+        warn!("comment webhook: /ci run but no repo path");
+        return;
+    };
+    let Some((owner, repo)) = owner_repo.rsplit_once('/') else {
+        warn!(owner_repo, "comment webhook: malformed repo path");
+        return;
+    };
+
+    let integration_id = match integration_id {
+        Some(id) => id,
+        None => {
+            let installation_id = match github_installation_id_from_comment_body(body) {
+                Some(id) => id,
+                None => {
+                    warn!("comment webhook (github): no installation_id");
+                    return;
+                }
+            };
+            match resolve_github_integration_id(state, installation_id).await {
+                Some(id) => id,
+                None => {
+                    warn!(installation_id, "comment webhook (github): no integration");
+                    return;
+                }
+            }
+        }
+    };
+
+    let project_ids = match active_project_ids_for_integration(state, integration_id).await {
+        Ok(rows) => rows,
+        Err(e) => {
+            warn!(error = %e, "comment webhook: failed to load project list");
+            return;
+        }
+    };
+
+    let mut unparked_any = false;
+    for project_id in project_ids {
+        let Ok(Some(eval)) =
+            find_approval_gated_eval(&state.web_db, project_id, pr_number).await
+        else {
+            continue;
+        };
+        if !sender_is_trusted(state, project_id, owner, repo, &sender).await {
+            warn!(
+                project_id = %project_id,
+                pr_number,
+                %sender,
+                "Rejecting /ci run — sender is not a repo writer"
+            );
+            continue;
+        }
+        match unpark_approval(&state.web_db, eval.id).await {
+            Ok(Some(unparked)) => {
+                info!(
+                    evaluation_id = %eval.id,
+                    pr_number,
+                    %sender,
+                    "PR approval gate cleared via /ci run comment"
+                );
+                scheduler::ci::spawn_pending_ci_for_eval(Arc::clone(state), &unparked);
+                unparked_any = true;
+            }
+            Ok(None) => {}
+            Err(e) => warn!(error = %e, evaluation_id = %eval.id, "Failed to unpark approval gate"),
+        }
+    }
+    if !unparked_any {
+        debug_no_match(pr_number);
+    }
+}
+
+fn debug_no_match(pr_number: u64) {
+    tracing::debug!(pr_number, "/ci run comment had no matching parked evaluation");
+}
+
+/// Lifts `/ci run` (and tolerated variants) from a comment body. Matches the
+/// trimmed first non-empty line so a maintainer can quote-reply context and
+/// add the command on its own line.
+fn is_ci_run_command(body: &str) -> bool {
+    for line in body.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        return trimmed.eq_ignore_ascii_case("/ci run");
+    }
+    false
+}
+
+fn github_installation_id_from_comment_body(body: &[u8]) -> Option<i64> {
+    #[derive(Deserialize)]
+    struct WithInstallation {
+        installation: Option<InstallationId>,
+    }
+    #[derive(Deserialize)]
+    struct InstallationId {
+        id: i64,
+    }
+    serde_json::from_slice::<WithInstallation>(body)
+        .ok()
+        .and_then(|p| p.installation)
+        .map(|i| i.id)
+}
+
+async fn active_project_ids_for_integration(
+    state: &Arc<ServerState>,
+    integration_id: IntegrationId,
+) -> Result<Vec<ProjectId>, sea_orm::DbErr> {
+    let stmt = Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        "SELECT DISTINCT project FROM project_trigger \
+         WHERE active = true \
+           AND trigger_type = $1 \
+           AND (config->>'integration_id')::uuid = $2"
+            .to_string(),
+        [
+            Value::SmallInt(Some(i16::from(TriggerType::ReporterPullRequest))),
+            Value::Uuid(Some(Box::new(integration_id.into_inner()))),
+        ],
+    );
+
+    #[derive(sea_orm::FromQueryResult)]
+    struct ProjectRow {
+        project: ProjectId,
+    }
+    ProjectRow::find_by_statement(stmt)
+        .all(&state.web_db)
+        .await
+        .map(|rows| rows.into_iter().map(|r| r.project).collect())
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::WebhookTriggerOutcome;
-    use super::{glob_match_pattern, glob_matches};
+    use super::{glob_match_pattern, glob_matches, is_ci_run_command};
+
+    #[test]
+    fn ci_run_command_matches_canonical_form() {
+        assert!(is_ci_run_command("/ci run"));
+    }
+
+    #[test]
+    fn ci_run_command_matches_with_surrounding_whitespace() {
+        assert!(is_ci_run_command("   /ci run   "));
+        assert!(is_ci_run_command("\n/ci run\n"));
+    }
+
+    #[test]
+    fn ci_run_command_matches_first_non_empty_line() {
+        assert!(is_ci_run_command("\n\nquote-reply context\n\n/ci run"));
+    }
+
+    #[test]
+    fn ci_run_command_case_insensitive() {
+        assert!(is_ci_run_command("/CI Run"));
+        assert!(is_ci_run_command("/Ci RUN"));
+    }
+
+    #[test]
+    fn ci_run_command_rejects_unrelated_text() {
+        assert!(!is_ci_run_command("looks good"));
+        assert!(!is_ci_run_command("/ci run please"));
+        assert!(!is_ci_run_command("foo\n/ci run\nbar"));
+    }
 
     #[test]
     fn trigger_outcome_default_is_empty() {

--- a/backend/web/src/endpoints/forge_hooks/trigger.rs
+++ b/backend/web/src/endpoints/forge_hooks/trigger.rs
@@ -977,18 +977,28 @@ fn debug_no_match(pr_number: u64) {
     tracing::debug!(pr_number, "/ci run comment had no matching parked evaluation");
 }
 
-/// Lifts `/ci run` (and tolerated variants) from a comment body. Matches the
-/// trimmed first non-empty line so a maintainer can quote-reply context and
-/// add the command on its own line.
+/// Lifts `/ci run` from a comment body. The command must appear on its own
+/// line (after trimming whitespace). Blank lines and forge quote-reply lines
+/// (`> …`) are skipped so a maintainer can quote the PR context above the
+/// command, but any other prose before or after the command disqualifies
+/// the comment — that protects against accidental unparks when a contributor
+/// quotes an earlier `/ci run` in a reply.
 fn is_ci_run_command(body: &str) -> bool {
+    let mut saw_command = false;
     for line in body.lines() {
         let trimmed = line.trim();
-        if trimmed.is_empty() {
+        if trimmed.is_empty() || trimmed.starts_with('>') {
             continue;
         }
-        return trimmed.eq_ignore_ascii_case("/ci run");
+        if saw_command {
+            return false;
+        }
+        if !trimmed.eq_ignore_ascii_case("/ci run") {
+            return false;
+        }
+        saw_command = true;
     }
-    false
+    saw_command
 }
 
 fn github_installation_id_from_comment_body(body: &[u8]) -> Option<i64> {
@@ -1050,8 +1060,10 @@ mod tests {
     }
 
     #[test]
-    fn ci_run_command_matches_first_non_empty_line() {
-        assert!(is_ci_run_command("\n\nquote-reply context\n\n/ci run"));
+    fn ci_run_command_matches_after_quote_reply() {
+        assert!(is_ci_run_command(
+            "> @maintainer asked us to retrigger\n> after rebasing main\n\n/ci run"
+        ));
     }
 
     #[test]
@@ -1065,6 +1077,10 @@ mod tests {
         assert!(!is_ci_run_command("looks good"));
         assert!(!is_ci_run_command("/ci run please"));
         assert!(!is_ci_run_command("foo\n/ci run\nbar"));
+        assert!(
+            !is_ci_run_command("quote-reply context\n\n/ci run"),
+            "non-quote prose before /ci run must reject"
+        );
     }
 
     #[test]

--- a/backend/web/src/endpoints/orgs/settings.rs
+++ b/backend/web/src/endpoints/orgs/settings.rs
@@ -178,6 +178,11 @@ pub async fn post_organization_subscribe_cache(
         .and_then(|b| b.mode.clone())
         .unwrap_or(CacheSubscriptionMode::ReadWrite);
 
+    let unparks_builds = matches!(
+        mode,
+        CacheSubscriptionMode::ReadWrite | CacheSubscriptionMode::WriteOnly
+    );
+
     AOrganizationCache {
         id: Set(OrganizationCacheId::now_v7()),
         organization: Set(org.id),
@@ -186,6 +191,26 @@ pub async fn post_organization_subscribe_cache(
     }
     .insert(&state.web_db)
     .await?;
+
+    // Re-queue any evaluations parked with WaitingReason::NoCache for this
+    // org. Only ReadWrite/WriteOnly subscriptions unblock builds; ReadOnly
+    // subscriptions leave the org without anywhere to push outputs.
+    if unparks_builds {
+        match gradient_core::ci::unpark_no_cache_for_org(&state.web_db, org.id).await {
+            Ok(unparked) => {
+                for eval in &unparked {
+                    scheduler::ci::spawn_pending_ci_for_eval(Arc::clone(&state), eval);
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    org_id = %org.id,
+                    "failed to unpark no-cache evaluations after cache subscription",
+                );
+            }
+        }
+    }
 
     // Enqueue signing of every cached path the org already owns for this
     // new cache. We insert `cached_path_signature` placeholders with

--- a/backend/web/src/endpoints/projects/evaluations.rs
+++ b/backend/web/src/endpoints/projects/evaluations.rs
@@ -221,7 +221,7 @@ pub async fn post_project_evaluate(
         ));
     }
 
-    gradient_core::ci::trigger_evaluation(
+    let eval = gradient_core::ci::trigger_evaluation(
         &state.web_db,
         &project,
         commit_hash,
@@ -240,6 +240,8 @@ pub async fn post_project_evaluate(
         }
         gradient_core::ci::TriggerError::Db(db_err) => WebError::from(db_err),
     })?;
+
+    gradient_core::ci::park_if_no_cache(&state.web_db, eval, project.organization).await?;
 
     Ok(ok_json("Evaluation started".to_string()))
 }

--- a/backend/web/src/endpoints/projects/triggers.rs
+++ b/backend/web/src/endpoints/projects/triggers.rs
@@ -394,6 +394,7 @@ pub async fn fire_now(
         commit_message: Some(commit_message),
         author_name: Some(author_name),
         manual: true,
+        gate_approval: None,
     };
 
     let outcome = apply_trigger(&state.web_db, &proj, input)

--- a/backend/web/tests/forge_hooks.rs
+++ b/backend/web/tests/forge_hooks.rs
@@ -252,6 +252,33 @@ fn commit_row() -> entity::commit::Model {
     }
 }
 
+fn cache_row() -> entity::cache::Model {
+    entity::cache::Model {
+        id: CacheId::now_v7(),
+        name: "test-cache".into(),
+        display_name: "Test Cache".into(),
+        description: String::new(),
+        active: true,
+        priority: 10,
+        local_priority: None,
+        public_key: String::new(),
+        private_key: String::new(),
+        public: false,
+        created_by: UserId::nil(),
+        created_at: fixture_date(),
+        managed: false,
+    }
+}
+
+fn org_cache_row() -> entity::organization_cache::Model {
+    entity::organization_cache::Model {
+        id: OrganizationCacheId::now_v7(),
+        organization: org_id(),
+        cache: CacheId::now_v7(),
+        mode: entity::organization_cache::CacheSubscriptionMode::ReadWrite,
+    }
+}
+
 /// Build a `project_trigger` row with the given config.
 fn trigger_row(cfg: TriggerConfig) -> entity::project_trigger::Model {
     entity::project_trigger::Model {
@@ -293,7 +320,8 @@ fn reporter_pr_trigger(actions: Vec<&str>) -> TriggerConfig {
 }
 
 /// Mock DB chain for a successful `apply_trigger` call with no prior evaluation
-/// (skips same-commit dedup) and no in-flight evaluation.
+/// (skips same-commit dedup) and no in-flight evaluation. Includes the
+/// `org_has_writable_cache` lookup that runs after the eval is created.
 fn apply_trigger_db_chain(db: MockDatabase) -> MockDatabase {
     db.append_query_results([Vec::<entity::evaluation::Model>::new()]) // in-flight check
         .append_query_results([Vec::<entity::evaluation::Model>::new()]) // trigger_evaluation: in-progress check
@@ -304,6 +332,8 @@ fn apply_trigger_db_chain(db: MockDatabase) -> MockDatabase {
             last_insert_id: 0,
             rows_affected: 1,
         }]) // UPDATE project
+        .append_query_results([vec![org_cache_row()]]) // org_has_writable_cache: subscription rows
+        .append_query_results([vec![cache_row()]]) // org_has_writable_cache: active cache rows
 }
 
 // ── Test 1: Generic forge — no matching trigger (Gitea) ───────────────────────

--- a/backend/web/tests/forge_hooks.rs
+++ b/backend/web/tests/forge_hooks.rs
@@ -316,6 +316,9 @@ fn reporter_pr_trigger(actions: Vec<&str>) -> TriggerConfig {
         integration_id: integration_id(),
         branches: vec![],
         actions: actions.into_iter().map(String::from).collect(),
+        // Existing fan-out tests don't depend on the approval gate. Keep
+        // the legacy "run anything that matches" behaviour explicit here.
+        require_approval: false,
     }
 }
 

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -5614,18 +5614,39 @@ components:
           $ref: '#/components/schemas/WaitingReason'
 
     WaitingReason:
-      type: object
       description: |
-        Populated only when `status == "Waiting"`. In the build phase, lists
-        the `(architecture, required_features)` combinations no connected
-        worker can satisfy, alongside the architectures the connected pool
-        *does* offer. In the pre-build phase, an empty `unmet` list with
-        `connected_workers == 0` indicates the evaluation is stalled simply
-        because no worker is connected at all. Refreshed whenever the
-        scheduler reconciles the evaluation against the live worker pool
-        (worker connect/disconnect, capability update, dispatch tick).
-      required: [unmet, connected_workers, available_architectures]
+        Populated only when `status == "Waiting"`. Tagged by `kind`:
+
+        - `workers`: no connected worker can satisfy the pending builds'
+          `(architecture, required_features)` combos. Refreshed whenever the
+          scheduler reconciles the evaluation against the live worker pool.
+        - `approval`: the PR comes from a contributor who is not a forge
+          repo writer, and the trigger has `require_approval = true`. The
+          evaluation stays parked until a maintainer clicks "Approve and
+          run" on the GitHub Check or comments `/ci run` on
+          Gitea/Forgejo/GitLab.
+        - `no_cache`: the project's organisation has no writable cache
+          subscription, so build outputs would have nowhere to land. The
+          evaluation auto-unparks the moment a writable cache is
+          subscribed.
+      oneOf:
+        - $ref: '#/components/schemas/WaitingReasonWorkers'
+        - $ref: '#/components/schemas/WaitingReasonApproval'
+        - $ref: '#/components/schemas/WaitingReasonNoCache'
+      discriminator:
+        propertyName: kind
+        mapping:
+          workers: '#/components/schemas/WaitingReasonWorkers'
+          approval: '#/components/schemas/WaitingReasonApproval'
+          no_cache: '#/components/schemas/WaitingReasonNoCache'
+
+    WaitingReasonWorkers:
+      type: object
+      required: [kind, unmet, connected_workers, available_architectures]
       properties:
+        kind:
+          type: string
+          enum: [workers]
         unmet:
           type: array
           description: |
@@ -5641,11 +5662,32 @@ components:
           description: Total number of workers currently connected to the scheduler.
         available_architectures:
           type: array
-          description: |
-            Distinct architectures advertised by the connected pool. Empty if no
-            workers are connected.
+          description: Distinct architectures advertised by the connected pool. Empty if no workers are connected.
           items:
             type: string
+
+    WaitingReasonApproval:
+      type: object
+      required: [kind, pr_number, pr_author]
+      properties:
+        kind:
+          type: string
+          enum: [approval]
+        pr_number:
+          type: integer
+          minimum: 0
+          description: PR / MR number on the forge that the maintainer must approve.
+        pr_author:
+          type: string
+          description: Forge login of the PR author whose contribution is being gated.
+
+    WaitingReasonNoCache:
+      type: object
+      required: [kind]
+      properties:
+        kind:
+          type: string
+          enum: [no_cache]
 
     UnmetRequirement:
       type: object
@@ -6602,6 +6644,15 @@ components:
           items:
             type: string
           description: 'PR actions that fire the trigger. Defaults to ["opened","synchronize","reopened"].'
+        require_approval:
+          type: boolean
+          default: true
+          description: |
+            When `true` (default), PRs from contributors who are not forge
+            repo writers are parked in `Waiting + WaitingReason::Approval`
+            until a maintainer clicks "Approve and run" on the GitHub Check
+            or comments `/ci run` on Gitea/Forgejo/GitLab. Set to `false` to
+            disable the gate and run every PR build automatically.
 
     TimeTriggerConfig:
       type: object

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -2429,3 +2429,30 @@ CLI integration tests in `cli/tests/`:
 - `download_attr.rs` — `gradient download '#attr' --json` writes the right files; `--json` without args returns a structured missing-argument envelope and exits 2.
 
 Run a single connector test file with `cargo test -p connector --test <name>`; CI runs the full suite.
+
+## PR approval gate (#247)
+
+Untrusted PRs (from forks where the contributor is not a forge repo writer)
+are parked in `Waiting + WaitingReason::Approval` instead of running
+immediately. Coverage:
+
+- `core/src/types/triggers.rs` — `reporter_pull_request_require_approval_defaults_true_for_legacy_rows`
+  asserts the secure-by-default `require_approval = true` decoding for
+  pre-#247 rows that lack the field in stored JSON.
+- `core/src/types/waiting_reason.rs` — round-trips for the
+  `workers` / `approval` / `no_cache` variants plus the legacy-row
+  decoder.
+- `core/src/ci/apply.rs::no_writable_cache_parks_evaluation_in_waiting_no_cache`
+  — `apply_trigger` parks newly-created evals as `NoCache` when the org
+  has no writable cache subscription.
+- `web/src/endpoints/forge_hooks/events.rs` — extraction of
+  `pr_number`, `pr_author`, `is_fork`, `base_owner`, `base_repo` from
+  GitHub / Gitea / GitLab payloads.
+- `web/src/endpoints/forge_hooks/trigger.rs::is_ci_run_command_*` —
+  recogniser for the `/ci run` comment unpark command (case
+  insensitive, allows leading quote-reply lines, rejects trailing
+  noise).
+- `core/src/ci/unpark.rs::unpark_approval_*` — transitions
+  `Waiting + Approval` back to `Queued` once a maintainer authorises
+  the PR; no-ops when the row's reason is something else (NoCache /
+  Workers).

--- a/frontend/src/app/core/models/project.model.ts
+++ b/frontend/src/app/core/models/project.model.ts
@@ -101,10 +101,23 @@ export interface Evaluation {
   trigger: { id: string; type: TriggerType } | null;
 }
 
-export interface WaitingReason {
+export type WaitingReason = WorkersWaitingReason | ApprovalWaitingReason | NoCacheWaitingReason;
+
+export interface WorkersWaitingReason {
+  kind: 'workers';
   unmet: UnmetRequirement[];
   connected_workers: number;
   available_architectures: string[];
+}
+
+export interface ApprovalWaitingReason {
+  kind: 'approval';
+  pr_number: number;
+  pr_author: string;
+}
+
+export interface NoCacheWaitingReason {
+  kind: 'no_cache';
 }
 
 export interface UnmetRequirement {

--- a/frontend/src/app/core/models/trigger.model.ts
+++ b/frontend/src/app/core/models/trigger.model.ts
@@ -39,6 +39,10 @@ export interface ReporterPullRequestTriggerConfig {
   integration_id: string;
   branches?: string[];
   actions?: string[];
+  /** When true (default), PRs from non-writer contributors are parked until
+   *  a maintainer approves them via the forge's check-run action (GitHub)
+   *  or a `/ci run` comment (Gitea/Forgejo/GitLab). */
+  require_approval?: boolean;
 }
 
 export interface TimeTriggerConfig {

--- a/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.html
+++ b/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.html
@@ -218,8 +218,8 @@
           } @else if (ev.status === 'Waiting') {
             <div class="queued-hint">
               <span class="material-symbols-outlined queued-icon">pause_circle</span>
-              <span class="queued-title">Waiting for Workers</span>
-              @if (ev.waiting_reason && ev.waiting_reason.unmet.length > 0) {
+              <span class="queued-title">{{ waitingTitle(ev.waiting_reason) }}</span>
+              @if (ev.waiting_reason && ev.waiting_reason.kind === 'workers' && ev.waiting_reason.unmet.length > 0) {
                 <span class="queued-sub">{{ formatWaitingReason(ev.waiting_reason) }}</span>
                 <ul class="waiting-unmet">
                   @for (req of ev.waiting_reason.unmet; track req.architecture + ':' + req.required_features.join(',')) {
@@ -235,6 +235,8 @@
                     </li>
                   }
                 </ul>
+              } @else if (ev.waiting_reason) {
+                <span class="queued-sub">{{ formatWaitingReason(ev.waiting_reason) }}</span>
               } @else {
                 <span class="queued-sub">No build workers are currently available. Evaluation will resume when a worker connects&hellip;</span>
               }

--- a/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.ts
+++ b/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.ts
@@ -783,13 +783,34 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
   }
 
   formatWaitingReason(reason: WaitingReason): string {
-    const archs = reason.available_architectures;
-    if (reason.connected_workers === 0) {
-      return 'No workers are connected. The evaluation requires:';
+    switch (reason.kind) {
+      case 'workers': {
+        if (reason.connected_workers === 0) {
+          return 'No workers are connected. The evaluation requires:';
+        }
+        const archList = reason.available_architectures.length > 0
+          ? reason.available_architectures.join(', ')
+          : 'none';
+        const workerWord = reason.connected_workers === 1 ? 'worker' : 'workers';
+        return `${reason.connected_workers} connected ${workerWord} (${archList}) cannot satisfy:`;
+      }
+      case 'approval':
+        return `Awaiting maintainer approval for pull request #${reason.pr_number} by ${reason.pr_author}.`;
+      case 'no_cache':
+        return 'No cache is configured for this organization. Configure a cache before this evaluation can run.';
     }
-    const archList = archs.length > 0 ? archs.join(', ') : 'none';
-    const workerWord = reason.connected_workers === 1 ? 'worker' : 'workers';
-    return `${reason.connected_workers} connected ${workerWord} (${archList}) cannot satisfy:`;
+  }
+
+  waitingTitle(reason: WaitingReason | undefined): string {
+    switch (reason?.kind) {
+      case 'approval': return 'Awaiting Approval';
+      case 'no_cache': return 'No Cache Configured';
+      default: return 'Waiting for Workers';
+    }
+  }
+
+  isWorkersWaiting(reason: WaitingReason | undefined): boolean {
+    return reason?.kind === 'workers';
   }
 
   getTriggerLabel(type: TriggerType | null): string {

--- a/frontend/src/app/features/projects/project-detail/project-detail.component.html
+++ b/frontend/src/app/features/projects/project-detail/project-detail.component.html
@@ -86,9 +86,9 @@
               <div class="evaluation-status">
                 <span
                   class="status-icon material-symbols-outlined"
-                  [class]="getBuildStatusClass(ep.build_status)"
+                  [class]="effectiveEntryStatusClass(ep)"
                 >
-                  {{ getBuildStatusIcon(ep.build_status) }}
+                  {{ effectiveEntryStatusIcon(ep) }}
                 </span>
               </div>
               <div class="evaluation-content">
@@ -98,8 +98,8 @@
                       {{ getDerivationName(ep.derivation_path) }}
                     </a>
                   </h3>
-                  <span class="status-badge" [class]="getBuildStatusClass(ep.build_status)">
-                    {{ formatBuildStatus(ep.build_status) }}
+                  <span class="status-badge" [class]="effectiveEntryStatusClass(ep)">
+                    {{ effectiveEntryStatusLabel(ep) }}
                   </span>
                   <a
                     [class.graph-icon-link]="true"

--- a/frontend/src/app/features/projects/project-detail/project-detail.component.ts
+++ b/frontend/src/app/features/projects/project-detail/project-detail.component.ts
@@ -214,6 +214,24 @@ export class ProjectDetailComponent implements OnInit, OnDestroy {
     }
   }
 
+  effectiveEntryStatusClass(ep: EntryPointSummary): string {
+    return ep.evaluation_status === 'Waiting'
+      ? this.getStatusClass(ep.evaluation_status)
+      : this.getBuildStatusClass(ep.build_status);
+  }
+
+  effectiveEntryStatusIcon(ep: EntryPointSummary): string {
+    return ep.evaluation_status === 'Waiting'
+      ? this.getStatusIcon(ep.evaluation_status)
+      : this.getBuildStatusIcon(ep.build_status);
+  }
+
+  effectiveEntryStatusLabel(ep: EntryPointSummary): string {
+    return ep.evaluation_status === 'Waiting'
+      ? this.getStatusLabel(ep.evaluation_status)
+      : this.formatBuildStatus(ep.build_status);
+  }
+
   getEvaluationDuration(evaluation: EvaluationSummary): string {
     const start = parseUtcTimestamp(evaluation.created_at);
     const end = this.isRunningStatus(evaluation.status)

--- a/frontend/src/app/features/projects/project-triggers/project-triggers.component.html
+++ b/frontend/src/app/features/projects/project-triggers/project-triggers.component.html
@@ -254,6 +254,23 @@
       />
       <small class="text-secondary">Comma-separated PR action names. Leave blank to fire on any action.</small>
     </div>
+
+    <div class="form-group checkbox-group">
+      <p-checkbox
+        inputId="trig-require-approval"
+        [(ngModel)]="form.require_approval"
+        [binary]="true"
+      />
+      <label for="trig-require-approval">
+        Require maintainer approval for PRs from non-writers
+      </label>
+      <small class="text-secondary">
+        When enabled (secure-by-default), PRs from contributors who are not
+        repo writers on the forge are parked until a maintainer clicks
+        “Approve and run” on the GitHub Check or comments <code>/ci run</code>
+        on Gitea/Forgejo/GitLab. Disable to run every PR build automatically.
+      </small>
+    </div>
   }
 
   @if (form.type === 'time') {

--- a/frontend/src/app/features/projects/project-triggers/project-triggers.component.ts
+++ b/frontend/src/app/features/projects/project-triggers/project-triggers.component.ts
@@ -44,6 +44,7 @@ interface TriggerFormState {
   tags: string;
   releases_only: boolean;
   actions: string;
+  require_approval: boolean;
   cron: string;
 }
 
@@ -57,6 +58,7 @@ const DEFAULT_FORM: TriggerFormState = {
   tags: '',
   releases_only: false,
   actions: '',
+  require_approval: true,
   cron: '',
 };
 
@@ -177,6 +179,7 @@ export class ProjectTriggersComponent implements OnInit {
       tags: (cfg.tags ?? []).join(', '),
       releases_only: cfg.releases_only ?? false,
       actions: (cfg.actions ?? []).join(', '),
+      require_approval: cfg.require_approval ?? true,
       cron: cfg.cron ?? '',
     };
     this.error.set(null);
@@ -216,6 +219,7 @@ export class ProjectTriggersComponent implements OnInit {
         const actions = this.splitList(this.form.actions);
         if (branches.length) cfg.branches = branches;
         if (actions.length) cfg.actions = actions;
+        cfg.require_approval = this.form.require_approval !== false;
         return cfg;
       }
       case 'time':
@@ -321,6 +325,7 @@ export class ProjectTriggersComponent implements OnInit {
         const parts: string[] = [`from ${this.integrationLabel(trigger)}`];
         if (cfg.branches?.length) parts.push(`branches: ${cfg.branches.join(', ')}`);
         if (cfg.actions?.length) parts.push(`actions: ${cfg.actions.join(', ')}`);
+        if (cfg.require_approval === false) parts.push('approval gate off');
         return parts.join(' / ');
       }
       case 'time':

--- a/nix/modules/gradient-state.nix
+++ b/nix/modules/gradient-state.nix
@@ -406,10 +406,16 @@
 
           - `polling`: `{ interval_secs = 300; branch = "main"; }` (minimum 10 seconds; `branch` optional, defaults to remote HEAD)
           - `reporter_push`: `{ branches = [ "main" "release/*" ]; tags = [ ]; releases_only = false; }`
-          - `reporter_pull_request`: `{ branches = [ ]; actions = [ "opened" "synchronize" "reopened" ]; }`
+          - `reporter_pull_request`: `{ branches = [ ]; actions = [ "opened" "synchronize" "reopened" ]; require_approval = true; }`
           - `time`: `{ cron = "0 0 2 * * *"; }` (six-field: sec min hour dom mon dow, UTC)
 
           Empty `branches`/`tags`/`actions` lists mean "match all".
+
+          `require_approval` (PR triggers only, default `true`) parks evaluations
+          for PRs from contributors who are not repo writers on the forge until
+          a maintainer clicks "Approve and run" on the GitHub check or comments
+          `/ci run` on Gitea/Forgejo/GitLab. Set to `false` to disable the gate
+          and run every PR build automatically.
         '';
         example = literalExpression ''
           { interval_secs = 60; }


### PR DESCRIPTION
## Summary

Closes #247.

- Forge PRs from contributors who are not repo writers are parked in `Waiting + WaitingReason::Approval` instead of running automatically. Trust is probed via the project's outbound CI reporter (`is_repo_writer`) against the forge's permission API on every fire — same-repo PRs and confirmed writers run as before, fork PRs from unknown contributors park until a maintainer approves.
- Maintainers can release the gate via the native GitHub Check action button (`check_run.requested_action` with identifier `approve-and-run`) or by commenting `/ci run` on Gitea / Forgejo / GitLab / GitHub. Comment unparkers go through the same writer-trust probe before re-queueing.
- `require_approval` is a new field on `TriggerConfig::ReporterPullRequest` (default `true`, secure-by-default), surfaced in the project trigger UI, `nix/modules/gradient-state.nix`, and `docs/gradient-api.yaml`.
- `WaitingReason` was refactored to a tagged enum (`workers` / `approval` / `no_cache`) with a JSONB backfill migration; the scheduler's reconciler skips non-`workers` parks so user-actionable gates aren't accidentally undone.
- New no-cache gate parks evaluations when the org has no writable cache subscription and auto-unparks on first cache subscribe.
- Frontend now surfaces the Waiting status (Approval / NoCache / Workers) above any Queued sub-builds on entry-point cards.

## Test plan

- [x] `cargo check --workspace --tests` clean
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] Unit coverage: `core::ci::apply::tests::gate_approval_parks_pr_evaluation_in_waiting_approval`, `core::ci::unpark::tests::unpark_approval_*`, `web::forge_hooks::trigger::tests::ci_run_command_*`, `web::forge_hooks::events::tests::{github_pr_from_fork_*, gitlab_mr_different_projects_*}`.
- [x] Manually: install GitHub App on a test org, open a PR from a fork → eval parked, "Approve and run" check action → unparks and runs.
- [x] Manually: open a PR on Gitea from a non-writer, comment `/ci run` from a maintainer → unparks; comment from a non-writer → ignored.
- [x] Manually: set `require_approval = false` on a PR trigger → fork PRs run immediately.