### PR TITLE
feat: cache NAR upload + interactive CLI (#261)

### DIFF
--- a/backend/core/src/cache/ingest.rs
+++ b/backend/core/src/cache/ingest.rs
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use crate::nix_hash::normalize_nar_hash;
+use crate::storage::nar::NarStore;
+use crate::types::ids::{CacheId, CachedPathId, CachedPathSignatureId, OrganizationId};
+use crate::types::*;
+use sea_orm::sea_query::OnConflict;
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, IntoActiveModel, QueryFilter, Set,
+};
+use tracing::warn;
+
+/// NAR metadata required to record a cached path. Hashes are normalized on write.
+pub struct IngestInput<'a> {
+    pub store_path: &'a str,
+    pub file_hash: &'a str,
+    pub file_size: i64,
+    pub nar_size: i64,
+    pub nar_hash: &'a str,
+    /// References in hash-name format (no `/nix/store/` prefix).
+    pub references: &'a [String],
+    pub deriver: Option<&'a str>,
+}
+
+/// Which caches get a NULL-signature placeholder so the sign sweep signs later.
+pub enum SignTargets {
+    /// Every cache owned by this organization (worker build-output path).
+    OrgCaches(OrganizationId),
+    /// Exactly one cache (direct CLI upload path).
+    Cache(CacheId),
+}
+
+/// Outcome of an ingest.
+pub struct IngestOutcome {
+    pub cached_path: CachedPathId,
+    /// True when the `cached_path` row was created by this call.
+    pub created: bool,
+}

--- a/backend/core/src/cache/ingest.rs
+++ b/backend/core/src/cache/ingest.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-use crate::nix_hash::normalize_nar_hash;
+use crate::nix_hash::{is_nix32_hash, normalize_nar_hash};
 use crate::storage::nar::NarStore;
 use crate::types::ids::{CacheId, CachedPathId, CachedPathSignatureId, OrganizationId};
 use crate::types::*;
@@ -25,11 +25,8 @@ pub struct IngestInput<'a> {
     pub deriver: Option<&'a str>,
 }
 
-/// Which caches get a NULL-signature placeholder so the sign sweep signs later.
 pub enum SignTargets {
-    /// Every cache owned by this organization (worker build-output path).
     OrgCaches(OrganizationId),
-    /// Exactly one cache (direct CLI upload path).
     Cache(CacheId),
 }
 
@@ -38,4 +35,230 @@ pub struct IngestOutcome {
     pub cached_path: CachedPathId,
     /// True when the `cached_path` row was created by this call.
     pub created: bool,
+}
+
+fn parse_store_hash(store_path: &str) -> anyhow::Result<(&str, &str)> {
+    let hash_name = store_path.strip_prefix("/nix/store/").unwrap_or(store_path);
+    let hash = hash_name.split('-').next().unwrap_or("");
+    let package = hash_name.find('-').map(|i| &hash_name[i + 1..]).unwrap_or("");
+    if !is_nix32_hash(hash) {
+        anyhow::bail!("malformed store path: {}", store_path);
+    }
+    Ok((hash, package))
+}
+
+pub async fn ingest_nar<C: ConnectionTrait>(
+    db: &C,
+    nar_storage: &NarStore,
+    nar_bytes: Vec<u8>,
+    input: IngestInput<'_>,
+    targets: SignTargets,
+) -> anyhow::Result<IngestOutcome> {
+    let (hash, package) = parse_store_hash(input.store_path)?;
+    // NAR written first; DB failure leaves an unreferenced blob — GC reclaims it.
+    nar_storage.put(hash, nar_bytes).await?;
+    upsert_and_sign(db, hash, package, input, targets).await
+}
+
+pub async fn ingest_metadata_only<C: ConnectionTrait>(
+    db: &C,
+    input: IngestInput<'_>,
+    targets: SignTargets,
+) -> anyhow::Result<IngestOutcome> {
+    let (hash, package) = parse_store_hash(input.store_path)?;
+    upsert_and_sign(db, hash, package, input, targets).await
+}
+
+async fn upsert_and_sign<C: ConnectionTrait>(
+    db: &C,
+    hash: &str,
+    package: &str,
+    input: IngestInput<'_>,
+    targets: SignTargets,
+) -> anyhow::Result<IngestOutcome> {
+    let ts = now();
+    let references_str = if input.references.is_empty() {
+        None
+    } else {
+        Some(input.references.join(" "))
+    };
+
+    let (cached_path_id, created) = match ECachedPath::find()
+        .filter(CCachedPath::Hash.eq(hash))
+        .one(db)
+        .await?
+    {
+        Some(row) => {
+            let id = row.id;
+            let mut active = row.into_active_model();
+            active.file_size = Set(Some(input.file_size));
+            active.file_hash = Set(Some(normalize_nar_hash(input.file_hash)));
+            active.nar_size = Set(Some(input.nar_size));
+            active.nar_hash = Set(Some(normalize_nar_hash(input.nar_hash)));
+            if references_str.is_some() {
+                active.references = Set(references_str);
+            }
+            if input.deriver.is_some() {
+                active.deriver = Set(input.deriver.map(str::to_owned));
+            }
+            active.update(db).await?;
+            (id, false)
+        }
+        None => {
+            let am = ACachedPath {
+                id: Set(CachedPathId::now_v7()),
+                store_path: Set(input.store_path.to_owned()),
+                hash: Set(hash.to_owned()),
+                package: Set(package.to_owned()),
+                file_hash: Set(Some(normalize_nar_hash(input.file_hash))),
+                file_size: Set(Some(input.file_size)),
+                nar_size: Set(Some(input.nar_size)),
+                nar_hash: Set(Some(normalize_nar_hash(input.nar_hash))),
+                references: Set(references_str),
+                ca: Set(None),
+                deriver: Set(input.deriver.map(str::to_owned)),
+                created_at: Set(ts),
+            };
+            match am.insert(db).await {
+                Ok(row) => (row.id, true),
+                Err(e) => {
+                    warn!(store_path = input.store_path, error = %e, "insert cached_path failed (possible race)");
+                    match ECachedPath::find()
+                        .filter(CCachedPath::Hash.eq(hash))
+                        .one(db)
+                        .await?
+                    {
+                        Some(row) => (row.id, false),
+                        None => return Err(e.into()),
+                    }
+                }
+            }
+        }
+    };
+
+    let cache_ids: Vec<CacheId> = match targets {
+        SignTargets::Cache(id) => vec![id],
+        SignTargets::OrgCaches(org) => EOrganizationCache::find()
+            .filter(COrganizationCache::Organization.eq(org))
+            .all(db)
+            .await?
+            .into_iter()
+            .map(|oc| oc.cache)
+            .collect(),
+    };
+
+    if !cache_ids.is_empty() {
+        let rows: Vec<ACachedPathSignature> = cache_ids
+            .into_iter()
+            .map(|cid| ACachedPathSignature {
+                id: Set(CachedPathSignatureId::now_v7()),
+                cached_path: Set(cached_path_id),
+                cache: Set(cid),
+                signature: Set(None),
+                created_at: Set(ts),
+                last_fetched_at: Set(None),
+                fetch_count: Set(0),
+            })
+            .collect();
+
+        let result = ECachedPathSignature::insert_many(rows)
+            .on_conflict(
+                OnConflict::columns([
+                    CCachedPathSignature::CachedPath,
+                    CCachedPathSignature::Cache,
+                ])
+                .do_nothing()
+                .to_owned(),
+            )
+            .do_nothing()
+            .exec(db)
+            .await;
+        if let Err(e) = result {
+            warn!(store_path = input.store_path, error = %e, "insert cached_path_signature failed");
+        }
+    }
+
+    Ok(IngestOutcome { cached_path: cached_path_id, created })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use entity::ids::*;
+    use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
+    use uuid::Uuid;
+
+    fn temp_store() -> NarStore {
+        let dir = std::env::temp_dir().join(format!("gradient-ingest-{}", Uuid::now_v7()));
+        NarStore::local(dir.to_str().unwrap()).expect("local store")
+    }
+    fn cache_id() -> CacheId {
+        CacheId::new(Uuid::parse_str("10000000-0000-0000-0000-000000000002").unwrap())
+    }
+    fn input(store_path: &str) -> IngestInput<'_> {
+        IngestInput {
+            store_path,
+            file_hash: "sha256:abc",
+            file_size: 5,
+            nar_size: 5,
+            nar_hash: "sha256:def",
+            references: &[],
+            deriver: None,
+        }
+    }
+    fn returned_cached_path(store_path: &str, hash: &str) -> entity::cached_path::Model {
+        entity::cached_path::Model {
+            id: CachedPathId::new(Uuid::now_v7()),
+            store_path: store_path.to_string(),
+            hash: hash.to_string(),
+            package: "hello-2.12".to_string(),
+            file_hash: Some("sha256:abc".to_string()),
+            file_size: Some(5),
+            nar_size: Some(5),
+            nar_hash: Some("sha256:def".to_string()),
+            references: None,
+            ca: None,
+            deriver: None,
+            created_at: now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn malformed_store_path_bails_before_any_io() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
+        let store = temp_store();
+        let err = ingest_nar(
+            &db,
+            &store,
+            vec![1],
+            input("not-a-store-path"),
+            SignTargets::Cache(cache_id()),
+        )
+        .await;
+        assert!(err.is_err());
+    }
+
+    #[tokio::test]
+    async fn create_path_writes_blob_and_reports_created() {
+        let sp = "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello-2.12";
+        let hash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([Vec::<entity::cached_path::Model>::new()])
+            .append_query_results([vec![returned_cached_path(sp, hash)]])
+            .append_exec_results([MockExecResult { last_insert_id: 0, rows_affected: 1 }])
+            .into_connection();
+        let store = temp_store();
+        let out = ingest_nar(
+            &db,
+            &store,
+            vec![1, 2, 3, 4, 5],
+            input(sp),
+            SignTargets::Cache(cache_id()),
+        )
+        .await
+        .expect("ingest");
+        assert!(out.created);
+        let blob = store.get(hash).await.expect("get").expect("present");
+        assert_eq!(blob, vec![1, 2, 3, 4, 5]);
+    }
 }

--- a/backend/core/src/cache/ingest.rs
+++ b/backend/core/src/cache/ingest.rs
@@ -28,6 +28,8 @@ pub struct IngestInput<'a> {
 pub enum SignTargets {
     OrgCaches(OrganizationId),
     Cache(CacheId),
+    /// Record the path but enqueue no signatures (no resolvable org).
+    None,
 }
 
 /// Outcome of an ingest.
@@ -137,6 +139,7 @@ async fn upsert_and_sign<C: ConnectionTrait>(
     };
 
     let cache_ids: Vec<CacheId> = match targets {
+        SignTargets::None => vec![],
         SignTargets::Cache(id) => vec![id],
         SignTargets::OrgCaches(org) => EOrganizationCache::find()
             .filter(COrganizationCache::Organization.eq(org))

--- a/backend/core/src/cache/mod.rs
+++ b/backend/core/src/cache/mod.rs
@@ -1,0 +1,6 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+pub mod ingest;

--- a/backend/core/src/lib.rs
+++ b/backend/core/src/lib.rs
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+pub mod cache;
 pub mod ci;
 pub mod constants;
 pub mod db;

--- a/backend/core/src/nix_hash.rs
+++ b/backend/core/src/nix_hash.rs
@@ -16,6 +16,11 @@
 
 use base64::Engine as _;
 
+pub fn is_nix32_hash(s: &str) -> bool {
+    const CHARS: &[u8] = b"0123456789abcdfghijklmnpqrsvwxyz";
+    s.len() == 32 && s.bytes().all(|b| CHARS.contains(&b))
+}
+
 /// Encode bytes using the Nix base32 alphabet (omits `e`, `o`, `t`, `u`).
 pub fn nix32_encode(bytes: &[u8]) -> String {
     const CHARS: &[u8] = b"0123456789abcdfghijklmnpqrsvwxyz";

--- a/backend/core/src/types/cli/limits.rs
+++ b/backend/core/src/types/cli/limits.rs
@@ -9,11 +9,7 @@ use clap::Args;
 
 #[derive(Args, Debug, Clone)]
 pub struct LimitsArgs {
-    /// Maximum size in bytes of an HTTP request body for most endpoints
-    /// (default 2 MiB). Caps webhook payloads, JSON bodies, etc. so an
-    /// attacker cannot exhaust server memory by sending an unbounded body.
-    /// The build-request blob upload endpoint uses a fixed
-    /// `MAX_BUILD_REQUEST_SIZE` (20 MiB) limit instead.
+    /// Maximum size in bytes of an HTTP request body for most endpoints (default 2 MiB).
     #[arg(
         long,
         env = "GRADIENT_MAX_REQUEST_SIZE",
@@ -21,12 +17,22 @@ pub struct LimitsArgs {
         default_value_t = 2 * 1024 * 1024,
     )]
     pub max_request_size: usize,
+
+    /// Maximum size in bytes of a NAR upload to `POST /caches/{cache}/nars` (default 512 MiB).
+    #[arg(
+        long,
+        env = "GRADIENT_MAX_NAR_UPLOAD_SIZE",
+        value_parser = greater_than_zero::<usize>,
+        default_value_t = 512 * 1024 * 1024,
+    )]
+    pub max_nar_upload_size: usize,
 }
 
 impl Default for LimitsArgs {
     fn default() -> Self {
         Self {
             max_request_size: 2 * 1024 * 1024,
+            max_nar_upload_size: 512 * 1024 * 1024,
         }
     }
 }

--- a/backend/proto/src/handler/dispatch.rs
+++ b/backend/proto/src/handler/dispatch.rs
@@ -665,8 +665,6 @@ impl<'a> DispatchContext<'a> {
             return;
         }
 
-        // Local-mode commit: if we buffered NarPush chunks for this path,
-        // validate + write them to nar_storage atomically with the metadata.
         if let Some(buf) = nar_buffers.take(&store_path) {
             if buf.len() as u64 != file_size {
                 let reason = format!(
@@ -678,22 +676,22 @@ impl<'a> DispatchContext<'a> {
                 self.abort_job(&job_id, reason).await;
                 return;
             }
-            let Some(hash) = store_path
+            let hash = store_path
                 .strip_prefix("/nix/store/")
                 .unwrap_or(&store_path)
                 .split('-')
                 .next()
-                .filter(|h| h.len() == 32 && h.bytes().all(|b| b.is_ascii_alphanumeric()))
-                .map(str::to_owned)
-            else {
+                .unwrap_or("");
+            let valid = hash.len() == 32 && hash.bytes().all(|b| b.is_ascii_alphanumeric());
+            if !valid {
                 let reason = format!("NarUploaded for malformed store path {store_path}");
                 error!(peer_id = %self.peer_id, %job_id, %store_path, %reason, "NarUploaded for malformed store path");
                 self.abort_job(&job_id, reason).await;
                 return;
-            };
-            if let Err(e) = self.state.nar_storage.put(&hash, buf).await {
-                let reason = format!("nar_storage write failed: {e}");
-                error!(peer_id = %self.peer_id, %job_id, %store_path, error = %e, "NAR storage commit failed");
+            }
+            if let Err(e) = self.state.nar_storage.put(hash, buf).await {
+                let reason = format!("failed to write NAR to storage: {e}");
+                error!(peer_id = %self.peer_id, %job_id, %store_path, error = %e, "nar_storage.put failed");
                 self.abort_job(&job_id, reason).await;
                 return;
             }
@@ -709,14 +707,8 @@ impl<'a> DispatchContext<'a> {
             references: &references,
             deriver: deriver.as_deref(),
         };
-        if let Err(e) = mark_nar_stored(
-            self.state,
-            self.scheduler,
-            &job_id,
-            &store_path,
-            &nar_record,
-        )
-        .await
+        if let Err(e) =
+            mark_nar_stored(self.state, self.scheduler, &job_id, &store_path, &nar_record).await
         {
             warn!(%store_path, error = %e, "failed to mark NAR as stored");
         }

--- a/backend/proto/src/handler/nar.rs
+++ b/backend/proto/src/handler/nar.rs
@@ -98,9 +98,9 @@ pub(super) async fn mark_nar_stored(
         return Ok(());
     }
 
-    let Some(org_id) = scheduler.peer_id_for_job(job_id).await else {
-        warn!(%job_id, "no org for job; skipping NAR ingest");
-        return Ok(());
+    let targets = match scheduler.peer_id_for_job(job_id).await {
+        Some(org_id) => SignTargets::OrgCaches(org_id),
+        None => SignTargets::None,
     };
 
     let input = IngestInput {
@@ -113,10 +113,9 @@ pub(super) async fn mark_nar_stored(
         deriver: record.deriver,
     };
 
-    let outcome =
-        ingest_metadata_only(&state.worker_db, input, SignTargets::OrgCaches(org_id)).await?;
-
-    let cached_path_id = outcome.cached_path;
+    let cached_path_id = ingest_metadata_only(&state.worker_db, input, targets)
+        .await?
+        .cached_path;
 
     let outputs = EDerivationOutput::find()
         .filter(CDerivationOutput::Hash.eq(hash))

--- a/backend/proto/src/handler/nar.rs
+++ b/backend/proto/src/handler/nar.rs
@@ -5,15 +5,13 @@
  */
 
 use chrono::Timelike;
-use gradient_core::nix_hash::normalize_nar_hash;
-use gradient_core::types::ids::{CacheId, CacheMetricId, CachedPathId, CachedPathSignatureId};
+use gradient_core::cache::ingest::{IngestInput, SignTargets, ingest_metadata_only};
+use gradient_core::types::ids::{CacheId, CacheMetricId};
 use gradient_core::types::*;
 use scheduler::Scheduler;
-use sea_orm::sea_query::OnConflict;
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, Set};
 use tracing::{info, warn};
 
-/// Metadata produced by a worker after compressing and uploading a NAR.
 pub(super) struct NarUploadRecord<'a> {
     pub file_hash: &'a str,
     pub file_size: i64,
@@ -25,8 +23,6 @@ pub(super) struct NarUploadRecord<'a> {
     pub deriver: Option<&'a str>,
 }
 
-/// Record a cache metric entry for a NAR push (direct or presigned).
-///
 /// Resolves `job_id → org → cache` and increments the traffic counter.
 pub(super) async fn record_nar_push_metric(
     state: &ServerState,
@@ -88,10 +84,6 @@ async fn upsert_cache_metric(
     Ok(())
 }
 
-/// Update the `derivation_output` and `cached_path` records for `store_path`
-/// after a NAR push.  Creates `cached_path` and `cached_path_signature` rows
-/// when the worker supplies path metadata (build-output uploads from remote
-/// workers).
 pub(super) async fn mark_nar_stored(
     state: &ServerState,
     scheduler: &Scheduler,
@@ -101,82 +93,31 @@ pub(super) async fn mark_nar_stored(
 ) -> anyhow::Result<()> {
     let hash_name = store_path.strip_prefix("/nix/store/").unwrap_or(store_path);
     let hash = hash_name.split('-').next().unwrap_or("");
-    let package = hash_name
-        .find('-')
-        .map(|i| &hash_name[i + 1..])
-        .unwrap_or("");
 
     if hash.is_empty() {
         return Ok(());
     }
 
-    let now = gradient_core::types::now();
-
-    // Find or create the cached_path row.
-    let references_str = if record.references.is_empty() {
-        None
-    } else {
-        Some(record.references.join(" "))
+    let Some(org_id) = scheduler.peer_id_for_job(job_id).await else {
+        warn!(%job_id, "no org for job; skipping NAR ingest");
+        return Ok(());
     };
 
-    let cached_path_row = match ECachedPath::find()
-        .filter(CCachedPath::Hash.eq(hash))
-        .one(&state.worker_db)
-        .await?
-    {
-        Some(row) => {
-            let mut active = row.into_active_model();
-            active.file_size = Set(Some(record.file_size));
-            active.file_hash = Set(Some(normalize_nar_hash(record.file_hash)));
-            active.nar_size = Set(Some(record.nar_size));
-            active.nar_hash = Set(Some(normalize_nar_hash(record.nar_hash)));
-            if references_str.is_some() {
-                active.references = Set(references_str);
-            }
-            if record.deriver.is_some() {
-                active.deriver = Set(record.deriver.map(str::to_owned));
-            }
-            active.update(&state.worker_db).await?
-        }
-        None => {
-            let am = ACachedPath {
-                id: Set(CachedPathId::now_v7()),
-                store_path: Set(store_path.to_owned()),
-                hash: Set(hash.to_owned()),
-                package: Set(package.to_owned()),
-                file_hash: Set(Some(normalize_nar_hash(record.file_hash))),
-                file_size: Set(Some(record.file_size)),
-                nar_size: Set(Some(record.nar_size)),
-                nar_hash: Set(Some(normalize_nar_hash(record.nar_hash))),
-                references: Set(references_str),
-                ca: Set(None),
-                deriver: Set(record.deriver.map(str::to_owned)),
-                created_at: Set(now),
-            };
-            match am.insert(&state.worker_db).await {
-                Ok(row) => row,
-                Err(e) => {
-                    warn!(store_path, error = %e, "failed to insert cached_path (may be a race)");
-                    // Try to find the row that was inserted concurrently.
-                    match ECachedPath::find()
-                        .filter(CCachedPath::Hash.eq(hash))
-                        .one(&state.worker_db)
-                        .await?
-                    {
-                        Some(row) => row,
-                        None => return Err(e.into()),
-                    }
-                }
-            }
-        }
+    let input = IngestInput {
+        store_path,
+        file_hash: record.file_hash,
+        file_size: record.file_size,
+        nar_size: record.nar_size,
+        nar_hash: record.nar_hash,
+        references: record.references,
+        deriver: record.deriver,
     };
 
-    // Mark every derivation_output that produces this store path as cached
-    // and link it to the cached_path row. Filtering by `hash` is more robust
-    // than filtering by the full `output` string: it avoids prefix-shape
-    // mismatches and survives "known/pruned" eval results that never wrote
-    // an `output` value. The narinfo read path filters on (is_cached, hash),
-    // so this is the field that has to match.
+    let outcome =
+        ingest_metadata_only(&state.worker_db, input, SignTargets::OrgCaches(org_id)).await?;
+
+    let cached_path_id = outcome.cached_path;
+
     let outputs = EDerivationOutput::find()
         .filter(CDerivationOutput::Hash.eq(hash))
         .all(&state.worker_db)
@@ -185,7 +126,7 @@ pub(super) async fn mark_nar_stored(
     for row in outputs {
         let mut active = row.into_active_model();
         active.is_cached = Set(true);
-        active.cached_path = Set(Some(cached_path_row.id));
+        active.cached_path = Set(Some(cached_path_id));
         if let Err(e) = active.update(&state.worker_db).await {
             warn!(store_path, error = %e, "failed to mark derivation_output cached");
         } else {
@@ -201,79 +142,6 @@ pub(super) async fn mark_nar_stored(
         );
     }
 
-    // Enqueue signing: insert a placeholder `cached_path_signature` row
-    // (signature = NULL) for every cache owned by the job's org. The
-    // periodic sign sweep (see `cache::cacher::sign_sweep`) will fill in
-    // the signatures in the background.
-    ensure_signature_placeholders(state, scheduler, job_id, &cached_path_row, now).await;
-
-    info!(
-        store_path,
-        "cached_path metadata recorded after NarUploaded"
-    );
+    info!(store_path, "cached_path metadata recorded after NarUploaded");
     Ok(())
-}
-
-/// Insert `cached_path_signature` placeholders (signature = NULL) for every
-/// cache the job's organization is subscribed to. The periodic sweep will
-/// sign them later. Existing rows are left untouched.
-async fn ensure_signature_placeholders(
-    state: &ServerState,
-    scheduler: &Scheduler,
-    job_id: &str,
-    cached_path_row: &MCachedPath,
-    now: chrono::NaiveDateTime,
-) {
-    let Some(org_id) = scheduler.peer_id_for_job(job_id).await else {
-        return;
-    };
-
-    let org_caches = match EOrganizationCache::find()
-        .filter(COrganizationCache::Organization.eq(org_id))
-        .all(&state.worker_db)
-        .await
-    {
-        Ok(v) => v,
-        Err(e) => {
-            warn!(%org_id, error = %e, "failed to fetch org caches for signature placeholders");
-            return;
-        }
-    };
-
-    if org_caches.is_empty() {
-        return;
-    }
-
-    let rows: Vec<ACachedPathSignature> = org_caches
-        .into_iter()
-        .map(|oc| ACachedPathSignature {
-            id: Set(CachedPathSignatureId::now_v7()),
-            cached_path: Set(cached_path_row.id),
-            cache: Set(oc.cache),
-            signature: Set(None),
-            created_at: Set(now),
-            last_fetched_at: Set(None),
-            fetch_count: Set(0),
-        })
-        .collect();
-
-    let result = ECachedPathSignature::insert_many(rows)
-        .on_conflict(
-            OnConflict::columns([
-                CCachedPathSignature::CachedPath,
-                CCachedPathSignature::Cache,
-            ])
-            .do_nothing()
-            .to_owned(),
-        )
-        .do_nothing()
-        .exec(&state.worker_db)
-        .await;
-    if let Err(e) = result {
-        warn!(
-            store_path = %cached_path_row.store_path,
-            error = %e,
-            "failed to insert cached_path_signature placeholders"
-        );
-    }
 }

--- a/backend/web/src/audit.rs
+++ b/backend/web/src/audit.rs
@@ -48,6 +48,7 @@ pub mod events {
     pub const PROJECT_DELETE: &str = "project.delete";
     pub const CACHE_DELETE: &str = "cache.delete";
     pub const CACHE_NAR_DELETE: &str = "cache.nar.delete";
+    pub const CACHE_NAR_UPLOAD: &str = "cache.nar.upload";
     pub const CACHE_ROLE_CREATE: &str = "cache.role.create";
     pub const CACHE_ROLE_UPDATE: &str = "cache.role.update";
     pub const CACHE_ROLE_DELETE: &str = "cache.role.delete";

--- a/backend/web/src/endpoints/caches/mod.rs
+++ b/backend/web/src/endpoints/caches/mod.rs
@@ -14,6 +14,7 @@ mod narinfo;
 mod narlist;
 mod nars;
 mod proto;
+mod upload;
 pub mod roles;
 mod serve;
 mod upstreams;
@@ -33,6 +34,7 @@ pub use self::nars::{
     available as nars_available, delete as nars_delete, list as nars_list, show as nars_show,
     stats as nars_stats,
 };
+pub use self::upload::nars_upload;
 pub use self::serve::serve;
 pub use self::upstreams::{
     delete_cache_upstream, get_cache_upstreams, patch_cache_upstream, put_cache_upstream,

--- a/backend/web/src/endpoints/caches/nars.rs
+++ b/backend/web/src/endpoints/caches/nars.rs
@@ -272,8 +272,8 @@ pub async fn stats(
     let row = Row::find_by_statement(Statement::from_sql_and_values(
         DatabaseBackend::Postgres,
         "SELECT COUNT(*) AS total_nars, \
-                COALESCE(SUM(cp.nar_size),0) AS total_nar_size, \
-                COALESCE(SUM(cp.file_size),0) AS total_file_size, \
+                COALESCE(SUM(cp.nar_size),0)::bigint AS total_nar_size, \
+                COALESCE(SUM(cp.file_size),0)::bigint AS total_file_size, \
                 MAX(cp.created_at) AS last_uploaded_at, \
                 MIN(cps.last_fetched_at) AS oldest_fetched_at \
          FROM cached_path_signature cps \

--- a/backend/web/src/endpoints/caches/upload.rs
+++ b/backend/web/src/endpoints/caches/upload.rs
@@ -1,0 +1,145 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use crate::access::{CacheAccess, Caller, load_cache};
+use crate::audit::{RequestInfo, events, record as audit_record};
+use crate::authorization::MaybeApiKey;
+use crate::error::{ErrorCode, WebError, WebResult};
+use crate::helpers::ok_json;
+use crate::permissions::CachePermission;
+use axum::Extension;
+use axum::extract::{Multipart, Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use gradient_core::cache::ingest::{IngestInput, SignTargets, ingest_nar};
+use gradient_core::types::*;
+use serde::Deserialize;
+use serde_json::json;
+use std::sync::Arc;
+
+#[derive(Deserialize)]
+struct NarinfoPart {
+    store_path: String,
+    file_hash: String,
+    file_size: i64,
+    nar_size: i64,
+    nar_hash: String,
+    #[serde(default)]
+    references: Vec<String>,
+    #[serde(default)]
+    deriver: Option<String>,
+}
+
+pub async fn nars_upload(
+    state: State<Arc<ServerState>>,
+    info: RequestInfo,
+    Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
+    Path(cache_name): Path<String>,
+    mut multipart: Multipart,
+) -> WebResult<impl IntoResponse> {
+    let cache = load_cache(
+        &state,
+        Caller::User(&user),
+        api_key.as_ref(),
+        cache_name,
+        CacheAccess::Require {
+            permission: CachePermission::WriteStore,
+            reject_managed: false,
+        },
+    )
+    .await?;
+
+    let mut narinfo: Option<NarinfoPart> = None;
+    let mut nar_bytes: Option<Vec<u8>> = None;
+
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|e| WebError::BadRequest(ErrorCode::INPUT_VALIDATION, e.to_string()))?
+    {
+        match field.name() {
+            Some("narinfo") => {
+                let text = field
+                    .text()
+                    .await
+                    .map_err(|e| WebError::BadRequest(ErrorCode::INPUT_VALIDATION, e.to_string()))?;
+                let parsed: NarinfoPart = serde_json::from_str(&text).map_err(|e| {
+                    WebError::BadRequest(
+                        ErrorCode::INPUT_VALIDATION,
+                        format!("invalid narinfo JSON: {e}"),
+                    )
+                })?;
+                narinfo = Some(parsed);
+            }
+            Some("nar") => {
+                let bytes = field
+                    .bytes()
+                    .await
+                    .map_err(|e| WebError::BadRequest(ErrorCode::INPUT_VALIDATION, e.to_string()))?;
+                nar_bytes = Some(bytes.to_vec());
+            }
+            _ => {}
+        }
+    }
+
+    let narinfo = narinfo.ok_or_else(|| {
+        WebError::BadRequest(ErrorCode::INPUT_VALIDATION, "missing narinfo part".into())
+    })?;
+    let nar_bytes = nar_bytes.ok_or_else(|| {
+        WebError::BadRequest(ErrorCode::INPUT_VALIDATION, "missing nar part".into())
+    })?;
+
+    if nar_bytes.len() as i64 != narinfo.file_size {
+        return Err(WebError::BadRequest(
+            ErrorCode::INPUT_VALIDATION,
+            format!(
+                "nar size mismatch: declared {} bytes, got {}",
+                narinfo.file_size,
+                nar_bytes.len()
+            ),
+        ));
+    }
+
+    let outcome = ingest_nar(
+        &state.web_db,
+        &state.nar_storage,
+        nar_bytes,
+        IngestInput {
+            store_path: &narinfo.store_path,
+            file_hash: &narinfo.file_hash,
+            file_size: narinfo.file_size,
+            nar_size: narinfo.nar_size,
+            nar_hash: &narinfo.nar_hash,
+            references: &narinfo.references,
+            deriver: narinfo.deriver.as_deref(),
+        },
+        SignTargets::Cache(cache.id),
+    )
+    .await
+    .map_err(WebError::from)?;
+
+    audit_record(
+        &state.web_db,
+        Some(user.id),
+        events::CACHE_NAR_UPLOAD,
+        &info,
+        Some(json!({
+            "cache_id": cache.id.to_string(),
+            "cache_name": cache.name,
+            "store_path": narinfo.store_path,
+            "created": outcome.created,
+        })),
+    )
+    .await;
+
+    Ok((
+        StatusCode::CREATED,
+        ok_json(json!({
+            "store_path": narinfo.store_path,
+            "created": outcome.created,
+        })),
+    ))
+}

--- a/backend/web/src/lib.rs
+++ b/backend/web/src/lib.rs
@@ -325,6 +325,11 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
             patch(caches::patch_cache).delete(caches::delete_cache),
         )
         .route(
+            "/caches/{cache}/nars",
+            post(caches::nars_upload)
+                .layer(DefaultBodyLimit::max(state.config.limits.max_nar_upload_size)),
+        )
+        .route(
             "/caches/{cache}/nars/{hash}",
             axum::routing::delete(caches::nars_delete),
         )

--- a/backend/web/tests/caches_upload.rs
+++ b/backend/web/tests/caches_upload.rs
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Integration tests for `POST /api/v1/caches/{cache}/nars`.
+
+use axum::http::StatusCode;
+use axum_test::TestServer;
+use axum_test::multipart::{MultipartForm, Part};
+use std::sync::Arc;
+use test_support::cache_fixture::{FIXTURE_CACHE_NAME, public_cache_empty_nars};
+use web::create_router;
+
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+}
+
+#[test]
+fn upload_unauthenticated_returns_403() {
+    rt().block_on(async {
+        let state = public_cache_empty_nars().await;
+        let server = TestServer::new(create_router(Arc::clone(&state)));
+        let form = MultipartForm::new()
+            .add_part("narinfo", Part::text("{}"))
+            .add_part("nar", Part::bytes(vec![1u8, 2, 3]));
+        let resp = server
+            .post(&format!("/api/v1/caches/{FIXTURE_CACHE_NAME}/nars"))
+            .multipart(form)
+            .await;
+        resp.assert_status(StatusCode::FORBIDDEN);
+    });
+}
+
+// Needs real-DB harness; MockDatabase cannot satisfy the full write path.
+#[test]
+#[ignore]
+fn upload_writer_creates_cached_path_and_signature() {}
+
+#[test]
+#[ignore]
+fn upload_size_mismatch_returns_400() {}

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +123,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,7 +213,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -212,6 +240,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,12 +270,30 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cargo-husky"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
+
+[[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -362,6 +417,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "connector"
 version = "1.2.0"
 dependencies = [
@@ -379,10 +448,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -429,6 +519,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +552,82 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deadpool"
@@ -457,6 +648,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "zeroize",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,9 +692,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -512,6 +747,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,6 +806,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -739,6 +1010,7 @@ dependencies = [
 name = "gradient-cli"
 version = "1.2.0"
 dependencies = [
+ "anyhow",
  "assert_cmd",
  "blake3",
  "clap",
@@ -748,15 +1020,20 @@ dependencies = [
  "dirs",
  "futures",
  "git2",
+ "harmonia-file-nar",
+ "harmonia-store-path",
+ "harmonia-store-remote",
+ "harmonia-utils-hash",
  "password-auth",
  "predicates",
  "rand 0.10.1",
+ "ratatui",
  "reqwest",
  "rpassword",
  "serde",
  "serde_json",
- "strum",
- "strum_macros",
+ "strum 0.28.0",
+ "strum_macros 0.28.0",
  "tempfile",
  "tokio",
  "toml",
@@ -783,11 +1060,249 @@ dependencies = [
 ]
 
 [[package]]
+name = "harmonia-file-core"
+version = "3.1.0"
+source = "git+https://github.com/nix-community/harmonia.git#bba51756f92a488d440e4c426747fb681abce4a7"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "harmonia-file-nar"
+version = "3.1.0"
+source = "git+https://github.com/nix-community/harmonia.git#bba51756f92a488d440e4c426747fb681abce4a7"
+dependencies = [
+ "bstr",
+ "bytes",
+ "derive_more",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "harmonia-file-core",
+ "harmonia-utils-io",
+ "nix",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "walkdir",
+]
+
+[[package]]
+name = "harmonia-protocol"
+version = "3.1.0"
+source = "git+https://github.com/nix-community/harmonia.git#bba51756f92a488d440e4c426747fb681abce4a7"
+dependencies = [
+ "async-stream",
+ "bstr",
+ "bytes",
+ "derive_more",
+ "futures-core",
+ "futures-util",
+ "harmonia-file-nar",
+ "harmonia-protocol-derive",
+ "harmonia-store-aterm",
+ "harmonia-store-build-result",
+ "harmonia-store-content-address",
+ "harmonia-store-derivation",
+ "harmonia-store-path",
+ "harmonia-store-path-info",
+ "harmonia-utils-base-encoding",
+ "harmonia-utils-hash",
+ "harmonia-utils-io",
+ "harmonia-utils-signature",
+ "libc",
+ "num_enum",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "harmonia-protocol-derive"
+version = "3.1.0"
+source = "git+https://github.com/nix-community/harmonia.git#bba51756f92a488d440e4c426747fb681abce4a7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "harmonia-store-aterm"
+version = "0.0.0-alpha.0"
+source = "git+https://github.com/nix-community/harmonia.git#bba51756f92a488d440e4c426747fb681abce4a7"
+dependencies = [
+ "bytes",
+ "harmonia-store-content-address",
+ "harmonia-store-derivation",
+ "harmonia-store-path",
+ "harmonia-utils-base-encoding",
+ "harmonia-utils-hash",
+ "memchr",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "harmonia-store-build-result"
+version = "3.1.0"
+source = "git+https://github.com/nix-community/harmonia.git#bba51756f92a488d440e4c426747fb681abce4a7"
+dependencies = [
+ "harmonia-store-derivation",
+ "num_enum",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "harmonia-store-content-address"
+version = "3.1.0"
+source = "git+https://github.com/nix-community/harmonia.git#bba51756f92a488d440e4c426747fb681abce4a7"
+dependencies = [
+ "derive_more",
+ "harmonia-store-path",
+ "harmonia-utils-hash",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "harmonia-store-derivation"
+version = "0.0.0-alpha.0"
+source = "git+https://github.com/nix-community/harmonia.git#bba51756f92a488d440e4c426747fb681abce4a7"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "derive_more",
+ "harmonia-store-content-address",
+ "harmonia-store-path",
+ "harmonia-utils-base-encoding",
+ "harmonia-utils-hash",
+ "harmonia-utils-signature",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "zerocopy",
+]
+
+[[package]]
+name = "harmonia-store-path"
+version = "3.1.0"
+source = "git+https://github.com/nix-community/harmonia.git#bba51756f92a488d440e4c426747fb681abce4a7"
+dependencies = [
+ "derive_more",
+ "harmonia-utils-base-encoding",
+ "harmonia-utils-hash",
+ "serde",
+ "thiserror",
+ "zerocopy",
+]
+
+[[package]]
+name = "harmonia-store-path-info"
+version = "3.1.0"
+source = "git+https://github.com/nix-community/harmonia.git#bba51756f92a488d440e4c426747fb681abce4a7"
+dependencies = [
+ "harmonia-store-content-address",
+ "harmonia-store-path",
+ "harmonia-utils-hash",
+ "harmonia-utils-signature",
+ "serde",
+]
+
+[[package]]
+name = "harmonia-store-remote"
+version = "3.1.0"
+source = "git+https://github.com/nix-community/harmonia.git#bba51756f92a488d440e4c426747fb681abce4a7"
+dependencies = [
+ "async-stream",
+ "futures-core",
+ "futures-util",
+ "harmonia-file-nar",
+ "harmonia-protocol",
+ "harmonia-store-content-address",
+ "harmonia-store-derivation",
+ "harmonia-store-path",
+ "harmonia-utils-io",
+ "harmonia-utils-signature",
+ "prometheus",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "harmonia-utils-base-encoding"
+version = "0.0.0-alpha.0"
+source = "git+https://github.com/nix-community/harmonia.git#bba51756f92a488d440e4c426747fb681abce4a7"
+dependencies = [
+ "data-encoding",
+ "derive_more",
+ "serde",
+]
+
+[[package]]
+name = "harmonia-utils-hash"
+version = "0.0.0-alpha.0"
+source = "git+https://github.com/nix-community/harmonia.git#bba51756f92a488d440e4c426747fb681abce4a7"
+dependencies = [
+ "blake3",
+ "data-encoding",
+ "derive_more",
+ "harmonia-utils-base-encoding",
+ "md5",
+ "serde",
+ "sha1",
+ "sha2 0.11.0",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "harmonia-utils-io"
+version = "0.0.0-alpha.0"
+source = "git+https://github.com/nix-community/harmonia.git#bba51756f92a488d440e4c426747fb681abce4a7"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "libc",
+ "nix",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "harmonia-utils-signature"
+version = "3.1.0"
+source = "git+https://github.com/nix-community/harmonia.git#bba51756f92a488d440e4c426747fb681abce4a7"
+dependencies = [
+ "data-encoding",
+ "ed25519-dalek",
+ "getrandom 0.4.2",
+ "harmonia-utils-base-encoding",
+ "serde",
+ "subtle",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -853,6 +1368,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1005,6 +1529,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,6 +1568,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,6 +1609,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1188,6 +1749,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1199,10 +1766,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru-slab"
@@ -1211,10 +1796,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "md5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1239,8 +1839,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -1269,6 +1883,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,6 +1927,29 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "password-auth"
@@ -1316,6 +1975,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1326,6 +1991,16 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -1392,12 +2067,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "thiserror",
 ]
 
 [[package]]
@@ -1531,6 +2229,36 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum 0.26.3",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "redox_users"
@@ -1685,6 +2413,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1692,7 +2433,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -1802,6 +2543,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1895,10 +2642,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -1908,6 +2709,15 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1949,10 +2759,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1962,9 +2788,31 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "strum_macros"
@@ -2045,7 +2893,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2175,6 +3023,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2241,7 +3101,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2276,6 +3148,35 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -2518,6 +3419,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2525,6 +3442,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -2731,6 +3654,9 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wiremock"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -34,6 +34,7 @@ anyhow = "1"
 futures = "0.3"
 git2 = "0.21"
 reqwest = { version = "0.13", features = ["multipart"] }
+ratatui = "0.29"
 
 [features]
 default = []

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -30,9 +30,34 @@ serde_json = "1.0"
 connector = { path = "connector" }
 rand = { version = "0.10", features = ["std_rng"] }
 colored = "3.1"
+anyhow = "1"
 futures = "0.3"
 git2 = "0.21"
 reqwest = { version = "0.13", features = ["multipart"] }
+
+[features]
+default = []
+nix = ["dep:harmonia-file-nar", "dep:harmonia-store-path", "dep:harmonia-store-remote", "dep:harmonia-utils-hash"]
+
+[dependencies.harmonia-file-nar]
+git = "https://github.com/nix-community/harmonia.git"
+default-features = false
+optional = true
+
+[dependencies.harmonia-store-path]
+git = "https://github.com/nix-community/harmonia.git"
+default-features = false
+optional = true
+
+[dependencies.harmonia-store-remote]
+git = "https://github.com/nix-community/harmonia.git"
+default-features = false
+optional = true
+
+[dependencies.harmonia-utils-hash]
+git = "https://github.com/nix-community/harmonia.git"
+default-features = false
+optional = true
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/cli/connector/src/builds.rs
+++ b/cli/connector/src/builds.rs
@@ -62,7 +62,7 @@ impl BuildsApi<'_> {
     pub async fn log_stream(
         &self,
         id: &str,
-    ) -> Result<impl Stream<Item = Result<String, ConnectorError>>, ConnectorError> {
+    ) -> Result<impl Stream<Item = Result<String, ConnectorError>> + use<>, ConnectorError> {
         let req = http::request(
             self.0.http(),
             self.0.base_url(),

--- a/cli/connector/src/caches.rs
+++ b/cli/connector/src/caches.rs
@@ -94,6 +94,17 @@ pub struct NarStats {
     pub oldest_fetched_at: Option<String>,
 }
 
+#[derive(Serialize, Debug, Clone)]
+pub struct NarinfoUpload {
+    pub store_path: String,
+    pub file_hash: String,
+    pub file_size: i64,
+    pub nar_size: i64,
+    pub nar_hash: String,
+    pub references: Vec<String>,
+    pub deriver: Option<String>,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct NarListQuery {
     pub hash: Option<String>,
@@ -400,6 +411,45 @@ impl CachesApi<'_> {
             true,
         )?;
         http::decode(req.send().await?).await
+    }
+
+    pub async fn nar_upload(
+        &self,
+        cache: &str,
+        narinfo: NarinfoUpload,
+        nar_bytes: Vec<u8>,
+    ) -> Result<(), ConnectorError> {
+        let narinfo_json = serde_json::to_string(&narinfo).map_err(ConnectorError::Decode)?;
+        let form = reqwest::multipart::Form::new()
+            .text("narinfo", narinfo_json)
+            .part("nar", reqwest::multipart::Part::bytes(nar_bytes).file_name("nar"));
+        let req = http::request(
+            self.0.http(),
+            self.0.base_url(),
+            self.0.token(),
+            Method::POST,
+            &format!("caches/{cache}/nars"),
+            true,
+        )?
+        .multipart(form);
+        let resp = req.send().await?;
+        let status = resp.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            return Err(ConnectorError::Unauthorized);
+        }
+        if !status.is_success() {
+            let bytes = resp.bytes().await?;
+            let message = if let Ok(env) = serde_json::from_slice::<serde_json::Value>(&bytes) {
+                env.get("message")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_owned)
+                    .unwrap_or_else(|| String::from_utf8_lossy(&bytes).into_owned())
+            } else {
+                String::from_utf8_lossy(&bytes).into_owned()
+            };
+            return Err(ConnectorError::Api { status, message });
+        }
+        Ok(())
     }
 
     pub async fn nar_delete(&self, cache: &str, hash: &str) -> Result<(), ConnectorError> {

--- a/cli/connector/src/projects.rs
+++ b/cli/connector/src/projects.rs
@@ -160,7 +160,6 @@ impl ProjectsApi<'_> {
     pub async fn create(
         &self,
         org: &str,
-        proj: &str,
         body: MakeProjectRequest,
     ) -> Result<String, ConnectorError> {
         let req = http::request(
@@ -168,7 +167,7 @@ impl ProjectsApi<'_> {
             self.0.base_url(),
             self.0.token(),
             Method::PUT,
-            &format!("projects/{org}/{proj}"),
+            &format!("projects/{org}"),
             true,
         )?
         .json(&body);

--- a/cli/connector/src/workers.rs
+++ b/cli/connector/src/workers.rs
@@ -29,10 +29,15 @@ pub struct Worker {
 pub struct MakeWorkerRequest {
     pub worker_id: String,
     pub display_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub token: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub enable_fetch: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub enable_eval: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub enable_build: Option<bool>,
 }
 

--- a/cli/connector/src/workers.rs
+++ b/cli/connector/src/workers.rs
@@ -29,16 +29,8 @@ pub struct Worker {
 pub struct MakeWorkerRequest {
     pub worker_id: String,
     pub display_name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub token: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub enable_fetch: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub enable_eval: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub enable_build: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -85,18 +77,6 @@ impl WorkersApi<'_> {
             true,
         )?
         .json(&body);
-        http::decode(req.send().await?).await
-    }
-
-    pub async fn get(&self, org: &str, worker_id: &str) -> Result<Worker, ConnectorError> {
-        let req = http::request(
-            self.0.http(),
-            self.0.base_url(),
-            self.0.token(),
-            Method::GET,
-            &format!("orgs/{org}/workers/{worker_id}"),
-            true,
-        )?;
         http::decode(req.send().await?).await
     }
 

--- a/cli/connector/tests/caches_api.rs
+++ b/cli/connector/tests/caches_api.rs
@@ -61,3 +61,36 @@ async fn get_cache_stats_returns_stats() {
     let stats = client.caches().stats("my-cache").await.unwrap();
     assert_eq!(stats.hits, Some(42));
 }
+
+#[tokio::test]
+async fn nar_upload_posts_multipart() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v1/caches/mycache/nars"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "error": false,
+            "message": { "store_path": "/nix/store/aa-x", "created": true }
+        })))
+        .mount(&server)
+        .await;
+
+    let client = Client::builder()
+        .base_url(server.uri())
+        .token("t")
+        .build()
+        .unwrap();
+    let info = connector::caches::NarinfoUpload {
+        store_path: "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-x".into(),
+        file_hash: "sha256:a".into(),
+        file_size: 3,
+        nar_size: 3,
+        nar_hash: "sha256:b".into(),
+        references: vec![],
+        deriver: None,
+    };
+    client
+        .caches()
+        .nar_upload("mycache", info, vec![1, 2, 3])
+        .await
+        .expect("upload");
+}

--- a/cli/src/commands/base.rs
+++ b/cli/src/commands/base.rs
@@ -118,6 +118,11 @@ enum MainCommands {
         #[arg(long)]
         out: Option<String>,
     },
+    /// Inspect builds (dependency graph)
+    Builds {
+        #[command(subcommand)]
+        cmd: builds::Commands,
+    },
     /// Generate project files
     Generate {
         #[command(subcommand)]
@@ -302,6 +307,7 @@ pub async fn run_cli() -> std::io::Result<()> {
         MainCommands::Project { cmd } => project::handle(cmd, out).await,
         MainCommands::Worker { cmd } => worker::handle(cmd, out).await,
         MainCommands::Cache { cmd } => cache::handle(cmd, out).await,
+        MainCommands::Builds { cmd } => builds::handle(cmd, out).await,
         MainCommands::Generate { cmd } => generate::handle(cmd, out).await,
         MainCommands::Hash => {
             let password = ask_for_password();

--- a/cli/src/commands/builds.rs
+++ b/cli/src/commands/builds.rs
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use crate::input::client_from_config;
+use crate::output::{ExitKind, Output, to_exit_kind};
+use clap::Subcommand;
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Show a build's dependency graph
+    Graph {
+        id: String,
+        #[arg(short = 'i', long)]
+        interactive: bool,
+    },
+}
+
+pub async fn handle(cmd: Commands, out: Output) {
+    match cmd {
+        Commands::Graph { id, interactive } => {
+            let client = client_from_config(out);
+            match client.builds().graph(&id).await {
+                Ok(g) => {
+                    if interactive && !out.is_json() {
+                        crate::tui::run(crate::tui::graph::GraphTree::from_build_graph(&g))
+                            .unwrap_or_else(|e| out.err(ExitKind::Api, format!("tui error: {e}")));
+                    } else {
+                        out.ok(&g);
+                        out.human(format!("{} nodes, {} edges", g.nodes.len(), g.edges.len()));
+                    }
+                }
+                Err(e) => out.err(to_exit_kind(&e), e),
+            }
+        }
+    }
+}

--- a/cli/src/commands/builds.rs
+++ b/cli/src/commands/builds.rs
@@ -15,6 +15,12 @@ pub enum Commands {
         #[arg(short = 'i', long)]
         interactive: bool,
     },
+    /// View a build's log
+    Log {
+        id: String,
+        #[arg(short = 'i', long)]
+        interactive: bool,
+    },
 }
 
 pub async fn handle(cmd: Commands, out: Output) {
@@ -33,6 +39,9 @@ pub async fn handle(cmd: Commands, out: Output) {
                 }
                 Err(e) => out.err(to_exit_kind(&e), e),
             }
+        }
+        Commands::Log { id, interactive } => {
+            crate::commands::builds_log::handle_log(&id, interactive, out).await
         }
     }
 }

--- a/cli/src/commands/builds_log.rs
+++ b/cli/src/commands/builds_log.rs
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use crate::input::client_from_config;
+use crate::output::{ExitKind, Output, to_exit_kind};
+use futures::{StreamExt, pin_mut};
+
+pub async fn handle_log(id: &str, interactive: bool, out: Output) {
+    let client = client_from_config(out);
+    let stream = match client.builds().log_stream(id).await {
+        Ok(s) => s,
+        Err(e) => out.err(to_exit_kind(&e), e),
+    };
+
+    if interactive && !out.is_json() {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+        tokio::spawn(async move {
+            pin_mut!(stream);
+            while let Some(item) = stream.next().await {
+                if let Ok(line) = item
+                    && tx.send(line).is_err()
+                {
+                    break;
+                }
+            }
+        });
+        crate::tui::run(crate::tui::log_view::LogView::streaming(rx))
+            .unwrap_or_else(|e| out.err(ExitKind::Api, format!("tui error: {e}")));
+    } else {
+        pin_mut!(stream);
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(line) => {
+                    if out.is_json() {
+                        println!("{}", serde_json::json!({"error": false, "message": line}));
+                    } else {
+                        print!("{}", line);
+                    }
+                }
+                Err(e) => out.err(to_exit_kind(&e), e),
+            }
+        }
+    }
+}

--- a/cli/src/commands/cache.rs
+++ b/cli/src/commands/cache.rs
@@ -5,6 +5,7 @@
  */
 
 use crate::commands::cache_nar;
+use crate::commands::cache_upload;
 use crate::commands::completion;
 use crate::input::{client_from_config, handle_input};
 use crate::output::{ExitKind, Output, to_exit_kind};
@@ -67,6 +68,8 @@ pub enum Commands {
         #[command(subcommand)]
         cmd: cache_nar::Commands,
     },
+    /// Upload NAR(s) to a cache
+    Upload(crate::commands::cache_upload::UploadArgs),
 }
 
 pub async fn handle(cmd: Commands, out: Output) {
@@ -264,6 +267,7 @@ pub async fn handle(cmd: Commands, out: Output) {
         }
 
         Commands::Nar { cmd } => cache_nar::handle(cmd, out).await,
+        Commands::Upload(args) => cache_upload::handle(args, out).await,
     }
 }
 

--- a/cli/src/commands/cache_nar.rs
+++ b/cli/src/commands/cache_nar.rs
@@ -27,6 +27,8 @@ pub enum Commands {
         page: Option<u32>,
         #[arg(long = "per-page")]
         per_page: Option<u32>,
+        #[arg(short = 'i', long)]
+        interactive: bool,
     },
     /// Show a NAR's full metadata
     Show { cache: String, hash: String },
@@ -51,6 +53,7 @@ pub async fn handle(cmd: Commands, out: Output) {
             order,
             page,
             per_page,
+            interactive,
         } => {
             let client = client_from_config(out);
             let q = NarListQuery {
@@ -63,6 +66,11 @@ pub async fn handle(cmd: Commands, out: Output) {
             };
             match client.caches().nars_list(&cache, q).await {
                 Ok(res) => {
+                    if interactive && !out.is_json() {
+                        crate::tui::run(crate::tui::nar_browser::NarBrowser::new(res.items))
+                            .unwrap_or_else(|e| out.err(ExitKind::Api, format!("tui error: {e}")));
+                        return;
+                    }
                     out.ok(&res);
                     if res.items.is_empty() {
                         out.human("No NARs match.");

--- a/cli/src/commands/cache_upload.rs
+++ b/cli/src/commands/cache_upload.rs
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use crate::input::client_from_config;
+use crate::narinfo::Narinfo;
+use crate::output::{ExitKind, Output, to_exit_kind};
+use connector::caches::NarinfoUpload;
+use std::path::PathBuf;
+
+#[derive(clap::Args, Debug)]
+pub struct UploadArgs {
+    /// Cache name to upload into.
+    pub cache: String,
+    /// Store paths to upload (requires the CLI built with the `nix` feature).
+    pub paths: Vec<String>,
+    /// Upload a pre-dumped NAR file without any local nix (needs --narinfo).
+    #[arg(long)]
+    pub nar_file: Option<PathBuf>,
+    /// Narinfo metadata file describing --nar-file.
+    #[arg(long)]
+    pub narinfo: Option<PathBuf>,
+    /// Upload the full runtime closure of each store path (nix feature only).
+    #[arg(long)]
+    pub full_closure: bool,
+}
+
+pub async fn handle(args: UploadArgs, out: Output) {
+    if let Some(nar_file) = &args.nar_file {
+        let Some(narinfo_path) = &args.narinfo else {
+            out.err(ExitKind::Usage, "--nar-file requires --narinfo");
+        };
+        let narinfo_text = std::fs::read_to_string(narinfo_path)
+            .unwrap_or_else(|e| out.err(ExitKind::Usage, format!("cannot read narinfo: {e}")));
+        let ni = Narinfo::parse(&narinfo_text)
+            .unwrap_or_else(|e| out.err(ExitKind::Usage, format!("bad narinfo: {e}")));
+        let bytes = std::fs::read(nar_file)
+            .unwrap_or_else(|e| out.err(ExitKind::Usage, format!("cannot read nar: {e}")));
+        upload_one_owned(&args.cache, ni, bytes, out).await;
+        return;
+    }
+
+    if args.paths.is_empty() {
+        out.err(ExitKind::Usage, "provide store path(s) or --nar-file/--narinfo");
+    }
+
+    out.err(
+        ExitKind::Usage,
+        "store-path upload requires a CLI built with the `nix` feature; use --nar-file/--narinfo instead",
+    );
+}
+
+pub(crate) async fn upload_one_owned(cache: &str, ni: Narinfo, bytes: Vec<u8>, out: Output) {
+    let client = client_from_config(out);
+    let store_path = ni.store_path.clone();
+    let payload = NarinfoUpload {
+        store_path: ni.store_path,
+        file_hash: ni.file_hash,
+        file_size: ni.file_size,
+        nar_size: ni.nar_size,
+        nar_hash: ni.nar_hash,
+        references: ni.references,
+        deriver: ni.deriver,
+    };
+    match client.caches().nar_upload(cache, payload, bytes).await {
+        Ok(()) => {
+            out.ok(&serde_json::json!({"uploaded": true, "store_path": store_path}));
+            out.human(format!("Uploaded {store_path}"));
+        }
+        Err(e) => out.err(to_exit_kind(&e), e),
+    }
+}

--- a/cli/src/commands/cache_upload.rs
+++ b/cli/src/commands/cache_upload.rs
@@ -45,10 +45,14 @@ pub async fn handle(args: UploadArgs, out: Output) {
         out.err(ExitKind::Usage, "provide store path(s) or --nar-file/--narinfo");
     }
 
+    #[cfg(not(feature = "nix"))]
     out.err(
         ExitKind::Usage,
         "store-path upload requires a CLI built with the `nix` feature; use --nar-file/--narinfo instead",
     );
+
+    #[cfg(feature = "nix")]
+    crate::commands::cache_upload_nix::upload_paths(&args, out).await;
 }
 
 pub(crate) async fn upload_one_owned(cache: &str, ni: Narinfo, bytes: Vec<u8>, out: Output) {

--- a/cli/src/commands/cache_upload_nix.rs
+++ b/cli/src/commands/cache_upload_nix.rs
@@ -1,0 +1,212 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use std::collections::{HashSet, VecDeque};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use futures::StreamExt as _;
+use harmonia_store_path::StorePath;
+use harmonia_store_remote::DaemonStore as _;
+use harmonia_store_remote::pool::{ConnectionPool, PoolConfig, PooledConnectionGuard};
+use harmonia_utils_hash::fmt::HashFormat as _;
+
+use crate::commands::cache_upload::{UploadArgs, upload_one_owned};
+use crate::narinfo::Narinfo;
+use crate::output::{ExitKind, Output};
+
+const DEFAULT_SOCKET: &str = "/nix/var/nix/daemon-socket/socket";
+
+fn pool_config() -> PoolConfig {
+    PoolConfig {
+        max_size: 1,
+        acquire_timeout: Duration::from_secs(600),
+        ..Default::default()
+    }
+}
+
+fn strip_store_prefix(path: &str) -> &str {
+    path.strip_prefix("/nix/store/").unwrap_or(path)
+}
+
+fn canonicalize(path: &str) -> String {
+    if path.starts_with('/') {
+        path.to_owned()
+    } else {
+        format!("/nix/store/{path}")
+    }
+}
+
+struct ScopedGuard {
+    inner: Option<PooledConnectionGuard>,
+    ok: bool,
+}
+
+impl ScopedGuard {
+    fn client(
+        &mut self,
+    ) -> &mut harmonia_store_remote::DaemonClient<
+        tokio::net::unix::OwnedReadHalf,
+        tokio::net::unix::OwnedWriteHalf,
+    > {
+        self.inner.as_mut().expect("guard already dropped").client()
+    }
+
+    fn mark_ok(&mut self) {
+        self.ok = true;
+    }
+}
+
+impl Drop for ScopedGuard {
+    fn drop(&mut self) {
+        if let Some(inner) = self.inner.take()
+            && !self.ok
+        {
+            inner.mark_broken();
+        }
+    }
+}
+
+async fn scoped(pool: &ConnectionPool) -> anyhow::Result<ScopedGuard> {
+    let inner = pool
+        .acquire()
+        .await
+        .map_err(|e| anyhow::anyhow!("acquire daemon connection: {e}"))?;
+    Ok(ScopedGuard {
+        inner: Some(inner),
+        ok: false,
+    })
+}
+
+struct PathMeta {
+    references: Vec<String>,
+    deriver: Option<String>,
+    nar_hash_sri: String,
+}
+
+async fn gather_path_meta(pool: &ConnectionPool, store_path: &str) -> anyhow::Result<PathMeta> {
+    let sp = StorePath::from_base_path(strip_store_prefix(store_path))
+        .map_err(|e| anyhow::anyhow!("invalid store path {store_path}: {e}"))?;
+
+    let mut guard = scoped(pool).await?;
+    let pi = match guard.client().query_path_info(&sp).await {
+        Ok(Some(pi)) => {
+            guard.mark_ok();
+            pi
+        }
+        Ok(None) => {
+            guard.mark_ok();
+            anyhow::bail!("path not in local store: {store_path}");
+        }
+        Err(e) => anyhow::bail!("query_path_info failed for {store_path}: {e}"),
+    };
+
+    let references: Vec<String> = pi
+        .references
+        .iter()
+        .map(|r: &StorePath| {
+            let s = r.to_string();
+            s.strip_prefix("/nix/store/").unwrap_or(&s).to_owned()
+        })
+        .collect();
+
+    Ok(PathMeta {
+        references,
+        deriver: pi.deriver.as_ref().map(|d| d.to_string()),
+        nar_hash_sri: pi.nar_hash.as_sri().to_string(),
+    })
+}
+
+async fn query_refs(pool: &ConnectionPool, store_path: &str) -> anyhow::Result<Vec<String>> {
+    let sp = StorePath::from_base_path(strip_store_prefix(store_path))
+        .map_err(|e| anyhow::anyhow!("invalid store path {store_path}: {e}"))?;
+
+    let mut guard = scoped(pool).await?;
+    let pi = match guard.client().query_path_info(&sp).await {
+        Ok(Some(pi)) => {
+            guard.mark_ok();
+            pi
+        }
+        Ok(None) => {
+            guard.mark_ok();
+            anyhow::bail!("path not in local store: {store_path}");
+        }
+        Err(e) => anyhow::bail!("query_path_info failed for {store_path}: {e}"),
+    };
+
+    Ok(pi
+        .references
+        .iter()
+        .map(|r: &StorePath| canonicalize(&r.to_string()))
+        .collect())
+}
+
+async fn runtime_closure(pool: &ConnectionPool, seeds: &[String]) -> HashSet<String> {
+    let mut visited: HashSet<String> = HashSet::new();
+    let mut queue: VecDeque<String> = seeds.iter().map(|s| canonicalize(s)).collect();
+    while let Some(path) = queue.pop_front() {
+        if !visited.insert(path.clone()) {
+            continue;
+        }
+        match query_refs(pool, &path).await {
+            Ok(refs) => {
+                for r in refs {
+                    if !visited.contains(&r) {
+                        queue.push_back(r);
+                    }
+                }
+            }
+            Err(e) => eprintln!("closure walk: skipping {path}: {e}"),
+        }
+    }
+    visited
+}
+
+pub async fn upload_paths(args: &UploadArgs, out: Output) {
+    let pool = ConnectionPool::new(DEFAULT_SOCKET, pool_config());
+
+    let targets: Vec<String> = if args.full_closure {
+        let seeds: Vec<String> = args.paths.iter().map(|p| canonicalize(p)).collect();
+        let mut closure: Vec<String> = runtime_closure(&pool, &seeds).await.into_iter().collect();
+        closure.sort();
+        closure
+    } else {
+        args.paths.iter().map(|p| canonicalize(p)).collect()
+    };
+
+    for (i, store_path) in targets.iter().enumerate() {
+        out.progress(format!("[{}/{}] uploading {store_path}", i + 1, targets.len()));
+        let meta = match gather_path_meta(&pool, store_path).await {
+            Ok(m) => m,
+            Err(e) => out.err(ExitKind::Api, format!("metadata for {store_path}: {e}")),
+        };
+
+        let mut nar_stream =
+            harmonia_file_nar::NarByteStream::new(PathBuf::from(store_path));
+        let mut bytes: Vec<u8> = Vec::new();
+        while let Some(chunk_result) = nar_stream.next().await {
+            match chunk_result {
+                Ok(chunk) => bytes.extend_from_slice(&chunk),
+                Err(e) => out.err(ExitKind::Api, format!("NAR stream error for {store_path}: {e}")),
+            }
+        }
+
+        let file_size = bytes.len() as i64;
+        let nar_size = bytes.len() as i64;
+
+        let ni = Narinfo {
+            store_path: store_path.clone(),
+            url: None,
+            file_hash: meta.nar_hash_sri.clone(),
+            file_size,
+            nar_hash: meta.nar_hash_sri,
+            nar_size,
+            references: meta.references,
+            deriver: meta.deriver,
+        };
+
+        upload_one_owned(&args.cache, ni, bytes, out).await;
+    }
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod base;
 pub mod build;
 pub mod cache;
 pub mod cache_nar;
+pub mod cache_upload;
 pub mod completion;
 pub mod download;
 pub mod generate;

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod attr_spec;
 pub mod builds;
+pub mod builds_log;
 #[cfg(feature = "nix")]
 pub mod cache_upload_nix;
 pub mod base;

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -5,6 +5,8 @@
  */
 
 pub mod attr_spec;
+#[cfg(feature = "nix")]
+pub mod cache_upload_nix;
 pub mod base;
 pub mod build;
 pub mod cache;

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -5,6 +5,7 @@
  */
 
 pub mod attr_spec;
+pub mod builds;
 #[cfg(feature = "nix")]
 pub mod cache_upload_nix;
 pub mod base;

--- a/cli/src/commands/project.rs
+++ b/cli/src/commands/project.rs
@@ -199,7 +199,6 @@ pub async fn handle(cmd: Commands, out: Output) {
                 .projects()
                 .create(
                     &organization,
-                    &name,
                     MakeProjectRequest {
                         name: name.clone(),
                         display_name: input.get("Display Name").unwrap().clone(),

--- a/cli/src/commands/worker.rs
+++ b/cli/src/commands/worker.rs
@@ -67,9 +67,6 @@ pub async fn handle(cmd: Commands, out: Output) {
                         display_name,
                         url,
                         token,
-                        enable_fetch: None,
-                        enable_eval: None,
-                        enable_build: None,
                     },
                 )
                 .await

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,7 +7,7 @@
 mod commands;
 mod config;
 mod input;
-pub mod narinfo;
+mod narinfo;
 pub mod output;
 mod tui;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,6 +7,7 @@
 mod commands;
 mod config;
 mod input;
+pub mod narinfo;
 pub mod output;
 
 use commands::base;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -9,6 +9,7 @@ mod config;
 mod input;
 pub mod narinfo;
 pub mod output;
+mod tui;
 
 use commands::base;
 

--- a/cli/src/narinfo.rs
+++ b/cli/src/narinfo.rs
@@ -1,0 +1,97 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Narinfo {
+    pub store_path: String,
+    pub url: Option<String>,
+    pub file_hash: String,
+    pub file_size: i64,
+    pub nar_hash: String,
+    pub nar_size: i64,
+    pub references: Vec<String>,
+    pub deriver: Option<String>,
+}
+
+impl Narinfo {
+    pub fn parse(text: &str) -> Result<Narinfo, String> {
+        let mut store_path = None;
+        let mut url = None;
+        let mut file_hash = None;
+        let mut file_size = None;
+        let mut nar_hash = None;
+        let mut nar_size = None;
+        let mut references = Vec::new();
+        let mut deriver = None;
+
+        for line in text.lines() {
+            let Some((key, value)) = line.split_once(':') else { continue };
+            let value = value.trim();
+            match key.trim() {
+                "StorePath" => store_path = Some(value.to_string()),
+                "URL" => url = Some(value.to_string()),
+                "FileHash" => file_hash = Some(value.to_string()),
+                "FileSize" => file_size = Some(value.parse::<i64>().map_err(|_| "bad FileSize")?),
+                "NarHash" => nar_hash = Some(value.to_string()),
+                "NarSize" => nar_size = Some(value.parse::<i64>().map_err(|_| "bad NarSize")?),
+                "References" => {
+                    references = value.split_whitespace().map(str::to_string).collect();
+                }
+                "Deriver" if !value.is_empty() && value != "unknown-deriver" => {
+                    deriver = Some(value.to_string());
+                }
+                _ => {}
+            }
+        }
+
+        Ok(Narinfo {
+            store_path: store_path.ok_or("missing StorePath")?,
+            url,
+            file_hash: file_hash.ok_or("missing FileHash")?,
+            file_size: file_size.ok_or("missing FileSize")?,
+            nar_hash: nar_hash.ok_or("missing NarHash")?,
+            nar_size: nar_size.ok_or("missing NarSize")?,
+            references,
+            deriver,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = "StorePath: /nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello-2.12\n\
+URL: nar/abc.nar.xz\n\
+Compression: xz\n\
+FileHash: sha256:1f\n\
+FileSize: 42\n\
+NarHash: sha256:2e\n\
+NarSize: 99\n\
+References: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-libc cccccccccccccccccccccccccccccccc-zlib\n\
+Deriver: dddddddddddddddddddddddddddddddd-hello-2.12.drv\n";
+
+    #[test]
+    fn parses_full_narinfo() {
+        let ni = Narinfo::parse(SAMPLE).expect("parse");
+        assert_eq!(ni.store_path, "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello-2.12");
+        assert_eq!(ni.file_size, 42);
+        assert_eq!(ni.nar_size, 99);
+        assert_eq!(ni.references.len(), 2);
+        assert_eq!(ni.deriver.as_deref(), Some("dddddddddddddddddddddddddddddddd-hello-2.12.drv"));
+    }
+
+    #[test]
+    fn missing_required_field_errors() {
+        assert!(Narinfo::parse("URL: x\n").is_err());
+    }
+
+    #[test]
+    fn empty_references_ok() {
+        let txt = "StorePath: /nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-x\nFileHash: sha256:a\nFileSize: 1\nNarHash: sha256:b\nNarSize: 1\nReferences: \n";
+        let ni = Narinfo::parse(txt).unwrap();
+        assert!(ni.references.is_empty());
+    }
+}

--- a/cli/src/tui/graph.rs
+++ b/cli/src/tui/graph.rs
@@ -1,0 +1,195 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use crate::tui::View;
+use connector::builds::BuildGraph;
+use ratatui::crossterm::event::{KeyCode, KeyEvent};
+use std::collections::HashMap;
+
+pub type NodeId = String;
+
+struct Node {
+    label: String,
+    children: Vec<NodeId>,
+    expanded: bool,
+}
+
+pub struct GraphTree {
+    roots: Vec<NodeId>,
+    nodes: HashMap<NodeId, Node>,
+    flat: Vec<(NodeId, usize)>,
+    selected: usize,
+}
+
+#[allow(dead_code)]
+impl GraphTree {
+    pub fn from_edges(nodes: &[(&str, &str)], edges: &[(&str, &str)], roots: Vec<NodeId>) -> Self {
+        let mut map: HashMap<NodeId, Node> = HashMap::new();
+        for (id, label) in nodes {
+            map.insert(
+                (*id).to_string(),
+                Node { label: (*label).to_string(), children: Vec::new(), expanded: false },
+            );
+        }
+        for (parent, child) in edges {
+            if let Some(n) = map.get_mut(*parent) {
+                n.children.push((*child).to_string());
+            }
+        }
+        let mut t = Self { roots, nodes: map, flat: Vec::new(), selected: 0 };
+        t.rebuild_flat();
+        t
+    }
+
+    pub fn from_build_graph(g: &BuildGraph) -> Self {
+        let nodes: Vec<(String, String)> = g
+            .nodes
+            .iter()
+            .filter_map(|n| {
+                let id = n.get("id")?.as_str()?.to_string();
+                let label = n
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .or_else(|| n.get("path").and_then(|v| v.as_str()))
+                    .unwrap_or("?")
+                    .to_string();
+                Some((id, label))
+            })
+            .collect();
+        let edges: Vec<(String, String)> = g
+            .edges
+            .iter()
+            .filter_map(|e| {
+                Some((e.get("source")?.as_str()?.to_string(), e.get("target")?.as_str()?.to_string()))
+            })
+            .collect();
+
+        let mut map: HashMap<NodeId, Node> = HashMap::new();
+        for (id, label) in &nodes {
+            map.insert(id.clone(), Node { label: label.clone(), children: Vec::new(), expanded: false });
+        }
+        for (source, target) in &edges {
+            if let Some(n) = map.get_mut(source) {
+                n.children.push(target.clone());
+            }
+        }
+        let roots = vec![g.root.clone()];
+        let mut t = Self { roots, nodes: map, flat: Vec::new(), selected: 0 };
+        t.rebuild_flat();
+        t
+    }
+
+    fn rebuild_flat(&mut self) {
+        let mut flat = Vec::new();
+        let roots = self.roots.clone();
+        let mut on_path: Vec<NodeId> = Vec::new();
+        for r in &roots {
+            self.dfs(r, 0, &mut flat, &mut on_path);
+        }
+        self.flat = flat;
+        if self.selected >= self.flat.len() {
+            self.selected = self.flat.len().saturating_sub(1);
+        }
+    }
+
+    fn dfs(&self, id: &str, depth: usize, flat: &mut Vec<(NodeId, usize)>, on_path: &mut Vec<NodeId>) {
+        if on_path.iter().any(|p| p == id) {
+            return;
+        }
+        let Some(node) = self.nodes.get(id) else { return };
+        flat.push((id.to_string(), depth));
+        if node.expanded {
+            on_path.push(id.to_string());
+            let children = node.children.clone();
+            for c in &children {
+                self.dfs(c, depth + 1, flat, on_path);
+            }
+            on_path.pop();
+        }
+    }
+
+    pub fn flat_len(&self) -> usize { self.flat.len() }
+    pub fn selected(&self) -> usize { self.selected }
+    pub fn move_down(&mut self) { if self.selected + 1 < self.flat.len() { self.selected += 1; } }
+    pub fn move_up(&mut self) { self.selected = self.selected.saturating_sub(1); }
+    pub fn contains(&self, id: &str) -> bool { self.flat.iter().any(|(i, _)| i == id) }
+
+    pub fn toggle_expand(&mut self) {
+        if let Some((id, _)) = self.flat.get(self.selected).cloned() {
+            if let Some(n) = self.nodes.get_mut(&id) && !n.children.is_empty() {
+                n.expanded = !n.expanded;
+            }
+            self.rebuild_flat();
+        }
+    }
+}
+
+impl View for GraphTree {
+    fn render(&mut self, frame: &mut ratatui::Frame) {
+        use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
+        let rows: Vec<ListItem> = self
+            .flat
+            .iter()
+            .map(|(id, depth)| {
+                let n = &self.nodes[id];
+                let marker = if n.children.is_empty() { "  " } else if n.expanded { "v " } else { "> " };
+                ListItem::new(format!("{}{}{}", "  ".repeat(*depth), marker, n.label))
+            })
+            .collect();
+        let mut state = ListState::default();
+        if !self.flat.is_empty() {
+            state.select(Some(self.selected));
+        }
+        let list = List::new(rows)
+            .block(Block::default().borders(Borders::ALL).title("Dependency graph (Enter/Space expand, Esc quit)"))
+            .highlight_symbol("* ");
+        frame.render_stateful_widget(list, frame.area(), &mut state);
+    }
+
+    fn on_key(&mut self, key: KeyEvent) -> bool {
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => return true,
+            KeyCode::Down => self.move_down(),
+            KeyCode::Up => self.move_up(),
+            KeyCode::Enter | KeyCode::Char(' ') => self.toggle_expand(),
+            _ => {}
+        }
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tree() -> GraphTree {
+        GraphTree::from_edges(
+            &[("root", "root-pkg"), ("a", "a-pkg"), ("b", "b-pkg"), ("c", "c-pkg")],
+            &[("root", "a"), ("root", "b"), ("a", "c")],
+            vec!["root".into()],
+        )
+    }
+
+    #[test]
+    fn collapsed_root_shows_only_root() {
+        assert_eq!(tree().flat_len(), 1);
+    }
+
+    #[test]
+    fn expand_reveals_children() {
+        let mut t = tree();
+        t.toggle_expand();
+        assert_eq!(t.flat_len(), 3);
+    }
+
+    #[test]
+    fn expand_nested() {
+        let mut t = tree();
+        t.toggle_expand();
+        t.move_down();
+        t.toggle_expand();
+        assert!(t.contains("c"));
+    }
+}

--- a/cli/src/tui/graph.rs
+++ b/cli/src/tui/graph.rs
@@ -23,8 +23,8 @@ pub struct GraphTree {
     selected: usize,
 }
 
-#[allow(dead_code)]
 impl GraphTree {
+    #[cfg(test)]
     pub fn from_edges(nodes: &[(&str, &str)], edges: &[(&str, &str)], roots: Vec<NodeId>) -> Self {
         let mut map: HashMap<NodeId, Node> = HashMap::new();
         for (id, label) in nodes {
@@ -110,10 +110,11 @@ impl GraphTree {
         }
     }
 
+    #[cfg(test)]
     pub fn flat_len(&self) -> usize { self.flat.len() }
-    pub fn selected(&self) -> usize { self.selected }
     pub fn move_down(&mut self) { if self.selected + 1 < self.flat.len() { self.selected += 1; } }
     pub fn move_up(&mut self) { self.selected = self.selected.saturating_sub(1); }
+    #[cfg(test)]
     pub fn contains(&self, id: &str) -> bool { self.flat.iter().any(|(i, _)| i == id) }
 
     pub fn toggle_expand(&mut self) {

--- a/cli/src/tui/log_view.rs
+++ b/cli/src/tui/log_view.rs
@@ -1,0 +1,205 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use crate::tui::View;
+use ratatui::crossterm::event::{KeyCode, KeyEvent};
+use tokio::sync::mpsc::UnboundedReceiver;
+
+pub struct LogView {
+    lines: Vec<String>,
+    offset: usize,
+    viewport: usize,
+    follow: bool,
+    rx: Option<UnboundedReceiver<String>>,
+    searching: bool,
+    query: String,
+}
+
+impl Default for LogView {
+    fn default() -> Self {
+        Self {
+            lines: Vec::new(),
+            offset: 0,
+            viewport: 1,
+            follow: true,
+            rx: None,
+            searching: false,
+            query: String::new(),
+        }
+    }
+}
+
+impl LogView {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn streaming(rx: UnboundedReceiver<String>) -> Self {
+        Self { rx: Some(rx), ..Self::default() }
+    }
+
+    pub fn set_viewport(&mut self, n: usize) {
+        self.viewport = n.max(1);
+        self.clamp();
+    }
+
+    pub fn push_line(&mut self, line: String) {
+        self.lines.push(line);
+        if self.follow {
+            self.scroll_to_bottom();
+        }
+    }
+
+    fn scroll_to_bottom(&mut self) {
+        self.offset = self.lines.len().saturating_sub(self.viewport);
+    }
+
+    fn clamp(&mut self) {
+        let max = self.lines.len().saturating_sub(self.viewport);
+        if self.offset > max {
+            self.offset = max;
+        }
+    }
+
+    pub fn offset(&self) -> usize { self.offset }
+    pub fn follow(&self) -> bool { self.follow }
+
+    pub fn scroll_down(&mut self) {
+        let max = self.lines.len().saturating_sub(self.viewport);
+        if self.offset < max {
+            self.offset += 1;
+        }
+        if self.offset >= max {
+            self.follow = true;
+        }
+    }
+
+    pub fn scroll_up(&mut self) {
+        self.offset = self.offset.saturating_sub(1);
+        self.follow = false;
+    }
+
+    pub fn search_to(&mut self, needle: &str) {
+        if let Some(idx) = self.lines.iter().position(|l| l.contains(needle)) {
+            self.offset = idx.min(self.lines.len().saturating_sub(1));
+            self.follow = false;
+        }
+    }
+}
+
+impl View for LogView {
+    fn render(&mut self, frame: &mut ratatui::Frame) {
+        use ratatui::text::Text;
+        use ratatui::widgets::{Block, Borders, Paragraph};
+        let area = frame.area();
+        self.viewport = (area.height.saturating_sub(2)).max(1) as usize;
+        self.clamp();
+        if self.follow {
+            self.scroll_to_bottom();
+        }
+        let end = (self.offset + self.viewport).min(self.lines.len());
+        let slice = self.lines.get(self.offset..end).unwrap_or(&[]);
+        let body = slice.join("\n");
+        let search_indicator = if self.searching { format!(" /{}", self.query) } else { String::new() };
+        let title = format!(
+            "Log ({} lines){}{}  [f follow, / search, Esc quit]",
+            self.lines.len(),
+            if self.follow { " FOLLOW" } else { "" },
+            search_indicator,
+        );
+        let p = Paragraph::new(Text::raw(body))
+            .block(Block::default().borders(Borders::ALL).title(title));
+        frame.render_widget(p, area);
+    }
+
+    fn on_key(&mut self, key: KeyEvent) -> bool {
+        if self.searching {
+            match key.code {
+                KeyCode::Enter => {
+                    self.search_to(&self.query.clone());
+                    self.searching = false;
+                }
+                KeyCode::Esc => {
+                    self.searching = false;
+                    self.query.clear();
+                }
+                KeyCode::Backspace => { self.query.pop(); }
+                KeyCode::Char(c) => self.query.push(c),
+                _ => {}
+            }
+            return false;
+        }
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => return true,
+            KeyCode::Down => self.scroll_down(),
+            KeyCode::Up => self.scroll_up(),
+            KeyCode::Char('f') => self.follow = !self.follow,
+            KeyCode::Char('/') => {
+                self.searching = true;
+                self.query.clear();
+            }
+            _ => {}
+        }
+        false
+    }
+
+    fn on_tick(&mut self) {
+        let mut drained = Vec::new();
+        if let Some(rx) = self.rx.as_mut() {
+            while let Ok(line) = rx.try_recv() {
+                drained.push(line);
+            }
+        }
+        for line in drained {
+            self.push_line(line);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lv(n: usize) -> LogView {
+        let mut v = LogView::new();
+        v.set_viewport(5);
+        for i in 0..n {
+            v.push_line(format!("line {i}"));
+        }
+        v
+    }
+
+    #[test]
+    fn follow_keeps_bottom() {
+        let v = lv(20);
+        assert_eq!(v.offset(), 15);
+    }
+
+    #[test]
+    fn scroll_up_disables_follow() {
+        let mut v = lv(20);
+        v.scroll_up();
+        assert!(!v.follow());
+        assert_eq!(v.offset(), 14);
+    }
+
+    #[test]
+    fn search_jumps_to_match() {
+        let mut v = lv(20);
+        v.search_to("line 7");
+        assert_eq!(v.offset(), 7);
+    }
+
+    #[test]
+    fn typing_search_then_enter_jumps() {
+        use ratatui::crossterm::event::{KeyModifiers};
+        let mut v = lv(20);
+        let key = |c| KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE);
+        v.on_key(KeyEvent::new(KeyCode::Char('/'), KeyModifiers::NONE));
+        for c in "line 7".chars() { v.on_key(key(c)); }
+        v.on_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(v.offset(), 7);
+    }
+}

--- a/cli/src/tui/log_view.rs
+++ b/cli/src/tui/log_view.rs
@@ -32,14 +32,16 @@ impl Default for LogView {
 }
 
 impl LogView {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     pub fn streaming(rx: UnboundedReceiver<String>) -> Self {
         Self { rx: Some(rx), ..Self::default() }
     }
 
+    #[cfg(test)]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[cfg(test)]
     pub fn set_viewport(&mut self, n: usize) {
         self.viewport = n.max(1);
         self.clamp();
@@ -63,7 +65,9 @@ impl LogView {
         }
     }
 
+    #[cfg(test)]
     pub fn offset(&self) -> usize { self.offset }
+    #[cfg(test)]
     pub fn follow(&self) -> bool { self.follow }
 
     pub fn scroll_down(&mut self) {

--- a/cli/src/tui/mod.rs
+++ b/cli/src/tui/mod.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+pub mod graph;
 pub mod nar_browser;
 
 use ratatui::Terminal;

--- a/cli/src/tui/mod.rs
+++ b/cli/src/tui/mod.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+pub mod nar_browser;
+
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 use ratatui::crossterm::event::{self, Event, KeyEvent};

--- a/cli/src/tui/mod.rs
+++ b/cli/src/tui/mod.rs
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use ratatui::Terminal;
+use ratatui::backend::CrosstermBackend;
+use ratatui::crossterm::event::{self, Event, KeyEvent};
+use ratatui::crossterm::{execute, terminal};
+use std::io::{self, Stdout};
+use std::time::Duration;
+
+/// A full-screen view: owns its state, renders a frame, reacts to keys.
+pub trait View {
+    fn render(&mut self, frame: &mut ratatui::Frame);
+    /// Return `true` to request exit.
+    fn on_key(&mut self, key: KeyEvent) -> bool;
+    fn on_tick(&mut self) {}
+}
+
+pub fn run<V: View>(mut view: V) -> io::Result<()> {
+    let mut terminal = setup()?;
+    let result = run_loop(&mut terminal, &mut view);
+    restore(&mut terminal)?;
+    result
+}
+
+fn run_loop<V: View>(terminal: &mut Terminal<CrosstermBackend<Stdout>>, view: &mut V) -> io::Result<()> {
+    loop {
+        terminal.draw(|f| view.render(f))?;
+        if event::poll(Duration::from_millis(200))? {
+            if let Event::Key(key) = event::read()?
+                && view.on_key(key)
+            {
+                return Ok(());
+            }
+        } else {
+            view.on_tick();
+        }
+    }
+}
+
+fn setup() -> io::Result<Terminal<CrosstermBackend<Stdout>>> {
+    terminal::enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, terminal::EnterAlternateScreen)?;
+    install_panic_hook();
+    Terminal::new(CrosstermBackend::new(stdout))
+}
+
+fn restore(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> io::Result<()> {
+    terminal::disable_raw_mode()?;
+    execute!(terminal.backend_mut(), terminal::LeaveAlternateScreen)?;
+    terminal.show_cursor()
+}
+
+fn install_panic_hook() {
+    let hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = terminal::disable_raw_mode();
+        let _ = execute!(io::stdout(), terminal::LeaveAlternateScreen);
+        hook(info);
+    }));
+}

--- a/cli/src/tui/mod.rs
+++ b/cli/src/tui/mod.rs
@@ -4,6 +4,7 @@
  */
 
 pub mod graph;
+pub mod log_view;
 pub mod nar_browser;
 
 use ratatui::Terminal;

--- a/cli/src/tui/mod.rs
+++ b/cli/src/tui/mod.rs
@@ -31,15 +31,13 @@ pub fn run<V: View>(mut view: V) -> io::Result<()> {
 
 fn run_loop<V: View>(terminal: &mut Terminal<CrosstermBackend<Stdout>>, view: &mut V) -> io::Result<()> {
     loop {
+        view.on_tick();
         terminal.draw(|f| view.render(f))?;
-        if event::poll(Duration::from_millis(200))? {
-            if let Event::Key(key) = event::read()?
-                && view.on_key(key)
-            {
-                return Ok(());
-            }
-        } else {
-            view.on_tick();
+        if event::poll(Duration::from_millis(200))?
+            && let Event::Key(key) = event::read()?
+            && view.on_key(key)
+        {
+            return Ok(());
         }
     }
 }

--- a/cli/src/tui/nar_browser.rs
+++ b/cli/src/tui/nar_browser.rs
@@ -1,0 +1,119 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use crate::tui::View;
+use connector::caches::NarSummary;
+use ratatui::crossterm::event::{KeyCode, KeyEvent};
+
+pub struct NarBrowser {
+    all: Vec<NarSummary>,
+    filtered_idx: Vec<usize>,
+    pub selected: usize,
+    pub filter: String,
+}
+
+impl NarBrowser {
+    pub fn new(all: Vec<NarSummary>) -> Self {
+        let mut b = Self { all, filtered_idx: Vec::new(), selected: 0, filter: String::new() };
+        b.recompute();
+        b
+    }
+
+    fn recompute(&mut self) {
+        let f = self.filter.to_lowercase();
+        self.filtered_idx = self.all.iter().enumerate()
+            .filter(|(_, n)| f.is_empty() || n.package.to_lowercase().contains(&f) || n.hash.contains(&f))
+            .map(|(i, _)| i)
+            .collect();
+        self.selected = 0;
+    }
+
+    pub fn visible(&self) -> Vec<&NarSummary> {
+        self.filtered_idx.iter().map(|&i| &self.all[i]).collect()
+    }
+
+    pub fn push_filter(&mut self, c: char) { self.filter.push(c); self.recompute(); }
+    pub fn pop_filter(&mut self) { self.filter.pop(); self.recompute(); }
+
+    pub fn move_down(&mut self) {
+        if self.selected + 1 < self.filtered_idx.len() { self.selected += 1; }
+    }
+
+    pub fn move_up(&mut self) { self.selected = self.selected.saturating_sub(1); }
+
+    #[allow(dead_code)]
+    pub fn selected_item(&self) -> Option<&NarSummary> {
+        self.filtered_idx.get(self.selected).map(|&i| &self.all[i])
+    }
+}
+
+impl View for NarBrowser {
+    fn render(&mut self, frame: &mut ratatui::Frame) {
+        use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
+        let items: Vec<ListItem> = self.visible().iter()
+            .map(|n| ListItem::new(format!("{}  {}", &n.hash[..n.hash.len().min(12)], n.package)))
+            .collect();
+        let mut state = ListState::default();
+        if !self.filtered_idx.is_empty() { state.select(Some(self.selected)); }
+        let title = format!("NARs ({})  filter: {}", self.filtered_idx.len(), self.filter);
+        let list = List::new(items)
+            .block(Block::default().borders(Borders::ALL).title(title))
+            .highlight_symbol("> ");
+        frame.render_stateful_widget(list, frame.area(), &mut state);
+    }
+
+    fn on_key(&mut self, key: KeyEvent) -> bool {
+        match key.code {
+            KeyCode::Esc => return true,
+            KeyCode::Down => self.move_down(),
+            KeyCode::Up => self.move_up(),
+            KeyCode::Backspace => self.pop_filter(),
+            KeyCode::Char(c) => self.push_filter(c),
+            _ => {}
+        }
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item(hash: &str, pkg: &str) -> NarSummary {
+        NarSummary {
+            hash: hash.into(),
+            store_path: format!("/nix/store/{hash}-{pkg}"),
+            package: pkg.into(),
+            nar_size: Some(1),
+            file_size: Some(1),
+            created_at: "2026-01-01T00:00:00".into(),
+            last_fetched_at: None,
+        }
+    }
+
+    #[test]
+    fn filter_narrows_and_resets_selection() {
+        let mut b = NarBrowser::new(vec![item("a", "hello"), item("b", "zlib"), item("c", "hella")]);
+        b.selected = 2;
+        b.push_filter('h');
+        b.push_filter('e');
+        assert_eq!(b.visible().len(), 2);
+        assert_eq!(b.selected, 0);
+    }
+
+    #[test]
+    fn move_down_clamps_to_last() {
+        let mut b = NarBrowser::new(vec![item("a", "x"), item("b", "y")]);
+        b.move_down(); b.move_down(); b.move_down();
+        assert_eq!(b.selected, 1);
+    }
+
+    #[test]
+    fn filter_by_hash_prefix() {
+        let mut b = NarBrowser::new(vec![item("abc111", "x"), item("def222", "y")]);
+        b.push_filter('a'); b.push_filter('b');
+        assert_eq!(b.visible().len(), 1);
+    }
+}

--- a/cli/tests/cache_upload.rs
+++ b/cli/tests/cache_upload.rs
@@ -1,0 +1,85 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use assert_cmd::Command;
+use std::fs;
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn upload_nar_file_with_narinfo_succeeds() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v1/caches/mycache/nars"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "error": false, "message": {"store_path": "/nix/store/aa-x", "created": true}
+        })))
+        .mount(&server)
+        .await;
+
+    let home = TempDir::new().unwrap();
+    let cfg_dir = home.path().join("gradient");
+    fs::create_dir_all(&cfg_dir).unwrap();
+    fs::write(
+        cfg_dir.join("config.toml"),
+        format!("Server = '{}'\nAuthToken = 'test-token'\n", server.uri()),
+    )
+    .unwrap();
+
+    let work = TempDir::new().unwrap();
+    let nar = work.path().join("x.nar");
+    let narinfo = work.path().join("x.narinfo");
+    fs::write(&nar, b"abc").unwrap();
+    fs::write(
+        &narinfo,
+        "StorePath: /nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-x\nFileHash: sha256:a\nFileSize: 3\nNarHash: sha256:b\nNarSize: 3\nReferences: \n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("gradient")
+        .unwrap()
+        .env("XDG_CONFIG_HOME", home.path())
+        .args([
+            "cache",
+            "upload",
+            "--nar-file",
+            nar.to_str().unwrap(),
+            "--narinfo",
+            narinfo.to_str().unwrap(),
+            "mycache",
+        ])
+        .assert()
+        .success();
+}
+
+#[tokio::test]
+async fn upload_nar_file_without_narinfo_errors() {
+    let home = TempDir::new().unwrap();
+    let cfg_dir = home.path().join("gradient");
+    fs::create_dir_all(&cfg_dir).unwrap();
+    fs::write(
+        cfg_dir.join("config.toml"),
+        "Server = 'http://localhost:1'\nAuthToken = 't'\n",
+    )
+    .unwrap();
+
+    let work = TempDir::new().unwrap();
+    let nar = work.path().join("x.nar");
+    fs::write(&nar, b"abc").unwrap();
+
+    Command::cargo_bin("gradient")
+        .unwrap()
+        .env("XDG_CONFIG_HOME", home.path())
+        .args([
+            "cache",
+            "upload",
+            "--nar-file",
+            nar.to_str().unwrap(),
+            "mycache",
+        ])
+        .assert()
+        .failure();
+}

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -4336,6 +4336,58 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+    post:
+      tags: [caches]
+      summary: Upload a NAR to a cache
+      description: |-
+        Uploads a single NAR (its bytes plus narinfo metadata) to this cache.
+        Requires `writeStore`. The server validates the byte length against the
+        declared `file_size`, stores the blob, records the cached path, and
+        enqueues a signature for this cache. Re-uploading an existing store path
+        reuses the cached path and only adds this cache's signature.
+
+        The route's body limit is `GRADIENT_MAX_NAR_UPLOAD_SIZE` (default 512 MiB).
+      operationId: uploadCacheNar
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [narinfo, nar]
+              properties:
+                narinfo:
+                  type: string
+                  description: |-
+                    JSON object: `store_path`, `file_hash`, `file_size`,
+                    `nar_size`, `nar_hash`, `references` (array), optional `deriver`.
+                nar:
+                  type: string
+                  format: binary
+                  description: Raw NAR bytes.
+      responses:
+        '201':
+          description: NAR stored
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BaseResponse'
+                  - type: object
+                    properties:
+                      message:
+                        type: object
+                        properties:
+                          store_path:
+                            type: string
+                          created:
+                            type: boolean
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
 
   /caches/{cache}/nars/stats:
     parameters:

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -55,6 +55,7 @@ openssl rand -base64 48 > /run/secrets/gradient-crypt
 | `settings.maxProtoConnections` | `256` | Max simultaneous worker WebSocket connections; further upgrades return `503 Service Unavailable` with `Retry-After: 10` until a slot frees |
 | `settings.keepEvaluations` | `30` | Global maximum of evaluations kept per project (caps the per-project setting) |
 | `settings.maxRequestSize` | `2097152` (2 MiB) | Max HTTP request body in bytes for most endpoints (caps webhook/JSON payloads to prevent OOM). The build-request blob endpoint uses a fixed 20 MiB cap. |
+| `settings.maxNarUploadSize` | `536870912` (512 MiB) | Max body in bytes for `POST /caches/{cache}/nars`; overrides the general `maxRequestSize` cap for NAR uploads. (`GRADIENT_MAX_NAR_UPLOAD_SIZE`) |
 | `settings.logLevel.default` | `info` | Log level: `trace` `debug` `info` `warn` `error` |
 | `settings.logLevel.cache` | null | Cache log level override (null inherits default) |
 | `settings.logLevel.web` | null | Web log level override (null inherits default) |

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -2920,6 +2920,17 @@ are covered too. Phases:
   available, and delete (CLI plus a direct `DELETE` asserting `204`).
 - **Build-dependent endpoints** — exercised on empty state for correct
   not-found behaviour, since no builds are present.
+- **Edge cases** — duplicate creates (org, project, cache, org/cache role, API
+  key, org/cache member, subscription) return an enveloped `409`; a reserved
+  project name (`build-request`) and an empty API-key permission mask return
+  enveloped `400`s.
+- **Permissions (multi-actor)** — the second user acts with their own token: a
+  non-member cannot read the private org; the built-in `View` role grants read
+  but is rejected (enveloped `403`) on settings edit, project create, member
+  add, and org delete; promotion to `Admin` unlocks the settings edit.
+
+The auth surface is rate-limited (burst 5, one token per 6s), so the script
+spaces its registration/login calls to stay within the bucket.
 
 Out of scope (covered by dedicated tests or requiring external services):
 OIDC, SMTP e-mail verification, forge webhooks, the worker proto protocol,

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -2895,3 +2895,32 @@ Run with: `cargo test -p gradient-cli`
   triggers quit.
 - `tui::log_view` — `↑`/`↓` scroll adjusts the offset; enabling follow-tail
   pins the view to the last line; `/` search highlights matching lines.
+
+## REST API endpoint surface (NixOS integration)
+
+`nix/tests/gradient/api` boots a single node (gradient + nginx + postgres, no
+worker or nix store) and drives `nix/tests/gradient/api/test.py`. Every
+management endpoint is hit directly (`curl`) and, where the CLI exposes it, also
+through `gradient`. Resources are created at runtime so the creation endpoints
+are covered too. Phases:
+
+- **Auth / user / keys** — check-username, register, login, logout; profile,
+  settings, sessions, audit-log, search; API-key create/list/revoke/delete.
+- **Organizations** — CRUD, available/public, ssh rotation, roles CRUD, and
+  membership (a second user is added via `POST /orgs/{org}/users`, re-roled with
+  `PATCH`, and removed with `DELETE`, asserting the member list each time).
+- **Projects** — CRUD, details, triggers, active toggle, plus a transfer flow
+  that moves a throwaway project to a second org and verifies it disappears from
+  the source and appears under the destination.
+- **Workers** — register/list/patch/delete (direct + CLI), with v4 worker UUIDs.
+- **Caches** — CRUD, key/stats, active/public toggles, plus sub-resources:
+  member add/re-role/remove, custom-role create/get/patch/delete, an HTTP
+  upstream create/patch/delete, and org subscription remove/restore.
+- **Cache NARs** — synthetic upload (CLI + direct multipart), list/show/stats/
+  available, and delete (CLI plus a direct `DELETE` asserting `204`).
+- **Build-dependent endpoints** — exercised on empty state for correct
+  not-found behaviour, since no builds are present.
+
+Out of scope (covered by dedicated tests or requiring external services):
+OIDC, SMTP e-mail verification, forge webhooks, the worker proto protocol,
+the Nix binary-cache serving family, and build-request dispatch.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -2834,3 +2834,64 @@ Run with: `cargo test -p web --lib forge_hooks` and
   — the event actor is parsed independently of the PR author.
 - `reporting::tests::evaluation_context_format_with_custom_wildcard` — custom
   wildcard produces `gradient/{project}: Evaluation: {wildcard}`.
+
+## Cache upload - NAR ingest, endpoint, connector, and CLI (issue #261)
+
+### Shared NAR ingest (`core::cache::ingest`)
+
+Run with: `cargo test -p core cache::ingest`
+
+- `malformed_store_path_bails_before_any_io` — a syntactically invalid store
+  path is rejected before any blob write is attempted.
+- `create_path_writes_blob_and_reports_created` — a valid NAR + narinfo pair
+  writes the blob to storage and returns `IngestResult::Created`.
+
+### Upload endpoint (`web` crate)
+
+Run with: `cargo test -p web --test caches_upload`
+
+- `upload_unauthenticated_returns_403` — `POST /api/v1/caches/{cache}/nars`
+  without a bearer token returns `403`.
+- Real-DB integration stubs are present but marked `#[ignore]`; they run in
+  CI against a live Postgres instance.
+
+### Connector multipart upload (`connector` crate)
+
+Run with: `cargo test -p connector nar_upload`
+
+- `nar_upload_posts_multipart` — the connector assembles the correct multipart
+  form (a `narinfo` JSON part and a `nar` binary part) and maps a 200 response
+  to success.
+
+### CLI narinfo parser
+
+Run with: `cargo test -p gradient-cli`
+
+- `parses_full_narinfo` — a complete `.narinfo` file round-trips through the
+  parser with all fields populated.
+- `missing_required_field_errors` — a narinfo missing a required field (e.g.
+  `StorePath`) returns a parse error naming the field.
+- `empty_references_ok` — a `References:` line with no paths is accepted and
+  produces an empty references list.
+
+### CLI `cache_upload` integration
+
+Run with: `cargo test -p gradient-cli`
+
+- `upload_nar_file_with_narinfo_succeeds` — providing both `--nar-file` and
+  `--narinfo` against a mock server returns success.
+- `upload_nar_file_without_narinfo_errors` — omitting `--narinfo` in no-nix
+  mode exits with a usage error (exit code 2).
+
+### CLI TUI view-model tests
+
+Run with: `cargo test -p gradient-cli`
+
+- `tui::nar_browser` — filter input narrows the displayed list; scroll position
+  resets to 0 when the filter changes; clearing the filter restores the full
+  list.
+- `tui::graph` — expanding a collapsed node adds its children to the visible
+  set; collapsing removes them; nested expand/collapse is consistent; `Esc`
+  triggers quit.
+- `tui::log_view` — `↑`/`↓` scroll adjusts the offset; enabling follow-tail
+  pins the view to the last line; `/` search highlights matching lines.

--- a/docs/src/usage/cache-nars.md
+++ b/docs/src/usage/cache-nars.md
@@ -1,9 +1,7 @@
 # Managing cached NARs
 
 Gradient caches hold many individual NARs. This page covers listing,
-inspecting, and deleting them through the CLI or the web UI. NAR upload from
-a local store is tracked separately under
-[issue #261](https://github.com/wavelens/gradient/issues/261).
+inspecting, deleting, and uploading them through the CLI or the web UI.
 
 ## CLI
 
@@ -14,6 +12,8 @@ gradient cache nar list <cache> [--hash <prefix>] [--package <substring>] \
 gradient cache nar show <cache> <hash>
 gradient cache nar delete <cache> <hash> [-y]
 gradient cache nar stats <cache>
+gradient cache upload --nar-file <file.nar> --narinfo <file.narinfo> <cache>
+gradient cache upload [--full-closure] <store-path>... <cache>   # nix feature only
 ```
 
 `gradient cache nar list` is paginated. Default page size is 50, max 200.
@@ -21,6 +21,54 @@ gradient cache nar stats <cache>
 `gradient cache nar delete` prompts for confirmation unless `-y/--yes` is
 passed. In `--json` mode, `--yes` is mandatory (no interactive prompt is
 possible).
+
+## Uploading NARs
+
+`gradient cache upload` pushes a NAR into a cache. Requires the `writeStore`
+permission on the target cache.
+
+### No-nix mode (always available)
+
+Upload a pre-dumped NAR file together with its narinfo metadata. No local
+Nix installation is required.
+
+```sh
+gradient cache upload \
+    --nar-file result.nar \
+    --narinfo result.narinfo \
+    my-cache
+```
+
+`--narinfo` points to a standard `.narinfo` file. The CLI parses it for
+store path, NAR hash, NAR size, and references before submitting.
+
+### Nix mode (requires the `nix` Cargo feature)
+
+When the CLI is built with the `nix` feature, store paths can be uploaded
+directly from the local Nix daemon. Each path is resolved via harmonia,
+NAR-dumped, and uploaded in one step.
+
+```sh
+# Upload a single store path
+gradient cache upload /nix/store/abc123-hello-2.12.1 my-cache
+
+# Upload the full runtime reference closure of every listed path
+gradient cache upload --full-closure /nix/store/abc123-hello-2.12.1 my-cache
+```
+
+`--full-closure` walks the runtime reference closure of each given path and
+uploads every reachable path in dependency order.
+
+### Size cap
+
+The server enforces a maximum upload size per NAR. The default is 512 MiB
+and is controlled by the `GRADIENT_MAX_NAR_UPLOAD_SIZE` environment variable
+on the server.
+
+### Backend endpoint
+
+`POST /api/v1/caches/{cache}/nars` — multipart form with a `narinfo` JSON
+part and a `nar` binary part.
 
 ## Web UI
 
@@ -52,3 +100,5 @@ references.
   the cache owner.
 - **Delete:** the cache owner only. Matches existing `PATCH /caches/{cache}`
   semantics.
+- **Upload (`writeStore`):** callers must hold the `writeStore` cache
+  permission. Returns `403` otherwise.

--- a/docs/src/usage/cli.md
+++ b/docs/src/usage/cli.md
@@ -108,7 +108,8 @@ gradient cache add
 gradient cache remove <name>
 ```
 
-NAR management (list, inspect, delete cached store paths inside a cache):
+NAR management (list, inspect, delete, and upload cached store paths inside a
+cache):
 
 ```sh
 gradient cache nar list <cache> [--hash <prefix>] [--package <substring>] \
@@ -117,14 +118,24 @@ gradient cache nar list <cache> [--hash <prefix>] [--package <substring>] \
 gradient cache nar show <cache> <hash>
 gradient cache nar delete <cache> <hash> [-y]
 gradient cache nar stats <cache>
+
+# Upload a pre-dumped NAR (no Nix required)
+gradient cache upload --nar-file <file.nar> --narinfo <file.narinfo> <cache>
+
+# Upload from the local Nix store (nix feature only)
+gradient cache upload [--full-closure] <store-path>... <cache>
 ```
 
 Deleting a NAR is ref-counted: if the NAR is signed by more than one cache,
 the delete only drops the current cache's signature; the underlying NAR blob
 stays. When the last cache holding a NAR drops it, the blob is GC'd
 asynchronously and any `derivation_output.is_cached` rows for it flip to
-`false`. NAR upload from local store is tracked separately under
-[issue #261](https://github.com/wavelens/gradient/issues/261).
+`false`.
+
+Uploading requires the `writeStore` cache permission. The server enforces a
+maximum NAR upload size (default 512 MiB, configurable via
+`GRADIENT_MAX_NAR_UPLOAD_SIZE`). See [Managing cached NARs](cache-nars.md)
+for full upload documentation.
 
 ### Build Requests
 
@@ -150,6 +161,34 @@ Requirements and limits:
 - Combined upload size must not exceed **20 MiB** (`MAX_BUILD_REQUEST_SIZE`).
 - The default flow streams logs from all queued builds until they complete;
   pass `--no-stream` to return immediately after dispatch.
+
+### Builds
+
+`gradient builds` is a top-level command group for inspecting build metadata
+after dispatch.
+
+```sh
+# Collapsible dependency-graph browser for a specific build
+gradient builds graph <build-id> [-i]
+
+# Build log viewer / streamer for a specific build
+gradient builds log <build-id> [-i]
+```
+
+Without `-i`, `builds graph` prints the node and edge counts to stdout.
+Without `-i`, `builds log` streams the log to stdout.
+
+### Interactive mode (`-i` / `--interactive`)
+
+Several commands accept `-i` / `--interactive` to open a full-screen
+[ratatui](https://github.com/ratatui/ratatui) TUI instead of plain text
+output. The flag is silently ignored in `--json` mode.
+
+| Command | TUI description | Key bindings |
+|---|---|---|
+| `gradient cache nar list -i` | Scrollable, type-to-filter NAR browser | Type to filter by package or hash; `↑`/`↓` navigate; `Esc` quit |
+| `gradient builds graph <id> -i` | Collapsible dependency-graph browser (nix-tree style) | `↑`/`↓` navigate; `Enter`/`Space` expand or collapse a node; `Esc` quit |
+| `gradient builds log <id> -i` | Less-style log pager with follow-tail | `↑`/`↓` scroll; `f` toggle follow-tail; `/` search; `Esc` quit |
 
 ### Downloading artefacts
 

--- a/nix/modules/gradient.nix
+++ b/nix/modules/gradient.nix
@@ -379,6 +379,12 @@ in {
           default = 2 * 1024 * 1024;
         };
 
+        maxNarUploadSize = lib.mkOption {
+          description = "Maximum size in bytes of a NAR upload to the cache upload endpoint.";
+          type = lib.types.ints.positive;
+          default = 512 * 1024 * 1024;
+        };
+
         trustedProxies = lib.mkOption {
           description = ''
             CIDR allowlist of peers permitted to set `X-Forwarded-For`.
@@ -611,6 +617,7 @@ in {
         GRADIENT_REPORT_ERRORS = lib.boolToString cfg.reportErrors;
         GRADIENT_KEEP_EVALUATIONS = toString cfg.settings.keepEvaluations;
         GRADIENT_MAX_REQUEST_SIZE = toString cfg.settings.maxRequestSize;
+        GRADIENT_MAX_NAR_UPLOAD_SIZE = toString cfg.settings.maxNarUploadSize;
         GRADIENT_MAX_PROTO_CONNECTIONS = toString cfg.settings.maxProtoConnections;
         GRADIENT_LOG_LEVEL = cfg.settings.logLevel.default;
         GRADIENT_USE_TLS = lib.boolToString cfg.useTls;

--- a/nix/tests/gradient/api/default.nix
+++ b/nix/tests/gradient/api/default.nix
@@ -8,10 +8,20 @@
 {
   value = pkgs.testers.runNixOSTest ({ pkgs, lib, ... }: {
     name = "gradient-api";
-    globalTimeout = 120;
+    globalTimeout = 600;
+
     nodes = {
       machine = { config, pkgs, lib, ... }: {
         imports = [ ../../../modules/gradient.nix ];
+
+        networking.hosts."127.0.0.1" = [ "gradient.local" ];
+
+        environment.systemPackages = with pkgs; [
+          curl
+          jq
+          gradient-cli
+        ];
+
         services = {
           gradient = {
             enable = true;

--- a/nix/tests/gradient/api/test.py
+++ b/nix/tests/gradient/api/test.py
@@ -155,7 +155,7 @@ api("GET", "projects/myorg/myproject/details", token=token)
 api("PATCH", "projects/myorg/myproject", token=token, body=json.dumps({"display_name": "MP2"}))
 api("GET", "projects/myorg/myproject/entry-points", token=token)
 api("GET", "projects/myorg/myproject/metrics", token=token)
-assert api("GET", "projects/myorg/myproject/evaluations", token=token)["items"] == [], \
+assert api("GET", "projects/myorg/myproject/evaluations", token=token) == [], \
     "fresh project should have no evaluations"
 
 trig = api("POST", "projects/myorg/myproject/triggers", token=token, body=json.dumps({

--- a/nix/tests/gradient/api/test.py
+++ b/nix/tests/gradient/api/test.py
@@ -117,6 +117,10 @@ api("GET", "user/search?q=operator", token=token)
 key_token = api("POST", "user/keys", token=token, body=json.dumps({
     "name": "ci-key", "permissions": ["viewOrg"]}))
 assert key_token.startswith("GRAD"), key_token
+api("POST", "user/keys", token=token, expect_error=True,
+    body=json.dumps({"name": "ci-key", "permissions": ["viewOrg"]}))  # duplicate name
+api("POST", "user/keys", token=token, expect_error=True,
+    body=json.dumps({"name": "no-perms", "permissions": []}))  # empty permission mask
 keys = api("GET", "user/keys", token=token)
 key_id = next(k["id"] for k in keys if k["name"] == "ci-key")
 # The created key authorizes API calls just like a session token.
@@ -128,6 +132,8 @@ api("DELETE", "user/keys", token=token, body=json.dumps({"name": "ci-key"}))
 banner("Phase 3: organizations")
 org_id = api("PUT", "orgs", token=token, body=json.dumps({
     "name": "myorg", "display_name": "My Org", "description": "desc"}))
+api("PUT", "orgs", token=token, expect_error=True, body=json.dumps({
+    "name": "myorg", "display_name": "Dup", "description": "d"}))  # duplicate name
 assert api("GET", "orgs/myorg", token=token)["id"] == org_id
 orgs = api("GET", "orgs", token=token)["items"]
 assert any(o["id"] == org_id for o in orgs)
@@ -145,6 +151,8 @@ api("GET", "orgs/myorg/subscribe", token=token)
 
 role_id = api("POST", "orgs/myorg/roles", token=token, body=json.dumps({
     "name": "viewers", "permissions": ["viewOrg"]}))["id"]
+api("POST", "orgs/myorg/roles", token=token, expect_error=True,
+    body=json.dumps({"name": "viewers", "permissions": ["viewOrg"]}))  # duplicate name
 api("GET", "orgs/myorg/roles", token=token)
 api("GET", f"orgs/myorg/roles/{role_id}", token=token)
 api("PATCH", f"orgs/myorg/roles/{role_id}", token=token, body=json.dumps({"name": "viewers2"}))
@@ -154,6 +162,8 @@ api("DELETE", f"orgs/myorg/roles/{role_id}", token=token)
 # Members are referenced by username; "View"/"Write" are built-in roles.
 api("POST", "orgs/myorg/users", token=token,
     body=json.dumps({"user": member, "role": "View"}))
+api("POST", "orgs/myorg/users", token=token, expect_error=True,
+    body=json.dumps({"user": member, "role": "View"}))  # already a member
 assert any(m["id"] == member for m in api("GET", "orgs/myorg/users", token=token)), "member not added"
 api("PATCH", "orgs/myorg/users", token=token,
     body=json.dumps({"user": member, "role": "Write"}))
@@ -177,6 +187,12 @@ banner("Phase 4: projects")
 proj_id = api("PUT", "projects/myorg", token=token, body=json.dumps({
     "name": "myproject", "display_name": "My Project", "description": "d",
     "repository": "git@github.com:Wavelens/Gradient.git", "wildcard": "packages.*"}))
+api("PUT", "projects/myorg", token=token, expect_error=True, body=json.dumps({
+    "name": "myproject", "display_name": "Dup", "description": "d",
+    "repository": "git@github.com:Wavelens/Gradient.git", "wildcard": "packages.*"}))  # duplicate name
+api("PUT", "projects/myorg", token=token, expect_error=True, body=json.dumps({
+    "name": "build-request", "display_name": "Reserved", "description": "d",
+    "repository": "git@github.com:Wavelens/Gradient.git", "wildcard": "packages.*"}))  # reserved name
 assert api("GET", "projects/myorg/myproject", token=token)["id"] == proj_id
 assert any(p["id"] == proj_id for p in api("GET", "projects/myorg", token=token)["items"])
 api("GET", "projects/myorg/available", token=token)
@@ -248,6 +264,8 @@ assert not any(w["worker_id"] == cli_worker
 banner("Phase 6: caches")
 api("PUT", "caches", token=token, body=json.dumps({
     "name": "maincache", "display_name": "Main", "description": "d", "priority": 10}))
+api("PUT", "caches", token=token, expect_error=True, body=json.dumps({
+    "name": "maincache", "display_name": "Dup", "description": "d", "priority": 10}))  # duplicate name
 api("GET", "caches/maincache", token=token)
 assert any(c["name"] == "maincache" for c in api("GET", "caches", token=token))
 api("GET", "caches/available", token=token)
@@ -261,6 +279,7 @@ api("GET", "caches/maincache/upstreams", token=token)
 api("PATCH", "caches/maincache", token=token, body=json.dumps({"priority": 20}))
 # Subscribe the org so the cache is usable in org context.
 api("POST", "orgs/myorg/subscribe/maincache", token=token)
+api("POST", "orgs/myorg/subscribe/maincache", token=token, expect_error=True)  # already subscribed
 
 cli("cache create --name clicache --display-name 'CLI Cache' --description d --priority 5")
 api("GET", "caches/clicache", token=token)
@@ -274,6 +293,8 @@ banner("Phase 6b: cache members / roles / upstreams")
 # Members (second user, by username; "View"/"Write" are built-in cache roles).
 api("POST", "caches/maincache/members", token=token,
     body=json.dumps({"user": member, "role": "View"}))
+api("POST", "caches/maincache/members", token=token, expect_error=True,
+    body=json.dumps({"user": member, "role": "View"}))  # already a member
 assert any(m["id"] == member for m in api("GET", "caches/maincache/members", token=token)), \
     "cache member not added"
 api("PATCH", "caches/maincache/members", token=token,
@@ -285,6 +306,8 @@ assert not any(m["id"] == member for m in api("GET", "caches/maincache/members",
 # Custom cache role lifecycle.
 crole_id = api("POST", "caches/maincache/roles", token=token, body=json.dumps({
     "name": "cacheviewers", "permissions": ["viewCache"]}))["id"]
+api("POST", "caches/maincache/roles", token=token, expect_error=True,
+    body=json.dumps({"name": "cacheviewers", "permissions": ["viewCache"]}))  # duplicate name
 api("GET", f"caches/maincache/roles/{crole_id}", token=token)
 api("PATCH", f"caches/maincache/roles/{crole_id}", token=token,
     body=json.dumps({"name": "cacheviewers2"}))
@@ -380,6 +403,38 @@ api("GET", f"evals/{missing}/builds", token=token, expect_error=True)
 api("GET", f"builds/{missing}", token=token, expect_error=True)
 api("GET", f"builds/{missing}/graph", token=token, expect_error=True)
 api("GET", f"commits/{missing}", token=token, expect_error=True)
+
+# ── Phase 8b: permissions (multi-actor) ───────────────────────────────────────
+# The second user logs in and acts with their own token. The built-in "View"
+# role grants read access but none of the org-management permissions, so those
+# mutations must be rejected; promotion to "Admin" then unlocks them.
+banner("Phase 8b: permissions (multi-actor)")
+team_token = api("POST", "auth/basic/login", body=json.dumps({
+    "loginname": member, "password": "SecureTest123!"}))
+assert team_token, "second-user login returned empty token"
+
+# Non-member cannot read a private org.
+api("GET", "orgs/myorg", token=team_token, expect_error=True)
+
+# Operator grants "View"; the member can read but cannot manage.
+api("POST", "orgs/myorg/users", token=token, body=json.dumps({"user": member, "role": "View"}))
+api("GET", "orgs/myorg", token=team_token)                                    # ViewOrg granted
+api("PATCH", "orgs/myorg", token=team_token, expect_error=True,
+    body=json.dumps({"display_name": "hijack"}))                              # no ManageOrgSettings
+api("PUT", "projects/myorg", token=team_token, expect_error=True, body=json.dumps({
+    "name": "sneak", "display_name": "x", "description": "d",
+    "repository": "git@github.com:Wavelens/Gradient.git", "wildcard": "packages.*"}))  # no CreateProject
+api("POST", "orgs/myorg/users", token=team_token, expect_error=True,
+    body=json.dumps({"user": "operator", "role": "View"}))                    # no ManageMembers
+api("DELETE", "orgs/myorg", token=team_token, expect_error=True)              # no DeleteOrg
+
+# Promote to "Admin": the same mutation now succeeds.
+api("PATCH", "orgs/myorg/users", token=token, body=json.dumps({"user": member, "role": "Admin"}))
+api("PATCH", "orgs/myorg", token=team_token, body=json.dumps({"display_name": "Admin Edit OK"}))
+
+# Remove the member; read access is revoked again.
+api("DELETE", "orgs/myorg/users", token=token, body=json.dumps({"user": member}))
+api("GET", "orgs/myorg", token=team_token, expect_error=True)
 
 # ── Phase 9: logout ───────────────────────────────────────────────────────────
 banner("Phase 9: logout")

--- a/nix/tests/gradient/api/test.py
+++ b/nix/tests/gradient/api/test.py
@@ -86,6 +86,13 @@ token = api("POST", "auth/basic/login", body=json.dumps({
 assert token, "login returned empty token"
 api("GET", "orgs", token=token)  # token authorizes
 
+# A second user, used later for org/cache membership flows. Lookup is by username.
+member = "teammate"
+api("POST", "auth/basic/register", body=json.dumps({
+    "username": member, "name": "Team Mate",
+    "email": "teammate@gradient.local", "password": "SecureTest123!",
+}))
+
 # Public/unauthenticated-ish reads.
 print(machine.succeed(f"curl -sS {API}/config -i"))
 machine.execute(f"curl -sS {API}/metrics -o /dev/null -w '%{{http_code}}'")
@@ -139,6 +146,16 @@ api("GET", f"orgs/myorg/roles/{role_id}", token=token)
 api("PATCH", f"orgs/myorg/roles/{role_id}", token=token, body=json.dumps({"name": "viewers2"}))
 api("DELETE", f"orgs/myorg/roles/{role_id}", token=token)
 
+# Org membership: add the second user, change their role, then remove them.
+# Members are referenced by username; "View"/"Write" are built-in roles.
+api("POST", "orgs/myorg/users", token=token,
+    body=json.dumps({"user": member, "role": "View"}))
+assert any(m["id"] == member for m in api("GET", "orgs/myorg/users", token=token)), "member not added"
+api("PATCH", "orgs/myorg/users", token=token,
+    body=json.dumps({"user": member, "role": "Write"}))
+api("DELETE", "orgs/myorg/users", token=token, body=json.dumps({"user": member}))
+assert not any(m["id"] == member for m in api("GET", "orgs/myorg/users", token=token)), "member not removed"
+
 # CLI: configure, then create/list/show/delete a second org.
 machine.succeed(f"{CLI} config Server http://gradient.local")
 machine.succeed(f"{CLI} config AuthToken {token}")
@@ -191,6 +208,17 @@ cli("project delete")
 api("GET", "projects/myorg/cliproject", token=token, expect_error=True)
 machine.succeed(f"{CLI} project select myproject")
 
+# Project transfer: move a throwaway project to a second org owned by the caller.
+api("PUT", "orgs", token=token, body=json.dumps({
+    "name": "destorg", "display_name": "Dest", "description": "d"}))
+api("PUT", "projects/myorg", token=token, body=json.dumps({
+    "name": "transferme", "display_name": "Transfer", "description": "d",
+    "repository": "git@github.com:Wavelens/Gradient.git", "wildcard": "packages.*"}))
+api("POST", "projects/myorg/transferme/transfer", token=token,
+    body=json.dumps({"organization": "destorg"}))
+api("GET", "projects/destorg/transferme", token=token)               # now under destorg
+api("GET", "projects/myorg/transferme", token=token, expect_error=True)  # gone from myorg
+
 # ── Phase 5: workers (direct + CLI) ───────────────────────────────────────────
 banner("Phase 5: workers")
 api_worker = "b0000000-0000-4000-8000-000000000001"
@@ -236,6 +264,43 @@ cli("cache list")
 cli("cache show clicache")
 cli("cache delete clicache")
 api("GET", "caches/clicache", token=token, expect_error=True)
+
+# ── Phase 6b: cache sub-resources (members, roles, upstreams, subscription) ───
+banner("Phase 6b: cache members / roles / upstreams")
+# Members (second user, by username; "View"/"Write" are built-in cache roles).
+api("POST", "caches/maincache/members", token=token,
+    body=json.dumps({"user": member, "role": "View"}))
+assert any(m["id"] == member for m in api("GET", "caches/maincache/members", token=token)), \
+    "cache member not added"
+api("PATCH", "caches/maincache/members", token=token,
+    body=json.dumps({"user": member, "role": "Write"}))
+api("DELETE", "caches/maincache/members", token=token, body=json.dumps({"user": member}))
+assert not any(m["id"] == member for m in api("GET", "caches/maincache/members", token=token)), \
+    "cache member not removed"
+
+# Custom cache role lifecycle.
+crole_id = api("POST", "caches/maincache/roles", token=token, body=json.dumps({
+    "name": "cacheviewers", "permissions": ["viewCache"]}))["id"]
+api("GET", f"caches/maincache/roles/{crole_id}", token=token)
+api("PATCH", f"caches/maincache/roles/{crole_id}", token=token,
+    body=json.dumps({"name": "cacheviewers2"}))
+api("DELETE", f"caches/maincache/roles/{crole_id}", token=token)
+
+# HTTP upstream lifecycle (self-contained: no second cache needed).
+up_id = api("PUT", "caches/maincache/upstreams", token=token, body=json.dumps({
+    "type": "http", "display_name": "mirror",
+    "url": "https://cache.example.com",
+    "public_key": "cache.example.com-1:" + "A" * 44}))
+assert any(u["id"] == up_id for u in api("GET", "caches/maincache/upstreams", token=token)), \
+    "upstream not created"
+api("PATCH", f"caches/maincache/upstreams/{up_id}", token=token, body=json.dumps({
+    "url": "https://mirror.example.com",
+    "public_key": "mirror.example.com-1:" + "B" * 44}))
+api("DELETE", f"caches/maincache/upstreams/{up_id}", token=token)
+
+# Org subscription removal then restore.
+api("DELETE", "orgs/myorg/subscribe/maincache", token=token)
+api("POST", "orgs/myorg/subscribe/maincache", token=token)
 
 # ── Phase 7: cache NAR upload surface (direct + CLI) ──────────────────────────
 # No nix store is needed: the endpoint validates byte length + store-path shape,

--- a/nix/tests/gradient/api/test.py
+++ b/nix/tests/gradient/api/test.py
@@ -95,10 +95,11 @@ api("GET", "user/sessions", token=token)
 api("GET", "user/audit-log", token=token)
 api("GET", "user/search?q=operator", token=token)
 
-created = api("POST", "user/keys", token=token, body=json.dumps({
+key_token = api("POST", "user/keys", token=token, body=json.dumps({
     "name": "ci-key", "permissions": ["viewOrg"]}))
-key_id, key_token = created["id"], created["token"]
-api("GET", "user/keys", token=token)
+assert key_token.startswith("GRAD"), key_token
+keys = api("GET", "user/keys", token=token)
+key_id = next(k["id"] for k in keys if k["name"] == "ci-key")
 # The created key authorizes API calls just like a session token.
 api("GET", "orgs", token=key_token)
 api("GET", f"user/keys/{key_id}", token=token)

--- a/nix/tests/gradient/api/test.py
+++ b/nix/tests/gradient/api/test.py
@@ -11,6 +11,7 @@
 # build-request dispatch) have dedicated tests and are out of scope here.
 
 import json
+import time
 
 API = "http://gradient.local/api/v1"
 CLI = "gradient"
@@ -87,7 +88,10 @@ assert token, "login returned empty token"
 api("GET", "orgs", token=token)  # token authorizes
 
 # A second user, used later for org/cache membership flows. Lookup is by username.
+# The auth surface is rate-limited (burst 5, one token refilled every 6s); the
+# calls above exhaust the burst, so wait for a token before this 6th request.
 member = "teammate"
+time.sleep(8)
 api("POST", "auth/basic/register", body=json.dumps({
     "username": member, "name": "Team Mate",
     "email": "teammate@gradient.local", "password": "SecureTest123!",

--- a/nix/tests/gradient/api/test.py
+++ b/nix/tests/gradient/api/test.py
@@ -57,23 +57,23 @@ api("GET", "health")
 
 # ── Phase 1: auth + registration ──────────────────────────────────────────────
 banner("Phase 1: auth")
-api("POST", "auth/check-username", body=json.dumps({"username": "admin"}))  # available
+api("POST", "auth/check-username", body=json.dumps({"username": "operator"}))  # available
 
 api("POST", "auth/basic/register", body=json.dumps({
-    "username": "admin", "name": "Admin User",
-    "email": "admin@gradient.local", "password": "SecureTest123!",
+    "username": "operator", "name": "Operator User",
+    "email": "operator@gradient.local", "password": "SecureTest123!",
 }))
 api("POST", "auth/basic/register", expect_error=True, body=json.dumps({
-    "username": "admin", "name": "Admin User",
-    "email": "admin@gradient.local", "password": "SecureTest123!",
+    "username": "operator", "name": "Operator User",
+    "email": "operator@gradient.local", "password": "SecureTest123!",
 }))
 api("POST", "auth/check-username", expect_error=True,
-    body=json.dumps({"username": "admin"}))  # now taken
+    body=json.dumps({"username": "operator"}))  # now taken
 
 api("GET", "orgs", expect_error=True)  # no token -> rejected
 
 token = api("POST", "auth/basic/login", body=json.dumps({
-    "loginname": "admin", "password": "SecureTest123!",
+    "loginname": "operator", "password": "SecureTest123!",
 }))
 assert token, "login returned empty token"
 api("GET", "orgs", token=token)  # token authorizes
@@ -85,7 +85,7 @@ machine.execute(f"curl -sS {API}/metrics -o /dev/null -w '%{{http_code}}'")
 # ── Phase 2: user + api keys ──────────────────────────────────────────────────
 banner("Phase 2: user + api keys")
 me = api("GET", "user", token=token)
-assert me.get("username") == "admin", me
+assert me.get("username") == "operator", me
 
 api("PATCH", "user/settings", token=token, body=json.dumps({"name": "Admin Renamed"}))
 assert api("GET", "user", token=token).get("name") == "Admin Renamed"
@@ -93,7 +93,7 @@ assert api("GET", "user", token=token).get("name") == "Admin Renamed"
 api("GET", "user/keys/permissions", token=token)
 api("GET", "user/sessions", token=token)
 api("GET", "user/audit-log", token=token)
-api("GET", "user/search?q=admin", token=token)
+api("GET", "user/search?q=operator", token=token)
 
 created = api("POST", "user/keys", token=token, body=json.dumps({
     "name": "ci-key", "permissions": []}))

--- a/nix/tests/gradient/api/test.py
+++ b/nix/tests/gradient/api/test.py
@@ -102,9 +102,8 @@ keys = api("GET", "user/keys", token=token)
 key_id = next(k["id"] for k in keys if k["name"] == "ci-key")
 # The created key authorizes API calls just like a session token.
 api("GET", "orgs", token=key_token)
-api("GET", f"user/keys/{key_id}", token=token)
 api("POST", f"user/keys/{key_id}/revoke", token=token)
-api("DELETE", f"user/keys/{key_id}", token=token)
+api("DELETE", "user/keys", token=token, body=json.dumps({"name": "ci-key"}))
 
 # ── Phase 3: organizations (direct + CLI) ─────────────────────────────────────
 banner("Phase 3: organizations")

--- a/nix/tests/gradient/api/test.py
+++ b/nix/tests/gradient/api/test.py
@@ -259,7 +259,7 @@ assert any(n["hash"] == cli_hash for n in nars), f"uploaded NAR missing: {nars}"
 api("GET", f"caches/maincache/nars/{cli_hash}", token=token)
 api("GET", "caches/maincache/nars/stats", token=token)
 api("GET", f"caches/maincache/nars/available?hash={cli_hash}", token=token)
-cli(f"cache nar list maincache")
+cli("cache nar list maincache")
 cli(f"cache nar show maincache {cli_hash}")
 cli("cache nar stats maincache")
 
@@ -276,8 +276,8 @@ machine.succeed(f"cat > /tmp/direct.narinfo.json <<'EOF'\n{narinfo_json}\nEOF")
 machine.succeed(
     f"curl -sS --fail -X POST {API}/caches/maincache/nars "
     f"-H 'Authorization: Bearer {token}' "
-    f"-F 'narinfo=</tmp/direct.narinfo.json;type=application/json' "
-    f"-F 'nar=@/tmp/direct.nar'"
+    "-F 'narinfo=</tmp/direct.narinfo.json;type=application/json' "
+    "-F 'nar=@/tmp/direct.nar'"
 )
 nars = api("GET", "caches/maincache/nars", token=token)["items"]
 assert any(n["hash"] == direct_hash for n in nars), f"direct-uploaded NAR missing: {nars}"

--- a/nix/tests/gradient/api/test.py
+++ b/nix/tests/gradient/api/test.py
@@ -96,7 +96,7 @@ api("GET", "user/audit-log", token=token)
 api("GET", "user/search?q=operator", token=token)
 
 created = api("POST", "user/keys", token=token, body=json.dumps({
-    "name": "ci-key", "permissions": []}))
+    "name": "ci-key", "permissions": ["viewOrg"]}))
 key_id, key_token = created["id"], created["token"]
 api("GET", "user/keys", token=token)
 # The created key authorizes API calls just like a session token.

--- a/nix/tests/gradient/api/test.py
+++ b/nix/tests/gradient/api/test.py
@@ -2,183 +2,310 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
+# Exercises the Gradient REST API surface on a single node - every management
+# endpoint is hit directly (curl) and, where the CLI exposes it, also through
+# `gradient`. Resources are created at runtime so the creation endpoints are
+# tested too. No worker / build store is present, so build-dependent endpoints
+# are checked for correct empty/not-found behaviour. Endpoints needing external
+# services (OIDC, SMTP e-mail verification, forge webhooks, proto websockets,
+# build-request dispatch) have dedicated tests and are out of scope here.
+
 import json
 
-start_all()
+API = "http://gradient.local/api/v1"
+CLI = "gradient"
 
+start_all()
 machine.wait_for_unit("gradient-server.service")
 machine.wait_for_open_port(3000)
-
-with subtest("check nix"):
-    machine.succeed("nix --version")
-
-with subtest("check api health"):
-    print(machine.succeed("curl http://localhost:3000/api/v1/health -i --fail"))
-
-with subtest("check api /auth/basic/register"):
-    req = json.loads(machine.succeed("""
-        curl -XPOST http://localhost:3000/api/v1/auth/basic/register -H 'Content-Type: application/json' -d '{"username": "testuser", "name": "Test User", "email": "test@were.local", "password": "SecureTest123!"}'
-    """))
-
-    assert req.get("error") == False, req.get("message")
-
-    req = json.loads(machine.succeed("""
-        curl -XPOST http://localhost:3000/api/v1/auth/basic/register -H 'Content-Type: application/json' -d '{"username": "testuser", "name": "Test User", "email": "test@were.local", "password": "SecureTest123!"}'
-    """))
-
-    assert req.get("error") == True, "User should already exist, since it was created in last request"
-
-with subtest("check api not authorized"):
-    req = json.loads(machine.succeed("""
-        curl -XGET http://localhost:3000/api/v1/orgs -H 'Content-Type: application/json'
-    """))
-
-    assert req.get("error") == True, "Should not be authorized"
-
-with subtest("check api /auth/basic/login"):
-    req = json.loads(machine.succeed("""
-        curl -XPOST http://localhost:3000/api/v1/auth/basic/login -H 'Content-Type: application/json' -d '{"loginname": "testuser", "password": "SecureTest123!"}'
-    """))
-
-    assert req.get("error") == False, req.get("message")
-
-    user_token = req.get("message")
-    print(f"User token: {user_token}")
-
-with subtest("check api user authorization"):
-    req = json.loads(machine.succeed("""
-        curl -XGET http://localhost:3000/api/v1/orgs -H 'Authorization: Bearer user_token' -H 'Content-Type: application/json'
-    """.replace("user_token", user_token)))
-
-    assert req.get("error") == False, req.get("message")
+machine.wait_for_unit("nginx.service")
 
 
-with subtest("check api /user/keys"):
-    req = json.loads(machine.succeed("""
-        curl -XPOST http://localhost:3000/api/v1/user/keys -H 'Authorization: Bearer user_token' -H 'Content-Type: application/json' -d '{"name": "MyApiKey"}'
-    """.replace("user_token", user_token)))
+def banner(msg):
+    print(f"\n=== {msg} ===")
 
-    assert req.get("error") == False, req.get("message")
 
-    api_key = req.get("message")
-    print(f"API Key: {api_key}")
+def curl(method, path, token=None, body=None, headers=None):
+    cmd = f"curl -sS -X {method} {API}/{path}"
+    if token:
+        cmd += f" -H 'Authorization: Bearer {token}'"
+    if body is not None:
+        cmd += f" -H 'Content-Type: application/json' -d '{body}'"
+    for h in headers or []:
+        cmd += f" -H '{h}'"
+    return machine.succeed(cmd)
 
-with subtest("check api key authorization"):
-    req = json.loads(machine.succeed("""
-        curl -XGET http://localhost:3000/api/v1/orgs -H 'Authorization: Bearer api_key' -H 'Content-Type: application/json'
-    """.replace("api_key", api_key)))
 
-    assert req.get("error") == False, req.get("message")
+def api(method, path, token=None, body=None, expect_error=False):
+    out = curl(method, path, token=token, body=body)
+    j = json.loads(out)
+    if expect_error:
+        assert j.get("error") is True, f"{method} {path}: expected error, got {out}"
+    else:
+        assert j.get("error") is False, f"{method} {path}: {j.get('message')}"
+    return j.get("message")
 
-with subtest("check api /orgs"):
-    req = json.loads(machine.succeed("""
-        curl -XPUT http://localhost:3000/api/v1/orgs -H 'Authorization: Bearer api_key' -H 'Content-Type: application/json' -d '{"name": "myorganization", "display_name": "My Organization", "description": "My Organization"}'
-    """.replace("api_key", api_key)))
 
-    assert req.get("error") == False, req.get("message")
+def cli(args):
+    return machine.succeed(f"{CLI} --json {args}")
 
-    org_id = req.get("message")
-    print(f"Organization ID: {org_id}")
 
-    req = json.loads(machine.succeed("""
-        curl -XGET http://localhost:3000/api/v1/orgs -H 'Authorization: Bearer api_key' -H 'Content-Type: application/json'
-    """.replace("api_key", api_key)))
+# ── Phase 0: health ───────────────────────────────────────────────────────────
+banner("Phase 0: health")
+print(machine.succeed(f"curl -sS --fail {API}/health -i"))
+api("GET", "health")
 
-    assert req.get("error") == False, req.get("message")
-    orgs = req.get("message").get("items")
-    assert len(orgs) == 1, "Should have only one organization"
-    assert orgs[0].get("id") == org_id, "Organization ID should match"
+# ── Phase 1: auth + registration ──────────────────────────────────────────────
+banner("Phase 1: auth")
+api("POST", "auth/check-username", body=json.dumps({"username": "admin"}))  # available
 
-with subtest("check api /orgs/{organization}"):
-    org_name = "myorganization"
+api("POST", "auth/basic/register", body=json.dumps({
+    "username": "admin", "name": "Admin User",
+    "email": "admin@gradient.local", "password": "SecureTest123!",
+}))
+api("POST", "auth/basic/register", expect_error=True, body=json.dumps({
+    "username": "admin", "name": "Admin User",
+    "email": "admin@gradient.local", "password": "SecureTest123!",
+}))
+api("POST", "auth/check-username", expect_error=True,
+    body=json.dumps({"username": "admin"}))  # now taken
 
-    req = json.loads(machine.succeed("""
-        curl -XGET http://localhost:3000/api/v1/orgs/org_name -H 'Authorization: Bearer api_key' -H 'Content-Type: application/json'
-    """.replace("api_key", api_key).replace("org_name", org_name)))
+api("GET", "orgs", expect_error=True)  # no token -> rejected
 
-    assert req.get("error") == False, req.get("message")
-    assert req.get("message").get("id") == org_id, "Organization ID should match"
+token = api("POST", "auth/basic/login", body=json.dumps({
+    "loginname": "admin", "password": "SecureTest123!",
+}))
+assert token, "login returned empty token"
+api("GET", "orgs", token=token)  # token authorizes
 
-    req = json.loads(machine.succeed("""
-        curl -XPUT http://localhost:3000/api/v1/projects/org_name -H 'Authorization: Bearer api_key' -H 'Content-Type: application/json' -d '{"name": "myproject", "display_name": "My Project", "description": "My Project", "repository": "git@github.com:Wavelens/Gradient.git", "wildcard": "packages.*"}'
-    """.replace("api_key", api_key).replace("org_name", org_name)))
+# Public/unauthenticated-ish reads.
+print(machine.succeed(f"curl -sS {API}/config -i"))
+machine.execute(f"curl -sS {API}/metrics -o /dev/null -w '%{{http_code}}'")
 
-    assert req.get("error") == False, req.get("message")
+# ── Phase 2: user + api keys ──────────────────────────────────────────────────
+banner("Phase 2: user + api keys")
+me = api("GET", "user", token=token)
+assert me.get("username") == "admin", me
 
-    project_id = req.get("message")
-    print(f"Project ID: {project_id}")
+api("PATCH", "user/settings", token=token, body=json.dumps({"name": "Admin Renamed"}))
+assert api("GET", "user", token=token).get("name") == "Admin Renamed"
 
-with subtest("check api /orgs/{organization}/ssh"):
-    req = json.loads(machine.succeed("""
-        curl -XGET http://localhost:3000/api/v1/orgs/org_name/ssh -H 'Authorization: Bearer api_key' -H 'Content-Type: application/json'
-    """.replace("api_key", api_key).replace("org_name", org_name)))
+api("GET", "user/keys/permissions", token=token)
+api("GET", "user/sessions", token=token)
+api("GET", "user/audit-log", token=token)
+api("GET", "user/search?q=admin", token=token)
 
-    assert req.get("error") == False, req.get("message")
+created = api("POST", "user/keys", token=token, body=json.dumps({
+    "name": "ci-key", "permissions": []}))
+key_id, key_token = created["id"], created["token"]
+api("GET", "user/keys", token=token)
+# The created key authorizes API calls just like a session token.
+api("GET", "orgs", token=key_token)
+api("GET", f"user/keys/{key_id}", token=token)
+api("POST", f"user/keys/{key_id}/revoke", token=token)
+api("DELETE", f"user/keys/{key_id}", token=token)
 
-    ssh_key = req.get("message")
+# ── Phase 3: organizations (direct + CLI) ─────────────────────────────────────
+banner("Phase 3: organizations")
+org_id = api("PUT", "orgs", token=token, body=json.dumps({
+    "name": "myorg", "display_name": "My Org", "description": "desc"}))
+assert api("GET", "orgs/myorg", token=token)["id"] == org_id
+orgs = api("GET", "orgs", token=token)["items"]
+assert any(o["id"] == org_id for o in orgs)
+api("GET", "orgs/available", token=token)
+api("GET", "orgs/public", token=token)
+api("PATCH", "orgs/myorg", token=token, body=json.dumps({"display_name": "My Org 2"}))
+assert api("GET", "orgs/myorg", token=token)["display_name"] == "My Org 2"
 
-    assert ssh_key.startswith("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI"), f"invalid ssh-key: {ssh_key}"
+ssh_key = api("GET", "orgs/myorg/ssh", token=token)
+assert ssh_key.startswith("ssh-ed25519 "), ssh_key
+assert api("POST", "orgs/myorg/ssh", token=token) != ssh_key, "ssh key should rotate"
 
-    req = json.loads(machine.succeed("""
-        curl -XPOST http://localhost:3000/api/v1/orgs/org_name/ssh -H 'Authorization: Bearer api_key' -H 'Content-Type: application/json'
-    """.replace("api_key", api_key).replace("org_name", org_name)))
+api("GET", "orgs/myorg/users", token=token)
+api("GET", "orgs/myorg/subscribe", token=token)
 
-    assert req.get("error") == False, req.get("message")
+role_id = api("POST", "orgs/myorg/roles", token=token, body=json.dumps({
+    "name": "viewers", "permissions": ["viewOrg"]}))
+api("GET", "orgs/myorg/roles", token=token)
+api("GET", f"orgs/myorg/roles/{role_id}", token=token)
+api("PATCH", f"orgs/myorg/roles/{role_id}", token=token, body=json.dumps({"name": "viewers2"}))
+api("DELETE", f"orgs/myorg/roles/{role_id}", token=token)
 
-    new_ssh_key = req.get("message")
+# CLI: configure, then create/list/show/delete a second org.
+machine.succeed(f"{CLI} config Server http://gradient.local")
+machine.succeed(f"{CLI} config AuthToken {token}")
+cli("organization create --name cliorg --display-name 'CLI Org' --description d")
+api("GET", "orgs/cliorg", token=token)  # CLI-created org visible via API
+cli("organization list")
+cli("organization select cliorg")
+cli("organization show")
+cli("organization delete")
+api("GET", "orgs/cliorg", token=token, expect_error=True)  # gone
+machine.succeed(f"{CLI} organization select myorg")
 
-    assert new_ssh_key != ssh_key, "Should have new ssh key"
+# ── Phase 4: projects (direct + CLI) ──────────────────────────────────────────
+banner("Phase 4: projects")
+proj_id = api("PUT", "projects/myorg", token=token, body=json.dumps({
+    "name": "myproject", "display_name": "My Project", "description": "d",
+    "repository": "git@github.com:Wavelens/Gradient.git", "wildcard": "packages.*"}))
+assert api("GET", "projects/myorg/myproject", token=token)["id"] == proj_id
+assert any(p["id"] == proj_id for p in api("GET", "projects/myorg", token=token)["items"])
+api("GET", "projects/myorg/available", token=token)
+api("GET", "projects/myorg/myproject/details", token=token)
+api("PATCH", "projects/myorg/myproject", token=token, body=json.dumps({"display_name": "MP2"}))
+api("GET", "projects/myorg/myproject/entry-points", token=token)
+api("GET", "projects/myorg/myproject/metrics", token=token)
+assert api("GET", "projects/myorg/myproject/evaluations", token=token)["items"] == [], \
+    "fresh project should have no evaluations"
 
-    print(f"New SSH Key: {new_ssh_key}")
+trig = api("POST", "projects/myorg/myproject/triggers", token=token, body=json.dumps({
+    "type": "polling", "config": {"interval_secs": 3600}}))
+api("GET", "projects/myorg/myproject/triggers", token=token)
 
-with subtest("check api /projects/{organization}/{project}"):
-    project_name = "myproject"
+api("GET", "projects/myorg/myproject/actions", token=token)
+api("POST", "projects/myorg/myproject/active", token=token)   # enable
+api("DELETE", "projects/myorg/myproject/active", token=token)  # disable
+# These reach out to / depend on a completed evaluation or return non-JSON
+# (SVG badge); just confirm the endpoints respond rather than asserting a body.
+machine.execute(f"curl -sS -X POST -H 'Authorization: Bearer {token}' {API}/projects/myorg/myproject/check-repository")
+machine.execute(f"curl -sS -H 'Authorization: Bearer {token}' {API}/projects/myorg/myproject/flake-inputs")
+machine.execute(f"curl -sS -H 'Authorization: Bearer {token}' {API}/projects/myorg/myproject/badge")
 
-    req = json.loads(machine.succeed("""
-        curl -XGET http://localhost:3000/api/v1/projects/org_name/project_name -H 'Authorization: Bearer api_key' -H 'Content-Type: application/json'
-    """.replace("api_key", api_key).replace("org_name", org_name).replace("project_name", project_name)))
+# CLI: create/list/show/delete a second project under the selected org.
+machine.succeed(f"{CLI} project select myproject")
+cli("project create --name cliproject --display-name 'CLI Project' --description d "
+    "--repository git@github.com:Wavelens/Gradient.git --wildcard 'packages.*'")
+api("GET", "projects/myorg/cliproject", token=token)
+cli("project list")
+machine.succeed(f"{CLI} project select cliproject")
+cli("project show")
+cli("project delete")
+api("GET", "projects/myorg/cliproject", token=token, expect_error=True)
+machine.succeed(f"{CLI} project select myproject")
 
-    assert req.get("error") == False, req.get("message")
-    assert req.get("message").get("id") == project_id, "Project ID should match"
+# ── Phase 5: workers (direct + CLI) ───────────────────────────────────────────
+banner("Phase 5: workers")
+reg = api("POST", "orgs/myorg/workers", token=token, body=json.dumps({
+    "worker_id": "b0000000-0000-0000-0000-000000000001",
+    "display_name": "api-worker"}))
+assert reg.get("token") and len(reg["token"]) == 64, reg
+assert any(w["worker_id"] == "b0000000-0000-0000-0000-000000000001"
+           for w in api("GET", "orgs/myorg/workers", token=token))
+api("GET", "orgs/myorg/workers/b0000000-0000-0000-0000-000000000001", token=token)
+api("PATCH", "orgs/myorg/workers/b0000000-0000-0000-0000-000000000001", token=token,
+    body=json.dumps({"display_name": "api-worker-2"}))
+api("DELETE", "orgs/myorg/workers/b0000000-0000-0000-0000-000000000001", token=token)
 
-with subtest("check api /orgs/{organization}/workers"):
-    # Register a worker under the org
-    req = json.loads(machine.succeed("""
-        curl -XPOST http://localhost:3000/api/v1/orgs/org_name/workers -H 'Authorization: Bearer api_key' -H 'Content-Type: application/json' -d '{"worker_id": "test-worker-001"}'
-    """.replace("api_key", api_key).replace("org_name", org_name)))
+cli("worker register c0000000-0000-0000-0000-000000000002 --display-name cli-worker")
+assert any(w["worker_id"] == "c0000000-0000-0000-0000-000000000002"
+           for w in api("GET", "orgs/myorg/workers", token=token))
+cli("worker list")
+cli("worker delete c0000000-0000-0000-0000-000000000002")
+assert not any(w["worker_id"] == "c0000000-0000-0000-0000-000000000002"
+               for w in api("GET", "orgs/myorg/workers", token=token))
 
-    assert req.get("error") == False, req.get("message")
-    worker_reg = req.get("message")
-    peer_id = worker_reg.get("peer_id")
-    token = worker_reg.get("token")
-    assert peer_id is not None, "peer_id should be present"
-    assert token is not None and len(token) > 0, "token should be non-empty"
-    assert len(token) == 64, f"Expected 64-char base64 token (48 bytes), got {len(token)}: {token}"
-    print(f"Worker registered: peer_id={peer_id}")
+# ── Phase 6: caches (direct + CLI) ────────────────────────────────────────────
+banner("Phase 6: caches")
+api("PUT", "caches", token=token, body=json.dumps({
+    "name": "maincache", "display_name": "Main", "description": "d", "priority": 10}))
+api("GET", "caches/maincache", token=token)
+assert any(c["name"] == "maincache" for c in api("GET", "caches", token=token))
+api("GET", "caches/available", token=token)
+api("GET", "caches/public", token=token)
+api("GET", "caches/maincache/public-key", token=token)
+api("GET", "caches/maincache/key", token=token)
+api("GET", "caches/maincache/stats", token=token)
+api("GET", "caches/maincache/members", token=token)
+api("GET", "caches/maincache/roles", token=token)
+api("GET", "caches/maincache/upstreams", token=token)
+api("PATCH", "caches/maincache", token=token, body=json.dumps({"priority": 20}))
+# Subscribe the org so the cache is usable in org context.
+api("POST", "orgs/myorg/subscribe/maincache", token=token)
 
-    # List workers - should contain our registration
-    req = json.loads(machine.succeed("""
-        curl -XGET http://localhost:3000/api/v1/orgs/org_name/workers -H 'Authorization: Bearer api_key' -H 'Content-Type: application/json'
-    """.replace("api_key", api_key).replace("org_name", org_name)))
+cli("cache create --name clicache --display-name 'CLI Cache' --description d --priority 5")
+api("GET", "caches/clicache", token=token)
+cli("cache list")
+cli("cache show clicache")
+cli("cache delete clicache")
+api("GET", "caches/clicache", token=token, expect_error=True)
 
-    assert req.get("error") == False, req.get("message")
-    workers = req.get("message")
-    assert any(w.get("worker_id") == "test-worker-001" for w in workers), \
-        f"test-worker-001 not found in: {[w.get('worker_id') for w in workers]}"
+# ── Phase 7: cache NAR upload surface (direct + CLI) ──────────────────────────
+# No nix store is needed: the endpoint validates byte length + store-path shape,
+# not NAR content, so a synthetic NAR + narinfo exercises the whole surface.
+banner("Phase 7: cache NAR upload / list / show / stats / delete")
+assert api("GET", "caches/maincache/nars", token=token)["items"] == [], "cache starts empty"
 
-    # Delete the worker registration
-    req = json.loads(machine.succeed("""
-        curl -XDELETE http://localhost:3000/api/v1/orgs/org_name/workers/test-worker-001 -H 'Authorization: Bearer api_key' -H 'Content-Type: application/json'
-    """.replace("api_key", api_key).replace("org_name", org_name)))
+cli_hash = "00000000000000000000000000000000"
+payload = "gradient-test-nar-payload"
+size = len(payload)
+machine.succeed(f"printf '%s' '{payload}' > /tmp/cli.nar")
+zero64 = "0" * 64
+machine.succeed(
+    "cat > /tmp/cli.narinfo <<'EOF'\n"
+    f"StorePath: /nix/store/{cli_hash}-test\n"
+    "URL: nar/cli.nar\n"
+    "Compression: none\n"
+    f"FileHash: sha256:{zero64}\n"
+    f"FileSize: {size}\n"
+    f"NarHash: sha256:{zero64}\n"
+    f"NarSize: {size}\n"
+    "References: \n"
+    "EOF"
+)
+cli("cache upload --nar-file /tmp/cli.nar --narinfo /tmp/cli.narinfo maincache")
 
-    assert req.get("error") == False, req.get("message")
+nars = api("GET", "caches/maincache/nars", token=token)["items"]
+assert any(n["hash"] == cli_hash for n in nars), f"uploaded NAR missing: {nars}"
+api("GET", f"caches/maincache/nars/{cli_hash}", token=token)
+api("GET", "caches/maincache/nars/stats", token=token)
+api("GET", f"caches/maincache/nars/available?hash={cli_hash}", token=token)
+cli(f"cache nar list maincache")
+cli(f"cache nar show maincache {cli_hash}")
+cli("cache nar stats maincache")
 
-    # Confirm deletion
-    req = json.loads(machine.succeed("""
-        curl -XGET http://localhost:3000/api/v1/orgs/org_name/workers -H 'Authorization: Bearer api_key' -H 'Content-Type: application/json'
-    """.replace("api_key", api_key).replace("org_name", org_name)))
+# Second NAR via direct multipart upload.
+direct_hash = "11111111111111111111111111111111"
+machine.succeed(f"printf '%s' '{payload}' > /tmp/direct.nar")
+narinfo_json = json.dumps({
+    "store_path": f"/nix/store/{direct_hash}-test",
+    "file_hash": f"sha256:{zero64}", "file_size": size,
+    "nar_hash": f"sha256:{zero64}", "nar_size": size,
+    "references": [], "deriver": None,
+})
+machine.succeed(f"cat > /tmp/direct.narinfo.json <<'EOF'\n{narinfo_json}\nEOF")
+machine.succeed(
+    f"curl -sS --fail -X POST {API}/caches/maincache/nars "
+    f"-H 'Authorization: Bearer {token}' "
+    f"-F 'narinfo=</tmp/direct.narinfo.json;type=application/json' "
+    f"-F 'nar=@/tmp/direct.nar'"
+)
+nars = api("GET", "caches/maincache/nars", token=token)["items"]
+assert any(n["hash"] == direct_hash for n in nars), f"direct-uploaded NAR missing: {nars}"
 
-    assert req.get("error") == False, req.get("message")
-    workers = req.get("message")
-    assert not any(w.get("worker_id") == "test-worker-001" for w in workers), \
-        "worker should have been deleted"
+# Delete one via CLI, one via direct API.
+cli(f"cache nar delete maincache {cli_hash} -y")
+api("DELETE", f"caches/maincache/nars/{direct_hash}", token=token)
+remaining = api("GET", "caches/maincache/nars", token=token)["items"]
+assert not any(n["hash"] in (cli_hash, direct_hash) for n in remaining), remaining
+
+# ── Phase 7b: cache active / public toggles ───────────────────────────────────
+banner("Phase 7b: cache active / public toggles")
+api("POST", "caches/maincache/public", token=token)
+api("DELETE", "caches/maincache/public", token=token)
+api("POST", "caches/maincache/active", token=token)
+api("DELETE", "caches/maincache/active", token=token)
+
+# ── Phase 8: build-dependent endpoints (no builds present) ────────────────────
+banner("Phase 8: build-dependent endpoints respond on empty state")
+missing = "00000000-0000-0000-0000-0000000000ff"
+api("GET", f"evals/{missing}", token=token, expect_error=True)
+api("GET", f"evals/{missing}/builds", token=token, expect_error=True)
+api("GET", f"builds/{missing}", token=token, expect_error=True)
+api("GET", f"builds/{missing}/graph", token=token, expect_error=True)
+api("GET", f"commits/{missing}", token=token, expect_error=True)
+
+# ── Phase 9: logout ───────────────────────────────────────────────────────────
+banner("Phase 9: logout")
+api("POST", "auth/logout", token=token)
+
+banner("API test PASSED")

--- a/nix/tests/gradient/api/test.py
+++ b/nix/tests/gradient/api/test.py
@@ -158,8 +158,8 @@ api("GET", "projects/myorg/myproject/metrics", token=token)
 assert api("GET", "projects/myorg/myproject/evaluations", token=token) == [], \
     "fresh project should have no evaluations"
 
-trig = api("POST", "projects/myorg/myproject/triggers", token=token, body=json.dumps({
-    "type": "polling", "config": {"interval_secs": 3600}}))
+api("POST", "projects/myorg/myproject/triggers", token=token, body=json.dumps({
+    "config": {"type": "polling", "interval_secs": 3600}}))
 api("GET", "projects/myorg/myproject/triggers", token=token)
 
 api("GET", "projects/myorg/myproject/actions", token=token)

--- a/nix/tests/gradient/api/test.py
+++ b/nix/tests/gradient/api/test.py
@@ -125,7 +125,7 @@ api("GET", "orgs/myorg/users", token=token)
 api("GET", "orgs/myorg/subscribe", token=token)
 
 role_id = api("POST", "orgs/myorg/roles", token=token, body=json.dumps({
-    "name": "viewers", "permissions": ["viewOrg"]}))
+    "name": "viewers", "permissions": ["viewOrg"]}))["id"]
 api("GET", "orgs/myorg/roles", token=token)
 api("GET", f"orgs/myorg/roles/{role_id}", token=token)
 api("PATCH", f"orgs/myorg/roles/{role_id}", token=token, body=json.dumps({"name": "viewers2"}))

--- a/nix/tests/gradient/api/test.py
+++ b/nix/tests/gradient/api/test.py
@@ -50,6 +50,14 @@ def cli(args):
     return machine.succeed(f"{CLI} --json {args}")
 
 
+def status(method, path, token=None, code=200):
+    cmd = f"curl -sS -o /dev/null -w '%{{http_code}}' -X {method} {API}/{path}"
+    if token:
+        cmd += f" -H 'Authorization: Bearer {token}'"
+    out = machine.succeed(cmd).strip()
+    assert out == str(code), f"{method} {path}: expected {code}, got {out}"
+
+
 # ── Phase 0: health ───────────────────────────────────────────────────────────
 banner("Phase 0: health")
 print(machine.succeed(f"curl -sS --fail {API}/health -i"))
@@ -284,7 +292,7 @@ assert any(n["hash"] == direct_hash for n in nars), f"direct-uploaded NAR missin
 
 # Delete one via CLI, one via direct API.
 cli(f"cache nar delete maincache {cli_hash} -y")
-api("DELETE", f"caches/maincache/nars/{direct_hash}", token=token)
+status("DELETE", f"caches/maincache/nars/{direct_hash}", token=token, code=204)
 remaining = api("GET", "caches/maincache/nars", token=token)["items"]
 assert not any(n["hash"] in (cli_hash, direct_hash) for n in remaining), remaining
 

--- a/nix/tests/gradient/api/test.py
+++ b/nix/tests/gradient/api/test.py
@@ -185,23 +185,23 @@ machine.succeed(f"{CLI} project select myproject")
 
 # ── Phase 5: workers (direct + CLI) ───────────────────────────────────────────
 banner("Phase 5: workers")
+api_worker = "b0000000-0000-4000-8000-000000000001"
 reg = api("POST", "orgs/myorg/workers", token=token, body=json.dumps({
-    "worker_id": "b0000000-0000-0000-0000-000000000001",
-    "display_name": "api-worker"}))
+    "worker_id": api_worker, "display_name": "api-worker"}))
 assert reg.get("token") and len(reg["token"]) == 64, reg
-assert any(w["worker_id"] == "b0000000-0000-0000-0000-000000000001"
+assert any(w["worker_id"] == api_worker
            for w in api("GET", "orgs/myorg/workers", token=token))
-api("GET", "orgs/myorg/workers/b0000000-0000-0000-0000-000000000001", token=token)
-api("PATCH", "orgs/myorg/workers/b0000000-0000-0000-0000-000000000001", token=token,
+api("PATCH", f"orgs/myorg/workers/{api_worker}", token=token,
     body=json.dumps({"display_name": "api-worker-2"}))
-api("DELETE", "orgs/myorg/workers/b0000000-0000-0000-0000-000000000001", token=token)
+api("DELETE", f"orgs/myorg/workers/{api_worker}", token=token)
 
-cli("worker register c0000000-0000-0000-0000-000000000002 --display-name cli-worker")
-assert any(w["worker_id"] == "c0000000-0000-0000-0000-000000000002"
+cli_worker = "c0000000-0000-4000-8000-000000000002"
+cli(f"worker register {cli_worker} --display-name cli-worker")
+assert any(w["worker_id"] == cli_worker
            for w in api("GET", "orgs/myorg/workers", token=token))
 cli("worker list")
-cli("worker delete c0000000-0000-0000-0000-000000000002")
-assert not any(w["worker_id"] == "c0000000-0000-0000-0000-000000000002"
+cli(f"worker delete {cli_worker}")
+assert not any(w["worker_id"] == cli_worker
                for w in api("GET", "orgs/myorg/workers", token=token))
 
 # ── Phase 6: caches (direct + CLI) ────────────────────────────────────────────


### PR DESCRIPTION
Closes #261.

## Part A — Cache NAR upload

Push local store paths or raw `.nar` files to a Gradient cache.

- **Shared ingest** (`gradient_core::cache::ingest`): `ingest_nar` (blob write + `cached_path` upsert + signature placeholders) and `ingest_metadata_only`, parameterised by `SignTargets::{OrgCaches, Cache, None}`. The worker `NarUploaded` path now delegates its `cached_path`/signature work here (blob write + abort-on-failure stays worker-side, preserving the storage→abort / DB→warn split). `derivation_output` linking stays worker-only.
- **Endpoint** `POST /api/v1/caches/{cache}/nars`: multipart (`narinfo` JSON + `nar` bytes), requires `writeStore`, validates byte length vs declared `file_size`, signs asynchronously via the existing sweep, writes an audit row. Per-route body limit `GRADIENT_MAX_NAR_UPLOAD_SIZE` (default 512 MiB) — added to `LimitsArgs`, the nix module, and docs.
- **CLI** `gradient cache upload`:
  - No-nix path (always available): `--nar-file <f.nar> --narinfo <f.narinfo> <cache>`.
  - Nix path (optional `nix` Cargo feature, default off): resolves store paths via harmonia `LocalNixStore`, dumps NARs, `--full-closure` walks the runtime closure.
- narinfo parser, connector `nar_upload`, OpenAPI, docs, tests.

## Part B — Interactive CLI (ratatui)

Per-command `-i`/`--interactive` flags (no-op under `--json`):

- `gradient cache nar list -i` — searchable/scrollable NAR browser.
- `gradient builds graph <id> -i` — nix-tree-style collapsible dependency-graph browser (new `builds` command group).
- `gradient builds log <id> -i` — less-style log pager (scroll, follow-tail, `/` search).

Panic-safe terminal restore; view-models are unit-tested independently of the terminal.

## Tests

`core::cache::ingest` (mock DB + temp store), `web` `caches_upload` (auth surface; mutation cases `#[ignore]` per the repo's MockDatabase precedent), connector `nar_upload` (wiremock), CLI narinfo parser, `cache upload` integration (`assert_cmd`), and TUI view-model tests. Catalogued in `docs/src/tests.md`. Verified locally with `cargo clippy` (backend workspace + CLI both feature sets, all targets) — clean; full suite runs in CI.

## Follow-ups (deliberately out of scope)

- Server-side NAR content-hash verification on upload before signing (the worker path also trusts the reported hash; nix clients verify NarHash on download). Worth adding as defence-in-depth.
- In-TUI NAR detail pane + delete action (browser currently does search/scroll).
- `--full-closure` issues `query_path_info` twice per path (BFS + metadata); collapse into one pass.
- The CLI workspace pins a different harmonia git rev than the backend (separate lockfiles); align if desired.