### PR TITLE
frontend: show only one loading indicator

### DIFF
--- a/frontend/src/app/features/caches/cache-list/cache-list.component.html
+++ b/frontend/src/app/features/caches/cache-list/cache-list.component.html
@@ -97,7 +97,7 @@
   }
 
   <!-- Public Caches -->
-  @if (publicLoading()) {
+  @if (publicLoading() && !loading()) {
     <app-loading-spinner message="Loading public caches..." />
   } @else if (filteredPublicCaches.length > 0) {
     <div class="discover-header">

--- a/frontend/src/app/features/organizations/organization-list/organization-list.component.html
+++ b/frontend/src/app/features/organizations/organization-list/organization-list.component.html
@@ -62,7 +62,7 @@
     }
   }
 
-  @if (publicLoading()) {
+  @if (publicLoading() && !loading()) {
     <app-loading-spinner message="Loading public organizations..." />
   } @else if (filteredPublicOrgs.length > 0) {
     <div class="section-header discover-header">


### PR DESCRIPTION
Currently the Organizations and Caches pages show one loading indicator each for public Caches / organizations and the owned Caches / Orgs by the user.
However they are the only two elements on the page which looks quite odd (imo).

This PR only shows one loading indicator, while loading both ressources.
Should one ressource load before the other, it is shown but there is still a loading indicator for the other ressource.