### PR TITLE
fix: maintainer forge approval bypass + wildcard eval check name (#298)

### DIFF
--- a/backend/core/src/ci/actions.rs
+++ b/backend/core/src/ci/actions.rs
@@ -587,7 +587,9 @@ async fn build_ci_report_from_payload(
             None => return Ok(None),
         },
         Some(reporting::CheckContextKind::Evaluation) | None => {
-            reporting::evaluation_check_context(&project.name)
+            let wildcard_suffix =
+                (evaluation.wildcard != project.wildcard).then_some(evaluation.wildcard.as_str());
+            reporting::evaluation_check_context(&project.name, wildcard_suffix)
         }
     };
 

--- a/backend/core/src/ci/reporting.rs
+++ b/backend/core/src/ci/reporting.rs
@@ -27,9 +27,15 @@ pub fn approval_check_context(project_name: &str) -> String {
     format!("gradient/{}: Approval", project_name)
 }
 
-/// CI check name for the per-evaluation roll-up status.
-pub fn evaluation_check_context(project_name: &str) -> String {
-    format!("gradient/{}: Evaluation", project_name)
+/// CI check name for the per-evaluation roll-up status. `wildcard_suffix` is
+/// `Some` only when a run targets a wildcard other than the project default
+/// (e.g. `/gradient run <wildcard>`), so that custom-wildcard runs report as
+/// their own check line instead of overwriting the default evaluation check.
+pub fn evaluation_check_context(project_name: &str, wildcard_suffix: Option<&str>) -> String {
+    match wildcard_suffix {
+        Some(w) => format!("gradient/{}: Evaluation: {}", project_name, w),
+        None => format!("gradient/{}: Evaluation", project_name),
+    }
 }
 
 /// CI check name for a single entry-point build under an evaluation.
@@ -130,8 +136,16 @@ mod tests {
     #[test]
     fn evaluation_context_format() {
         assert_eq!(
-            evaluation_check_context("my-project"),
+            evaluation_check_context("my-project", None),
             "gradient/my-project: Evaluation"
+        );
+    }
+
+    #[test]
+    fn evaluation_context_format_with_custom_wildcard() {
+        assert_eq!(
+            evaluation_check_context("my-project", Some("packages.x86_64-linux.foo")),
+            "gradient/my-project: Evaluation: packages.x86_64-linux.foo"
         );
     }
 

--- a/backend/web/src/endpoints/forge_hooks/events.rs
+++ b/backend/web/src/endpoints/forge_hooks/events.rs
@@ -68,6 +68,8 @@ pub(super) struct GitHubPullRequestPayload {
     pub action: String,
     pub pull_request: GitHubPullRequest,
     pub repository: GitHubRepository,
+    #[serde(default)]
+    pub sender: Option<GitHubUser>,
 }
 
 #[derive(Deserialize)]
@@ -127,6 +129,8 @@ pub(super) struct GiteaPullRequestPayload {
     pub action: String,
     pub pull_request: GiteaPullRequest,
     pub repository: GiteaRepository,
+    #[serde(default)]
+    pub sender: Option<GiteaUser>,
 }
 
 #[derive(Deserialize)]
@@ -266,6 +270,11 @@ pub(super) struct ParsedPullRequestEvent {
     pub pr_number: Option<u64>,
     /// Login/username of the PR author.
     pub pr_author: Option<String>,
+    /// Login/username of the actor who triggered this event (the pusher on a
+    /// `synchronize`, the opener on `opened`). Distinct from `pr_author` when a
+    /// maintainer force-pushes onto a contributor's branch. Used to bypass the
+    /// approval gate when the actor is a trusted repo writer.
+    pub sender: Option<String>,
     /// `true` when the head repo is not the base repo (i.e. the PR comes
     /// from a fork). `false` when same-repo. `None` when the payload lacks
     /// enough information to decide - callers should treat as untrusted.
@@ -468,6 +477,7 @@ impl ParsedPullRequestEvent {
             .user
             .as_ref()
             .and_then(|u| u.login.clone());
+        let sender = payload.sender.as_ref().and_then(|s| s.login.clone());
         let mut repository_urls = Vec::with_capacity(4);
         let mut head_repo_clone_url: Option<String> = None;
         if let (Some(true), Some(repo)) = (is_fork, head_repo) {
@@ -488,6 +498,7 @@ impl ParsedPullRequestEvent {
             branch: Some(payload.pull_request.head.branch),
             pr_number: payload.pull_request.number,
             pr_author,
+            sender,
             is_fork,
             head_repo_clone_url,
         })
@@ -529,6 +540,10 @@ impl ParsedPullRequestEvent {
             .user
             .as_ref()
             .and_then(|u| u.username.clone().or_else(|| u.login.clone()));
+        let sender = payload
+            .sender
+            .as_ref()
+            .and_then(|s| s.username.clone().or_else(|| s.login.clone()));
         let mut repository_urls = Vec::with_capacity(4);
         let mut head_repo_clone_url: Option<String> = None;
         if let (Some(true), Some(repo)) = (is_fork, head_repo) {
@@ -548,6 +563,7 @@ impl ParsedPullRequestEvent {
             branch,
             pr_number: payload.pull_request.number,
             pr_author,
+            sender,
             is_fork,
             head_repo_clone_url,
         })
@@ -575,6 +591,7 @@ impl ParsedPullRequestEvent {
             _ => None,
         };
         let pr_author = payload.user.as_ref().and_then(|u| u.username.clone());
+        let sender = pr_author.clone();
         let mut repository_urls = Vec::with_capacity(4);
         let mut head_repo_clone_url: Option<String> = None;
         if let (Some(true), Some(src)) = (is_fork, payload.object_attributes.source.as_ref()) {
@@ -594,6 +611,7 @@ impl ParsedPullRequestEvent {
             branch: Some(payload.object_attributes.source_branch),
             pr_number: payload.object_attributes.iid,
             pr_author,
+            sender,
             is_fork,
             head_repo_clone_url,
         })
@@ -766,6 +784,75 @@ mod tests {
         assert_eq!(ev.pr_number, Some(42));
         assert_eq!(ev.pr_author.as_deref(), Some("external-contrib"));
         assert_eq!(ev.is_fork, Some(true));
+    }
+
+    #[test]
+    fn github_pr_sender_distinct_from_author_on_force_push() {
+        let body = format!(
+            r#"{{
+                "action": "synchronize",
+                "sender": {{ "login": "maintainer" }},
+                "pull_request": {{
+                    "number": 42,
+                    "user": {{ "login": "external-contrib" }},
+                    "head": {{
+                        "sha": "{VALID_SHA}",
+                        "ref": "patch-1",
+                        "repo": {{ "full_name": "external-contrib/repo" }}
+                    }},
+                    "base": {{
+                        "sha": "0000000000000000000000000000000000000000",
+                        "ref": "main",
+                        "repo": {{ "full_name": "org/repo" }}
+                    }}
+                }},
+                "repository": {{
+                    "clone_url": "https://github.com/org/repo.git",
+                    "ssh_url": "git@github.com:org/repo.git",
+                    "full_name": "org/repo"
+                }}
+            }}"#
+        );
+        let ev = ParsedPullRequestEvent::from_github(body.as_bytes()).unwrap();
+        assert_eq!(ev.is_fork, Some(true));
+        assert_eq!(ev.pr_author.as_deref(), Some("external-contrib"));
+        assert_eq!(ev.sender.as_deref(), Some("maintainer"));
+    }
+
+    #[test]
+    fn gitea_pr_parses_sender_login() {
+        let body = format!(
+            r#"{{
+                "action": "synchronize",
+                "sender": {{ "username": "maintainer" }},
+                "pull_request": {{
+                    "user": {{ "username": "external-contrib" }},
+                    "head": {{ "sha": "{VALID_SHA}", "ref": "feat" }}
+                }},
+                "repository": {{ "clone_url": "https://gitea.example.com/org/repo.git" }}
+            }}"#
+        );
+        let ev = ParsedPullRequestEvent::from_gitea(body.as_bytes()).unwrap();
+        assert_eq!(ev.pr_author.as_deref(), Some("external-contrib"));
+        assert_eq!(ev.sender.as_deref(), Some("maintainer"));
+    }
+
+    #[test]
+    fn gitlab_mr_sender_falls_back_to_event_user() {
+        let body = format!(
+            r#"{{
+                "object_attributes": {{
+                    "action": "update",
+                    "iid": 11,
+                    "source_branch": "feat",
+                    "last_commit": {{ "id": "{VALID_SHA}" }}
+                }},
+                "project": {{ "http_url": "https://gitlab.example.com/group/repo.git" }},
+                "user": {{ "username": "maintainer" }}
+            }}"#
+        );
+        let ev = ParsedPullRequestEvent::from_gitlab(body.as_bytes()).unwrap();
+        assert_eq!(ev.sender.as_deref(), Some("maintainer"));
     }
 
     #[test]

--- a/backend/web/src/endpoints/forge_hooks/mod.rs
+++ b/backend/web/src/endpoints/forge_hooks/mod.rs
@@ -292,6 +292,7 @@ fn approval_context_from(parsed: &ParsedPullRequestEvent) -> trigger::PullReques
         pr_number: parsed.pr_number,
         pr_author: parsed.pr_author.clone(),
         is_fork: parsed.is_fork,
+        sender: parsed.sender.clone(),
     }
 }
 

--- a/backend/web/src/endpoints/forge_hooks/trigger.rs
+++ b/backend/web/src/endpoints/forge_hooks/trigger.rs
@@ -10,7 +10,7 @@ use super::response::{QueuedEvaluation, SkippedProject, WebhookTriggerOutcome};
 use entity::project_trigger as ept;
 use gradient_core::ci::{
     APPROVAL_ACTION_ID, ApplyInput, ApplyOutcome, ApprovalInfo, ForgeType, apply_trigger,
-    find_approval_gated_eval, set_evaluation_source_comment, unpark_approval,
+    find_approval_gated_eval, parse_owner_repo, set_evaluation_source_comment, unpark_approval,
     unpark_approval_with_wildcard,
 };
 use gradient_core::types::triggers::{TriggerConfig, TriggerType};
@@ -33,6 +33,10 @@ pub(super) struct PullRequestApprovalContext {
     pub pr_number: Option<u64>,
     pub pr_author: Option<String>,
     pub is_fork: Option<bool>,
+    /// Login of the actor who triggered this PR event. When this actor is a
+    /// trusted repo writer the approval gate is bypassed, so a maintainer
+    /// force-pushing onto a contributor's branch does not re-park the run.
+    pub sender: Option<String>,
 }
 
 // ── GitHub installation payload ────────────────────────────────────────────
@@ -488,7 +492,7 @@ where
             .unwrap_or_default();
 
         let gate_approval = if pr_require_approval {
-            decide_pr_gate(approval_ctx.as_ref()).await
+            decide_pr_gate(state, &project, approval_ctx.as_ref()).await
         } else {
             None
         };
@@ -572,11 +576,40 @@ where
 /// Resolves whether a PR webhook fire should be gated on maintainer approval.
 ///
 /// Fail-closed: returns `Some(ApprovalInfo)` whenever the PR is (or might be) a
-/// fork, deferring the trust decision to maintainers via the forge UI / `/ci
-/// run` comment. Same-repo PRs (`is_fork == Some(false)`) bypass the gate.
-async fn decide_pr_gate(ctx: Option<&PullRequestApprovalContext>) -> Option<ApprovalInfo> {
+/// fork, deferring the trust decision to maintainers via the forge UI /
+/// `/gradient run` comment. The gate is bypassed when:
+/// - the PR is same-repo (`is_fork == Some(false)`), or
+/// - the actor who triggered the event (`sender`) is a trusted repo writer,
+///   so a maintainer force-pushing onto a contributor's branch runs without
+///   re-parking.
+async fn decide_pr_gate(
+    state: &Arc<ServerState>,
+    project: &MProject,
+    ctx: Option<&PullRequestApprovalContext>,
+) -> Option<ApprovalInfo> {
     let ctx = ctx?;
-    if matches!(ctx.is_fork, Some(false)) {
+    let sender_trusted = match ctx.sender.as_deref() {
+        Some(sender) if !matches!(ctx.is_fork, Some(false)) => {
+            match parse_owner_repo(&project.repository) {
+                Some((owner, repo)) => {
+                    sender_is_trusted(state, project.id, &owner, &repo, sender).await
+                }
+                None => false,
+            }
+        }
+        _ => false,
+    };
+    gate_decision(ctx, sender_trusted)
+}
+
+/// Pure approval-gate decision given whether the event's actor is a trusted
+/// repo writer. Returns `None` (run immediately) when the PR is same-repo or
+/// the actor is trusted; otherwise `Some(ApprovalInfo)` to park for approval.
+fn gate_decision(
+    ctx: &PullRequestApprovalContext,
+    sender_trusted: bool,
+) -> Option<ApprovalInfo> {
+    if matches!(ctx.is_fork, Some(false)) || sender_trusted {
         return None;
     }
     Some(ApprovalInfo {
@@ -1219,10 +1252,14 @@ pub(super) async fn handle_issue_comment(
                 continue;
             }
         };
+        // The maintainer running `/gradient run` was already trust-verified
+        // above, so `sender` lets `decide_pr_gate` bypass the approval gate -
+        // the command itself is the approval, even on a fork PR.
         let approval_ctx = PullRequestApprovalContext {
             pr_number: Some(pr_number),
             pr_author: None,
             is_fork: Some(snapshot.is_fork),
+            sender: Some(sender.clone()),
         };
         let source_comment_json = reaction_target.as_ref().map(|t| {
             serde_json::json!({
@@ -1500,9 +1537,55 @@ async fn active_project_ids_for_integration(
 mod tests {
     use super::super::WebhookTriggerOutcome;
     use super::{
-        GradientCommand, glob_match_pattern, glob_matches, normalize_repo_url,
-        parse_gradient_command,
+        GradientCommand, PullRequestApprovalContext, gate_decision, glob_match_pattern,
+        glob_matches, normalize_repo_url, parse_gradient_command,
     };
+
+    fn fork_ctx() -> PullRequestApprovalContext {
+        PullRequestApprovalContext {
+            pr_number: Some(7),
+            pr_author: Some("external".into()),
+            is_fork: Some(true),
+            sender: Some("maintainer".into()),
+        }
+    }
+
+    #[test]
+    fn gate_same_repo_pr_bypasses() {
+        let ctx = PullRequestApprovalContext {
+            is_fork: Some(false),
+            ..fork_ctx()
+        };
+        assert!(gate_decision(&ctx, false).is_none());
+    }
+
+    #[test]
+    fn gate_fork_untrusted_sender_parks() {
+        let gate = gate_decision(&fork_ctx(), false).expect("fork PR must park");
+        assert_eq!(gate.pr_number, 7);
+        assert_eq!(gate.pr_author, "external");
+    }
+
+    #[test]
+    fn gate_fork_trusted_sender_bypasses() {
+        assert!(
+            gate_decision(&fork_ctx(), true).is_none(),
+            "a trusted maintainer (force-push / command) must bypass the gate"
+        );
+    }
+
+    #[test]
+    fn gate_unknown_fork_status_fails_closed() {
+        let ctx = PullRequestApprovalContext {
+            is_fork: None,
+            sender: None,
+            ..fork_ctx()
+        };
+        assert!(
+            gate_decision(&ctx, false).is_some(),
+            "uncertain fork status with untrusted sender must park"
+        );
+    }
 
     #[test]
     fn normalize_strips_dot_git_suffix() {

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -2802,3 +2802,35 @@ Run with: `cargo test -p scheduler --lib` and `cargo test -p worker --lib`
   fetch workers are penalised for cached-eval jobs, eval-only workers are not.
 - `executor::eval::tests::cached_source_requires_store_path_present` — the
   worker substitutes the cached source before eval.
+
+## Forge integration - maintainer approval bypass & wildcard check name (#298)
+
+A fork-PR approval gate must not re-park runs initiated by a maintainer, and a
+command-driven run with a custom wildcard must report under its own check line.
+
+The gate decision is split from its forge probe: `decide_pr_gate` resolves
+whether the event's actor is a trusted repo writer (via `sender_is_trusted`),
+then delegates the branching to the pure `gate_decision`. A `/gradient run`
+that creates a fresh evaluation, and a maintainer force-push onto a
+contributor's branch (`synchronize`), both thread the event `sender` so the
+gate is bypassed once the actor is verified.
+
+The Evaluation check name gains a wildcard suffix
+(`gradient/{project}: Evaluation: {wildcard}`) whenever the evaluation's
+wildcard differs from the project default.
+
+Run with: `cargo test -p web --lib forge_hooks` and
+`cargo test -p core --tests ci::reporting`.
+
+- `trigger::tests::gate_same_repo_pr_bypasses` — same-repo PR runs without a gate.
+- `trigger::tests::gate_fork_untrusted_sender_parks` — fork PR with an
+  untrusted sender parks for approval (carrying PR number/author).
+- `trigger::tests::gate_fork_trusted_sender_bypasses` — a trusted maintainer
+  (force-push / command) bypasses the gate.
+- `trigger::tests::gate_unknown_fork_status_fails_closed` — uncertain fork
+  status with an untrusted sender parks (fail-closed).
+- `events::tests::github_pr_sender_distinct_from_author_on_force_push` /
+  `gitea_pr_parses_sender_login` / `gitlab_mr_sender_falls_back_to_event_user`
+  — the event actor is parsed independently of the PR author.
+- `reporting::tests::evaluation_context_format_with_custom_wildcard` — custom
+  wildcard produces `gradient/{project}: Evaluation: {wildcard}`.

--- a/docs/src/usage/actions.md
+++ b/docs/src/usage/actions.md
@@ -84,6 +84,10 @@ Token management: the plaintext token is revealed exactly once — on create or 
 
 Posts commit status (pending / success / failure / action-required) back to the forge as three separate check runs per PR — `gradient/{project}: Approval` (fork-PR gate), `gradient/{project}: Evaluation` (eval phase), and `gradient/{project}: Build {label}` (one per build, labelled by entry-point name or by `{drv-name}.{architecture}` when no entry-point matched). Each check is updated in place as the phase progresses; the Approval check flips to Success when a maintainer clears the gate, and the Evaluation check is posted as Pending at the same instant so the PR immediately reflects that the pipeline is in flight.
 
+A run that targets a wildcard other than the project default — e.g. `/gradient run packages.x86_64-linux.foo` — reports under `gradient/{project}: Evaluation: {wildcard}` so the custom run shows as its own check line instead of overwriting the default evaluation check.
+
+**Maintainer-initiated runs skip the fork-PR approval gate.** The gate only exists to hold untrusted external contributions; when the action comes from a repo writer it is not needed. The Evaluation runs immediately (no `Approval` check) when either: a maintainer issues `/gradient run` / `/gradient approve` on the PR, or a maintainer force-pushes onto the contributor's branch (the `synchronize` event's actor is verified as a repo writer via the forge API before bypassing).
+
 **Config fields:**
 
 | Field | Required | Description |


### PR DESCRIPTION
Fixes #298.

## Problem
Two minor forge-integration issues:

1. **Approval gate ignored maintainer actions.** A fork-PR run was re-parked for approval even when a maintainer initiated it — both when a maintainer issued `/gradient run …` and when a maintainer force-pushed onto the contributor's branch. The gate decision (`decide_pr_gate`) only looked at `is_fork`, never at *who* triggered the event.
2. **Custom-wildcard runs overwrote the default check.** A `/gradient run <wildcard>` reported under the same `gradient/{project}: Evaluation` check as the default-config eval, so the two collided.

## Fix
- Parse the event **actor** (`sender`) from PR/MR payloads across GitHub, Gitea/Forgejo and GitLab, independently of the PR author.
- `decide_pr_gate` now bypasses the gate when the actor is a trusted repo writer (verified via the existing `is_repo_writer` forge probe). The branching is split into a pure, unit-tested `gate_decision` separate from the I/O probe.
- The maintainer `/gradient run` fresh-eval path threads the already-verified sender so the command itself counts as approval.
- `evaluation_check_context` gains a wildcard suffix: a run whose wildcard differs from the project default reports under `gradient/{project}: Evaluation: {wildcard}`.

## Tests
- `gate_decision` unit tests: same-repo bypass, fork+untrusted parks, fork+trusted bypasses, unknown-fork fail-closed.
- `sender` parser tests for GitHub/Gitea/GitLab (distinct from PR author on force-push).
- `evaluation_check_context` custom-wildcard naming test.

Docs updated: `docs/src/usage/actions.md`, `docs/src/tests.md`. No API/env/config surface changed.