### PR TITLE
frontend: add declerative cache netrc instructions

### DIFF
--- a/frontend/src/app/features/caches/cache-detail/cache-detail.component.html
+++ b/frontend/src/app/features/caches/cache-detail/cache-detail.component.html
@@ -187,8 +187,22 @@ trusted-public-keys = &lt;unavailable&gt;</pre>
                 <span class="material-symbols-outlined">{{ copied() === 'netrc' ? 'check' : 'content_copy' }}</span>
               </button>
             </div>
+            <p class="text-secondary usage-hint">Replace <code>&lt;YOUR_TOKEN&gt;</code> with your API key or login token. The command writes the credentials to <code>/etc/nix/netrc</code> so the Nix daemon can authenticate against this cache.</p>
           </div>
-          <p class="text-secondary usage-hint">Replace <code>&lt;YOUR_TOKEN&gt;</code> with your API key or login token. The command writes the credentials to <code>/etc/nix/netrc</code> so the Nix daemon can authenticate against this cache.</p>
+          <div class="usage-row">
+            <span class="usage-label">Or install <code>/etc/nix/netrc</code> decleratively</span>
+            <div class="code-block multiline">
+              <pre>
+                {{ declerativeNetrcCode }}
+              </pre>
+              <button class="copy-btn" (click)="copy(declerativeNetrcCode, 'netrc-code')" [title]="copied() === 'netrc-code' ? 'Copied!' : 'Copy'">
+                <span class="material-symbols-outlined">{{ copied() === 'netrc-code' ? 'check' : 'content_copy' }}</span>
+              </button>
+            </div>
+            <p class="text-secondary usage-hint">
+              This example uses <a href="https://github.com/Mic92/sops-nix">sops-nix</a>.
+              Replace <code>&lt;YOUR_USERNAME&gt;</code> with the user who should be able to use this cache. </p>
+          </div>
         }
       </div>
     </div>

--- a/frontend/src/app/features/caches/cache-detail/cache-detail.component.scss
+++ b/frontend/src/app/features/caches/cache-detail/cache-detail.component.scss
@@ -358,7 +358,19 @@
   }
 
   .usage-hint {
+    align-items: center;
     margin-top: $spacing-sm;
     font-size: $font-size-xs;
+
+    a {
+      padding: 0;
+      text-decoration: underline;
+      color: inherit;
+
+      &:hover {
+        background: none;
+        color: $text-primary;
+      }
+    }
   }
 }

--- a/frontend/src/app/features/caches/cache-detail/cache-detail.component.ts
+++ b/frontend/src/app/features/caches/cache-detail/cache-detail.component.ts
@@ -83,6 +83,24 @@ export class CacheDetailComponent implements OnInit {
     return `nix run wavelens/gradient#gradient-cli -- cache install-netrc --server ${this.serverUrl} --token <YOUR_TOKEN> --cache ${this.cacheName}`;
   }
 
+  get declerativeNetrcCode(): string {
+    return `
+{ config, ... }: {
+  sops.secrets."gradient-api-token" = { };
+  sops.templates."nix-netrc" = {
+    content = ''
+      maschine ${window.location.hostname}
+      login gradient
+      password \${config.sops.placeholder."gradient-api-token"}
+    '';
+    owner = "YOUR_USERNAME";
+  };
+  systemd.tmpfiles.rules = [
+    "L+ /etc/nix/netrc - - - - \${config.sops.templates."nix-netrc".path}"
+  ];
+}`;
+  }
+
   readonly windows: { key: Window; label: string }[] = [
     { key: 'minutes', label: 'Minutes' },
     { key: 'hours', label: 'Hours' },


### PR DESCRIPTION
This PR adds instructions to the Cache info page on how to install the netrc file to authenticate against a private cache.

<img width="1164" height="633" alt="image" src="https://github.com/user-attachments/assets/d8318858-db30-4c0f-991b-7d73f0867cdb" />


This closes issue #160