### PR TITLE
fix(proto): dedicated reject code for orgs with no cache (#302)

### DIFF
--- a/backend/proto/src/handler/session.rs
+++ b/backend/proto/src/handler/session.rs
@@ -150,9 +150,12 @@ impl ProtoSession<Opening> {
             None => return None,
         };
 
-        let (authorized_peers, mut failed_peers) = validate_tokens(&registered_peers, &tokens);
+        let (token_authorized, mut failed_peers) = validate_tokens(&registered_peers, &tokens);
+        let had_token_authorized = !token_authorized.is_empty();
         let (authorized_peers, demoted) =
-            filter_org_peers_without_cache(&self.state, authorized_peers).await;
+            filter_org_peers_without_cache(&self.state, token_authorized).await;
+        let emptied_by_missing_cache =
+            authorized_peers.is_empty() && had_token_authorized && !demoted.is_empty();
         failed_peers.extend(demoted);
 
         let has_any =
@@ -162,6 +165,7 @@ impl ProtoSession<Opening> {
             registered_peers.is_empty(),
             has_any,
             authorized_peers.is_empty(),
+            emptied_by_missing_cache,
         ) {
             AuthDecision::Accept => {
                 if registered_peers.is_empty() {
@@ -409,11 +413,15 @@ enum AuthDecision {
 ///   (i.e. it once existed but is now deactivated).
 /// - `authorized_peers_empty`: zero of the peers in the challenge produced a
 ///   valid token.
+/// - `emptied_by_missing_cache`: tokens validated for at least one peer, but
+///   every such peer was demoted because its organization has no subscribed
+///   cache. Distinguishes "incomplete server setup" from a real auth failure.
 fn decide_auth(
     server_initiated: bool,
     registered_peers_empty: bool,
     has_any_registrations: bool,
     authorized_peers_empty: bool,
+    emptied_by_missing_cache: bool,
 ) -> AuthDecision {
     if registered_peers_empty {
         if has_any_registrations {
@@ -430,9 +438,16 @@ fn decide_auth(
         }
         AuthDecision::Accept
     } else if authorized_peers_empty {
-        AuthDecision::Reject {
-            code: 401,
-            reason: "no valid peer tokens provided",
+        if emptied_by_missing_cache {
+            AuthDecision::Reject {
+                code: 495,
+                reason: "organization has no cache subscribed",
+            }
+        } else {
+            AuthDecision::Reject {
+                code: 401,
+                reason: "no valid peer tokens provided",
+            }
         }
     } else {
         AuthDecision::Accept
@@ -449,7 +464,7 @@ mod auth_decision_tests {
     /// `server_initiated` branch ran for everyone.
     #[test]
     fn inbound_unknown_worker_rejected() {
-        let d = decide_auth(false, true, false, true);
+        let d = decide_auth(false, true, false, true, false);
         assert_eq!(
             d,
             AuthDecision::Reject {
@@ -463,7 +478,10 @@ mod auth_decision_tests {
     /// the only legitimate "open mode" path.
     #[test]
     fn outbound_unknown_worker_accepted() {
-        assert_eq!(decide_auth(true, true, false, true), AuthDecision::Accept);
+        assert_eq!(
+            decide_auth(true, true, false, true, false),
+            AuthDecision::Accept
+        );
     }
 
     /// Worker had a registration once but it's been removed → reject as
@@ -471,7 +489,7 @@ mod auth_decision_tests {
     #[test]
     fn deactivated_worker_rejected_inbound() {
         assert_eq!(
-            decide_auth(false, true, true, true),
+            decide_auth(false, true, true, true, false),
             AuthDecision::Reject {
                 code: 403,
                 reason: "worker is deactivated",
@@ -482,7 +500,7 @@ mod auth_decision_tests {
     #[test]
     fn deactivated_worker_rejected_outbound() {
         assert_eq!(
-            decide_auth(true, true, true, true),
+            decide_auth(true, true, true, true, false),
             AuthDecision::Reject {
                 code: 403,
                 reason: "worker is deactivated",
@@ -494,10 +512,23 @@ mod auth_decision_tests {
     #[test]
     fn registered_but_no_valid_token() {
         assert_eq!(
-            decide_auth(false, false, false, true),
+            decide_auth(false, false, false, true, false),
             AuthDecision::Reject {
                 code: 401,
                 reason: "no valid peer tokens provided",
+            }
+        );
+    }
+
+    /// Tokens validated but every authorized peer was demoted because its
+    /// organization has no cache → distinct 495, not a misleading 401.
+    #[test]
+    fn registered_emptied_by_missing_cache() {
+        assert_eq!(
+            decide_auth(false, false, false, true, true),
+            AuthDecision::Reject {
+                code: 495,
+                reason: "organization has no cache subscribed",
             }
         );
     }
@@ -506,7 +537,7 @@ mod auth_decision_tests {
     #[test]
     fn registered_with_valid_token_accepted() {
         assert_eq!(
-            decide_auth(false, false, false, false),
+            decide_auth(false, false, false, false, false),
             AuthDecision::Accept
         );
     }

--- a/docs/src/development/proto.md
+++ b/docs/src/development/proto.md
@@ -131,7 +131,7 @@ AuthResponse {
 
 The server validates each token independently. The worker is authorized for every peer whose token is valid. If some tokens fail, the connection continues with the successful peers - only a total failure causes `Reject`.
 
-When validating peer tokens, the server additionally checks each authorized peer that is an organization against the `organization_cache` table. If the organization has no subscribed cache, that peer is moved into `failed_peers` with reason `"organization has no cache subscribed"`. If this leaves the authorized peer set empty, the connection is rejected with `401 no valid peer tokens provided`.
+When validating peer tokens, the server additionally checks each authorized peer that is an organization against the `organization_cache` table. If the organization has no subscribed cache, that peer is moved into `failed_peers` with reason `"organization has no cache subscribed"`. If this leaves the authorized peer set empty - i.e. the worker authenticated but every peer it presented a valid token for lacks a cache - the connection is rejected with the dedicated `495 organization has no cache subscribed` rather than a misleading `401`. A `401 no valid peer tokens provided` is only sent when no token validated at all.
 
 What authorization means depends on the peer type:
  - **Org** - worker receives jobs from that org's projects
@@ -1370,6 +1370,7 @@ On receiving `ServerMessage::Draining`, workers:
 |------|---------|
 | 400  | Malformed message or unsupported protocol version |
 | 401  | Unauthorized (missing or invalid token) |
+| 495  | Organization has no cache subscribed (incomplete server setup) |
 | 499  | Capability not negotiated for this session |
 | 498  | Job not found (e.g. AbortJob for unknown job_id) |
 | 497  | Job already assigned or completed |

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -134,16 +134,24 @@ Helper `filter_org_peers_without_cache` runs during the `/proto` handshake's
 `perform_auth` step. After token validation, each authorized peer that is an
 organization is checked against the `organization_cache` table. Organizations
 without a subscribed cache are moved into `failed_peers` with reason
-`"organization has no cache subscribed"`. If the authorized peer set ends up
-empty the connection is rejected with `401 no valid peer tokens provided`.
+`"organization has no cache subscribed"`. If the worker authenticated but the
+authorized peer set ends up empty solely because of missing caches, the
+connection is rejected with the dedicated `495 organization has no cache
+subscribed` instead of a misleading `401`; a `401 no valid peer tokens provided`
+is reserved for genuine token failures.
 
-Backend tests (in `backend/core/src/proto/handler/auth.rs`):
+Backend tests (in `backend/proto/src/handler/auth.rs`):
 
-- `proto::handler::auth::tests::filter_org_peers_passes_through_org_with_cache`
-- `proto::handler::auth::tests::filter_org_peers_demotes_org_without_cache`
-- `proto::handler::auth::tests::filter_org_peers_passes_through_non_org_uuids`
-- `proto::handler::auth::tests::filter_org_peers_mixed`
-- `proto::handler::auth::tests::validate_then_filter_demotes_org_without_cache`
+- `tests::filter_org_peers_passes_through_org_with_cache`
+- `tests::filter_org_peers_demotes_org_without_cache`
+- `tests::filter_org_peers_passes_through_non_org_uuids`
+- `tests::filter_org_peers_mixed`
+- `tests::validate_then_filter_demotes_org_without_cache`
+
+Auth-decision tests (in `backend/proto/src/handler/session.rs`):
+
+- `auth_decision_tests::registered_but_no_valid_token`
+- `auth_decision_tests::registered_emptied_by_missing_cache`
 
 ## Frontend - workers page no-cache banner
 


### PR DESCRIPTION
Closes #302.

## Problem
When a worker connected to a server whose organization had no subscribed cache, the handshake failed with a generic `401 Unauthorized`. The token actually validated fine — the connection was refused only because the org has no cache — so `401` was misleading and gave no actionable reason.

## Fix
`decide_auth` now distinguishes the two cases. When the worker authenticated (at least one token validated) but every authorized peer was demoted because its organization has no cache, the handshake is rejected with a dedicated **`495 organization has no cache subscribed`** ("incomplete server setup"). A genuine token failure still returns `401 no valid peer tokens provided`.

`perform_auth` computes `emptied_by_missing_cache` from the token-validation and cache-filter steps and threads it into the pure `decide_auth` policy function. The worker surfaces the code+reason verbatim, so the operator sees the real cause.

## Tests (TDD)
- `auth_decision_tests::registered_emptied_by_missing_cache` — new case asserting `495`.
- Existing `decide_auth` cases updated for the new parameter; `registered_but_no_valid_token` confirms genuine failures stay `401`.

## Docs
- `docs/src/development/proto.md` — handshake description + error-code table (`495`).
- `docs/src/tests.md` — updated reject behaviour and test inventory.