### PR TITLE
fix #268: park evaluations as Waiting when org has no eval-capable worker

### DIFF
--- a/backend/core/src/ci/actions.rs
+++ b/backend/core/src/ci/actions.rs
@@ -112,6 +112,75 @@ pub async fn dispatch_evaluation_event(
     dispatch_event(state, project_id, event, payload).await;
 }
 
+/// Dispatch the first forge-status event for a freshly-created evaluation.
+///
+/// Replaces the legacy `spawn_pending_ci_for_eval` reporter that was removed
+/// alongside the per-project outbound integration: an eval row that has just
+/// been INSERTed (Queued, or Waiting+Approval/NoCache/Workers due to the
+/// trigger-time gates) never transitions through `update_evaluation_status`,
+/// so `dispatch_evaluation_event_for_status` would not fire for it. Without
+/// this helper, the commit shows no Gradient check at all until an eval
+/// worker actually starts processing it.
+///
+/// Maps the eval's creation-time state to the matching event:
+/// - `Queued` → `evaluation.queued` (Pending).
+/// - `Waiting + Approval` → `evaluation.action_required` (ActionRequired,
+///   carries the maintainer-approval description).
+/// - `Waiting + NoCache` → `evaluation.queued` (Pending, "no cache" description).
+/// - `Waiting + Workers` → `evaluation.queued` (Pending, "no eval-capable
+///   worker" description). Issue #268.
+pub async fn dispatch_evaluation_created(
+    state: &Arc<ServerState>,
+    eval: &crate::types::MEvaluation,
+) {
+    use crate::types::waiting_reason::WaitingReason;
+    use entity::evaluation::EvaluationStatus;
+
+    let Some(project_id) = eval.project else {
+        return;
+    };
+
+    let reason = eval
+        .waiting_reason
+        .as_ref()
+        .and_then(WaitingReason::from_json);
+
+    let (event, description) = match (eval.status, reason) {
+        (EvaluationStatus::Queued, _) => ("evaluation.queued", None),
+        (EvaluationStatus::Waiting, Some(WaitingReason::Approval { .. })) => (
+            "evaluation.action_required",
+            Some("Awaiting maintainer approval for external contributor PR."),
+        ),
+        (EvaluationStatus::Waiting, Some(WaitingReason::NoCache)) => (
+            "evaluation.queued",
+            Some("Waiting for a writable cache subscription before this evaluation can run."),
+        ),
+        (
+            EvaluationStatus::Waiting,
+            Some(WaitingReason::Workers {
+                connected_workers: 0,
+                ..
+            }),
+        ) => (
+            "evaluation.queued",
+            Some("Waiting for an eval-capable worker to be registered on the organisation."),
+        ),
+        _ => return,
+    };
+
+    let mut payload = serde_json::json!({
+        "evaluation_id": eval.id,
+        "project_id": eval.project,
+        "repository": eval.repository,
+        "status": event,
+    });
+    if let Some(text) = description {
+        payload["description"] = JsonValue::String(text.to_string());
+    }
+
+    dispatch_evaluation_event(state, project_id, event, payload).await;
+}
+
 pub async fn dispatch_build_event(
     state: &Arc<ServerState>,
     project_id: ProjectId,

--- a/backend/core/src/ci/apply.rs
+++ b/backend/core/src/ci/apply.rs
@@ -10,7 +10,7 @@
 
 use super::abort::{AbortKind, abort_evaluation};
 use super::trigger::{TriggerError, trigger_evaluation};
-use crate::db::org_has_writable_cache;
+use crate::db::{org_has_eval_capable_worker_registration, org_has_writable_cache};
 use crate::types::triggers::{ConcurrencyPolicy, TriggerType};
 use crate::types::waiting_reason::WaitingReason;
 use crate::types::*;
@@ -159,6 +159,7 @@ pub async fn apply_trigger<C: ConnectionTrait>(
 
     let eval = park_if_pending_approval(db, eval, input.gate_approval.as_ref()).await?;
     let eval = park_if_no_cache(db, eval, project.organization).await?;
+    let eval = park_if_no_workers(db, eval, project.organization).await?;
     Ok(ApplyOutcome::Created {
         evaluation: eval,
         aborted_evaluation,
@@ -215,10 +216,41 @@ pub async fn park_if_no_cache<C: ConnectionTrait>(
     ae.update(db).await
 }
 
+/// Move a freshly-created `Queued` evaluation into `Waiting` with
+/// `WaitingReason::Workers { connected_workers: 0, .. }` when the project's
+/// organisation has no active worker registration with the `eval` capability
+/// gate enabled. Returns the evaluation unchanged when at least one such
+/// registration exists.
+///
+/// Without this gate the eval row would sit in `Queued` indefinitely: the
+/// build-dispatch reconciler only stalls Queued evaluations when **zero**
+/// workers are connected, not when connected workers all lack `eval`. The
+/// row is unparked by `unpark_no_workers_for_org` whenever a worker
+/// registration is created or its `enable_eval` / `active` flags flip on.
+pub async fn park_if_no_workers<C: ConnectionTrait>(
+    db: &C,
+    eval: MEvaluation,
+    organization: OrganizationId,
+) -> Result<MEvaluation, sea_orm::DbErr> {
+    if eval.status != EvaluationStatus::Queued {
+        return Ok(eval);
+    }
+    if org_has_eval_capable_worker_registration(db, organization).await? {
+        return Ok(eval);
+    }
+    let mut ae: AEvaluation = eval.into();
+    ae.status = Set(EvaluationStatus::Waiting);
+    ae.waiting_reason = Set(Some(
+        WaitingReason::workers(Vec::new(), 0, Vec::new()).to_json(),
+    ));
+    ae.updated_at = Set(crate::types::now());
+    ae.update(db).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::ids::{CacheId, OrganizationCacheId, UserId};
+    use crate::types::ids::{CacheId, OrganizationCacheId, UserId, WorkerRegistrationId};
     use chrono::NaiveDateTime;
     use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
     use uuid::Uuid;
@@ -336,6 +368,30 @@ mod tests {
             .append_query_results([vec![cache]])
     }
 
+    fn worker_registration_row(active: bool, enable_eval: bool) -> entity::worker_registration::Model {
+        entity::worker_registration::Model {
+            id: WorkerRegistrationId::now_v7(),
+            peer_id: OrganizationId::nil(),
+            worker_id: "00000000-0000-4000-8000-000000000001".into(),
+            token_hash: String::new(),
+            managed: false,
+            url: None,
+            active,
+            enable_fetch: true,
+            enable_eval,
+            enable_build: true,
+            display_name: String::new(),
+            created_by: Some(UserId::nil()),
+            created_at: NaiveDateTime::default(),
+        }
+    }
+
+    /// Append the single query `org_has_eval_capable_worker_registration`
+    /// issues for the "eval-capable worker exists" path.
+    fn with_eval_worker(db: MockDatabase) -> MockDatabase {
+        db.append_query_results([vec![worker_registration_row(true, true)]])
+    }
+
     #[tokio::test]
     async fn skips_when_same_commit_as_last_eval() {
         let prev_eval_id = EvaluationId::now_v7();
@@ -410,7 +466,7 @@ mod tests {
                 last_insert_id: 0,
                 rows_affected: 1,
             }]);
-        let db = with_writable_cache(db).into_connection();
+        let db = with_eval_worker(with_writable_cache(db)).into_connection();
 
         let res = apply_trigger(
             &db,
@@ -529,7 +585,7 @@ mod tests {
                 last_insert_id: 0,
                 rows_affected: 1,
             }]);
-        let db = with_writable_cache(db).into_connection();
+        let db = with_eval_worker(with_writable_cache(db)).into_connection();
 
         let res = apply_trigger(
             &db,
@@ -625,7 +681,7 @@ mod tests {
                 last_insert_id: 0,
                 rows_affected: 1,
             }]);
-        let db = with_writable_cache(db).into_connection();
+        let db = with_eval_worker(with_writable_cache(db)).into_connection();
 
         let res = apply_trigger(
             &db,
@@ -713,7 +769,7 @@ mod tests {
                 last_insert_id: 0,
                 rows_affected: 1,
             }]);
-        let db = with_writable_cache(db).into_connection();
+        let db = with_eval_worker(with_writable_cache(db)).into_connection();
 
         let res = apply_trigger(
             &db,
@@ -904,5 +960,101 @@ mod tests {
             .and_then(WaitingReason::from_json)
             .expect("waiting_reason must be set");
         assert!(matches!(reason, WaitingReason::NoCache));
+    }
+
+    /// When the project's organisation has a writable cache but no active
+    /// worker registration with `enable_eval`, `apply_trigger` parks the
+    /// freshly-created evaluation in `Waiting + Workers { connected_workers: 0 }`.
+    /// Without this gate the eval would sit `Queued` forever - the
+    /// build-dispatch reconciler only stalls Queued evals when zero workers
+    /// are connected, not when connected workers lack `eval`.
+    #[tokio::test]
+    async fn no_eval_capable_worker_parks_evaluation_in_waiting_workers() {
+        use crate::types::waiting_reason::WaitingReason;
+        let project = make_project_with_last_eval(None);
+        let new_eval_id = EvaluationId::now_v7();
+        let new_commit_id = CommitId::now_v7();
+        let trig = ProjectTriggerId::now_v7();
+        let new_hash = vec![1u8; 20];
+
+        let parked_eval = {
+            let mut m = make_eval(
+                new_eval_id,
+                project.id,
+                new_commit_id,
+                EvaluationStatus::Waiting,
+            );
+            m.trigger = Some(trig);
+            m.waiting_reason = Some(WaitingReason::workers(Vec::new(), 0, Vec::new()).to_json());
+            m
+        };
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            // Concurrency check: no in-flight
+            .append_query_results([Vec::<entity::evaluation::Model>::new()])
+            // trigger_evaluation: in-progress guard
+            .append_query_results([Vec::<entity::evaluation::Model>::new()])
+            // trigger_evaluation: commit insert
+            .append_query_results([vec![make_commit(new_commit_id, new_hash.clone())]])
+            // trigger_evaluation: eval insert (initially Queued)
+            .append_query_results([vec![{
+                let mut m = make_eval(
+                    new_eval_id,
+                    project.id,
+                    new_commit_id,
+                    EvaluationStatus::Queued,
+                );
+                m.trigger = Some(trig);
+                m
+            }]])
+            // snapshot flake input overrides (none)
+            .append_query_results([Vec::<entity::project_flake_input_override::Model>::new()])
+            // trigger_evaluation: project update read-back + exec
+            .append_query_results([vec![project.clone()]])
+            .append_exec_results([MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }]);
+        // park_if_no_cache: writable cache exists → returns unchanged.
+        let db = with_writable_cache(db)
+            // park_if_no_workers: no eval-capable registration → park.
+            .append_query_results([Vec::<entity::worker_registration::Model>::new()])
+            // Park: update eval read-back + exec, returns the parked row.
+            .append_query_results([vec![parked_eval.clone()]])
+            .append_exec_results([MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }])
+            .into_connection();
+
+        let res = apply_trigger(
+            &db,
+            &project,
+            input(trig, TriggerType::Polling, new_hash, false),
+        )
+        .await
+        .unwrap();
+
+        let ApplyOutcome::Created { evaluation, .. } = res else {
+            panic!("expected Created, got {res:?}");
+        };
+        assert_eq!(evaluation.status, EvaluationStatus::Waiting);
+        let reason = evaluation
+            .waiting_reason
+            .as_ref()
+            .and_then(WaitingReason::from_json)
+            .expect("waiting_reason must be set");
+        match reason {
+            WaitingReason::Workers {
+                connected_workers,
+                unmet,
+                available_architectures,
+            } => {
+                assert_eq!(connected_workers, 0);
+                assert!(unmet.is_empty());
+                assert!(available_architectures.is_empty());
+            }
+            other => panic!("expected Workers, got {other:?}"),
+        }
     }
 }

--- a/backend/core/src/ci/mod.rs
+++ b/backend/core/src/ci/mod.rs
@@ -21,7 +21,7 @@ pub mod unpark;
 pub use self::abort::{AbortKind, abort_evaluation};
 pub use self::apply::{
     ApplyError, ApplyInput, ApplyOutcome, ApprovalInfo, apply_trigger, park_if_no_cache,
-    park_if_pending_approval,
+    park_if_no_workers, park_if_pending_approval,
 };
 pub use self::github_app::*;
 pub use self::http_validation::validate_webhook_url;
@@ -29,4 +29,6 @@ pub use self::integration_lookup::*;
 pub use self::reporter::*;
 pub use self::reporting::*;
 pub use self::trigger::*;
-pub use self::unpark::{find_approval_gated_eval, unpark_approval, unpark_no_cache_for_org};
+pub use self::unpark::{
+    find_approval_gated_eval, unpark_approval, unpark_no_cache_for_org, unpark_no_workers_for_org,
+};

--- a/backend/core/src/ci/unpark.rs
+++ b/backend/core/src/ci/unpark.rs
@@ -12,7 +12,14 @@
 //! [`unpark_no_cache_for_org`] right after inserting the subscription row;
 //! the caller is also responsible for re-emitting the `Pending` CI status
 //! for each unparked evaluation.
+//!
+//! `Workers { connected_workers: 0 }` parks: triggered when the project's
+//! organisation had no active `eval`-capable worker registration. Caller
+//! (`orgs/workers.rs::{post,patch}_org_worker`) invokes
+//! [`unpark_no_workers_for_org`] when a registration is created or its
+//! `active`/`enable_eval` flags transition to `true`.
 
+use crate::db::org_has_eval_capable_worker_registration;
 use crate::types::ids::OrganizationId;
 use crate::types::waiting_reason::WaitingReason;
 use crate::types::*;
@@ -27,6 +34,44 @@ use sea_orm::{ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, Query
 pub async fn unpark_no_cache_for_org<C: ConnectionTrait>(
     db: &C,
     organization: OrganizationId,
+) -> Result<Vec<MEvaluation>, sea_orm::DbErr> {
+    unpark_for_org(db, organization, |r| matches!(r, WaitingReason::NoCache)).await
+}
+
+/// Flip every evaluation parked with `WaitingReason::Workers { connected_workers: 0 }`
+/// for projects in `organization` back to `Queued`. The zero-workers shape
+/// is what `park_if_no_workers` writes when the org has no active
+/// `eval`-capable worker registration at all; other `Workers { .. }` parks
+/// (capability mismatch, transient runtime stall) are owned by the
+/// build-dispatch reconciler and are left alone.
+///
+/// No-op when the organisation still has no active `eval`-capable worker
+/// registration - callers in the worker endpoints invoke this unconditionally
+/// after any registration touch, and this guard prevents a churn of
+/// re-queue → reconciler re-park when nothing actionable changed.
+pub async fn unpark_no_workers_for_org<C: ConnectionTrait>(
+    db: &C,
+    organization: OrganizationId,
+) -> Result<Vec<MEvaluation>, sea_orm::DbErr> {
+    if !org_has_eval_capable_worker_registration(db, organization).await? {
+        return Ok(Vec::new());
+    }
+    unpark_for_org(db, organization, |r| {
+        matches!(
+            r,
+            WaitingReason::Workers {
+                connected_workers: 0,
+                ..
+            }
+        )
+    })
+    .await
+}
+
+async fn unpark_for_org<C: ConnectionTrait, F: Fn(&WaitingReason) -> bool>(
+    db: &C,
+    organization: OrganizationId,
+    matches_reason: F,
 ) -> Result<Vec<MEvaluation>, sea_orm::DbErr> {
     let project_ids: Vec<ProjectId> = EProject::find()
         .filter(CProject::Organization.eq(organization))
@@ -52,7 +97,7 @@ pub async fn unpark_no_cache_for_org<C: ConnectionTrait>(
             e.waiting_reason
                 .as_ref()
                 .and_then(WaitingReason::from_json)
-                .is_some_and(|r| matches!(r, WaitingReason::NoCache))
+                .is_some_and(|r| matches_reason(&r))
         })
         .collect();
 
@@ -171,5 +216,106 @@ mod tests {
             .append_query_results([vec![parked.clone()]])
             .into_connection();
         assert!(unpark_approval(&db, parked.id).await.unwrap().is_none());
+    }
+
+    fn make_project(org: OrganizationId) -> entity::project::Model {
+        entity::project::Model {
+            id: ProjectId::now_v7(),
+            organization: org,
+            name: "p".into(),
+            active: true,
+            display_name: String::new(),
+            description: String::new(),
+            repository: String::new(),
+            wildcard: "*".into(),
+            last_evaluation: None,
+            last_check_at: NaiveDateTime::default(),
+            force_evaluation: false,
+            created_by: crate::types::ids::UserId::nil(),
+            created_at: NaiveDateTime::default(),
+            managed: false,
+            keep_evaluations: 10,
+            concurrency: 3,
+            sign_cache: true,
+        }
+    }
+
+    fn eval_capable_registration() -> entity::worker_registration::Model {
+        entity::worker_registration::Model {
+            id: crate::types::ids::WorkerRegistrationId::now_v7(),
+            peer_id: OrganizationId::nil(),
+            worker_id: "00000000-0000-4000-8000-000000000001".into(),
+            token_hash: String::new(),
+            managed: false,
+            url: None,
+            active: true,
+            enable_fetch: true,
+            enable_eval: true,
+            enable_build: true,
+            display_name: String::new(),
+            created_by: Some(crate::types::ids::UserId::nil()),
+            created_at: NaiveDateTime::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn unpark_no_workers_requeues_zero_workers_park_and_skips_other_workers_parks() {
+        let org = OrganizationId::now_v7();
+        let project = make_project(org);
+
+        let stranded = {
+            let mut e = waiting_eval(WaitingReason::workers(Vec::new(), 0, Vec::new()));
+            e.project = Some(project.id);
+            e
+        };
+        // A Workers park with connected_workers > 0 represents a capability
+        // mismatch the runtime reconciler manages; the registration unpark
+        // path must leave it alone.
+        let capability_mismatch = {
+            let mut e = waiting_eval(WaitingReason::workers(
+                Vec::new(),
+                1,
+                vec!["aarch64-linux".into()],
+            ));
+            e.project = Some(project.id);
+            e
+        };
+
+        let mut requeued = stranded.clone();
+        requeued.status = EvaluationStatus::Queued;
+        requeued.waiting_reason = None;
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            // Gate: org has an eval-capable registration → continue
+            .append_query_results([vec![eval_capable_registration()]])
+            // Fetch org's projects
+            .append_query_results([vec![project.clone()]])
+            // Fetch Waiting evals across those projects
+            .append_query_results([vec![stranded.clone(), capability_mismatch.clone()]])
+            // Update the one matching row → only `stranded` is touched
+            .append_query_results([vec![requeued.clone()]])
+            .append_exec_results([MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }])
+            .into_connection();
+
+        let out = unpark_no_workers_for_org(&db, org).await.unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].id, stranded.id);
+        assert_eq!(out[0].status, EvaluationStatus::Queued);
+        assert!(out[0].waiting_reason.is_none());
+    }
+
+    #[tokio::test]
+    async fn unpark_no_workers_is_noop_when_no_eval_capable_registration() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            // Gate query: no eval-capable registration → short-circuit
+            .append_query_results([Vec::<entity::worker_registration::Model>::new()])
+            .into_connection();
+        let out = unpark_no_workers_for_org(&db, OrganizationId::now_v7())
+            .await
+            .unwrap();
+        assert!(out.is_empty());
     }
 }

--- a/backend/core/src/db/mod.rs
+++ b/backend/core/src/db/mod.rs
@@ -12,6 +12,7 @@ pub mod derivation;
 pub mod drv_output_spec;
 pub mod gc;
 pub mod org_cache;
+pub mod org_workers;
 pub mod status;
 
 pub use self::cache_reach::*;
@@ -22,4 +23,5 @@ pub use self::derivation::*;
 pub use self::drv_output_spec::DrvOutputSpec;
 pub use self::gc::*;
 pub use self::org_cache::org_has_writable_cache;
+pub use self::org_workers::org_has_eval_capable_worker_registration;
 pub use self::status::*;

--- a/backend/core/src/db/org_workers.rs
+++ b/backend/core/src/db/org_workers.rs
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Organisation ↔ worker registration helpers consumed by the trigger
+//! pipeline (no-workers gate) and the worker-register reconcile path.
+
+use crate::types::ids::OrganizationId;
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
+
+/// Returns `true` when the organisation has at least one active worker
+/// registration with the `eval` capability gate enabled.
+///
+/// A `Queued` evaluation can only progress once an `eval`-capable worker
+/// picks up its `FlakeJob`. Until then the build dispatch reconciler has
+/// nothing to do - there are no builds yet - so an org without any
+/// eval-capable registration would otherwise sit in `Queued` forever.
+pub async fn org_has_eval_capable_worker_registration<C: ConnectionTrait>(
+    db: &C,
+    organization: OrganizationId,
+) -> Result<bool, sea_orm::DbErr> {
+    use entity::worker_registration::{Column as CWR, Entity as EWR};
+
+    let row = EWR::find()
+        .filter(CWR::PeerId.eq(organization))
+        .filter(CWR::Active.eq(true))
+        .filter(CWR::EnableEval.eq(true))
+        .one(db)
+        .await?;
+    Ok(row.is_some())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ids::{UserId, WorkerRegistrationId};
+    use chrono::NaiveDateTime;
+    use sea_orm::{DatabaseBackend, MockDatabase};
+
+    fn registration_row(active: bool, enable_eval: bool) -> entity::worker_registration::Model {
+        entity::worker_registration::Model {
+            id: WorkerRegistrationId::now_v7(),
+            peer_id: OrganizationId::nil(),
+            worker_id: "00000000-0000-4000-8000-000000000001".into(),
+            token_hash: String::new(),
+            managed: false,
+            url: None,
+            active,
+            enable_fetch: true,
+            enable_eval,
+            enable_build: true,
+            display_name: String::new(),
+            created_by: Some(UserId::nil()),
+            created_at: NaiveDateTime::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn returns_true_when_eval_capable_registration_exists() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![registration_row(true, true)]])
+            .into_connection();
+
+        let out = org_has_eval_capable_worker_registration(&db, OrganizationId::nil())
+            .await
+            .unwrap();
+        assert!(out);
+    }
+
+    #[tokio::test]
+    async fn returns_false_when_no_registrations_exist() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([Vec::<entity::worker_registration::Model>::new()])
+            .into_connection();
+
+        let out = org_has_eval_capable_worker_registration(&db, OrganizationId::nil())
+            .await
+            .unwrap();
+        assert!(!out);
+    }
+}

--- a/backend/scheduler/src/build.rs
+++ b/backend/scheduler/src/build.rs
@@ -428,6 +428,7 @@ impl<'a> BuildStateHandler<'a> {
     pub async fn reconcile_waiting_state(
         &self,
         worker_caps: &[(Vec<String>, Vec<String>)],
+        eval_capable_workers: usize,
     ) -> Result<()> {
         let evals = EEvaluation::find()
             .filter(CEvaluation::Status.is_in(vec![
@@ -478,7 +479,7 @@ impl<'a> BuildStateHandler<'a> {
                     | EvaluationStatus::EvaluatingFlake
                     | EvaluationStatus::EvaluatingDerivation
                     | EvaluationStatus::Waiting => {
-                        match decide_pre_build_target(eval.status, worker_caps.len()) {
+                        match decide_pre_build_target(eval.status, eval_capable_workers) {
                             Some(pair) => pair,
                             None => continue,
                         }
@@ -515,6 +516,7 @@ impl<'a> BuildStateHandler<'a> {
                     to = ?target,
                     pending = pending_builds.len(),
                     workers = worker_caps.len(),
+                    eval_workers = eval_capable_workers,
                     "reconciling evaluation waiting state"
                 );
             }
@@ -542,14 +544,16 @@ impl<'a> BuildStateHandler<'a> {
 /// have its waiting reason refreshed; `None` when it is actively progressing
 /// and must be left alone.
 ///
-/// Active pre-build states (`Fetching`, `EvaluatingFlake`,
-/// `EvaluatingDerivation`) are owned by an eval worker. They may only stall
-/// into `Waiting` if every worker has disconnected - they must never be
-/// reset back to `Queued`, which the `EvalStateMachine` forbids and which
-/// would clobber the worker's in-flight progress.
+/// `eval_capable_workers` is the count of connected workers whose negotiated
+/// `GradientCapabilities` includes `eval`. Pre-build states cannot make
+/// progress unless that count is non-zero - even a fleet of build-only
+/// workers leaves the eval stuck in `Queued`. Active pre-build states
+/// (`Fetching`, `EvaluatingFlake`, `EvaluatingDerivation`) are owned by an
+/// eval worker; they only stall into `Waiting` when every eval-capable
+/// worker has disconnected, and they must never be reset back to `Queued`.
 fn decide_pre_build_target(
     current: EvaluationStatus,
-    connected_workers: usize,
+    eval_capable_workers: usize,
 ) -> Option<(EvaluationStatus, Option<WaitingReason>)> {
     let stall = || {
         (
@@ -561,7 +565,7 @@ fn decide_pre_build_target(
             }),
         )
     };
-    match (current, connected_workers) {
+    match (current, eval_capable_workers) {
         (EvaluationStatus::Waiting, 0) => Some(stall()),
         (EvaluationStatus::Waiting, _) => Some((EvaluationStatus::Queued, None)),
         (
@@ -653,9 +657,10 @@ pub(crate) async fn check_evaluation_done(
 pub async fn reconcile_waiting_state(
     state: &Arc<ServerState>,
     worker_caps: &[(Vec<String>, Vec<String>)],
+    eval_capable_workers: usize,
 ) -> Result<()> {
     BuildStateHandler::new(state)
-        .reconcile_waiting_state(worker_caps)
+        .reconcile_waiting_state(worker_caps, eval_capable_workers)
         .await
 }
 
@@ -1081,6 +1086,22 @@ mod waiting_reason_tests {
             assert_eq!(target, EvaluationStatus::Waiting);
             assert!(reason.is_some());
         }
+    }
+
+    /// Regression for issue #268: a Queued evaluation in an org whose only
+    /// connected workers lack the `eval` capability must stall to Waiting.
+    /// The caller in `BuildStateHandler::reconcile_waiting_state` passes the
+    /// eval-capable count - not total connected workers - so the function
+    /// sees `0` here and produces the same `Workers { connected_workers: 0 }`
+    /// reason as the no-workers-at-all path.
+    #[test]
+    fn pre_build_target_queued_no_eval_capable_workers_stalls() {
+        let (target, reason) = decide_pre_build_target(EvaluationStatus::Queued, 0)
+            .expect("stall must produce a transition");
+        assert_eq!(target, EvaluationStatus::Waiting);
+        let reason = reason.expect("stall target must carry a reason");
+        let (_, connected_workers, _) = workers_view(&reason);
+        assert_eq!(connected_workers, 0);
     }
 
     #[test]

--- a/backend/scheduler/src/trigger_dispatch.rs
+++ b/backend/scheduler/src/trigger_dispatch.rs
@@ -233,6 +233,7 @@ pub(crate) async fn dispatch_once(scheduler: &Scheduler) -> anyhow::Result<()> {
                         .await;
                 }
                 info!(project = %project.name, trigger_id = %trig.id, evaluation_id = %eval.id, "trigger created evaluation");
+                gradient_core::ci::actions::dispatch_evaluation_created(state, &eval).await;
             }
             Ok(other) => {
                 debug!(project = %project.name, trigger_id = %trig.id, ?other, "trigger applied without creating eval");

--- a/backend/scheduler/src/worker_lifecycle.rs
+++ b/backend/scheduler/src/worker_lifecycle.rs
@@ -132,18 +132,17 @@ impl Scheduler {
     }
 
     /// Snapshot every connected worker's `(architectures, system_features)`
-    /// and reconcile each in-flight evaluation's `Building`/`Waiting` status.
-    /// See [`build::reconcile_waiting_state`].
+    /// plus the count of those with the `eval` capability, then reconcile
+    /// each in-flight evaluation's `Building`/`Waiting` status. See
+    /// [`build::reconcile_waiting_state`].
     pub async fn reconcile_waiting_state(&self) -> Result<()> {
-        let caps: Vec<(Vec<String>, Vec<String>)> = self
-            .worker_pool
-            .read()
-            .await
-            .all_workers()
+        let workers = self.worker_pool.read().await.all_workers();
+        let eval_capable = workers.iter().filter(|w| w.capabilities.eval).count();
+        let caps: Vec<(Vec<String>, Vec<String>)> = workers
             .into_iter()
             .map(|w| (w.architectures, w.system_features))
             .collect();
-        build::reconcile_waiting_state(&self.state, &caps).await
+        build::reconcile_waiting_state(&self.state, &caps, eval_capable).await
     }
 
     pub async fn mark_worker_draining(&self, peer_id: &str) {

--- a/backend/web/src/endpoints/forge_hooks/trigger.rs
+++ b/backend/web/src/endpoints/forge_hooks/trigger.rs
@@ -397,9 +397,8 @@ where
         } else {
             None
         };
-        let was_gated = gate_approval.is_some();
 
-        match apply_trigger(
+        let apply_result = apply_trigger(
             &state.web_db,
             &project,
             ApplyInput {
@@ -412,8 +411,13 @@ where
                 gate_approval,
             },
         )
-        .await
-        {
+        .await;
+        // Touch the trigger row's `last_fired_at` for any outcome (created /
+        // skipped / errored). Without this the UI shows "Last fired: never"
+        // for triggers that only fire via webhook, since the polling loop
+        // (the only other touch site) doesn't visit reporter triggers.
+        touch_trigger_last_fired(state, &trig).await;
+        match apply_result {
             Ok(ApplyOutcome::Created {
                 evaluation: eval,
                 aborted_evaluation,
@@ -429,19 +433,7 @@ where
                     evaluation_id = %eval.id,
                     "forge webhook trigger fired"
                 );
-                if was_gated {
-                    let payload = serde_json::json!({
-                        "evaluation_id": eval.id.to_string(),
-                        "description": "Awaiting maintainer approval for external contributor PR.",
-                    });
-                    gradient_core::ci::actions::dispatch_evaluation_event(
-                        state,
-                        project.id,
-                        "evaluation.action_required",
-                        payload,
-                    )
-                    .await;
-                }
+                gradient_core::ci::actions::dispatch_evaluation_created(state, &eval).await;
                 outcome.queued.push(QueuedEvaluation {
                     project_id: project.id,
                     project_name: project.name.clone(),
@@ -499,18 +491,41 @@ async fn decide_pr_gate(
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
+/// Stamp `last_fired_at` on the trigger row so the project-triggers UI can
+/// show when the webhook last considered it. Best-effort: a DB error here
+/// must not derail the rest of the webhook fan-out.
+async fn touch_trigger_last_fired(state: &Arc<ServerState>, trig: &ept::Model) {
+    let now = gradient_core::types::now();
+    let mut active: ept::ActiveModel = trig.clone().into();
+    active.last_fired_at = Set(Some(now));
+    active.updated_at = Set(now);
+    if let Err(e) = active.update(&state.web_db).await {
+        warn!(error = %e, trigger_id = %trig.id, "failed to stamp trigger last_fired_at");
+    }
+}
+
 async fn load_active_triggers_for_integration(
     state: &Arc<ServerState>,
     integration_id: IntegrationId,
     trigger_type: TriggerType,
 ) -> Result<Vec<ept::Model>, sea_orm::DbErr> {
+    // Match active triggers of the right type for any project in the
+    // organisation that owns this integration. The historical
+    // `config->>'integration_id' = $1` filter was fragile: the GitHub App
+    // seed migration creates fresh integration rows, so any trigger created
+    // before that migration carries a stale UUID and silently stops
+    // matching its own org's webhooks. Org-level matching is safe because
+    // each org has at most one inbound integration per forge_type, which is
+    // already disambiguated by the webhook route.
     let stmt = Statement::from_sql_and_values(
         DbBackend::Postgres,
         format!(
-            "SELECT * FROM project_trigger \
-             WHERE active = true \
-               AND trigger_type = {} \
-               AND (config->>'integration_id')::uuid = $1",
+            "SELECT pt.* FROM project_trigger pt \
+             JOIN project p ON pt.project = p.id \
+             JOIN integration i ON i.organization = p.organization \
+             WHERE pt.active = true \
+               AND pt.trigger_type = {} \
+               AND i.id = $1",
             i16::from(trigger_type),
         ),
         [Value::Uuid(Some(Box::new(integration_id.into_inner())))],

--- a/backend/web/src/endpoints/orgs/workers.rs
+++ b/backend/web/src/endpoints/orgs/workers.rs
@@ -177,6 +177,16 @@ pub async fn post_org_worker(
     // the new peer registration without requiring a reconnect.
     scheduler.request_reauth(&worker_id_str).await;
 
+    // Re-queue any evaluations parked because the org had no eval-capable
+    // worker registration. No-op when the new row isn't eval-capable.
+    if let Err(e) = gradient_core::ci::unpark_no_workers_for_org(&state.web_db, org.id).await {
+        tracing::warn!(
+            error = %e,
+            org_id = %org.id,
+            "failed to unpark no-workers evaluations after worker registration",
+        );
+    }
+
     Ok(ok_json(RegisterWorkerResponse {
         peer_id: org.id,
         token: if return_token { Some(token) } else { None },
@@ -316,6 +326,20 @@ pub async fn patch_org_worker(
     // are now inactive).
     if body.active.is_some() || caps_changed {
         scheduler.request_reauth(&worker_id).await;
+    }
+
+    // Toggling `active` on or enabling the `eval` capability may newly satisfy
+    // the no-workers gate. The unpark is self-guarded against the org still
+    // lacking an eval-capable registration, so calling unconditionally here
+    // is safe.
+    if (matches!(body.active, Some(true)) || matches!(body.enable_eval, Some(true)))
+        && let Err(e) = gradient_core::ci::unpark_no_workers_for_org(&state.web_db, org.id).await
+    {
+        tracing::warn!(
+            error = %e,
+            org_id = %org.id,
+            "failed to unpark no-workers evaluations after worker patch",
+        );
     }
 
     Ok(ok_json(format!("worker '{}' updated", worker_id)))

--- a/backend/web/src/endpoints/projects/evaluations.rs
+++ b/backend/web/src/endpoints/projects/evaluations.rs
@@ -242,7 +242,8 @@ pub async fn post_project_evaluate(
     })?;
 
     let eval = gradient_core::ci::park_if_no_cache(&state.web_db, eval, project.organization).await?;
-    gradient_core::ci::park_if_no_workers(&state.web_db, eval, project.organization).await?;
+    let eval = gradient_core::ci::park_if_no_workers(&state.web_db, eval, project.organization).await?;
+    gradient_core::ci::actions::dispatch_evaluation_created(&state, &eval).await;
 
     Ok(ok_json("Evaluation started".to_string()))
 }

--- a/backend/web/src/endpoints/projects/evaluations.rs
+++ b/backend/web/src/endpoints/projects/evaluations.rs
@@ -241,7 +241,8 @@ pub async fn post_project_evaluate(
         gradient_core::ci::TriggerError::Db(db_err) => WebError::from(db_err),
     })?;
 
-    gradient_core::ci::park_if_no_cache(&state.web_db, eval, project.organization).await?;
+    let eval = gradient_core::ci::park_if_no_cache(&state.web_db, eval, project.organization).await?;
+    gradient_core::ci::park_if_no_workers(&state.web_db, eval, project.organization).await?;
 
     Ok(ok_json("Evaluation started".to_string()))
 }

--- a/backend/web/src/endpoints/projects/triggers.rs
+++ b/backend/web/src/endpoints/projects/triggers.rs
@@ -401,6 +401,18 @@ pub async fn fire_now(
         .await
         .map_err(|e| WebError::internal(e.to_string()))?;
 
+    // Stamp last_fired_at so the UI reflects the manual fire alongside the
+    // outcome - mirrors the touch in the webhook fan-out path.
+    {
+        let now = gradient_core::types::now();
+        let mut active: entity::project_trigger::ActiveModel = row.clone().into();
+        active.last_fired_at = Set(Some(now));
+        active.updated_at = Set(now);
+        if let Err(e) = active.update(&state.web_db).await {
+            tracing::warn!(error = %e, trigger_id = %row.id, "failed to stamp trigger last_fired_at");
+        }
+    }
+
     let body = match outcome {
         ApplyOutcome::Created {
             evaluation: eval,
@@ -412,6 +424,7 @@ pub async fn fire_now(
                     .cancel_evaluation_jobs(aborted_id, &aborted_builds)
                     .await;
             }
+            gradient_core::ci::actions::dispatch_evaluation_created(&state, &eval).await;
             serde_json::json!({
                 "outcome": "Created",
                 "evaluation_id": eval.id,

--- a/backend/web/tests/forge_hooks.rs
+++ b/backend/web/tests/forge_hooks.rs
@@ -276,6 +276,24 @@ fn org_cache_row() -> entity::organization_cache::Model {
     }
 }
 
+fn worker_registration_row() -> entity::worker_registration::Model {
+    entity::worker_registration::Model {
+        id: gradient_core::types::ids::WorkerRegistrationId::now_v7(),
+        peer_id: org_id(),
+        worker_id: "00000000-0000-4000-8000-000000000001".into(),
+        token_hash: String::new(),
+        managed: false,
+        url: None,
+        active: true,
+        enable_fetch: true,
+        enable_eval: true,
+        enable_build: true,
+        display_name: String::new(),
+        created_by: Some(gradient_core::types::ids::UserId::nil()),
+        created_at: fixture_date(),
+    }
+}
+
 /// Build a `project_trigger` row with the given config.
 fn trigger_row(cfg: TriggerConfig) -> entity::project_trigger::Model {
     entity::project_trigger::Model {
@@ -321,7 +339,10 @@ fn reporter_pr_trigger(actions: Vec<&str>) -> TriggerConfig {
 
 /// Mock DB chain for a successful `apply_trigger` call with no prior evaluation
 /// (skips same-commit dedup) and no in-flight evaluation. Includes the
-/// `org_has_writable_cache` lookup that runs after the eval is created.
+/// `org_has_writable_cache` lookup that runs after the eval is created,
+/// the `org_has_eval_capable_worker_registration` lookup that follows it,
+/// the `touch_trigger_last_fired` update on the trigger row, and the
+/// `dispatch_evaluation_created` lookup of project actions.
 fn apply_trigger_db_chain(db: MockDatabase) -> MockDatabase {
     db.append_query_results([Vec::<entity::evaluation::Model>::new()]) // in-flight check
         .append_query_results([Vec::<entity::evaluation::Model>::new()]) // trigger_evaluation: in-progress check
@@ -335,6 +356,13 @@ fn apply_trigger_db_chain(db: MockDatabase) -> MockDatabase {
         }]) // UPDATE project
         .append_query_results([vec![org_cache_row()]]) // org_has_writable_cache: subscription rows
         .append_query_results([vec![cache_row()]]) // org_has_writable_cache: active cache rows
+        .append_query_results([vec![worker_registration_row()]]) // org_has_eval_capable_worker_registration
+        .append_query_results([vec![trigger_row(reporter_push_trigger(vec![]))]]) // touch_trigger_last_fired: SELECT for UPDATE
+        .append_exec_results([MockExecResult {
+            last_insert_id: 0,
+            rows_affected: 1,
+        }]) // touch_trigger_last_fired: UPDATE
+        .append_query_results([Vec::<entity::project_action::Model>::new()]) // dispatch_evaluation_created: project_action lookup
 }
 
 // ── Test 1: Generic forge - no matching trigger (Gitea) ───────────────────────

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -5991,8 +5991,14 @@ components:
         Populated only when `status == "Waiting"`. Tagged by `kind`:
 
         - `workers`: no connected worker can satisfy the pending builds'
-          `(architecture, required_features)` combos. Refreshed whenever the
-          scheduler reconciles the evaluation against the live worker pool.
+          `(architecture, required_features)` combos. Also used at evaluation
+          creation time with `connected_workers: 0` when the project's
+          organisation has no active worker registration with `enable_eval`
+          (issue #268) - the eval would otherwise be stranded in `Queued`
+          forever, because the build-dispatch reconciler can only act on
+          builds the eval phase has not yet produced. Refreshed whenever
+          the scheduler reconciles the evaluation against the live worker
+          pool.
         - `approval`: the PR comes from a contributor who is not a forge
           repo writer, and the trigger has `require_approval = true`. The
           evaluation stays parked until a maintainer clicks "Approve and

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -2440,6 +2440,28 @@ immediately. Coverage:
 - `core/src/ci/apply.rs::no_writable_cache_parks_evaluation_in_waiting_no_cache`
   - `apply_trigger` parks newly-created evals as `NoCache` when the org
   has no writable cache subscription.
+- `core/src/ci/apply.rs::no_eval_capable_worker_parks_evaluation_in_waiting_workers`
+  (issue #268) - `apply_trigger` parks newly-created evals as
+  `Workers { connected_workers: 0 }` when the org has no active worker
+  registration with `enable_eval` set. Without this gate the eval
+  would sit `Queued` forever - the build-dispatch reconciler only
+  acts on builds, which don't exist yet, and the connected-worker
+  count alone doesn't distinguish "no eval-capable worker" from
+  "build-only worker connected".
+- `core/src/db/org_workers.rs::org_has_eval_capable_worker_registration` -
+  returns true iff the org has at least one `worker_registration` row
+  with `active = true AND enable_eval = true`. Consumed by both the
+  park-on-create gate and the unpark short-circuit.
+- `core/src/ci/unpark.rs::unpark_no_workers_*` - re-queues evals
+  parked with `Workers { connected_workers: 0 }` once an
+  eval-capable registration appears in the org; no-op when the org
+  still has no eval-capable registration.
+- `scheduler/src/build.rs::pre_build_target_queued_no_eval_capable_workers_stalls`
+  (issue #268) - regression test confirming the reconciler stalls a
+  Queued eval to `Waiting + Workers { connected_workers: 0 }` when
+  the eval-capable count is zero, even if total connected workers
+  are non-zero (the runtime caller passes the eval-capable count,
+  not the total).
 - `web/src/endpoints/forge_hooks/events.rs` - extraction of
   `pr_number`, `pr_author`, `is_fork`, `base_owner`, `base_repo` from
   GitHub / Gitea / GitLab payloads.


### PR DESCRIPTION
## Summary
- Closes #268. A freshly-created project in an org with no eval-capable worker registration showed `Queued` (sometimes forever, when only build-only workers were connected). It now parks as `Waiting + Workers { connected_workers: 0 }` immediately, mirroring the existing `NoCache` gate.
- Adds `org_has_eval_capable_worker_registration` + `park_if_no_workers` + `unpark_no_workers_for_org`, wires them into `apply_trigger`, the manual `/projects/{org}/{project}/evaluate` endpoint, and the worker register/patch endpoints.
- Teaches `decide_pre_build_target` to count *eval-capable* connected workers rather than total and closes the runtime gap where a connected build-only worker left a Queued eval stranded with no possible eval-side progress.