### PR TITLE
frontend: fix debounce time on username check

### DIFF
--- a/frontend/src/app/features/auth/register/register.component.ts
+++ b/frontend/src/app/features/auth/register/register.component.ts
@@ -18,8 +18,8 @@ import { Router, RouterModule } from '@angular/router';
 import { AuthService } from '@core/services/auth.service';
 import { ConfigService } from '@core/services/config.service';
 import { environment } from '@environments/environment';
-import { debounceTime, switchMap, map } from 'rxjs/operators';
-import { of } from 'rxjs';
+import { switchMap, map } from 'rxjs/operators';
+import { of, timer } from 'rxjs';
 
 @Component({
   selector: 'app-register',
@@ -109,10 +109,9 @@ export class RegisterComponent {
       return of(null);
     }
 
-    return of(control.value).pipe(
-      debounceTime(500),
-      switchMap((username) =>
-        this.authService.checkUsername(username).pipe(
+    return timer(500).pipe(
+      switchMap(() =>
+        this.authService.checkUsername(control.value).pipe(
           map((available) => (available ? null : { usernameTaken: true }))
         )
       )


### PR DESCRIPTION
This PR fixes a logic bug in the username check debounce implementation on the register page.

The previous implementation wouldnt actually debounce the requests (as can be seen in the devtools) and would therefore often result in ratelimiting.
This bug is now fixed an the request is actually debounced as intended.