### PR TITLE
feat: admin deep-gc endpoint + admin_task ledger (#271)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -790,6 +790,7 @@ dependencies = [
  "ring",
  "sea-orm",
  "sentry",
+ "serde",
  "serde_json",
  "tempfile",
  "test-support",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -6499,6 +6499,7 @@ dependencies = [
  "base64",
  "blake3",
  "bytes",
+ "cache",
  "chrono",
  "core",
  "email_address",

--- a/backend/cache/Cargo.toml
+++ b/backend/cache/Cargo.toml
@@ -26,6 +26,7 @@ futures             = { workspace = true }
 ring                = { workspace = true }
 sea-orm             = { workspace = true }
 sentry              = { workspace = true }
+serde               = { workspace = true }
 serde_json          = { workspace = true }
 thiserror           = { workspace = true }
 tokio               = { workspace = true, features = ["process", "macros"] }

--- a/backend/cache/src/cacher/cleanup.rs
+++ b/backend/cache/src/cacher/cleanup.rs
@@ -11,10 +11,21 @@ use sea_orm::{
     ActiveModelTrait, ColumnTrait, ConnectionTrait, DatabaseBackend, EntityTrait, IntoActiveModel,
     QueryFilter, Statement,
 };
+use serde::Serialize;
 use std::collections::HashSet;
 use std::sync::Arc;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
+
+/// Per-pass counters returned by `cleanup_orphaned_cache_files`. The deep-GC
+/// sweep threads these into its progress report; the hourly loop just logs
+/// the result.
+#[derive(Debug, Default, Clone, Copy, Serialize)]
+pub struct CleanupReport {
+    pub orphan_nars_scanned: u64,
+    pub orphan_nars_removed: u64,
+    pub zombie_cached_paths_purged: u64,
+}
 
 /// Build-request blob TTL pass: drops `build_request_blob` rows whose
 /// `last_used_at` is older than `nar_ttl_hours` and removes the underlying
@@ -240,7 +251,7 @@ pub async fn cleanup_stale_cached_nars(state: Arc<ServerState>) -> Result<()> {
     Ok(())
 }
 
-pub async fn cleanup_orphaned_cache_files(state: Arc<ServerState>) -> Result<()> {
+pub async fn cleanup_orphaned_cache_files(state: Arc<ServerState>) -> Result<CleanupReport> {
     let keep = active_hashes(&state).await?;
 
     let on_disk = state
@@ -250,7 +261,10 @@ pub async fn cleanup_orphaned_cache_files(state: Arc<ServerState>) -> Result<()>
         .context("Failed to list NAR store")?;
     let on_disk_set: HashSet<String> = on_disk.iter().cloned().collect();
 
-    let mut removed = 0usize;
+    let mut report = CleanupReport {
+        orphan_nars_scanned: on_disk.len() as u64,
+        ..Default::default()
+    };
     for hash in &on_disk {
         if keep.contains(hash) {
             continue;
@@ -259,17 +273,16 @@ pub async fn cleanup_orphaned_cache_files(state: Arc<ServerState>) -> Result<()>
             error!(hash = %hash, error = %e, "Failed to remove orphaned NAR");
         } else {
             debug!(hash = %hash, "Removed orphaned NAR");
-            removed += 1;
+            report.orphan_nars_removed += 1;
         }
     }
 
-    if removed > 0 {
-        info!(count = removed, "Removed orphaned NAR files");
+    if report.orphan_nars_removed > 0 {
+        info!(count = report.orphan_nars_removed, "Removed orphaned NAR files");
     }
 
-    purge_zombie_cached_paths(&state, &on_disk_set).await?;
-
-    Ok(())
+    report.zombie_cached_paths_purged = purge_zombie_cached_paths(&state, &on_disk_set).await?;
+    Ok(report)
 }
 
 /// Drop `cached_path` rows whose `file_hash IS NOT NULL` but whose NAR is no
@@ -282,14 +295,14 @@ pub async fn cleanup_orphaned_cache_files(state: Arc<ServerState>) -> Result<()>
 async fn purge_zombie_cached_paths(
     state: &Arc<ServerState>,
     on_disk: &HashSet<String>,
-) -> Result<()> {
+) -> Result<u64> {
     let rows = ECachedPath::find()
         .filter(CCachedPath::FileHash.is_not_null())
         .all(&state.worker_db)
         .await
         .context("Failed to load cached_path rows for zombie purge")?;
 
-    let mut purged = 0usize;
+    let mut purged = 0u64;
     for row in rows {
         if on_disk.contains(&row.hash) {
             continue;
@@ -311,7 +324,7 @@ async fn purge_zombie_cached_paths(
         );
     }
 
-    Ok(())
+    Ok(purged)
 }
 
 /// Returns the set of NAR-storage hashes that must NOT be garbage-collected by

--- a/backend/cache/src/cacher/deep_gc.rs
+++ b/backend/cache/src/cacher/deep_gc.rs
@@ -1,0 +1,332 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Deep GC: bidirectional verification of every storage surface against the
+//! database. Triggered by `POST /admin/maintenance/deep-gc`; runs as a
+//! background task and writes progress + final state to an `admin_task` row.
+
+use anyhow::{Context, Result};
+use entity::ids::AdminTaskId;
+use gradient_core::db::admin_tasks;
+use gradient_core::types::*;
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter};
+use serde::Serialize;
+use std::collections::HashSet;
+use std::sync::Arc;
+use tracing::{error, info, warn};
+
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct DeepGcReport {
+    pub nars_scanned: u64,
+    pub orphan_nars_removed: u64,
+    pub zombie_cached_paths_purged: u64,
+    pub blobs_scanned: u64,
+    pub orphan_blobs_removed: u64,
+    pub zombie_blob_rows_purged: u64,
+    pub blob_check_errors: u64,
+    pub logs_scanned: u64,
+    pub orphan_logs_removed: u64,
+}
+
+impl DeepGcReport {
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap_or(serde_json::Value::Null)
+    }
+}
+
+/// Entry point spawned via `state.shutdown.spawn`.
+pub async fn run_deep_gc(state: Arc<ServerState>, task_id: AdminTaskId) {
+    if let Err(e) = admin_tasks::mark_running(&state.worker_db, task_id).await {
+        error!(error = ?e, %task_id, "deep_gc: mark_running failed");
+        return;
+    }
+
+    let mut report = DeepGcReport::default();
+
+    if let Err(e) = pass_nars(Arc::clone(&state), &mut report).await {
+        return finish_failed(state, task_id, e, report).await;
+    }
+    flush_progress(&state, task_id, &report).await;
+
+    if let Err(e) = pass_blobs(Arc::clone(&state), &mut report).await {
+        return finish_failed(state, task_id, e, report).await;
+    }
+    flush_progress(&state, task_id, &report).await;
+
+    if let Err(e) = pass_logs(Arc::clone(&state), &mut report).await {
+        return finish_failed(state, task_id, e, report).await;
+    }
+
+    if let Err(e) =
+        admin_tasks::mark_completed(&state.worker_db, task_id, report.to_json()).await
+    {
+        error!(error = ?e, %task_id, "deep_gc: mark_completed failed");
+    } else {
+        info!(?report, %task_id, "deep_gc completed");
+    }
+}
+
+async fn flush_progress(state: &Arc<ServerState>, task_id: AdminTaskId, report: &DeepGcReport) {
+    if let Err(e) =
+        admin_tasks::update_progress(&state.worker_db, task_id, report.to_json()).await
+    {
+        warn!(error = ?e, %task_id, "deep_gc: progress flush failed");
+    }
+}
+
+async fn finish_failed(
+    state: Arc<ServerState>,
+    task_id: AdminTaskId,
+    err: anyhow::Error,
+    report: DeepGcReport,
+) {
+    let msg = format!("{err:#}");
+    error!(%task_id, error = %msg, "deep_gc pass failed");
+    if let Err(e) =
+        admin_tasks::mark_failed(&state.worker_db, task_id, msg, Some(report.to_json())).await
+    {
+        error!(error = ?e, %task_id, "deep_gc: mark_failed failed");
+    }
+}
+
+async fn pass_nars(state: Arc<ServerState>, report: &mut DeepGcReport) -> Result<()> {
+    let r = super::cleanup_orphaned_cache_files(state)
+        .await
+        .context("deep_gc: NAR pass")?;
+    report.nars_scanned = r.orphan_nars_scanned;
+    report.orphan_nars_removed = r.orphan_nars_removed;
+    report.zombie_cached_paths_purged = r.zombie_cached_paths_purged;
+    Ok(())
+}
+
+async fn pass_blobs(state: Arc<ServerState>, report: &mut DeepGcReport) -> Result<()> {
+    let on_disk = state
+        .nar_storage
+        .list_blobs()
+        .await
+        .context("list_blobs")?;
+    report.blobs_scanned = on_disk.len() as u64;
+    let on_disk_set: HashSet<(uuid::Uuid, [u8; 32])> = on_disk.iter().copied().collect();
+
+    let rows = EBuildRequestBlob::find()
+        .all(&state.worker_db)
+        .await
+        .context("list build_request_blob rows")?;
+    let mut row_keys: HashSet<(uuid::Uuid, [u8; 32])> = HashSet::with_capacity(rows.len());
+    for row in &rows {
+        if row.hash.len() != 32 {
+            warn!(blob_id = %row.id, "deep_gc: skipping malformed blob row hash");
+            continue;
+        }
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(&row.hash);
+        let key = (row.organization.into_inner(), hash);
+        row_keys.insert(key);
+        if !on_disk_set.contains(&key) {
+            match state.nar_storage.get_blob(key.0, &key.1).await {
+                Ok(Some(_)) => {}
+                Ok(None) => {
+                    let blob_id = row.id;
+                    if let Err(e) = row
+                        .clone()
+                        .into_active_model()
+                        .delete(&state.worker_db)
+                        .await
+                    {
+                        warn!(error = %e, %blob_id, "deep_gc: failed to delete zombie blob row");
+                    } else {
+                        report.zombie_blob_rows_purged += 1;
+                    }
+                }
+                Err(e) => {
+                    warn!(error = %e, "deep_gc: blob probe failed");
+                    report.blob_check_errors += 1;
+                }
+            }
+        }
+    }
+
+    for key in &on_disk_set {
+        if !row_keys.contains(key) {
+            if let Err(e) = state.nar_storage.delete_blob(key.0, &key.1).await {
+                warn!(error = %e, "deep_gc: failed to delete orphan blob");
+            } else {
+                report.orphan_blobs_removed += 1;
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn pass_logs(state: Arc<ServerState>, report: &mut DeepGcReport) -> Result<()> {
+    let on_disk = state.log_storage.list_logs().await.context("list_logs")?;
+    report.logs_scanned = on_disk.len() as u64;
+    if on_disk.is_empty() {
+        return Ok(());
+    }
+
+    let referenced: HashSet<BuildId> = {
+        let by_log = EBuild::find()
+            .filter(CBuild::LogId.is_in(on_disk.clone()))
+            .all(&state.worker_db)
+            .await
+            .context("query builds by log_id")?
+            .into_iter()
+            .filter_map(|b| b.log_id)
+            .collect::<HashSet<_>>();
+        let by_id = EBuild::find()
+            .filter(CBuild::Id.is_in(on_disk.clone()))
+            .filter(CBuild::LogId.is_null())
+            .all(&state.worker_db)
+            .await
+            .context("query builds by id with null log_id")?
+            .into_iter()
+            .map(|b| b.id)
+            .collect::<HashSet<_>>();
+        by_log.into_iter().chain(by_id).collect()
+    };
+
+    for build_id in on_disk {
+        if !referenced.contains(&build_id) {
+            if let Err(e) = state.log_storage.delete(build_id).await {
+                warn!(error = %e, %build_id, "deep_gc: failed to delete orphan log");
+            } else {
+                report.orphan_logs_removed += 1;
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use entity::ids::{BuildRequestBlobId, OrganizationId};
+    use gradient_core::storage::{EmailSender, FileLogStorage, LogStorage, NarStore};
+    use sea_orm::{DatabaseBackend, MockDatabase};
+    use std::sync::Arc;
+    use test_support::fakes::email::InMemoryEmailSender;
+    use test_support::log_storage::NoopLogStorage;
+    use test_support::prelude::test_cli;
+
+    fn make_state(
+        nar: NarStore,
+        log: Arc<dyn LogStorage>,
+        db: sea_orm::DatabaseConnection,
+    ) -> Arc<ServerState> {
+        Arc::new(ServerState {
+            web_db: WebDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
+            worker_db: WorkerDb::new(db),
+            config: Arc::new(RuntimeConfig::from_cli(&test_cli()).expect("valid test config")),
+            log_storage: log,
+            email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,
+            nar_storage: nar,
+            manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            http: gradient_core::http::build_client().expect("http client"),
+            shutdown: gradient_core::shutdown::Shutdown::new(),
+            jwt_secret: gradient_core::types::SecretString::new("test-jwt-secret".to_string()),
+            started_at: chrono::Utc::now(),
+        })
+    }
+
+    #[tokio::test]
+    async fn pass_blobs_removes_orphan_blob() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nar = NarStore::local(tmp.path().to_str().unwrap()).unwrap();
+        let org = OrganizationId::now_v7();
+        let hash = [0x11u8; 32];
+        nar.put_blob(org.into_inner(), &hash, b"x".to_vec())
+            .await
+            .unwrap();
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results::<entity::build_request_blob::Model, _, _>([
+                Vec::<entity::build_request_blob::Model>::new(),
+            ])
+            .into_connection();
+        let state = make_state(nar, Arc::new(NoopLogStorage), db);
+
+        let mut report = DeepGcReport::default();
+        pass_blobs(Arc::clone(&state), &mut report).await.unwrap();
+        assert_eq!(report.orphan_blobs_removed, 1);
+        assert!(
+            state
+                .nar_storage
+                .get_blob(org.into_inner(), &hash)
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn pass_blobs_purges_zombie_row() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nar = NarStore::local(tmp.path().to_str().unwrap()).unwrap();
+        let org = OrganizationId::now_v7();
+        let hash = [0x22u8; 32];
+
+        let zombie = entity::build_request_blob::Model {
+            id: BuildRequestBlobId::now_v7(),
+            organization: org,
+            hash: hash.to_vec(),
+            size: 1,
+            created_at: now(),
+            last_used_at: now(),
+        };
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![zombie.clone()]])
+            .append_exec_results([sea_orm::MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }])
+            .into_connection();
+        let state = make_state(nar, Arc::new(NoopLogStorage), db);
+
+        let mut report = DeepGcReport::default();
+        pass_blobs(Arc::clone(&state), &mut report).await.unwrap();
+        assert_eq!(report.zombie_blob_rows_purged, 1);
+    }
+
+    #[tokio::test]
+    async fn pass_logs_removes_orphan_log() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nar_dir = tmp.path().join("nars");
+        std::fs::create_dir_all(&nar_dir).unwrap();
+        let log: Arc<dyn LogStorage> =
+            Arc::new(FileLogStorage::new(tmp.path()).await.unwrap());
+        let bid = BuildId::now_v7();
+        log.append(bid, "orphan").await.unwrap();
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results::<entity::build::Model, _, _>([
+                Vec::<entity::build::Model>::new(),
+            ])
+            .append_query_results::<entity::build::Model, _, _>([
+                Vec::<entity::build::Model>::new(),
+            ])
+            .into_connection();
+        let nar = NarStore::local(tmp.path().to_str().unwrap()).unwrap();
+        let state = make_state(nar, log, db);
+
+        let mut report = DeepGcReport::default();
+        pass_logs(Arc::clone(&state), &mut report).await.unwrap();
+        assert_eq!(report.orphan_logs_removed, 1);
+    }
+
+    #[test]
+    fn report_serialises_with_snake_case_keys() {
+        let r = DeepGcReport {
+            orphan_nars_removed: 1,
+            zombie_blob_rows_purged: 2,
+            ..Default::default()
+        };
+        let json = r.to_json();
+        assert_eq!(json["orphan_nars_removed"], 1);
+        assert_eq!(json["zombie_blob_rows_purged"], 2);
+    }
+}

--- a/backend/cache/src/cacher/mod.rs
+++ b/backend/cache/src/cacher/mod.rs
@@ -12,12 +12,15 @@
 //! GC passes against the cache's DB and NAR store.
 
 mod cleanup;
+mod deep_gc;
 mod invalidate;
 mod sign_sweep;
 
+pub use self::deep_gc::{DeepGcReport, run_deep_gc};
+
 pub use self::cleanup::{
-    cleanup_expired_upload_sessions, cleanup_old_evaluations, cleanup_orphaned_cache_files,
-    cleanup_stale_build_request_blobs, cleanup_stale_cached_nars,
+    CleanupReport, cleanup_expired_upload_sessions, cleanup_old_evaluations,
+    cleanup_orphaned_cache_files, cleanup_stale_build_request_blobs, cleanup_stale_cached_nars,
 };
 pub use self::invalidate::invalidate_cache_for_path;
 pub use self::sign_sweep::sign_missing_signatures;
@@ -52,10 +55,9 @@ pub async fn cache_loop(state: Arc<ServerState>) {
             _ = interval.tick() => {}
         }
 
-        if let Err(e) = cleanup_orphaned_cache_files(Arc::clone(&state)).await {
-            error!(error = ?e, "Cache cleanup failed");
-        } else {
-            info!("Cache cleanup completed successfully");
+        match cleanup_orphaned_cache_files(Arc::clone(&state)).await {
+            Ok(report) => info!(?report, "Cache cleanup completed"),
+            Err(e) => error!(error = ?e, "Cache cleanup failed"),
         }
         if let Err(e) = cleanup_old_evaluations(Arc::clone(&state)).await {
             error!(error = ?e, "Evaluation GC failed");

--- a/backend/core/src/ci/actions.rs
+++ b/backend/core/src/ci/actions.rs
@@ -845,6 +845,9 @@ mod tests {
             fn delete<'a>(&'a self, _: entity::ids::BuildId) -> BoxFuture<'a, anyhow::Result<()>> {
                 Box::pin(async { Ok(()) })
             }
+            fn list_logs<'a>(&'a self) -> BoxFuture<'a, anyhow::Result<Vec<entity::ids::BuildId>>> {
+                Box::pin(async { Ok(Vec::new()) })
+            }
         }
 
         #[derive(Debug)]

--- a/backend/core/src/db/admin_tasks.rs
+++ b/backend/core/src/db/admin_tasks.rs
@@ -1,0 +1,266 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! CRUD helpers for the `admin_task` table.
+
+use anyhow::{Context, Result};
+use sea_orm::ActiveValue::Set;
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, DatabaseBackend, DbErr, EntityTrait,
+    IntoActiveModel, QueryFilter, QueryOrder, QuerySelect, Statement,
+};
+use serde_json::Value as JsonValue;
+
+use crate::types::*;
+use entity::ids::{AdminTaskId, UserId};
+
+#[derive(Debug)]
+pub enum InsertPendingError {
+    AlreadyActive(AdminTaskId),
+    Db(anyhow::Error),
+}
+
+pub async fn insert_pending<C: ConnectionTrait>(
+    conn: &C,
+    kind: AdminTaskKind,
+    created_by: Option<UserId>,
+) -> std::result::Result<MAdminTask, InsertPendingError> {
+    let model = AAdminTask {
+        id: Set(AdminTaskId::now_v7()),
+        kind: Set(kind),
+        status: Set(AdminTaskStatus::Pending),
+        created_at: Set(now()),
+        started_at: Set(None),
+        finished_at: Set(None),
+        progress: Set(None),
+        error: Set(None),
+        created_by: Set(created_by),
+    };
+    match model.insert(conn).await {
+        Ok(m) => Ok(m),
+        Err(DbErr::Exec(e)) if is_unique_violation(&e.to_string()) => {
+            let active = find_active(conn, kind)
+                .await
+                .map_err(InsertPendingError::Db)?
+                .ok_or_else(|| {
+                    InsertPendingError::Db(anyhow::anyhow!(
+                        "unique violation but no active row found"
+                    ))
+                })?;
+            Err(InsertPendingError::AlreadyActive(active.id))
+        }
+        Err(DbErr::Query(e)) if is_unique_violation(&e.to_string()) => {
+            let active = find_active(conn, kind)
+                .await
+                .map_err(InsertPendingError::Db)?
+                .ok_or_else(|| {
+                    InsertPendingError::Db(anyhow::anyhow!(
+                        "unique violation but no active row found"
+                    ))
+                })?;
+            Err(InsertPendingError::AlreadyActive(active.id))
+        }
+        Err(other) => Err(InsertPendingError::Db(
+            anyhow::Error::from(other).context("insert admin_task"),
+        )),
+    }
+}
+
+fn is_unique_violation(msg: &str) -> bool {
+    let m = msg.to_ascii_lowercase();
+    m.contains("unique") || m.contains("duplicate key")
+}
+
+pub async fn find_active<C: ConnectionTrait>(
+    conn: &C,
+    kind: AdminTaskKind,
+) -> Result<Option<MAdminTask>> {
+    EAdminTask::find()
+        .filter(CAdminTask::Kind.eq(kind))
+        .filter(
+            CAdminTask::Status
+                .eq(AdminTaskStatus::Pending)
+                .or(CAdminTask::Status.eq(AdminTaskStatus::Running)),
+        )
+        .one(conn)
+        .await
+        .context("find active admin_task")
+}
+
+pub async fn list_recent<C: ConnectionTrait>(conn: &C, limit: u64) -> Result<Vec<MAdminTask>> {
+    EAdminTask::find()
+        .order_by_desc(CAdminTask::CreatedAt)
+        .limit(limit)
+        .all(conn)
+        .await
+        .context("list recent admin_task")
+}
+
+pub async fn get<C: ConnectionTrait>(conn: &C, id: AdminTaskId) -> Result<Option<MAdminTask>> {
+    EAdminTask::find_by_id(id)
+        .one(conn)
+        .await
+        .context("get admin_task")
+}
+
+pub async fn mark_running<C: ConnectionTrait>(conn: &C, id: AdminTaskId) -> Result<()> {
+    let Some(model) = get(conn, id).await? else {
+        return Ok(());
+    };
+    let mut a: AAdminTask = model.into_active_model();
+    a.status = Set(AdminTaskStatus::Running);
+    a.started_at = Set(Some(now()));
+    a.update(conn).await.context("mark_running")?;
+    Ok(())
+}
+
+pub async fn update_progress<C: ConnectionTrait>(
+    conn: &C,
+    id: AdminTaskId,
+    progress: JsonValue,
+) -> Result<()> {
+    let Some(model) = get(conn, id).await? else {
+        return Ok(());
+    };
+    let mut a: AAdminTask = model.into_active_model();
+    a.progress = Set(Some(progress));
+    a.update(conn).await.context("update_progress")?;
+    Ok(())
+}
+
+pub async fn mark_completed<C: ConnectionTrait>(
+    conn: &C,
+    id: AdminTaskId,
+    progress: JsonValue,
+) -> Result<()> {
+    let Some(model) = get(conn, id).await? else {
+        return Ok(());
+    };
+    let mut a: AAdminTask = model.into_active_model();
+    a.status = Set(AdminTaskStatus::Completed);
+    a.progress = Set(Some(progress));
+    a.finished_at = Set(Some(now()));
+    a.update(conn).await.context("mark_completed")?;
+    Ok(())
+}
+
+pub async fn mark_failed<C: ConnectionTrait>(
+    conn: &C,
+    id: AdminTaskId,
+    error: String,
+    progress: Option<JsonValue>,
+) -> Result<()> {
+    let Some(model) = get(conn, id).await? else {
+        return Ok(());
+    };
+    let mut a: AAdminTask = model.into_active_model();
+    a.status = Set(AdminTaskStatus::Failed);
+    a.error = Set(Some(error));
+    if let Some(p) = progress {
+        a.progress = Set(Some(p));
+    }
+    a.finished_at = Set(Some(now()));
+    a.update(conn).await.context("mark_failed")?;
+    Ok(())
+}
+
+pub const STARTUP_FAILURE_MESSAGE: &str = "server restarted before completion";
+
+pub async fn mark_all_active_failed<C: ConnectionTrait>(conn: &C) -> Result<u64> {
+    let res = conn
+        .execute(Statement::from_sql_and_values(
+            DatabaseBackend::Postgres,
+            r#"UPDATE admin_task
+               SET status = $1,
+                   error = COALESCE(error, $2),
+                   finished_at = NOW() AT TIME ZONE 'UTC'
+               WHERE status IN ($3, $4)"#,
+            [
+                sea_orm::Value::Int(Some(AdminTaskStatus::Failed as i32)),
+                sea_orm::Value::String(Some(Box::new(STARTUP_FAILURE_MESSAGE.into()))),
+                sea_orm::Value::Int(Some(AdminTaskStatus::Pending as i32)),
+                sea_orm::Value::Int(Some(AdminTaskStatus::Running as i32)),
+            ],
+        ))
+        .await
+        .context("mark_all_active_failed")?;
+    Ok(res.rows_affected())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
+
+    fn task_row(id: AdminTaskId, status: AdminTaskStatus) -> MAdminTask {
+        MAdminTask {
+            id,
+            kind: AdminTaskKind::DeepGc,
+            status,
+            created_at: now(),
+            started_at: None,
+            finished_at: None,
+            progress: None,
+            error: None,
+            created_by: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn insert_pending_returns_inserted_row() {
+        let id = AdminTaskId::now_v7();
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![task_row(id, AdminTaskStatus::Pending)]])
+            .into_connection();
+        let inserted = insert_pending(&db, AdminTaskKind::DeepGc, None)
+            .await
+            .unwrap();
+        assert_eq!(inserted.status, AdminTaskStatus::Pending);
+    }
+
+    #[tokio::test]
+    async fn find_active_filters_by_kind_and_status() {
+        let id = AdminTaskId::now_v7();
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![task_row(id, AdminTaskStatus::Running)]])
+            .into_connection();
+        let got = find_active(&db, AdminTaskKind::DeepGc).await.unwrap();
+        assert_eq!(got.map(|r| r.id), Some(id));
+    }
+
+    #[tokio::test]
+    async fn mark_running_sets_status_and_started_at() {
+        let id = AdminTaskId::now_v7();
+        let row = task_row(id, AdminTaskStatus::Pending);
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![row.clone()]])
+            .append_query_results([vec![row]])
+            .append_exec_results([MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }])
+            .into_connection();
+        mark_running(&db, id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn mark_all_active_failed_executes_statement() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_exec_results([MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 7,
+            }])
+            .into_connection();
+        assert_eq!(mark_all_active_failed(&db).await.unwrap(), 7);
+    }
+
+    #[test]
+    fn unique_violation_detection_is_case_insensitive() {
+        assert!(is_unique_violation("ERROR: duplicate key value"));
+        assert!(is_unique_violation("violates UNIQUE constraint"));
+        assert!(!is_unique_violation("connection refused"));
+    }
+}

--- a/backend/core/src/db/mod.rs
+++ b/backend/core/src/db/mod.rs
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+pub mod admin_tasks;
 pub mod cache_reach;
 pub mod cache_upstream;
 pub mod connection;

--- a/backend/core/src/db/status.rs
+++ b/backend/core/src/db/status.rs
@@ -737,6 +737,9 @@ mod reelect_leader_tests {
             fn delete<'a>(&'a self, _: entity::ids::BuildId) -> BoxFuture<'a, anyhow::Result<()>> {
                 Box::pin(async { Ok(()) })
             }
+            fn list_logs<'a>(&'a self) -> BoxFuture<'a, anyhow::Result<Vec<entity::ids::BuildId>>> {
+                Box::pin(async { Ok(Vec::new()) })
+            }
         }
 
         #[derive(Debug)]

--- a/backend/core/src/storage/log.rs
+++ b/backend/core/src/storage/log.rs
@@ -34,6 +34,10 @@ pub trait LogStorage: Send + Sync + std::fmt::Debug {
 
     /// Permanently delete the log for `build_id` from all backing stores.
     fn delete<'a>(&'a self, build_id: BuildId) -> BoxFuture<'a, Result<()>>;
+
+    /// Enumerate every `BuildId` that currently has a log in this backend.
+    /// Used by the deep-GC sweep to find orphan logs.
+    fn list_logs<'a>(&'a self) -> BoxFuture<'a, Result<Vec<BuildId>>>;
 }
 
 #[derive(Debug)]
@@ -86,6 +90,28 @@ impl LogStorage for FileLogStorage {
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
                 Err(e) => Err(e.into()),
             }
+        })
+    }
+
+    fn list_logs<'a>(&'a self) -> BoxFuture<'a, Result<Vec<BuildId>>> {
+        Box::pin(async move {
+            let mut out = Vec::new();
+            let mut entries = match fs::read_dir(&self.logs_dir).await {
+                Ok(e) => e,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+                Err(e) => return Err(e.into()),
+            };
+            while let Some(entry) = entries.next_entry().await? {
+                let name = entry.file_name();
+                let Some(s) = name.to_str() else { continue };
+                let Some(stem) = s.strip_suffix(".log") else {
+                    continue;
+                };
+                if let Ok(id) = stem.parse::<uuid::Uuid>() {
+                    out.push(BuildId::new(id));
+                }
+            }
+            Ok(out)
         })
     }
 }
@@ -176,6 +202,33 @@ impl LogStorage for S3LogStorage {
                 Ok(_) | Err(object_store::Error::NotFound { .. }) => Ok(()),
                 Err(e) => Err(e.into()),
             }
+        })
+    }
+
+    fn list_logs<'a>(&'a self) -> BoxFuture<'a, Result<Vec<BuildId>>> {
+        Box::pin(async move {
+            use futures::StreamExt as _;
+            let mut local = self.local.list_logs().await?;
+            let prefix = ObjectPath::from(format!("{}logs", self.prefix));
+            let mut stream = self.object_store.list(Some(&prefix));
+            let mut seen: std::collections::HashSet<BuildId> = local.iter().copied().collect();
+            while let Some(item) = stream.next().await {
+                let meta = item?;
+                let p = meta.location.to_string();
+                let Some(name) = p.split('/').next_back() else {
+                    continue;
+                };
+                let Some(stem) = name.strip_suffix(".log") else {
+                    continue;
+                };
+                if let Ok(id) = stem.parse::<uuid::Uuid>() {
+                    let bid = BuildId::new(id);
+                    if seen.insert(bid) {
+                        local.push(bid);
+                    }
+                }
+            }
+            Ok(local)
         })
     }
 }

--- a/backend/core/src/storage/nar.rs
+++ b/backend/core/src/storage/nar.rs
@@ -317,6 +317,42 @@ impl NarStore {
         }
         Ok(hashes)
     }
+
+    /// Lists every build-request blob currently in storage. Returns
+    /// `(org, hash)` pairs reconstructed from the
+    /// `build-request-blobs/<org-uuid>/<shard>/<full-hex>` path layout. Entries
+    /// whose name does not match the layout are skipped.
+    pub async fn list_blobs(&self) -> Result<Vec<(uuid::Uuid, [u8; 32])>> {
+        let prefix = Path::from(format!("{}build-request-blobs", self.prefix));
+        let mut stream = self.inner.list(Some(&prefix));
+        let mut out = Vec::new();
+        while let Some(item) = stream.next().await {
+            let meta = item.context("Failed to list build-request-blobs")?;
+            let p = meta.location.to_string();
+            let parts: Vec<&str> = p.split('/').collect();
+            if parts.len() < 3 {
+                continue;
+            }
+            let hash_hex = parts[parts.len() - 1];
+            let org_part = parts[parts.len() - 3];
+            let Ok(org) = uuid::Uuid::parse_str(org_part) else {
+                tracing::debug!(path = %p, "skipping blob with non-uuid org dir");
+                continue;
+            };
+            let Ok(hash_vec) = hex::decode(hash_hex) else {
+                tracing::debug!(path = %p, "skipping blob with non-hex name");
+                continue;
+            };
+            if hash_vec.len() != 32 {
+                tracing::debug!(path = %p, "skipping blob with non-32-byte hash");
+                continue;
+            }
+            let mut hash = [0u8; 32];
+            hash.copy_from_slice(&hash_vec);
+            out.push((org, hash));
+        }
+        Ok(out)
+    }
 }
 
 impl std::fmt::Debug for NarStore {

--- a/backend/core/src/types/entity_aliases.rs
+++ b/backend/core/src/types/entity_aliases.rs
@@ -30,6 +30,7 @@ pub struct ListItem {
 
 pub type ListResponse = Vec<ListItem>;
 
+pub type EAdminTask = admin_task::Entity;
 pub type EApi = api::Entity;
 pub type EAuditLog = audit_log::Entity;
 pub type EBuild = build::Entity;
@@ -69,6 +70,7 @@ pub type EUploadSession = upload_session::Entity;
 pub type EUser = user::Entity;
 pub type EWorkerRegistration = worker_registration::Entity;
 
+pub type MAdminTask = admin_task::Model;
 pub type MApi = api::Model;
 pub type MAuditLog = audit_log::Model;
 pub type MBuild = build::Model;
@@ -108,6 +110,7 @@ pub type MUploadSession = upload_session::Model;
 pub type MUser = user::Model;
 pub type MWorkerRegistration = worker_registration::Model;
 
+pub type AAdminTask = admin_task::ActiveModel;
 pub type AApi = api::ActiveModel;
 pub type AAuditLog = audit_log::ActiveModel;
 pub type ABuild = build::ActiveModel;
@@ -147,6 +150,7 @@ pub type AUploadSession = upload_session::ActiveModel;
 pub type AUser = user::ActiveModel;
 pub type AWorkerRegistration = worker_registration::ActiveModel;
 
+pub type CAdminTask = admin_task::Column;
 pub type CApi = api::Column;
 pub type CAuditLog = audit_log::Column;
 pub type CBuild = build::Column;
@@ -190,6 +194,7 @@ pub type CWorkerRegistration = worker_registration::Column;
 // `Entity::has_many` / `belongs_to` builder API rather than the `Relation`
 // enum directly. The aliases were unused outside this file. If a future
 // caller needs a relation type, prefer `entity::api::Relation`.
+pub use admin_task::{AdminTaskKind, AdminTaskStatus};
 pub use evaluation_message::MessageLevel;
 
 /// Convenience bundle for code that needs the attempt fields (`MBuild`) and

--- a/backend/entity/src/admin_task.rs
+++ b/backend/entity/src/admin_task.rs
@@ -1,0 +1,115 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use chrono::NaiveDateTime;
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::ids::{AdminTaskId, UserId};
+
+#[repr(i32)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    DeriveActiveEnum,
+    EnumIter,
+    Deserialize,
+    Serialize,
+    IntoPrimitive,
+    TryFromPrimitive,
+)]
+#[sea_orm(rs_type = "i32", db_type = "Integer")]
+pub enum AdminTaskKind {
+    #[sea_orm(num_value = 0)]
+    DeepGc = 0,
+}
+
+impl AdminTaskKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::DeepGc => "deep_gc",
+        }
+    }
+}
+
+#[repr(i32)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    DeriveActiveEnum,
+    EnumIter,
+    Deserialize,
+    Serialize,
+    IntoPrimitive,
+    TryFromPrimitive,
+)]
+#[sea_orm(rs_type = "i32", db_type = "Integer")]
+pub enum AdminTaskStatus {
+    #[sea_orm(num_value = 0)]
+    Pending = 0,
+    #[sea_orm(num_value = 1)]
+    Running = 1,
+    #[sea_orm(num_value = 2)]
+    Completed = 2,
+    #[sea_orm(num_value = 3)]
+    Failed = 3,
+}
+
+impl AdminTaskStatus {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+        }
+    }
+
+    pub const fn is_active(self) -> bool {
+        matches!(self, Self::Pending | Self::Running)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Deserialize, Serialize)]
+#[sea_orm(table_name = "admin_task")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: AdminTaskId,
+    pub kind: AdminTaskKind,
+    pub status: AdminTaskStatus,
+    pub created_at: NaiveDateTime,
+    pub started_at: Option<NaiveDateTime>,
+    pub finished_at: Option<NaiveDateTime>,
+    pub progress: Option<Json>,
+    pub error: Option<String>,
+    pub created_by: Option<UserId>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::user::Entity",
+        from = "Column::CreatedBy",
+        to = "super::user::Column::Id",
+        on_delete = "SetNull"
+    )]
+    User,
+}
+
+impl Related<super::user::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::User.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/backend/entity/src/ids.rs
+++ b/backend/entity/src/ids.rs
@@ -81,6 +81,7 @@ macro_rules! id_newtype {
     };
 }
 
+id_newtype!(AdminTaskId);
 id_newtype!(ApiId);
 id_newtype!(BuildId);
 id_newtype!(BuildProductId);

--- a/backend/entity/src/lib.rs
+++ b/backend/entity/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod ids;
 
+pub mod admin_task;
 pub mod api;
 pub mod audit_log;
 pub mod build;

--- a/backend/migration/src/lib.rs
+++ b/backend/migration/src/lib.rs
@@ -115,6 +115,7 @@ mod m20260524_000004_drop_table_project_integration;
 mod m20260525_000000_create_table_cache_role;
 mod m20260525_000001_create_table_cache_user;
 mod m20260525_000002_add_cache_to_api;
+mod m20260525_000003_create_admin_task;
 
 pub struct Migrator;
 
@@ -231,6 +232,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260525_000000_create_table_cache_role::Migration),
             Box::new(m20260525_000001_create_table_cache_user::Migration),
             Box::new(m20260525_000002_add_cache_to_api::Migration),
+            Box::new(m20260525_000003_create_admin_task::Migration),
         ]
     }
 }

--- a/backend/migration/src/m20260525_000003_create_admin_task.rs
+++ b/backend/migration/src/m20260525_000003_create_admin_task.rs
@@ -1,0 +1,90 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(AdminTask::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(AdminTask::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(AdminTask::Kind).integer().not_null())
+                    .col(ColumnDef::new(AdminTask::Status).integer().not_null())
+                    .col(
+                        ColumnDef::new(AdminTask::CreatedAt)
+                            .timestamp()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .col(ColumnDef::new(AdminTask::StartedAt).timestamp().null())
+                    .col(ColumnDef::new(AdminTask::FinishedAt).timestamp().null())
+                    .col(ColumnDef::new(AdminTask::Progress).json_binary().null())
+                    .col(ColumnDef::new(AdminTask::Error).text().null())
+                    .col(ColumnDef::new(AdminTask::CreatedBy).uuid().null())
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk-admin_task-created_by")
+                            .from(AdminTask::Table, AdminTask::CreatedBy)
+                            .to(User::Table, User::Id)
+                            .on_delete(ForeignKeyAction::SetNull),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"CREATE UNIQUE INDEX admin_task_one_active_per_kind
+                   ON admin_task (kind)
+                   WHERE status IN (0, 1)"#,
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared("DROP INDEX IF EXISTS admin_task_one_active_per_kind")
+            .await?;
+        manager
+            .drop_table(Table::drop().table(AdminTask::Table).to_owned())
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum AdminTask {
+    Table,
+    Id,
+    Kind,
+    Status,
+    CreatedAt,
+    StartedAt,
+    FinishedAt,
+    Progress,
+    Error,
+    CreatedBy,
+}
+
+#[derive(DeriveIden)]
+enum User {
+    Table,
+    Id,
+}

--- a/backend/test-support/src/log_storage.rs
+++ b/backend/test-support/src/log_storage.rs
@@ -26,6 +26,9 @@ impl LogStorage for NoopLogStorage {
     fn delete<'a>(&'a self, _build_id: BuildId) -> BoxFuture<'a, Result<()>> {
         Box::pin(async { Ok(()) })
     }
+    fn list_logs<'a>(&'a self) -> BoxFuture<'a, Result<Vec<BuildId>>> {
+        Box::pin(async { Ok(Vec::new()) })
+    }
 }
 
 /// Recording log storage: keeps every `(build_id, text)` append in memory so
@@ -78,6 +81,21 @@ impl LogStorage for RecordingLogStorage {
                 .expect("recording log mutex")
                 .retain(|(b, _)| *b != build_id);
             Ok(())
+        })
+    }
+
+    fn list_logs<'a>(&'a self) -> BoxFuture<'a, Result<Vec<BuildId>>> {
+        Box::pin(async move {
+            use std::collections::HashSet;
+            let entries = self.entries.lock().expect("recording log mutex");
+            let mut seen: HashSet<BuildId> = HashSet::new();
+            let mut out = Vec::new();
+            for (b, _) in entries.iter() {
+                if seen.insert(*b) {
+                    out.push(*b);
+                }
+            }
+            Ok(out)
         })
     }
 }
@@ -134,6 +152,18 @@ impl LogStorage for InMemoryLogStorage {
                 .expect("in-memory log mutex")
                 .remove(&build_id);
             Ok(())
+        })
+    }
+
+    fn list_logs<'a>(&'a self) -> BoxFuture<'a, Result<Vec<BuildId>>> {
+        Box::pin(async move {
+            Ok(self
+                .store
+                .lock()
+                .expect("in-memory log mutex")
+                .keys()
+                .copied()
+                .collect())
         })
     }
 }

--- a/backend/web/Cargo.toml
+++ b/backend/web/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 gradient-core = { workspace = true }
 proto         = { workspace = true }
 scheduler     = { workspace = true }
+cache         = { workspace = true }
 entity        = { workspace = true }
 
 anyhow        = { workspace = true }

--- a/backend/web/src/endpoints/admin/maintenance.rs
+++ b/backend/web/src/endpoints/admin/maintenance.rs
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! `POST /admin/maintenance/deep-gc`
+
+use crate::error::{WebError, WebResult, require_superuser};
+use crate::helpers::ok_json;
+use axum::http::StatusCode;
+use axum::{Extension, Json, extract::State};
+use cache::cacher::run_deep_gc;
+use entity::ids::AdminTaskId;
+use gradient_core::db::admin_tasks::{self, InsertPendingError};
+use gradient_core::types::{AdminTaskKind, BaseResponse, MUser, ServerState};
+use serde::Serialize;
+use std::sync::Arc;
+use tracing::info;
+
+#[derive(Serialize, Debug)]
+pub struct StartDeepGcResponse {
+    pub task_id: AdminTaskId,
+    pub status: &'static str,
+}
+
+pub async fn start_deep_gc(
+    State(state): State<Arc<ServerState>>,
+    Extension(user): Extension<MUser>,
+) -> WebResult<(StatusCode, Json<BaseResponse<StartDeepGcResponse>>)> {
+    require_superuser(&user)?;
+    match admin_tasks::insert_pending(&state.worker_db, AdminTaskKind::DeepGc, Some(user.id))
+        .await
+    {
+        Ok(task) => {
+            info!(task_id = %task.id, "deep_gc: spawning sweep");
+            state
+                .shutdown
+                .spawn(run_deep_gc(Arc::clone(&state), task.id));
+            let body = ok_json(StartDeepGcResponse {
+                task_id: task.id,
+                status: "pending",
+            });
+            Ok((StatusCode::ACCEPTED, body))
+        }
+        Err(InsertPendingError::AlreadyActive(id)) => Err(WebError::conflict(format!(
+            "deep_gc task {id} is already pending or running"
+        ))),
+        Err(InsertPendingError::Db(e)) => {
+            Err(WebError::internal(format!("admin_task insert failed: {e}")))
+        }
+    }
+}

--- a/backend/web/src/endpoints/admin/mod.rs
+++ b/backend/web/src/endpoints/admin/mod.rs
@@ -8,6 +8,8 @@
 //! `require_superuser`.
 
 pub mod github_app;
+pub mod maintenance;
+pub mod tasks;
 pub mod workers;
 
 use axum::Router;
@@ -26,4 +28,7 @@ pub fn admin_router() -> Router<Arc<ServerState>> {
         .route("/workers", get(workers::get_workers))
         .route("/github-app/manifest", post(github_app::request_manifest))
         .route("/github-app/credentials", get(github_app::credentials))
+        .route("/maintenance/deep-gc", post(maintenance::start_deep_gc))
+        .route("/tasks", get(tasks::list_tasks))
+        .route("/tasks/{task_id}", get(tasks::get_task))
 }

--- a/backend/web/src/endpoints/admin/tasks.rs
+++ b/backend/web/src/endpoints/admin/tasks.rs
@@ -1,0 +1,72 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! `GET /admin/tasks`, `GET /admin/tasks/{task_id}`
+
+use crate::error::{WebError, WebResult, require_superuser};
+use crate::helpers::ok_json;
+use axum::{
+    Extension, Json,
+    extract::{Path, State},
+};
+use entity::ids::{AdminTaskId, UserId};
+use gradient_core::db::admin_tasks;
+use gradient_core::types::{BaseResponse, MAdminTask, MUser, ServerState};
+use serde::Serialize;
+use std::sync::Arc;
+
+#[derive(Serialize, Debug)]
+pub struct AdminTaskDto {
+    pub id: AdminTaskId,
+    pub kind: &'static str,
+    pub status: &'static str,
+    pub created_at: chrono::NaiveDateTime,
+    pub started_at: Option<chrono::NaiveDateTime>,
+    pub finished_at: Option<chrono::NaiveDateTime>,
+    pub progress: Option<serde_json::Value>,
+    pub error: Option<String>,
+    pub created_by: Option<UserId>,
+}
+
+impl From<MAdminTask> for AdminTaskDto {
+    fn from(m: MAdminTask) -> Self {
+        Self {
+            id: m.id,
+            kind: m.kind.as_str(),
+            status: m.status.as_str(),
+            created_at: m.created_at,
+            started_at: m.started_at,
+            finished_at: m.finished_at,
+            progress: m.progress,
+            error: m.error,
+            created_by: m.created_by,
+        }
+    }
+}
+
+pub async fn list_tasks(
+    State(state): State<Arc<ServerState>>,
+    Extension(user): Extension<MUser>,
+) -> WebResult<Json<BaseResponse<Vec<AdminTaskDto>>>> {
+    require_superuser(&user)?;
+    let rows = admin_tasks::list_recent(&state.worker_db, 50)
+        .await
+        .map_err(|e| WebError::internal(format!("list_recent: {e}")))?;
+    Ok(ok_json(rows.into_iter().map(AdminTaskDto::from).collect()))
+}
+
+pub async fn get_task(
+    State(state): State<Arc<ServerState>>,
+    Extension(user): Extension<MUser>,
+    Path(task_id): Path<AdminTaskId>,
+) -> WebResult<Json<BaseResponse<AdminTaskDto>>> {
+    require_superuser(&user)?;
+    let row = admin_tasks::get(&state.worker_db, task_id)
+        .await
+        .map_err(|e| WebError::internal(format!("get_task: {e}")))?
+        .ok_or_else(|| WebError::not_found("admin_task"))?;
+    Ok(ok_json(AdminTaskDto::from(row)))
+}

--- a/backend/web/src/lib.rs
+++ b/backend/web/src/lib.rs
@@ -601,6 +601,18 @@ pub async fn serve_web(state: Arc<ServerState>) -> std::io::Result<()> {
         state.config.server.ip.clone(),
         state.config.server.port.clone()
     );
+
+    // Free the partial unique index from any admin_task left in Pending/Running
+    // by a previous process. Sweeps are idempotent so the operator can re-issue.
+    match gradient_core::db::admin_tasks::mark_all_active_failed(&state.worker_db).await {
+        Ok(n) if n > 0 => tracing::warn!(
+            tasks_marked_failed = n,
+            "marked stale admin tasks Failed (server restart)"
+        ),
+        Ok(_) => {}
+        Err(e) => tracing::error!(error = ?e, "failed to clear stale admin tasks"),
+    }
+
     let app = create_router(Arc::clone(&state));
 
     let listener = tokio::net::TcpListener::bind(&server_url)

--- a/backend/web/tests/cache_members.rs
+++ b/backend/web/tests/cache_members.rs
@@ -13,6 +13,7 @@ use gradient_core::types::SessionId;
 use gradient_core::types::consts::{BASE_CACHE_ROLE_ADMIN_ID, BASE_CACHE_ROLE_VIEW_ID};
 use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
 use serde_json::{Value, json};
+use std::collections::BTreeMap;
 use test_support::fixtures::{test_date, user, user_id};
 use test_support::web::{live_session, make_test_server, make_token};
 use uuid::Uuid;
@@ -43,6 +44,14 @@ fn cache_row(managed: bool) -> cache::Model {
         created_at: test_date(),
         managed,
     }
+}
+
+/// Build a one-row mock result that satisfies sea-orm's `count()` parser
+/// (`SELECT COUNT(*) AS num_items` → `try_get::<i64>("", "num_items")`).
+fn count_row(num: i64) -> BTreeMap<&'static str, sea_orm::Value> {
+    let mut row = BTreeMap::new();
+    row.insert("num_items", sea_orm::Value::BigInt(Some(num)));
+    row
 }
 
 fn admin_member() -> cache_user::Model {
@@ -303,8 +312,8 @@ fn remove_member_blocks_last_admin() {
             .append_query_results([vec![user()]])
             // find_cache_membership
             .append_query_results([vec![admin_member()]])
-            // COUNT admin members → 1
-            .append_query_results::<cache_user::Model, _, _>([vec![admin_member()]]);
+            // COUNT admin members → 1 (sea-orm count parses `num_items: i64`)
+            .append_query_results([vec![count_row(1)]]);
 
         let server = make_test_server(db.into_connection());
         let res = server

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -3533,6 +3533,112 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
 
+  /admin/maintenance/deep-gc:
+    post:
+      tags: [admin]
+      summary: Start a deep GC sweep
+      description: |
+        Starts an asynchronous reconciliation between the database and every
+        storage backend (NAR files, build-request blobs, build logs). Returns
+        `202` immediately with the task id; poll
+        `GET /admin/tasks/{task_id}` for progress and final state.
+
+        Returns `409 Conflict` if a `deep_gc` task is already `pending` or
+        `running`.
+
+        Requires `superuser`.
+      operationId: startDeepGc
+      security:
+        - bearerAuth: []
+      responses:
+        '202':
+          description: Sweep accepted
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BaseResponse'
+                  - type: object
+                    properties:
+                      message:
+                        type: object
+                        required: [task_id, status]
+                        properties:
+                          task_id:
+                            type: string
+                            format: uuid
+                          status:
+                            type: string
+                            enum: [pending]
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          description: A deep_gc task is already active.
+
+  /admin/tasks:
+    get:
+      tags: [admin]
+      summary: List recent admin tasks
+      description: |
+        Returns the 50 newest admin tasks ordered by `created_at` descending.
+        Requires `superuser`.
+      operationId: listAdminTasks
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Admin task list
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BaseResponse'
+                  - type: object
+                    properties:
+                      message:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/AdminTask'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /admin/tasks/{task_id}:
+    get:
+      tags: [admin]
+      summary: Get one admin task
+      operationId: getAdminTask
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: task_id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Admin task
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BaseResponse'
+                  - type: object
+                    properties:
+                      message:
+                        $ref: '#/components/schemas/AdminTask'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /admin/github-app/manifest:
     post:
       tags: [admin]
@@ -5111,6 +5217,58 @@ components:
             message: "Server Name already exists"
 
   schemas:
+
+    # ── Admin ─────────────────────────────────────────────────────────────────
+
+    AdminTaskKind:
+      type: string
+      enum: [deep_gc]
+      description: |
+        The kind of administrative task. Only `deep_gc` is currently defined.
+
+    AdminTaskStatus:
+      type: string
+      enum: [pending, running, completed, failed]
+      description: |
+        Lifecycle status for an admin task. `failed` includes the case where
+        the server was restarted while the task was running.
+
+    AdminTask:
+      type: object
+      required: [id, kind, status, created_at]
+      properties:
+        id:
+          type: string
+          format: uuid
+        kind:
+          $ref: '#/components/schemas/AdminTaskKind'
+        status:
+          $ref: '#/components/schemas/AdminTaskStatus'
+        created_at:
+          type: string
+          format: date-time
+        started_at:
+          type: string
+          format: date-time
+          nullable: true
+        finished_at:
+          type: string
+          format: date-time
+          nullable: true
+        progress:
+          type: object
+          additionalProperties: true
+          nullable: true
+          description: |
+            Free-form JSON object emitted by the sweep. For `deep_gc` this
+            mirrors `DeepGcReport` (counts per pass).
+        error:
+          type: string
+          nullable: true
+        created_by:
+          type: string
+          format: uuid
+          nullable: true
 
     # ── Common wrappers ───────────────────────────────────────────────────────
 

--- a/docs/src/development/internals.md
+++ b/docs/src/development/internals.md
@@ -176,3 +176,36 @@ A worker may be authorized for multiple orgs simultaneously - it sees job candid
 ## State-Managed Resources
 
 See [Declarative State](../usage/state.md#state-managed-resources).
+
+---
+
+## Admin tasks and the deep GC sweep
+
+Long-running administrative operations are tracked in the `admin_task`
+table. Each row has a `kind` (currently only `deep_gc`) and a `status`
+(`pending` → `running` → `completed`/`failed`). A partial unique index on
+`(kind) WHERE status IN (pending, running)` enforces that at most one
+active task per kind exists; a concurrent `POST` collides on the index
+and the endpoint returns `409 Conflict`.
+
+`POST /admin/maintenance/deep-gc` inserts a `pending` row and spawns the
+sweep via `Shutdown::spawn`. The sweep runs three passes — NAR, blob,
+log — each bidirectionally reconciling its storage backend against the
+DB:
+
+1. **NAR pass** reuses `cleanup_orphaned_cache_files`: removes
+   `cache_storage` files with no live DB reference and `cached_path`
+   rows whose NAR is gone.
+2. **Blob pass** lists `build-request-blobs/...` from `nar_storage` and
+   `build_request_blob` rows. Orphans on either side are removed.
+3. **Log pass** lists `BuildId`s from `log_storage`. Orphan logs (no
+   matching `build` row) are deleted. The DB→storage direction is
+   intentionally skipped because a `build` row without a log is a
+   legitimate state.
+
+Counters are flushed to `admin_task.progress` between passes.
+
+When the server restarts, any non-terminal admin task is marked `failed`
+with `error = "server restarted before completion"` before the web layer
+accepts traffic. Operators re-issue the POST to start a fresh sweep;
+each pass is idempotent.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -2571,3 +2571,8 @@ Run with: `pnpm --dir frontend exec ng test --watch=false`
 - `backend/web/tests/cache_members.rs` — member CRUD endpoint tests
 - `backend/web/tests/cache_subscription_gate.rs` — bilateral subscription tests
 - `backend/web/tests/cache_api_key_pinning.rs` — cache-pinned API key tests
+
+## Admin tasks & deep GC (issue #271)
+
+- `backend/core/src/db/admin_tasks.rs` — DB helper unit tests: insert/find/mark transitions, unique-violation detection, startup recovery `mark_all_active_failed`.
+- `backend/cache/src/cacher/deep_gc.rs` — sweep unit tests: blob pass removes orphan blob, blob pass purges zombie row, log pass removes orphan log, `DeepGcReport` serialises with snake_case keys.


### PR DESCRIPTION
## Summary
- Adds `POST /admin/maintenance/deep-gc` (superuser) that triggers an async, bidirectional reconciliation of every storage surface (NAR files, build-request blobs, build logs) against the database.
- Adds a generic `admin_task` table (`kind`/`status` as `DeriveActiveEnum` ints, partial unique index for at-most-one-active per kind) plus `GET /admin/tasks` and `GET /admin/tasks/{task_id}` for progress + history.
- On startup, any non-terminal `admin_task` row is marked `Failed` with a canonical message so the unique index is free for a fresh POST after a restart.

## How the sweep works
Three passes, each updating `admin_task.progress` between them:
1. **NAR pass** — reuses `cleanup_orphaned_cache_files` (now returns `CleanupReport`).
2. **Blob pass** — new `NarStore::list_blobs`, removes orphan blobs in `nar_storage` and zombie `build_request_blob` rows.
3. **Log pass** — new `LogStorage::list_logs` trait method (impls for File/S3/Noop), removes orphan log files. DB→storage skipped: a `build` with no log is a legitimate state.

Closes #271.

## Test plan
- [x] `cargo check --all-targets` clean
- [x] `cargo clippy --all-targets` clean
- [x] Unit tests pass on CI (`backend/cache/src/cacher/deep_gc.rs::tests`, `backend/core/src/db/admin_tasks.rs::tests`)
- [x] Existing cleanup tests pass on CI
- [x] Manual: hit `POST /admin/maintenance/deep-gc` as superuser, observe 202 + task row; second POST returns 409; `GET /admin/tasks/{id}` shows progress