### PR TITLE
fix(core): safe GC defaults for keep_evaluations and nar_ttl_hours

### DIFF
--- a/backend/cache/src/cacher/cleanup.rs
+++ b/backend/cache/src/cacher/cleanup.rs
@@ -700,12 +700,14 @@ mod tests {
     async fn build_request_blob_sweep_disabled_when_ttl_zero() {
         let tmp = tempfile::tempdir().unwrap();
         let nar_storage = NarStore::local(tmp.path().to_str().unwrap()).unwrap();
+        let mut cli = test_cli();
+        cli.storage.nar_ttl_hours = 0;
         let state = Arc::new(ServerState {
             web_db: WebDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
             worker_db: WorkerDb::new(
                 MockDatabase::new(DatabaseBackend::Postgres).into_connection(),
             ),
-            config: Arc::new(RuntimeConfig::from_cli(&test_cli()).expect("valid test config")),
+            config: Arc::new(RuntimeConfig::from_cli(&cli).expect("valid test config")),
             log_storage: Arc::new(NoopLogStorage),
             email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,
             nar_storage,

--- a/backend/core/src/types/cli/storage.rs
+++ b/backend/core/src/types/cli/storage.rs
@@ -48,3 +48,37 @@ impl Default for StorageArgs {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn default_keep_evaluations_is_thirty() {
+        assert_eq!(StorageArgs::default().keep_evaluations, 30);
+    }
+
+    #[test]
+    fn default_nar_ttl_hours_is_two_weeks() {
+        assert_eq!(StorageArgs::default().nar_ttl_hours, 336);
+    }
+
+    #[derive(Parser, Debug)]
+    struct StorageOnlyCli {
+        #[command(flatten)]
+        storage: StorageArgs,
+    }
+
+    #[test]
+    fn clap_default_keep_evaluations_is_thirty() {
+        let parsed = StorageOnlyCli::try_parse_from(["test"]).unwrap();
+        assert_eq!(parsed.storage.keep_evaluations, 30);
+    }
+
+    #[test]
+    fn clap_default_nar_ttl_hours_is_two_weeks() {
+        let parsed = StorageOnlyCli::try_parse_from(["test"]).unwrap();
+        assert_eq!(parsed.storage.nar_ttl_hours, 336);
+    }
+}

--- a/backend/core/src/types/cli/storage.rs
+++ b/backend/core/src/types/cli/storage.rs
@@ -16,12 +16,12 @@ pub struct StorageArgs {
     pub state_file: Option<String>,
     #[arg(long, env = "GRADIENT_DELETE_STATE", default_value = "true")]
     pub delete_state: bool,
-    #[arg(long, env = "GRADIENT_KEEP_EVALUATIONS", default_value = "0")]
+    #[arg(long, env = "GRADIENT_KEEP_EVALUATIONS", default_value = "30")]
     pub keep_evaluations: usize,
     /// TTL in hours for cached NAR files that have not been fetched recently.
     /// When expired the NAR is removed from storage and its GC root is deleted.
-    /// Set to 0 to disable (default).
-    #[arg(long, env = "GRADIENT_NAR_TTL_HOURS", default_value_t = 0)]
+    /// Defaults to 336 (2 weeks). Set to 0 to disable.
+    #[arg(long, env = "GRADIENT_NAR_TTL_HOURS", default_value_t = 336)]
     pub nar_ttl_hours: u64,
     /// Grace period in hours before the GC pass deletes a `derivation` row
     /// that no longer has any referencing `build` rows. The grace lets rapid
@@ -42,8 +42,8 @@ impl Default for StorageArgs {
             base_path: ".".into(),
             state_file: None,
             delete_state: true,
-            keep_evaluations: 0,
-            nar_ttl_hours: 0,
+            keep_evaluations: 30,
+            nar_ttl_hours: 336,
             keep_orphan_derivations_hours: 24,
         }
     }

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -53,7 +53,7 @@ openssl rand -base64 48 > /run/secrets/gradient-crypt
 | `settings.sentryDsn` | `null` | Override the Sentry DSN used when `reportErrors` is true. `null` ships reports to the upstream Wavelens instance at `reports.wavelens.io`; set your own DSN to keep reports in-house. (`GRADIENT_SENTRY_DSN`) |
 | `discoverable` | `true` | Accept incoming `/proto` WebSocket connections from workers |
 | `settings.maxProtoConnections` | `256` | Max simultaneous worker WebSocket connections; further upgrades return `503 Service Unavailable` with `Retry-After: 10` until a slot frees |
-| `settings.keepEvaluations` | `5` | Number of evaluations kept per project |
+| `settings.keepEvaluations` | `30` | Global maximum of evaluations kept per project (caps the per-project setting) |
 | `settings.maxRequestSize` | `2097152` (2 MiB) | Max HTTP request body in bytes for most endpoints (caps webhook/JSON payloads to prevent OOM). The build-request blob endpoint uses a fixed 20 MiB cap. |
 | `settings.logLevel.default` | `info` | Log level: `trace` `debug` `info` `warn` `error` |
 | `settings.logLevel.cache` | null | Cache log level override (null inherits default) |

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -477,6 +477,23 @@ Backend (`cargo test -p core --lib state::tests`):
   configuration validator rejects `keep_evaluations < 1`, matching the
   `types.ints.positive` constraint in `nix/modules/gradient-state.nix`
   and the API-level `apply_keep_evaluations` check.
+- `default_keep_evaluations_is_thirty`
+  (`backend/core/src/types/cli/storage.rs`) - `StorageArgs::default()`
+  yields `keep_evaluations = 30` so a default `gradient-server` install
+  bounds per-project evaluation retention instead of allowing unbounded
+  growth (issue #92).
+- `default_nar_ttl_hours_is_two_weeks`
+  (`backend/core/src/types/cli/storage.rs`) - `StorageArgs::default()`
+  yields `nar_ttl_hours = 336` (2 weeks) so cached NARs eventually
+  expire on a default deploy (issue #92).
+- `clap_default_keep_evaluations_is_thirty`
+  (`backend/core/src/types/cli/storage.rs`) - parsing an empty argv
+  through clap yields `keep_evaluations = 30`, guarding against drift
+  between the `#[arg(default_value …)]` attribute and the `Default`
+  impl.
+- `clap_default_nar_ttl_hours_is_two_weeks`
+  (`backend/core/src/types/cli/storage.rs`) - parsing an empty argv
+  through clap yields `nar_ttl_hours = 336`, same drift guard.
 - `state_project_silently_ignores_legacy_force_evaluation_field` -
   state files written before the rename may still carry
   `force_evaluation`; serde's default unknown-field handling drops it

--- a/nix/modules/gradient.nix
+++ b/nix/modules/gradient.nix
@@ -365,7 +365,7 @@ in {
         keepEvaluations = lib.mkOption {
           description = "Amount of evaluations to keep in the database and cache";
           type = lib.types.ints.positive;
-          default = 5;
+          default = 30;
         };
 
         maxRequestSize = lib.mkOption {


### PR DESCRIPTION
## Summary
- Flip `StorageArgs` defaults from `0` (disabled) to `30` evaluations and `336` hours (2 weeks) so a default `gradient-server` install bounds disk usage instead of growing unbounded.
- Align `services.gradient.settings.keepEvaluations` default (`5` → `30`) with the new CLI default.

Closes #92.

## Test plan
- [x] CI: new `StorageArgs` default tests pass (`default_keep_evaluations_is_thirty`, `default_nar_ttl_hours_is_two_weeks`, `clap_default_*`)
- [x] CI: existing `keep_evaluations` validator / cap-down tests still pass
- [x] Manual: spin up a fresh server with no env vars set, confirm `cli.storage.keep_evaluations == 30` and `cli.storage.nar_ttl_hours == 336`