### PR TITLE
nix: raise postgres max_connections default and fix cache test worker org key

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1779041105,
-        "narHash": "sha256-nnGD2f8OlAZT2i5OfwikJsw+ifWfiA4d6A8BWlgOXV0=",
+        "lastModified": 1779130139,
+        "narHash": "sha256-BLrtr42azquO7MdGFU5a7KiMl3YpFlTeIXqy1fT5GlQ=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "10e6e3cb966f7cfcc789fe5eee7a85f3188ce08b",
+        "rev": "edb38893982a3338972bb4a2ec7ce7c29ba10fd9",
         "type": "github"
       },
       "original": {

--- a/nix/modules/gradient.nix
+++ b/nix/modules/gradient.nix
@@ -660,6 +660,7 @@ in {
       postgresql = lib.mkIf cfg.configurePostgres {
         enable = true;
         ensureDatabases = [ "gradient" ];
+        settings.max_connections = lib.mkDefault 200;
         ensureUsers = [{
           name = "gradient";
           ensureDBOwnership = true;

--- a/nix/tests/gradient/cache/default.nix
+++ b/nix/tests/gradient/cache/default.nix
@@ -140,7 +140,7 @@ in {
               workers = {
                 builder = {
                   worker_id = "a0000000-0000-0000-0000-000000000001";
-                  organization = "org";
+                  organizations = [ "org" ];
                   token_file = "/etc/gradient/secrets/worker_token";
                   created_by = "admin";
                 };


### PR DESCRIPTION
## Summary
- Set `services.postgresql.settings.max_connections = lib.mkDefault 200` when `services.gradient.configurePostgres = true` — the default of 100 was being exhausted by the server's connection pool under load (`Connection pool timed out` errors).
- Fix `nix/tests/gradient/cache/default.nix` worker config: `organization = "org"` → `organizations = [ "org" ]` to match the `state.workers.<name>.organizations` option type.

## Test plan
- [x] `nix flake check` passes
- [x] gradient-cache NixOS test evaluates without the previous `option does not exist` error