### PR TITLE
fix(scheduler): gate fetch flake jobs on fetch capability + adaptive fetch/eval split

### DIFF
--- a/backend/scheduler/src/dispatch.rs
+++ b/backend/scheduler/src/dispatch.rs
@@ -110,12 +110,19 @@ pub(crate) async fn dispatch_queued_evals(scheduler: &Scheduler) -> anyhow::Resu
                 .collect::<Vec<_>>()
         };
 
-        let flake_job = FlakeJob {
-            tasks: vec![
+        let split_fetch = scheduler.worker_pool.read().await.has_idle_eval_only_worker();
+        let tasks = if split_fetch {
+            vec![FlakeTask::FetchFlake]
+        } else {
+            vec![
                 FlakeTask::FetchFlake,
                 FlakeTask::EvaluateFlake,
                 FlakeTask::EvaluateDerivations,
-            ],
+            ]
+        };
+
+        let flake_job = FlakeJob {
+            tasks,
             source: gradient_core::types::proto::FlakeSource::Repository {
                 url: eval.repository.clone(),
                 commit: commit_sha,
@@ -150,7 +157,7 @@ pub(crate) async fn dispatch_queued_evals(scheduler: &Scheduler) -> anyhow::Resu
         };
 
         scheduler.enqueue_eval_job(job_id.clone(), pending).await;
-        debug!(evaluation_id = %eval.id, %job_id, "eval job enqueued");
+        debug!(evaluation_id = %eval.id, %job_id, split_fetch, "eval job enqueued");
     }
 
     Ok(())

--- a/backend/scheduler/src/job_handlers.rs
+++ b/backend/scheduler/src/job_handlers.rs
@@ -361,6 +361,34 @@ impl Scheduler {
         let job = self.job_tracker.write().await.remove_active(job_id);
         match job {
             Some(PendingJob::Eval(j)) => {
+                // Split mode: a fetch-only job just archived the source. Enqueue
+                // the cached eval follow-up instead of finalizing - eval has not run.
+                if crate::jobs::is_fetch_only(&j.job) {
+                    // Reusing the `eval:{id}` job id is safe: remove_active above
+                    // already evicted it from the active map.
+                    let store_path = EEvaluation::find_by_id(j.evaluation_id)
+                        .one(&self.state.worker_db)
+                        .await?
+                        .and_then(|e| e.flake_source);
+                    return match store_path {
+                        Some(path) => {
+                            let follow_id = format!("eval:{}", j.evaluation_id);
+                            self.enqueue_eval_job(follow_id, j.cached_followup(path)).await;
+                            info!(evaluation_id = %j.evaluation_id, "fetch complete; enqueued cached eval follow-up");
+                            Ok(())
+                        }
+                        None => {
+                            warn!(evaluation_id = %j.evaluation_id, "fetch-only job reported no flake_source; failing eval");
+                            eval::handle_eval_job_failed(
+                                &self.state,
+                                j.evaluation_id,
+                                "fetch completed but no flake source was archived",
+                            )
+                            .await
+                        }
+                    };
+                }
+
                 // Flush deferred dependency edges BEFORE promoting builds,
                 // so the dispatch SQL's dep-gating sees the full graph.
                 let deferred = self

--- a/backend/scheduler/src/job_handlers.rs
+++ b/backend/scheduler/src/job_handlers.rs
@@ -24,7 +24,7 @@ use gradient_core::types::proto::{
 use gradient_core::types::*;
 
 use crate::Scheduler;
-use crate::jobs::{Assignment, PendingBuildJob, PendingEvalJob, PendingJob, WorkerBuildCaps};
+use crate::jobs::{Assignment, PendingBuildJob, PendingEvalJob, PendingJob, WorkerCaps};
 use crate::worker_pool::WorkerInfo;
 use crate::{build, dispatch, eval};
 
@@ -579,22 +579,27 @@ impl Scheduler {
 
     // ── Private helpers ───────────────────────────────────────────────────────
 
-    /// Fetch the peer auth filter and build capabilities for a worker from the pool.
+    /// Fetch the peer auth filter and capabilities for a worker from the pool.
     async fn worker_auth_and_caps(
         &self,
         worker_id: &str,
-    ) -> (Option<HashSet<OrganizationId>>, Option<WorkerBuildCaps>) {
+    ) -> (Option<HashSet<OrganizationId>>, Option<WorkerCaps>) {
         let pool = self.worker_pool.read().await;
         let authorized = pool
             .peer_auth_for(worker_id)
             .and_then(|a| a.as_filter())
             .cloned();
-        let caps = pool
-            .build_caps_for(worker_id)
-            .map(|(a, f)| WorkerBuildCaps {
-                architectures: a,
-                system_features: f,
-            });
+        let caps = match (
+            pool.gradient_caps_for(worker_id),
+            pool.build_caps_for(worker_id),
+        ) {
+            (Some(g), Some((architectures, system_features))) => Some(WorkerCaps {
+                fetch: g.fetch,
+                architectures,
+                system_features,
+            }),
+            _ => None,
+        };
         (authorized, caps)
     }
 
@@ -604,7 +609,7 @@ impl Scheduler {
         &self,
         peer_id: &str,
         authorized: Option<&HashSet<OrganizationId>>,
-        caps: Option<&WorkerBuildCaps>,
+        caps: Option<&WorkerCaps>,
         kind: &JobKind,
     ) -> Option<Assignment> {
         let policy = Arc::clone(&self.policy);

--- a/backend/scheduler/src/jobs.rs
+++ b/backend/scheduler/src/jobs.rs
@@ -10,7 +10,7 @@ use std::collections::{HashMap, HashSet};
 
 use gradient_core::types::ids::{BuildId, CommitId, EvaluationId, OrganizationId, ProjectId};
 use gradient_core::types::proto::{
-    BuildJob, CandidateScore, FlakeJob, Job, JobCandidate, JobKind, RequiredPath,
+    BuildJob, CandidateScore, FlakeJob, FlakeTask, Job, JobCandidate, JobKind, RequiredPath,
 };
 
 use crate::policy::{JobContext, Policy, WorkerContext};
@@ -52,15 +52,20 @@ pub struct PendingBuildJob {
     pub queued_at: chrono::NaiveDateTime,
 }
 
-/// A connected worker's build-relevant capabilities, used to gate which
-/// build jobs are eligible for assignment.
+/// A connected worker's capabilities, used to gate which jobs are eligible
+/// for assignment: the `fetch` gradient capability plus the Nix architectures
+/// and system features it can build for.
 #[derive(Debug, Clone, Default)]
-pub struct WorkerBuildCaps {
+pub struct WorkerCaps {
+    /// Worker can fetch flake sources from a repository. Required for any
+    /// FlakeJob carrying a `FetchFlake` task, since the server only sends SSH
+    /// credentials to fetch-capable workers.
+    pub fetch: bool,
     pub architectures: Vec<String>,
     pub system_features: Vec<String>,
 }
 
-impl WorkerBuildCaps {
+impl WorkerCaps {
     /// Returns true when this worker can execute a build with the given
     /// `architecture` and `required_features`. `"builtin"` derivations
     /// (`builtin:fetchurl` etc.) run on any architecture.
@@ -143,16 +148,18 @@ pub struct Assignment {
     pub peer_id: OrganizationId,
 }
 
-/// Returns true when `job` is either an eval job (no arch constraint) or a
-/// build job whose architecture/features the worker can satisfy. If `caps` is
-/// `None`, capability checks are skipped (used for tests / open mode).
-fn job_eligible_for_caps(job: &PendingJob, caps: Option<&WorkerBuildCaps>) -> bool {
+/// Returns true when the worker can execute `job`: a flake job that fetches
+/// from a repository (carries `FetchFlake`) needs the `fetch` capability; a
+/// build job needs matching architecture/features. If `caps` is `None`,
+/// capability checks are skipped (used for tests / open mode).
+fn job_eligible_for_caps(job: &PendingJob, caps: Option<&WorkerCaps>) -> bool {
     match (job, caps) {
         // No capability info known → don't block (legacy behaviour for callers
         // that don't supply caps, e.g. unit tests for unrelated logic).
         (_, None) => true,
-        // Eval jobs aren't gated by build caps.
-        (PendingJob::Eval(_), Some(_)) => true,
+        // A repository-source flake job clones over the network and so requires
+        // `fetch`; eval-only follow-up jobs (cached source) run on any worker.
+        (PendingJob::Eval(j), Some(c)) => c.fetch || !j.job.tasks.contains(&FlakeTask::FetchFlake),
         (PendingJob::Build(j), Some(c)) => c.can_build(&j.architecture, &j.required_features),
     }
 }
@@ -187,13 +194,13 @@ impl JobTracker {
 
     /// Returns all pending job candidates that the worker is authorized to receive
     /// AND can execute. `caps` filters build jobs to those matching the worker's
-    /// architectures and system features; eval jobs are always eligible.
-    /// Pass `None` for `authorized` to disable peer filtering (open mode).
-    /// Pass `None` for `caps` to disable capability filtering (e.g. eval-only worker).
+    /// architectures and system features, and fetch flake jobs to fetch-capable
+    /// workers. Pass `None` for `authorized` to disable peer filtering (open mode).
+    /// Pass `None` for `caps` to disable capability filtering.
     pub fn candidates_for_worker(
         &self,
         authorized: Option<&HashSet<OrganizationId>>,
-        caps: Option<&WorkerBuildCaps>,
+        caps: Option<&WorkerCaps>,
     ) -> Vec<JobCandidate> {
         self.pending
             .iter()
@@ -233,7 +240,7 @@ impl JobTracker {
         &mut self,
         peer_id: &str,
         authorized: Option<&HashSet<OrganizationId>>,
-        caps: Option<&WorkerBuildCaps>,
+        caps: Option<&WorkerCaps>,
         kind: &JobKind,
         policy: &Policy,
     ) -> Option<Assignment> {
@@ -422,6 +429,32 @@ mod tests {
         })
     }
 
+    fn fetch_eval_job(peer: OrganizationId) -> PendingJob {
+        PendingJob::Eval(PendingEvalJob {
+            evaluation_id: EvaluationId::now_v7(),
+            project_id: None,
+            peer_id: peer,
+            commit_id: CommitId::now_v7(),
+            repository: "git+ssh://git@example.com/repo".into(),
+            job: FlakeJob {
+                tasks: vec![
+                    FlakeTask::FetchFlake,
+                    FlakeTask::EvaluateFlake,
+                    FlakeTask::EvaluateDerivations,
+                ],
+                source: FlakeSource::Repository {
+                    url: "git+ssh://git@example.com/repo".into(),
+                    commit: "abc123".into(),
+                },
+                wildcards: vec!["*".into()],
+                timeout_secs: None,
+                input_overrides: vec![],
+            },
+            required_paths: vec![],
+            queued_at: gradient_core::types::now(),
+        })
+    }
+
     fn build_job(peer: OrganizationId, required: Vec<RequiredPath>) -> PendingJob {
         build_job_arch(peer, required, "x86_64-linux", vec![])
     }
@@ -456,7 +489,8 @@ mod tests {
         // Worker with multiple architectures must accept a build whose target
         // matches ANY (not ALL) of its listed architectures. Guards against
         // `.any()` → `.all()` in the capability check.
-        let caps = WorkerBuildCaps {
+        let caps = WorkerCaps {
+            fetch: false,
             architectures: vec!["x86_64-linux".into(), "aarch64-linux".into()],
             system_features: vec![],
         };
@@ -469,7 +503,8 @@ mod tests {
     fn can_build_requires_all_features() {
         // Worker must provide EVERY required feature (not just one). Guards
         // against `.all()` → `.any()` in the feature check.
-        let caps = WorkerBuildCaps {
+        let caps = WorkerCaps {
+            fetch: false,
             architectures: vec!["x86_64-linux".into()],
             system_features: vec!["kvm".into()],
         };
@@ -527,7 +562,8 @@ mod tests {
             build_job_arch(peer, vec![], "builtin", vec![]),
         );
 
-        let x86_caps = WorkerBuildCaps {
+        let x86_caps = WorkerCaps {
+            fetch: false,
             architectures: vec!["x86_64-linux".into()],
             system_features: vec![],
         };
@@ -538,6 +574,66 @@ mod tests {
     }
 
     #[test]
+    fn fetch_flake_job_requires_fetch_capability() {
+        // Regression guard for #252: a FlakeJob carrying FetchFlake clones a
+        // repository (over SSH) and so must only be offered to fetch-capable
+        // workers - the server only sends SSH credentials to those. A worker
+        // without `fetch` (e.g. eval+build only) previously received the job
+        // and failed with "authentication required but no callback set".
+        let mut tracker = JobTracker::new();
+        let peer = OrganizationId::now_v7();
+        tracker.add_pending("j1".into(), fetch_eval_job(peer));
+
+        let no_fetch = WorkerCaps {
+            fetch: false,
+            architectures: vec!["x86_64-linux".into()],
+            system_features: vec![],
+        };
+        let p = Policy::default_build_policy();
+        assert!(
+            tracker
+                .take_best_of_kind("w1", None, Some(&no_fetch), &JobKind::Flake, &p)
+                .is_none(),
+            "worker without fetch must not receive a fetch flake job"
+        );
+        assert_eq!(tracker.pending_count(), 1);
+
+        let with_fetch = WorkerCaps {
+            fetch: true,
+            architectures: vec!["x86_64-linux".into()],
+            system_features: vec![],
+        };
+        assert!(
+            tracker
+                .take_best_of_kind("w2", None, Some(&with_fetch), &JobKind::Flake, &p)
+                .is_some(),
+            "fetch-capable worker must receive the fetch flake job"
+        );
+    }
+
+    #[test]
+    fn cached_eval_job_runs_without_fetch_capability() {
+        // Eval-only follow-up jobs (no FetchFlake task) read an already-cached
+        // source and must remain servable by workers that lack `fetch`.
+        let mut tracker = JobTracker::new();
+        let peer = OrganizationId::now_v7();
+        tracker.add_pending("j1".into(), eval_job(peer));
+
+        let no_fetch = WorkerCaps {
+            fetch: false,
+            architectures: vec![],
+            system_features: vec![],
+        };
+        let p = Policy::default_build_policy();
+        assert!(
+            tracker
+                .take_best_of_kind("w1", None, Some(&no_fetch), &JobKind::Flake, &p)
+                .is_some(),
+            "cached eval job must run on a worker without fetch"
+        );
+    }
+
+    #[test]
     fn test_take_best_of_kind_skips_wrong_arch() {
         let mut tracker = JobTracker::new();
         let peer = OrganizationId::now_v7();
@@ -545,7 +641,8 @@ mod tests {
             "arm".into(),
             build_job_arch(peer, vec![], "aarch64-linux", vec![]),
         );
-        let x86_caps = WorkerBuildCaps {
+        let x86_caps = WorkerCaps {
+            fetch: false,
             architectures: vec!["x86_64-linux".into()],
             system_features: vec![],
         };
@@ -565,11 +662,13 @@ mod tests {
             "kvm".into(),
             build_job_arch(peer, vec![], "x86_64-linux", vec!["kvm".into()]),
         );
-        let no_kvm = WorkerBuildCaps {
+        let no_kvm = WorkerCaps {
+            fetch: false,
             architectures: vec!["x86_64-linux".into()],
             system_features: vec![],
         };
-        let with_kvm = WorkerBuildCaps {
+        let with_kvm = WorkerCaps {
+            fetch: false,
             architectures: vec!["x86_64-linux".into()],
             system_features: vec!["kvm".into()],
         };

--- a/backend/scheduler/src/jobs.rs
+++ b/backend/scheduler/src/jobs.rs
@@ -266,12 +266,14 @@ impl JobTracker {
         let worker_ctx = caps.map(|c| WorkerContext {
             architectures: &c.architectures,
             system_features: &c.system_features,
+            fetch: c.fetch,
         });
         let empty_archs: Vec<String> = vec![];
         let empty_feats: Vec<String> = vec![];
         let fallback_ctx = WorkerContext {
             architectures: &empty_archs,
             system_features: &empty_feats,
+            fetch: false,
         };
         let worker_ctx = worker_ctx.as_ref().unwrap_or(&fallback_ctx);
 

--- a/backend/scheduler/src/jobs.rs
+++ b/backend/scheduler/src/jobs.rs
@@ -164,6 +164,12 @@ fn job_eligible_for_caps(job: &PendingJob, caps: Option<&WorkerCaps>) -> bool {
     }
 }
 
+/// True when a flake job's only task is `FetchFlake` — a split-mode fetch-only
+/// job whose completion enqueues a cached eval follow-up rather than finalizing.
+pub fn is_fetch_only(job: &FlakeJob) -> bool {
+    job.tasks.as_slice() == [FlakeTask::FetchFlake]
+}
+
 /// Per-job score submitted by a worker after checking its local store.
 #[derive(Debug, Clone, Default)]
 pub struct WorkerJobScore {
@@ -932,5 +938,29 @@ mod tests {
     fn remove_job_unknown_id_is_noop() {
         let mut tracker = JobTracker::new();
         tracker.remove_job("does-not-exist");
+    }
+
+    #[test]
+    fn is_fetch_only_true_only_for_fetch_task_alone() {
+        let fetch_only = FlakeJob {
+            tasks: vec![FlakeTask::FetchFlake],
+            source: FlakeSource::Repository { url: "u".into(), commit: "c".into() },
+            wildcards: vec!["*".into()],
+            timeout_secs: None,
+            input_overrides: vec![],
+        };
+        assert!(is_fetch_only(&fetch_only));
+
+        let bundled = FlakeJob {
+            tasks: vec![FlakeTask::FetchFlake, FlakeTask::EvaluateFlake, FlakeTask::EvaluateDerivations],
+            ..fetch_only.clone()
+        };
+        assert!(!is_fetch_only(&bundled));
+
+        let cached = FlakeJob {
+            tasks: vec![FlakeTask::EvaluateFlake, FlakeTask::EvaluateDerivations],
+            ..fetch_only.clone()
+        };
+        assert!(!is_fetch_only(&cached));
     }
 }

--- a/backend/scheduler/src/jobs.rs
+++ b/backend/scheduler/src/jobs.rs
@@ -10,7 +10,8 @@ use std::collections::{HashMap, HashSet};
 
 use gradient_core::types::ids::{BuildId, CommitId, EvaluationId, OrganizationId, ProjectId};
 use gradient_core::types::proto::{
-    BuildJob, CandidateScore, FlakeJob, FlakeTask, Job, JobCandidate, JobKind, RequiredPath,
+    BuildJob, CandidateScore, FlakeJob, FlakeSource, FlakeTask, Job, JobCandidate, JobKind,
+    RequiredPath,
 };
 
 use crate::policy::{JobContext, Policy, WorkerContext};
@@ -29,6 +30,16 @@ pub struct PendingEvalJob {
     /// `evaluation.updated_at` at the time this job was dispatched.
     /// Used by the scoring policy to prefer evaluations that have waited longer.
     pub queued_at: chrono::NaiveDateTime,
+}
+
+impl PendingEvalJob {
+    pub fn cached_followup(&self, store_path: String) -> PendingEvalJob {
+        let mut follow = self.clone();
+        follow.job.tasks = vec![FlakeTask::EvaluateFlake, FlakeTask::EvaluateDerivations];
+        follow.job.source = FlakeSource::Cached { store_path: store_path.clone() };
+        follow.required_paths = vec![RequiredPath { path: store_path, cache_info: None }];
+        follow
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -938,6 +949,28 @@ mod tests {
     fn remove_job_unknown_id_is_noop() {
         let mut tracker = JobTracker::new();
         tracker.remove_job("does-not-exist");
+    }
+
+    #[test]
+    fn cached_followup_rewrites_source_and_tasks() {
+        let peer = OrganizationId::now_v7();
+        let PendingJob::Eval(original) = fetch_eval_job(peer) else { unreachable!() };
+
+        let follow = original.cached_followup("/nix/store/abc-source".into());
+
+        assert_eq!(
+            follow.job.tasks,
+            vec![FlakeTask::EvaluateFlake, FlakeTask::EvaluateDerivations]
+        );
+        match &follow.job.source {
+            FlakeSource::Cached { store_path } => assert_eq!(store_path, "/nix/store/abc-source"),
+            other => panic!("expected Cached, got {other:?}"),
+        }
+        assert_eq!(follow.evaluation_id, original.evaluation_id);
+        assert_eq!(follow.peer_id, original.peer_id);
+        assert_eq!(follow.repository, original.repository);
+        assert_eq!(follow.required_paths.len(), 1);
+        assert!(follow.required_paths.iter().any(|p| p.path == "/nix/store/abc-source"));
     }
 
     #[test]

--- a/backend/scheduler/src/policy.rs
+++ b/backend/scheduler/src/policy.rs
@@ -232,6 +232,35 @@ impl Rule for WaitTimeRule {
     }
 }
 
+/// Reserve scarce fetch workers for fetch work: penalize a fetch-capable worker
+/// scoring a cached eval job (no `FetchFlake` task) so idle eval-only workers
+/// win it. A penalty, not a ban — a fetch worker with nothing else to do still
+/// takes the job rather than idle.
+#[derive(Debug)]
+pub struct ReserveFetchWorkersRule {
+    pub penalty: f64,
+}
+
+impl Default for ReserveFetchWorkersRule {
+    fn default() -> Self {
+        Self { penalty: 300.0 }
+    }
+}
+
+impl Rule for ReserveFetchWorkersRule {
+    fn score(&self, job: &JobContext<'_>, worker: &WorkerContext<'_>) -> f64 {
+        use gradient_core::types::proto::FlakeTask;
+        match job.job {
+            PendingJob::Eval(j)
+                if worker.fetch && !j.job.tasks.contains(&FlakeTask::FetchFlake) =>
+            {
+                -self.penalty
+            }
+            _ => 0.0,
+        }
+    }
+}
+
 // ── Policy ────────────────────────────────────────────────────────────────────
 
 /// Ordered collection of [`Rule`]s.
@@ -267,6 +296,7 @@ impl Policy {
     /// 3. [`DependencyCountRule`] - prefer builds that unblock more downstream work
     /// 4. [`WaitTimeRule`] - prevent starvation by boosting long-waiting builds
     /// 5. [`BuiltinDeprioritizeRule`] - keep real builds ahead of synthetic helpers
+    /// 6. [`ReserveFetchWorkersRule`] - keep scarce fetch workers free for fetch work
     pub fn default_build_policy() -> Self {
         let mut p = Self::new();
         p.add_rule(MissingPathsRule::default());
@@ -274,6 +304,7 @@ impl Policy {
         p.add_rule(DependencyCountRule::default());
         p.add_rule(WaitTimeRule::default());
         p.add_rule(BuiltinDeprioritizeRule::default());
+        p.add_rule(ReserveFetchWorkersRule::default());
         p
     }
 }
@@ -599,6 +630,82 @@ mod tests {
             "1-hour-old build must beat fresh fully-cached candidate \
              (anti-starvation): old={s_old} fresh={s_fresh}"
         );
+    }
+
+    #[test]
+    fn reserve_rule_penalizes_fetch_worker_for_cached_eval_only() {
+        use crate::jobs::{PendingEvalJob, PendingJob};
+        use gradient_core::types::ids::*;
+        use gradient_core::types::proto::{FlakeJob, FlakeSource, FlakeTask};
+
+        let cached_eval = PendingJob::Eval(PendingEvalJob {
+            evaluation_id: EvaluationId::now_v7(),
+            project_id: None,
+            peer_id: OrganizationId::now_v7(),
+            commit_id: CommitId::now_v7(),
+            repository: "r".into(),
+            job: FlakeJob {
+                tasks: vec![FlakeTask::EvaluateFlake, FlakeTask::EvaluateDerivations],
+                source: FlakeSource::Cached { store_path: "/nix/store/x".into() },
+                wildcards: vec!["*".into()],
+                timeout_secs: None,
+                input_overrides: vec![],
+            },
+            required_paths: vec![],
+            queued_at: gradient_core::types::now(),
+        });
+        let ctx = JobContext {
+            job: &cached_eval,
+            missing_count: None,
+            missing_nar_size: None,
+            dependency_count: 0,
+            queued_at: gradient_core::types::now(),
+        };
+        let rule = ReserveFetchWorkersRule::default();
+        let archs: Vec<String> = vec![];
+        let feats: Vec<String> = vec![];
+        let fetch_worker = WorkerContext { architectures: &archs, system_features: &feats, fetch: true };
+        let eval_worker = WorkerContext { architectures: &archs, system_features: &feats, fetch: false };
+
+        assert!(rule.score(&ctx, &fetch_worker) < 0.0, "fetch worker penalized");
+        assert_eq!(rule.score(&ctx, &eval_worker), 0.0, "eval-only worker not penalized");
+
+        // A fetch-only eval job (carries FetchFlake) is the fetch worker's own work - no penalty.
+        let fetch_only = PendingJob::Eval(PendingEvalJob {
+            evaluation_id: EvaluationId::now_v7(),
+            project_id: None,
+            peer_id: OrganizationId::now_v7(),
+            commit_id: CommitId::now_v7(),
+            repository: "r".into(),
+            job: FlakeJob {
+                tasks: vec![FlakeTask::FetchFlake],
+                source: FlakeSource::Repository { url: "u".into(), commit: "c".into() },
+                wildcards: vec!["*".into()],
+                timeout_secs: None,
+                input_overrides: vec![],
+            },
+            required_paths: vec![],
+            queued_at: gradient_core::types::now(),
+        });
+        let fetch_only_ctx = JobContext {
+            job: &fetch_only,
+            missing_count: None,
+            missing_nar_size: None,
+            dependency_count: 0,
+            queued_at: gradient_core::types::now(),
+        };
+        assert_eq!(rule.score(&fetch_only_ctx, &fetch_worker), 0.0, "fetch-only eval not penalized");
+
+        // Build jobs are irrelevant to the fetch-reservation rule — no penalty.
+        let (build_job, ..) = build_job_ctx("x86_64-linux", None, None);
+        let build_ctx = JobContext {
+            job: &build_job,
+            missing_count: None,
+            missing_nar_size: None,
+            dependency_count: 0,
+            queued_at: gradient_core::types::now(),
+        };
+        assert_eq!(rule.score(&build_ctx, &fetch_worker), 0.0, "build job not penalized for fetch worker");
     }
 
     #[test]

--- a/backend/scheduler/src/policy.rs
+++ b/backend/scheduler/src/policy.rs
@@ -46,6 +46,8 @@ pub struct JobContext<'a> {
 pub struct WorkerContext<'a> {
     pub architectures: &'a [String],
     pub system_features: &'a [String],
+    /// Whether the worker can fetch. Used to reserve fetch workers for fetch.
+    pub fetch: bool,
 }
 
 // ── Rule trait ────────────────────────────────────────────────────────────────
@@ -289,6 +291,7 @@ mod tests {
         WorkerContext {
             architectures: archs,
             system_features: features,
+            fetch: false,
         }
     }
 

--- a/backend/scheduler/src/scheduler_tests.rs
+++ b/backend/scheduler/src/scheduler_tests.rs
@@ -341,6 +341,79 @@ async fn record_eval_message_inserts_for_active_build_job() {
 }
 
 #[tokio::test]
+async fn fetch_only_completion_enqueues_cached_eval_followup() {
+    use entity::evaluation::EvaluationStatus;
+    use sea_orm::{DatabaseBackend, MockDatabase};
+    use test_support::prelude::*;
+
+    let eval_id = EvaluationId::now_v7();
+    let peer = OrganizationId::now_v7();
+    let source_path = "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-source";
+
+    let archived_eval = entity::evaluation::Model {
+        id: eval_id,
+        project: None,
+        repository: "https://example.com/repo".into(),
+        commit: CommitId::nil(),
+        wildcard: "*".into(),
+        status: EvaluationStatus::Building,
+        previous: None,
+        next: None,
+        created_at: gradient_core::types::now(),
+        updated_at: gradient_core::types::now(),
+        flake_source: Some(source_path.into()),
+        check_run_ids: None,
+        waiting_reason: None,
+        trigger: None,
+        concurrent: false,
+        source_comment: None,
+    };
+
+    let db = MockDatabase::new(DatabaseBackend::Postgres)
+        .append_query_results([vec![archived_eval]])
+        .into_connection();
+    let scheduler = Arc::new(Scheduler::new(test_state(db)));
+
+    let mut fetch_job = eval_job(peer);
+    fetch_job.evaluation_id = eval_id;
+    fetch_job.job.tasks = vec![FlakeTask::FetchFlake];
+    let job_id = format!("eval:{eval_id}");
+
+    scheduler.enqueue_eval_job(job_id.clone(), fetch_job).await;
+    scheduler
+        .register_worker(
+            "w1",
+            GradientCapabilities { eval: true, fetch: true, ..GradientCapabilities::default() },
+            HashSet::new(),
+        )
+        .await;
+    scheduler.request_job("w1", JobKind::Flake).await;
+
+    scheduler
+        .handle_job_completed("w1", &job_id)
+        .await
+        .expect("fetch-only completion should succeed");
+
+    assert_eq!(scheduler.pending_job_count().await, 1);
+
+    // The follow-up reuses the `eval:{id}` id and carries a cached source.
+    let assignment = scheduler
+        .request_job("w1", JobKind::Flake)
+        .await
+        .expect("cached eval follow-up should be assignable");
+    assert_eq!(assignment.job_id, job_id);
+    match assignment.job {
+        gradient_core::types::proto::Job::Flake(j) => match j.source {
+            gradient_core::types::proto::FlakeSource::Cached { store_path } => {
+                assert_eq!(store_path, source_path)
+            }
+            other => panic!("expected Cached source, got {other:?}"),
+        },
+        other => panic!("expected a Flake job, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn cancel_evaluation_jobs_drops_eval_and_build_jobs() {
     use gradient_core::types::proto::{BuildJob, BuildTask};
 

--- a/backend/scheduler/src/worker_pool.rs
+++ b/backend/scheduler/src/worker_pool.rs
@@ -227,6 +227,15 @@ impl WorkerPool {
         }
     }
 
+    pub fn has_idle_eval_only_worker(&self) -> bool {
+        self.workers.values().any(|slot| match slot {
+            WorkerSlot::Active(w) => {
+                w.capabilities.eval && !w.capabilities.fetch && w.assigned_jobs.is_empty()
+            }
+            WorkerSlot::Draining(_) => false,
+        })
+    }
+
     pub fn assign_job(&mut self, worker_id: &str, job_id: &str) {
         if let Some(slot) = self.workers.get_mut(worker_id) {
             slot.shared_mut().assigned_jobs.insert(job_id.to_owned());
@@ -291,6 +300,31 @@ mod tests {
 
     fn caps() -> GradientCapabilities {
         GradientCapabilities::default()
+    }
+
+    fn caps_ef(eval: bool, fetch: bool) -> GradientCapabilities {
+        GradientCapabilities { eval, fetch, ..GradientCapabilities::default() }
+    }
+
+    #[test]
+    fn idle_eval_only_worker_detected() {
+        let mut pool = WorkerPool::new();
+        pool.register("f1".into(), caps_ef(true, true), HashSet::new());
+        assert!(!pool.has_idle_eval_only_worker(), "only a fetch worker present");
+
+        pool.register("e1".into(), caps_ef(true, false), HashSet::new());
+        assert!(pool.has_idle_eval_only_worker(), "idle eval-only worker present");
+
+        pool.assign_job("e1", "j1");
+        assert!(!pool.has_idle_eval_only_worker(), "eval-only worker is busy");
+    }
+
+    #[test]
+    fn draining_eval_only_worker_does_not_count() {
+        let mut pool = WorkerPool::new();
+        pool.register("e1".into(), caps_ef(true, false), HashSet::new());
+        pool.mark_draining("e1");
+        assert!(!pool.has_idle_eval_only_worker(), "draining worker excluded");
     }
 
     #[test]

--- a/backend/worker/src/executor/eval.rs
+++ b/backend/worker/src/executor/eval.rs
@@ -92,6 +92,16 @@ pub async fn evaluate_flake(_job: &FlakeJob, updater: &mut JobUpdater) -> Result
     updater.report_evaluating_flake()
 }
 
+/// For a `Cached` source, the store path that must be present locally before
+/// evaluation (substituted from the gradient cache if absent). A `Repository`
+/// source is fetched/cloned by the worker itself, so nothing to ensure.
+pub fn required_local_source(source: &FlakeSource) -> Option<&str> {
+    match source {
+        FlakeSource::Cached { store_path } => Some(store_path.as_str()),
+        FlakeSource::Repository { .. } => None,
+    }
+}
+
 /// Number of derivations to accumulate before flushing a mid-walk `EvalResult`.
 const EVAL_BATCH_SIZE: usize = 50;
 
@@ -600,6 +610,19 @@ mod tests {
         let drv_reader = FakeDrvReader::from_raw_drvs(fixture.raw_drvs.clone());
 
         (resolver, drv_reader)
+    }
+
+    #[test]
+    fn cached_source_requires_store_path_present() {
+        let cached = FlakeSource::Cached {
+            store_path: "/nix/store/abc-source".into(),
+        };
+        assert_eq!(required_local_source(&cached), Some("/nix/store/abc-source"));
+        let repo = FlakeSource::Repository {
+            url: "u".into(),
+            commit: "c".into(),
+        };
+        assert_eq!(required_local_source(&repo), None);
     }
 
     #[tokio::test]

--- a/backend/worker/src/executor/mod.rs
+++ b/backend/worker/src/executor/mod.rs
@@ -227,6 +227,16 @@ impl JobExecutor {
                 }
                 FlakeTask::EvaluateFlake => eval::evaluate_flake(&job, updater).await?,
                 FlakeTask::EvaluateDerivations => {
+                    // A `Cached` source was archived to a *different* worker's
+                    // store and pushed to the cache; substitute it locally
+                    // before eval, since nix won't pull a `path:` flake ref
+                    // from a binary cache.
+                    if local_flake_path.is_none()
+                        && let Some(src) = eval::required_local_source(&job.source)
+                    {
+                        crate::proto::nar_import::ensure_path(&self.store, src, updater).await?;
+                    }
+
                     let produced_drvs = eval::evaluate_derivations(
                         &self.evaluator,
                         &job,

--- a/backend/worker/src/proto/nar_import.rs
+++ b/backend/worker/src/proto/nar_import.rs
@@ -82,9 +82,9 @@ enum ClosureMode {
 struct InputPrefetcher<'a> {
     store: &'a LocalNixStore,
     /// Derivation path of the build task (used for logging and cache queries).
-    drv_path: &'a str,
+    drv_path: String,
     /// Build ID (used for logging only).
-    build_id: &'a str,
+    build_id: String,
     /// Live WS connection back to the server (used for `CacheQuery` /
     /// `NarRequest`). Requires `&mut` because sending advances the framing state.
     updater: &'a mut JobUpdater,
@@ -94,8 +94,20 @@ impl<'a> InputPrefetcher<'a> {
     fn new(store: &'a LocalNixStore, task: &'a BuildTask, updater: &'a mut JobUpdater) -> Self {
         Self {
             store,
-            drv_path: &task.drv_path,
-            build_id: &task.build_id,
+            drv_path: task.drv_path.clone(),
+            build_id: task.build_id.clone(),
+            updater,
+        }
+    }
+
+    /// Construct a prefetcher not tied to a `BuildTask` - used by
+    /// [`ensure_path`] to substitute a single store path (and its closure)
+    /// without a build context. `label` only feeds logging.
+    fn for_path(store: &'a LocalNixStore, label: String, updater: &'a mut JobUpdater) -> Self {
+        Self {
+            store,
+            drv_path: label.clone(),
+            build_id: label,
             updater,
         }
     }
@@ -117,7 +129,7 @@ impl<'a> InputPrefetcher<'a> {
     /// outputs are by construction not cached (we're about to produce them),
     /// and the daemon doesn't need them present to accept the `.drv` import.
     async fn ensure_self_drv_present(&mut self) -> Result<()> {
-        let full_drv_path = nix_store_path(self.drv_path);
+        let full_drv_path = nix_store_path(&self.drv_path);
         if tokio::fs::try_exists(&full_drv_path).await.unwrap_or(false) {
             return Ok(());
         }
@@ -146,7 +158,7 @@ impl<'a> InputPrefetcher<'a> {
     /// Reads `input_sources` (plain paths) and the output paths of each
     /// `input_derivation` by parsing their `.drv` files.
     async fn enumerate_inputs(&self) -> Result<HashSet<String>> {
-        let full_drv_path = nix_store_path(self.drv_path);
+        let full_drv_path = nix_store_path(&self.drv_path);
         let drv_bytes = tokio::fs::read(&full_drv_path)
             .await
             .with_context(|| format!("read .drv {} for prefetch", full_drv_path))?;
@@ -633,6 +645,28 @@ pub async fn prefetch_inputs(
         }
     }
     result
+}
+
+/// Ensure a single store path (plus its transitive runtime closure) is present
+/// in the local nix store, substituting it from the gradient cache when absent.
+///
+/// Used before evaluating a `FlakeSource::Cached` flake: the fetch ran on a
+/// different worker, so the archived source store path is only in the binary
+/// cache, not this worker's local store. `nix` won't substitute a `path:` flake
+/// ref from a cache, so we pull it in ourselves first. Reuses the same
+/// closure-expanding `CacheQuery Pull → download → import` pipeline as
+/// [`prefetch_inputs`].
+pub async fn ensure_path(
+    store: &LocalNixStore,
+    path: &str,
+    updater: &mut JobUpdater,
+) -> Result<()> {
+    if store.has_path(path).await? {
+        return Ok(());
+    }
+    InputPrefetcher::for_path(store, path.to_owned(), updater)
+        .fetch_closure(vec![path.to_owned()], ClosureMode::FollowOutputs)
+        .await
 }
 
 /// Worker side of an `external_cached` build: the build's outputs are

--- a/docs/src/scheduler.md
+++ b/docs/src/scheduler.md
@@ -57,3 +57,25 @@ from that upstream's `/log/{drv}` endpoint (the same one the Gradient cache
 exposes). If the upstream serves the log, it is stored under the same build
 record so the build's log tab shows it just like a locally-built one. If no
 upstream serves the log, the build is recorded without one.
+
+## Adaptive fetch/eval split
+
+When the scheduler detects an idle dedicated eval-only worker — determined by
+checking whether any connected worker is eval-only (fetch capability absent)
+and has no currently assigned job — it splits a flake evaluation into two
+sequential jobs instead of dispatching the usual bundled fetch+eval job. The
+split is a heuristic: if no idle eval-only worker exists at dispatch time, the
+original bundled job is issued unchanged.
+
+The first job (`FetchFlake` task only, `FlakeSource::Repository`) is routed
+exclusively to a fetch-capable worker; once it completes, the scheduler reads
+`evaluation.flake_source` from the finished job and immediately enqueues a
+cached-eval follow-up (`EvaluateFlake` + `EvaluateDerivations` tasks,
+`FlakeSource::Cached`) that any eval worker can run. The eval worker
+substitutes the cached source NAR from the gradient binary cache into its
+local store before evaluating, since a `path:` flakeref must point to a
+locally-present path. The `ReserveFetchWorkersRule` scoring policy applies a
+penalty when a fetch-capable worker is offered a cached-eval job, steering
+those workers toward fetch work; it is a soft steer rather than a ban, so a
+fetch worker still accepts cached-eval jobs when no other candidate is
+available.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -2779,3 +2779,26 @@ Run with: `cargo test -p scheduler --lib jobs`
   assigned to a worker lacking `fetch`, but is assigned to a fetch-capable one.
 - `cached_eval_job_runs_without_fetch_capability` — an eval-only follow-up job
   (cached source, no `FetchFlake`) still runs on a worker without `fetch`.
+
+## Adaptive fetch/eval split
+
+When an idle dedicated eval worker is connected, the scheduler dispatches a
+fetch-only flake job to a fetch worker and hands evaluation to the eval pool via
+a cached-source follow-up; a scoring penalty keeps fetch workers free. The eval
+worker substitutes the cached source from the binary cache before evaluating.
+
+Run with: `cargo test -p scheduler --lib` and `cargo test -p worker --lib`
+
+- `worker_pool::tests::idle_eval_only_worker_detected` /
+  `draining_eval_only_worker_does_not_count` — the split heuristic (an idle,
+  non-draining eval-only worker triggers the split).
+- `jobs::tests::is_fetch_only_true_only_for_fetch_task_alone` — recognises a
+  fetch-only job by its task list.
+- `jobs::tests::cached_followup_rewrites_source_and_tasks` — builds the cached
+  eval follow-up (Cached source, eval tasks, source as a required path).
+- `scheduler_tests::fetch_only_completion_enqueues_cached_eval_followup` — a
+  completed fetch-only job enqueues the cached eval follow-up reusing its id.
+- `policy::tests::reserve_rule_penalizes_fetch_worker_for_cached_eval_only` —
+  fetch workers are penalised for cached-eval jobs, eval-only workers are not.
+- `executor::eval::tests::cached_source_requires_store_path_present` — the
+  worker substitutes the cached source before eval.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -2763,3 +2763,19 @@ Run with: `cargo test -p core --test ip_allowlist`
 - `cargo test -p proto --lib handler::cache_session` — read-only message allow-list.
 - `cargo test -p proto --lib handler::limiter` — per-IP connection cap.
 - `cargo test -p proto --lib handler::cache_consumer` — ws URL building.
+
+## Fetch-capability gating for flake jobs (#252)
+
+A `FlakeJob` carrying a `FetchFlake` task clones its source repository (over
+SSH for private repos), and the server only sends SSH credentials to
+fetch-capable workers. Assigning such a job to a worker without the `fetch`
+capability left it cloning with no credentials callback, failing with
+`authentication required but no callback set`. The scheduler now gates these
+jobs on the worker's `fetch` capability.
+
+Run with: `cargo test -p scheduler --lib jobs`
+
+- `fetch_flake_job_requires_fetch_capability` — a `FetchFlake` flake job is not
+  assigned to a worker lacking `fetch`, but is assigned to a fetch-capable one.
+- `cached_eval_job_runs_without_fetch_capability` — an eval-only follow-up job
+  (cached source, no `FetchFlake`) still runs on a worker without `fetch`.


### PR DESCRIPTION
## Part 1 — Fix #252: SSH fetch failing (root cause: job assignment)

`authentication required but no callback set; class=Ssh` was a **job-assignment** bug, not an SSH bug (as the reporter suspected):

1. Every repository `FlakeJob` is dispatched with a `Repository` source + `FetchFlake` task, which requires the `fetch` capability.
2. The scheduler's `job_eligible_for_caps` returned `true` for **all** eval jobs — never checking the worker's `fetch` capability — so a worker with only `eval`+`build` could be assigned the clone job.
3. `send_credentials_for_job` correctly sends the SSH key **only** to fetch-capable workers, so the non-fetch worker got `has_ssh_key=false`.
4. `clone_and_checkout` registers a git2 credentials callback only when a key is present → libgit2 fails with exactly that error.

**Fix:** gate flake-job eligibility on the `fetch` capability when the job carries `FetchFlake`, symmetric with credential delivery. `WorkerBuildCaps` → `WorkerCaps` carries the `fetch` flag from the negotiated `GradientCapabilities`.

Fixes #252.

## Part 2 — Adaptive fetch/eval split

Builds on the capability gate to free scarce fetch workers. When an **idle dedicated eval-only worker** is connected, a flake eval is split:

- a **fetch-only** job (`[FetchFlake]`, `Repository`) runs on a fetch worker, archives the source and pushes its NAR to the cache;
- on completion the server reads `evaluation.flake_source` and enqueues a **cached eval follow-up** (`[EvaluateFlake, EvaluateDerivations]`, `FlakeSource::Cached`) that **any** eval worker runs, substituting the source NAR from the cache first.

When no idle eval-only worker exists, the original bundled fetch+eval job is dispatched unchanged. A `ReserveFetchWorkersRule` scoring penalty steers fetch workers away from cached-eval jobs (a soft steer, not a ban — no starvation).

## Tests
TDD throughout (`cargo test -p scheduler --lib`, `-p worker --lib`):
- `worker_pool`: `idle_eval_only_worker_detected`, `draining_eval_only_worker_does_not_count`
- `jobs`: `fetch_flake_job_requires_fetch_capability`, `cached_eval_job_runs_without_fetch_capability`, `is_fetch_only_*`, `cached_followup_rewrites_source_and_tasks`
- `scheduler_tests`: `fetch_only_completion_enqueues_cached_eval_followup`
- `policy`: `reserve_rule_penalizes_fetch_worker_for_cached_eval_only`
- `worker eval`: `cached_source_requires_store_path_present`

Docs updated: `docs/src/tests.md`, `docs/src/scheduler.md`.

## Follow-up ideas (not in this PR)
- Gate the split on a fetch worker also being present (`has_idle_eval_only_worker() && has_fetch_worker()`).
- `warn!` when a fetch-only job's source NAR push fails (it's load-bearing for the follow-up's substitution).