### PR TITLE
Closure size Sankey view + build-graph rework (#242)

### DIFF
--- a/backend/web/src/endpoints/builds/closure.rs
+++ b/backend/web/src/endpoints/builds/closure.rs
@@ -1,0 +1,316 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use crate::authorization::{MaybeApiKey, MaybeUser};
+use crate::endpoints::evals::EvalAccessContext;
+use crate::error::WebResult;
+use crate::helpers::ok_json;
+use axum::extract::{Path, State};
+use axum::{Extension, Json};
+use gradient_core::types::*;
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use super::BuildAccessContext;
+
+/// Cap on the number of nodes returned in the closure node/edge lists.
+/// `total_size_bytes` is always computed over the full closure and stays exact.
+const CLOSURE_NODE_CAP: usize = 1000;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct ClosureNode {
+    pub id: DerivationId,
+    pub name: String,
+    pub path: String,
+    pub nar_size: Option<i64>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct ClosureEdge {
+    pub source: DerivationId,
+    pub target: DerivationId,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct ClosureGraph {
+    pub roots: Vec<DerivationId>,
+    pub total_size_bytes: Option<i64>,
+    pub node_count: usize,
+    pub edge_count: usize,
+    pub truncated: bool,
+    pub nodes: Vec<ClosureNode>,
+    pub edges: Vec<ClosureEdge>,
+}
+
+/// BFS over `derivation_dependency` from `seed_drv_ids`; returns every reachable
+/// derivation id (seeds included).
+pub async fn derivation_closure_reachable<C: sea_orm::ConnectionTrait>(
+    db: &C,
+    seed_drv_ids: Vec<DerivationId>,
+) -> WebResult<HashSet<DerivationId>> {
+    let mut visited: HashSet<DerivationId> = seed_drv_ids.iter().cloned().collect();
+    let mut frontier = seed_drv_ids;
+
+    while !frontier.is_empty() {
+        let edges = EDerivationDependency::find()
+            .filter(CDerivationDependency::Derivation.is_in(frontier.clone()))
+            .all(db)
+            .await?;
+        frontier.clear();
+        for edge in edges {
+            if visited.insert(edge.dependency) {
+                frontier.push(edge.dependency);
+            }
+        }
+    }
+
+    Ok(visited)
+}
+
+/// Map each derivation id to its coalesced output NAR size
+/// (`derivation_output.nar_size`, else matching `cached_path.nar_size`).
+async fn output_sizes_by_drv<C: sea_orm::ConnectionTrait>(
+    db: &C,
+    drv_ids: Vec<DerivationId>,
+) -> WebResult<HashMap<DerivationId, i64>> {
+    if drv_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let outputs = EDerivationOutput::find()
+        .filter(CDerivationOutput::Derivation.is_in(drv_ids))
+        .all(db)
+        .await?;
+
+    let missing_hashes: Vec<String> = outputs
+        .iter()
+        .filter(|o| o.nar_size.is_none())
+        .map(|o| o.hash.clone())
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+
+    let cached_size_by_hash: HashMap<String, i64> = if missing_hashes.is_empty() {
+        HashMap::new()
+    } else {
+        ECachedPath::find()
+            .filter(CCachedPath::Hash.is_in(missing_hashes))
+            .all(db)
+            .await?
+            .into_iter()
+            .filter_map(|cp| cp.nar_size.map(|n| (cp.hash, n)))
+            .collect()
+    };
+
+    let mut by_drv: HashMap<DerivationId, i64> = HashMap::new();
+    for o in outputs {
+        if let Some(size) = o
+            .nar_size
+            .or_else(|| cached_size_by_hash.get(&o.hash).copied())
+        {
+            *by_drv.entry(o.derivation).or_insert(0) += size;
+        }
+    }
+    Ok(by_drv)
+}
+
+/// Sum coalesced output sizes across `drv_ids`. `Some(total)` when > 0 else `None`.
+pub async fn sum_output_sizes<C: sea_orm::ConnectionTrait>(
+    db: &C,
+    drv_ids: Vec<DerivationId>,
+) -> WebResult<Option<i64>> {
+    let by_drv = output_sizes_by_drv(db, drv_ids).await?;
+    let total: i64 = by_drv.values().sum();
+    Ok(if total > 0 { Some(total) } else { None })
+}
+
+/// Build a closure graph seeded at `roots`: full reachable derivation set, exact
+/// total size, per-node sizes, and dependency edges restricted to the closure.
+pub async fn build_closure_graph<C: sea_orm::ConnectionTrait>(
+    db: &C,
+    roots: Vec<DerivationId>,
+) -> WebResult<ClosureGraph> {
+    let closure = derivation_closure_reachable(db, roots.clone()).await?;
+    let all_ids: Vec<DerivationId> = closure.iter().cloned().collect();
+
+    let total_size_bytes = sum_output_sizes(db, all_ids.clone()).await?;
+    let size_by_drv = output_sizes_by_drv(db, all_ids.clone()).await?;
+
+    let drvs = EDerivation::find()
+        .filter(CDerivation::Id.is_in(all_ids.clone()))
+        .all(db)
+        .await?;
+
+    let mut nodes: Vec<ClosureNode> = drvs
+        .into_iter()
+        .map(|d| ClosureNode {
+            nar_size: size_by_drv.get(&d.id).copied(),
+            id: d.id,
+            name: d.name.clone(),
+            path: d.store_path(),
+        })
+        .collect();
+    // Largest first so a downstream cap keeps the biggest contributors.
+    nodes.sort_by_key(|n| std::cmp::Reverse(n.nar_size.unwrap_or(0)));
+
+    let truncated = nodes.len() > CLOSURE_NODE_CAP;
+    if truncated {
+        nodes.truncate(CLOSURE_NODE_CAP);
+    }
+    let kept: HashSet<DerivationId> = nodes.iter().map(|n| n.id).collect();
+
+    let dep_rows = EDerivationDependency::find()
+        .filter(CDerivationDependency::Derivation.is_in(all_ids))
+        .all(db)
+        .await?;
+    let edges: Vec<ClosureEdge> = dep_rows
+        .into_iter()
+        .filter(|e| kept.contains(&e.derivation) && kept.contains(&e.dependency))
+        .map(|e| ClosureEdge {
+            source: e.dependency,
+            target: e.derivation,
+        })
+        .collect();
+
+    Ok(ClosureGraph {
+        roots,
+        total_size_bytes,
+        node_count: nodes.len(),
+        edge_count: edges.len(),
+        truncated,
+        nodes,
+        edges,
+    })
+}
+
+/// GET /builds/{build}/closure - full closure (with sizes) of one build's derivation.
+pub async fn get_build_closure(
+    state: State<Arc<ServerState>>,
+    Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
+    Path(build_id): Path<BuildId>,
+) -> WebResult<Json<BaseResponse<ClosureGraph>>> {
+    let ctx = BuildAccessContext::load(&state, build_id, &maybe_user, api_key.as_ref()).await?;
+    let graph = build_closure_graph(&state.web_db, vec![ctx.build.derivation]).await?;
+    Ok(ok_json(graph))
+}
+
+/// GET /evals/{evaluation}/closure - union closure of all entry-point builds.
+pub async fn get_eval_closure(
+    state: State<Arc<ServerState>>,
+    Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
+    Path(evaluation_id): Path<EvaluationId>,
+) -> WebResult<Json<BaseResponse<ClosureGraph>>> {
+    let _ctx =
+        EvalAccessContext::load(&state, evaluation_id, &maybe_user, api_key.as_ref()).await?;
+
+    let ep_build_ids: Vec<BuildId> = EEntryPoint::find()
+        .filter(CEntryPoint::Evaluation.eq(evaluation_id))
+        .all(&state.web_db)
+        .await?
+        .into_iter()
+        .map(|ep| ep.build)
+        .collect();
+
+    let roots: Vec<DerivationId> = if ep_build_ids.is_empty() {
+        vec![]
+    } else {
+        EBuild::find()
+            .filter(CBuild::Id.is_in(ep_build_ids))
+            .all(&state.web_db)
+            .await?
+            .into_iter()
+            .map(|b| b.derivation)
+            .collect()
+    };
+
+    let graph = build_closure_graph(&state.web_db, roots).await?;
+    Ok(ok_json(graph))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use entity::{derivation, derivation_dependency, derivation_output};
+    use sea_orm::{DatabaseBackend, MockDatabase};
+
+    fn now() -> chrono::NaiveDateTime {
+        chrono::Utc::now().naive_utc()
+    }
+
+    fn drv(id: DerivationId, name: &str) -> derivation::Model {
+        derivation::Model {
+            id,
+            organization: OrganizationId::now_v7(),
+            hash: format!("hash{name}"),
+            name: name.into(),
+            architecture: "x86_64-linux".into(),
+            created_at: now(),
+        }
+    }
+
+    fn out(derivation: DerivationId, hash: &str, nar_size: Option<i64>) -> derivation_output::Model {
+        derivation_output::Model {
+            id: DerivationOutputId::now_v7(),
+            derivation,
+            name: "out".into(),
+            hash: hash.into(),
+            package: "foo".into(),
+            ca: None,
+            nar_size,
+            is_cached: false,
+            cached_path: None,
+            created_at: now(),
+        }
+    }
+
+    fn dep(derivation: DerivationId, dependency: DerivationId) -> derivation_dependency::Model {
+        derivation_dependency::Model {
+            id: DerivationDependencyId::now_v7(),
+            derivation,
+            dependency,
+        }
+    }
+
+    // root depends on child; sizes 100 + 40 => total 140, two nodes, one edge.
+    #[tokio::test]
+    async fn build_closure_graph_sums_and_links() {
+        let root = DerivationId::now_v7();
+        let child = DerivationId::now_v7();
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            // derivation_closure_reachable: wave 1 (root) -> edge root->child
+            .append_query_results([vec![dep(root, child)]])
+            // wave 2 (child) -> no further edges
+            .append_query_results([Vec::<derivation_dependency::Model>::new()])
+            // sum_output_sizes (total): outputs for [root, child]
+            .append_query_results([vec![out(root, "r", Some(100)), out(child, "c", Some(40))]])
+            // output_sizes_by_drv (per-node): outputs again
+            .append_query_results([vec![out(root, "r", Some(100)), out(child, "c", Some(40))]])
+            // EDerivation::find for nodes
+            .append_query_results([vec![drv(root, "root"), drv(child, "child")]])
+            // dep_rows for edges
+            .append_query_results([vec![dep(root, child)]])
+            .into_connection();
+
+        let g = build_closure_graph(&db, vec![root]).await.unwrap();
+        assert_eq!(g.total_size_bytes, Some(140));
+        assert_eq!(g.node_count, 2);
+        assert_eq!(g.edge_count, 1);
+        assert!(!g.truncated);
+        // Largest first.
+        assert_eq!(g.nodes[0].id, root);
+        assert_eq!(g.nodes[0].nar_size, Some(100));
+        assert_eq!(
+            g.edges[0],
+            ClosureEdge {
+                source: child,
+                target: root
+            }
+        );
+    }
+}

--- a/backend/web/src/endpoints/builds/mod.rs
+++ b/backend/web/src/endpoints/builds/mod.rs
@@ -4,11 +4,16 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+pub mod closure;
 pub mod downloads;
 pub mod graph;
 pub mod log;
 pub mod query;
 
+pub use self::closure::{
+    ClosureEdge, ClosureGraph, ClosureNode, build_closure_graph, derivation_closure_reachable,
+    get_build_closure, get_eval_closure, sum_output_sizes,
+};
 pub use self::downloads::{
     BuildProduct, DownloadQuery, get_build_download, get_build_download_token, get_build_downloads,
 };

--- a/backend/web/src/endpoints/projects/metrics.rs
+++ b/backend/web/src/endpoints/projects/metrics.rs
@@ -6,6 +6,7 @@
 
 use crate::access::{Caller, OrgAccess, load_org};
 use crate::authorization::{MaybeApiKey, MaybeUser};
+use crate::endpoints::builds::closure::{derivation_closure_reachable, sum_output_sizes};
 use crate::error::WebResult;
 use crate::helpers::{OptionExt, ok_json};
 use axum::extract::{Path, Query, State};
@@ -13,7 +14,6 @@ use axum::{Extension, Json};
 use gradient_core::types::*;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect};
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 use std::sync::Arc;
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -31,84 +31,6 @@ pub struct ProjectMetricPoint {
 pub struct ProjectMetricsResponse {
     pub keep_evaluations: i32,
     pub points: Vec<ProjectMetricPoint>,
-}
-
-// ── Shared metric helpers ─────────────────────────────────────────────────────
-
-/// BFS over `derivation_dependency` starting from `seed_drv_ids`.
-///
-/// Returns all reachable derivation UUIDs (including the seeds themselves).
-async fn derivation_closure_reachable<C: sea_orm::ConnectionTrait>(
-    db: &C,
-    seed_drv_ids: Vec<DerivationId>,
-) -> WebResult<HashSet<DerivationId>> {
-    let mut visited: HashSet<DerivationId> = seed_drv_ids.iter().cloned().collect();
-    let mut frontier = seed_drv_ids;
-
-    while !frontier.is_empty() {
-        let edges = EDerivationDependency::find()
-            .filter(CDerivationDependency::Derivation.is_in(frontier.clone()))
-            .all(db)
-            .await?;
-        frontier.clear();
-        for edge in edges {
-            if visited.insert(edge.dependency) {
-                frontier.push(edge.dependency);
-            }
-        }
-    }
-
-    Ok(visited)
-}
-
-/// Sum uncompressed NAR size of derivation outputs for `drv_ids`.
-///
-/// `derivation_output.nar_size` is populated only when the worker actually
-/// built the output. For substituted builds it's `None`, but the size lives
-/// on the matching `cached_path` row (joined by hash). This helper coalesces
-/// the two so that completed and substituted outputs both contribute.
-///
-/// Returns `Some(total)` when the total is > 0, `None` otherwise.
-async fn sum_output_sizes<C: sea_orm::ConnectionTrait>(
-    db: &C,
-    drv_ids: Vec<DerivationId>,
-) -> WebResult<Option<i64>> {
-    if drv_ids.is_empty() {
-        return Ok(None);
-    }
-    let outputs = EDerivationOutput::find()
-        .filter(CDerivationOutput::Derivation.is_in(drv_ids))
-        .all(db)
-        .await?;
-
-    let missing_hashes: Vec<String> = outputs
-        .iter()
-        .filter(|o| o.nar_size.is_none())
-        .map(|o| o.hash.clone())
-        .collect::<HashSet<_>>()
-        .into_iter()
-        .collect();
-
-    let cached_size_by_hash: std::collections::HashMap<String, i64> = if missing_hashes.is_empty() {
-        std::collections::HashMap::new()
-    } else {
-        ECachedPath::find()
-            .filter(CCachedPath::Hash.is_in(missing_hashes))
-            .all(db)
-            .await?
-            .into_iter()
-            .filter_map(|cp| cp.nar_size.map(|n| (cp.hash, n)))
-            .collect()
-    };
-
-    let total: i64 = outputs
-        .iter()
-        .filter_map(|o| {
-            o.nar_size
-                .or_else(|| cached_size_by_hash.get(&o.hash).copied())
-        })
-        .sum();
-    Ok(if total > 0 { Some(total) } else { None })
 }
 
 // ── Endpoints ─────────────────────────────────────────────────────────────────
@@ -214,6 +136,7 @@ pub struct EntryPointMetricsQuery {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct EntryPointMetricPoint {
     pub evaluation_id: EvaluationId,
+    pub build_id: BuildId,
     pub created_at: chrono::NaiveDateTime,
     pub build_status: entity::build::BuildStatus,
     pub build_time_ms: Option<i64>,
@@ -289,6 +212,7 @@ pub async fn get_entry_point_metrics(
 
         points.push(EntryPointMetricPoint {
             evaluation_id: evaluation.id,
+            build_id: build.id,
             created_at: evaluation.created_at,
             build_status: build.status.for_api(),
             build_time_ms,

--- a/backend/web/src/lib.rs
+++ b/backend/web/src/lib.rs
@@ -447,6 +447,7 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
             get(evals::get_evaluation_builds),
         )
         .route("/evals/{evaluation}/artefacts", get(evals::get_artefacts))
+        .route("/evals/{evaluation}/closure", get(builds::get_eval_closure))
         .route("/builds/{build}", get(builds::get_build))
         .route("/builds/{build}/log", get(builds::get_build_log))
         .route(
@@ -454,6 +455,7 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
             get(builds::get_build_dependencies),
         )
         .route("/builds/{build}/graph", get(builds::get_build_graph))
+        .route("/builds/{build}/closure", get(builds::get_build_closure))
         .route(
             "/builds/{build}/downloads",
             get(builds::get_build_downloads),

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -3016,6 +3016,34 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /evals/{evaluation}/closure:
+    parameters:
+      - $ref: '#/components/parameters/EvaluationId'
+    get:
+      tags: [evals]
+      summary: Get closure size graph for an evaluation
+      description: |-
+        Returns the union dependency closure of all the evaluation's entry-point
+        builds with per-node uncompressed NAR sizes and an exact `total_size_bytes`.
+        Same shape as `/builds/{build}/closure`.
+      operationId: getEvalClosure
+      responses:
+        '200':
+          description: Closure size graph
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BaseResponse'
+                  - type: object
+                    properties:
+                      message:
+                        $ref: '#/components/schemas/ClosureGraph'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   # ── Build Requests ───────────────────────────────────────────────────────────
 
   /build-requests/manifest:
@@ -3265,6 +3293,38 @@ paths:
                     properties:
                       message:
                         $ref: '#/components/schemas/BuildGraph'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /builds/{build}/closure:
+    parameters:
+      - $ref: '#/components/parameters/BuildId'
+    get:
+      tags: [builds]
+      summary: Get closure size graph
+      description: |-
+        Returns the full dependency closure of the build's derivation with per-node
+        uncompressed NAR sizes and an exact `total_size_bytes` over the whole closure.
+        The `nodes`/`edges` lists are capped (largest nodes first) with `truncated`
+        set when the cap is hit; `total_size_bytes` stays exact regardless. Intended
+        for the closure Sankey view and size-trimming tooling.
+
+        **Access:** Same as the dependency graph endpoint.
+      operationId: getBuildClosure
+      responses:
+        '200':
+          description: Closure size graph
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BaseResponse'
+                  - type: object
+                    properties:
+                      message:
+                        $ref: '#/components/schemas/ClosureGraph'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
@@ -6694,11 +6754,15 @@ components:
 
     EntryPointMetricPoint:
       type: object
-      required: [evaluation_id, created_at, build_status, dependencies_count]
+      required: [evaluation_id, build_id, created_at, build_status, dependencies_count]
       properties:
         evaluation_id:
           type: string
           format: uuid
+        build_id:
+          type: string
+          format: uuid
+          description: Entry-point build for this evaluation (target of the closure view)
         created_at:
           type: string
           format: date-time
@@ -7276,6 +7340,71 @@ components:
           items:
             $ref: '#/components/schemas/DependencyEdge'
           description: Dependency edges (`source` → `target` means source must be built before target)
+
+    ClosureNode:
+      type: object
+      required: [id, name, path, nar_size]
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Derivation UUID
+        name:
+          type: string
+          example: hello-2.12.1
+        path:
+          type: string
+          description: Full Nix store path of the `.drv`
+        nar_size:
+          type: integer
+          format: int64
+          nullable: true
+          description: Coalesced uncompressed NAR size of the derivation's outputs (null when unknown)
+
+    ClosureEdge:
+      type: object
+      required: [source, target]
+      properties:
+        source:
+          type: string
+          format: uuid
+          description: Dependency derivation
+        target:
+          type: string
+          format: uuid
+          description: Derivation that depends on `source`
+
+    ClosureGraph:
+      type: object
+      required: [roots, total_size_bytes, node_count, edge_count, truncated, nodes, edges]
+      properties:
+        roots:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: Seed derivations (one for a build, all entry points for an evaluation)
+        total_size_bytes:
+          type: integer
+          format: int64
+          nullable: true
+          description: Exact sum of NAR sizes over the whole closure, independent of the node cap
+        node_count:
+          type: integer
+          description: Number of nodes returned (after the cap)
+        edge_count:
+          type: integer
+        truncated:
+          type: boolean
+          description: True when the closure exceeded the node cap and the node/edge lists were trimmed (largest nodes kept)
+        nodes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ClosureNode'
+        edges:
+          type: array
+          items:
+            $ref: '#/components/schemas/ClosureEdge'
 
     BuildProduct:
       type: object

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -3076,3 +3076,23 @@ Run with: `cargo test -p entity --lib build`
 - `terminal_failure_excludes_transient` — `FailedTransient` returns
   `false` from `is_terminal_failure()` (it will be retried); `FailedPermanent`
   and `FailedTimeout` return `true`.
+
+## Closure size graph - issue #242
+
+### Closure builder - `backend/web/src/endpoints/builds/closure.rs`
+
+- `build_closure_graph_sums_and_links` - the closure builder walks the
+  dependency closure, sums per-derivation NAR sizes into an exact
+  `total_size_bytes`, orders nodes largest-first, and emits one edge per
+  in-closure dependency (`source` = dependency, `target` = dependent).
+
+The shared `derivation_closure_reachable` / `sum_output_sizes` helpers (lifted
+out of `projects/metrics.rs`) keep their existing coverage in
+`backend/web/src/endpoints/projects/metrics.rs` (`sum_output_sizes_*`).
+
+### Top-N aggregation - `frontend/.../closure-graph/closure-aggregate.spec.ts`
+
+- keeps the largest `N` nodes and buckets the remainder into an exact-sized
+  `others` node.
+- reattaches edges from dropped nodes onto the `others` node.
+- returns the graph unchanged when the node count is within `N`.

--- a/docs/src/usage/closure-view.md
+++ b/docs/src/usage/closure-view.md
@@ -1,0 +1,27 @@
+# Closure View
+
+The closure view shows a Sankey diagram of a build's (or evaluation's) full
+dependency closure, sized by uncompressed NAR size. It exists to answer "what is
+taking up space?" when trimming netboot images, ISOs, or container layers.
+
+Open it from an entry point's metrics page via the **View Closure** button, which
+links to the closure of that entry point's most recent build.
+
+The diagram renders the largest packages individually and aggregates the long
+tail into a single **others** node; the header shows the exact total closure
+size and warns when a very large closure had its node list truncated (the total
+stays exact regardless).
+
+## API
+
+Both endpoints return per-node sizes plus an exact `total_size_bytes`, so they
+are also useful for custom tooling and scripts:
+
+```sh
+GET /api/v1/builds/{build}/closure
+GET /api/v1/evals/{evaluation}/closure
+```
+
+Response (`ClosureGraph`): `roots`, `total_size_bytes`, `node_count`,
+`edge_count`, `truncated`, `nodes` (`id`, `name`, `path`, `nar_size`), and
+`edges` (`source` → `target`, where `target` depends on `source`).

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "@angular/router": "^21.2.13",
     "@primeuix/themes": "^2.0.3",
     "apexcharts": "^5.12.0",
+    "apexsankey": "^1.7.1",
     "ng-apexcharts": "^2.4.0",
     "primeicons": "^7.0.0",
     "primeng": "^21.1.8",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       apexcharts:
         specifier: ^5.12.0
         version: 5.12.0
+      apexsankey:
+        specifier: ^1.7.1
+        version: 1.7.1
       ng-apexcharts:
         specifier: ^2.4.0
         version: 2.4.0(@angular/common@21.2.13(@angular/core@21.2.13(@angular/compiler@21.2.13)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.13(@angular/compiler@21.2.13)(rxjs@7.8.2))(apexcharts@5.12.0)(rxjs@7.8.2)
@@ -1471,6 +1474,9 @@ packages:
 
   apexcharts@5.12.0:
     resolution: {integrity: sha512-vNCw62M5rhVg09FHFCL/ztpH7VlTOF8/+lWLUVjBdQffIAgQaxtyDGfojCyYoZHM3Hh17srWwz6rrD/XzblRSw==}
+
+  apexsankey@1.7.1:
+    resolution: {integrity: sha512-K9G+HfQdLBMNGY0MnaT36WDBQzI5gN27paXkNMh/oB+9InAnGEymqQUSnCj3sF3eVIdolH4QzIqPspgnFTd9uQ==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -4015,6 +4021,8 @@ snapshots:
   ansi-styles@6.2.3: {}
 
   apexcharts@5.12.0: {}
+
+  apexsankey@1.7.1: {}
 
   assertion-error@2.0.1: {}
 

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -150,6 +150,15 @@ export const routes: Routes = [
       ),
   },
   {
+    path: 'organization/:org/closure/:kind/:id',
+    title: 'Closure',
+    data: { hideFooter: true },
+    loadComponent: () =>
+      import('./features/evaluations/closure-graph/closure-graph.component').then(
+        (m) => m.ClosureGraphComponent
+      ),
+  },
+  {
     path: 'organization/:org/log/:evaluationId',
     title: 'Evaluation Log',
     data: { hideFooter: true },

--- a/frontend/src/app/core/services/evaluations.service.ts
+++ b/frontend/src/app/core/services/evaluations.service.ts
@@ -29,6 +29,28 @@ export interface BuildGraph {
   edges: DependencyEdge[];
 }
 
+export interface ClosureNode {
+  id: string;
+  name: string;
+  path: string;
+  nar_size: number | null;
+}
+
+export interface ClosureEdge {
+  source: string;
+  target: string;
+}
+
+export interface ClosureGraph {
+  roots: string[];
+  total_size_bytes: number | null;
+  node_count: number;
+  edge_count: number;
+  truncated: boolean;
+  nodes: ClosureNode[];
+  edges: ClosureEdge[];
+}
+
 export interface BuildItem {
   id: string;
   name: string;          // derivation path
@@ -94,6 +116,14 @@ export class EvaluationsService {
 
   getBuildGraph(buildId: string): Observable<BuildGraph> {
     return this.api.get<BuildGraph>(`builds/${buildId}/graph`);
+  }
+
+  getBuildClosure(buildId: string): Observable<ClosureGraph> {
+    return this.api.get<ClosureGraph>(`builds/${buildId}/closure`);
+  }
+
+  getEvalClosure(evalId: string): Observable<ClosureGraph> {
+    return this.api.get<ClosureGraph>(`evals/${evalId}/closure`);
   }
 
   getBuildDownloads(buildId: string): Observable<BuildProduct[]> {

--- a/frontend/src/app/core/services/projects.service.ts
+++ b/frontend/src/app/core/services/projects.service.ts
@@ -113,6 +113,7 @@ export interface ProjectMetricsResponse {
 
 export interface EntryPointMetricPoint {
   evaluation_id: string;
+  build_id: string;
   created_at: string;
   build_status: string;
   build_time_ms: number | null;

--- a/frontend/src/app/features/evaluations/closure-graph/closure-aggregate.spec.ts
+++ b/frontend/src/app/features/evaluations/closure-graph/closure-aggregate.spec.ts
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { aggregateTopN, OTHERS_ID } from './closure-aggregate';
+import type { ClosureGraph } from '@core/services/evaluations.service';
+
+function graph(nodes: [string, number][], edges: [string, string][], total: number): ClosureGraph {
+  return {
+    roots: [nodes[0][0]],
+    total_size_bytes: total,
+    node_count: nodes.length,
+    edge_count: edges.length,
+    truncated: false,
+    nodes: nodes.map(([id, s]) => ({ id, name: id, path: `/nix/store/${id}`, nar_size: s })),
+    edges: edges.map(([source, target]) => ({ source, target })),
+  };
+}
+
+describe('aggregateTopN', () => {
+  it('keeps top N nodes and buckets the rest into an others node', () => {
+    const g = graph(
+      [['a', 100], ['b', 50], ['c', 10], ['d', 5]],
+      [['b', 'a'], ['c', 'a'], ['d', 'b']],
+      165,
+    );
+    const r = aggregateTopN(g, 2);
+    const ids = r.nodes.map((n) => n.id);
+    expect(ids).toContain('a');
+    expect(ids).toContain('b');
+    expect(ids).toContain(OTHERS_ID);
+    const others = r.nodes.find((n) => n.id === OTHERS_ID)!;
+    expect(others.nar_size).toBe(15); // total 165 - (100 + 50)
+    expect(others.bucketedCount).toBe(2);
+  });
+
+  it('reattaches edges from dropped nodes to the others node', () => {
+    const g = graph(
+      [['a', 100], ['b', 50], ['c', 10]],
+      [['b', 'a'], ['c', 'b']],
+      160,
+    );
+    const r = aggregateTopN(g, 2);
+    // c is dropped -> edge c->b becomes __others__->b
+    expect(r.edges.find((e) => e.source === OTHERS_ID && e.target === 'b')).toBeTruthy();
+  });
+
+  it('returns the graph unchanged when node count <= n', () => {
+    const g = graph([['a', 100], ['b', 50]], [['b', 'a']], 150);
+    const r = aggregateTopN(g, 5);
+    expect(r.nodes.length).toBe(2);
+    expect(r.nodes.some((n) => n.id === OTHERS_ID)).toBe(false);
+  });
+});

--- a/frontend/src/app/features/evaluations/closure-graph/closure-aggregate.ts
+++ b/frontend/src/app/features/evaluations/closure-graph/closure-aggregate.ts
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ClosureGraph, ClosureEdge } from '@core/services/evaluations.service';
+
+export const OTHERS_ID = '__others__';
+
+export interface AggNode {
+  id: string;
+  name: string;
+  path: string;
+  nar_size: number | null;
+  bucketedCount?: number;
+}
+
+export interface AggregatedClosure {
+  nodes: AggNode[];
+  edges: ClosureEdge[];
+  total_size_bytes: number | null;
+  truncated: boolean;
+}
+
+/** Keep the `n` largest nodes by size; collapse the rest into a single
+ *  synthetic "others" node sized from the exact total, and reattach edges. */
+export function aggregateTopN(graph: ClosureGraph, n: number): AggregatedClosure {
+  const sorted = [...graph.nodes].sort((a, b) => (b.nar_size ?? 0) - (a.nar_size ?? 0));
+  if (sorted.length <= n) {
+    return {
+      nodes: sorted,
+      edges: graph.edges,
+      total_size_bytes: graph.total_size_bytes,
+      truncated: graph.truncated,
+    };
+  }
+
+  const kept = sorted.slice(0, n);
+  const dropped = sorted.slice(n);
+  const keptIds = new Set(kept.map((node) => node.id));
+  const keptSum = kept.reduce((acc, node) => acc + (node.nar_size ?? 0), 0);
+  const othersSize = (graph.total_size_bytes ?? keptSum) - keptSum;
+
+  const nodes: AggNode[] = [
+    ...kept,
+    {
+      id: OTHERS_ID,
+      name: `others (${dropped.length} packages)`,
+      path: '',
+      nar_size: othersSize > 0 ? othersSize : 0,
+      bucketedCount: dropped.length,
+    },
+  ];
+
+  const remap = (id: string) => (keptIds.has(id) ? id : OTHERS_ID);
+  const seen = new Set<string>();
+  const edges: ClosureEdge[] = [];
+  for (const e of graph.edges) {
+    const source = remap(e.source);
+    const target = remap(e.target);
+    if (source === target) continue; // collapsed self-loop within others
+    const key = `${source}->${target}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    edges.push({ source, target });
+  }
+
+  return { nodes, edges, total_size_bytes: graph.total_size_bytes, truncated: graph.truncated };
+}

--- a/frontend/src/app/features/evaluations/closure-graph/closure-graph.component.html
+++ b/frontend/src/app/features/evaluations/closure-graph/closure-graph.component.html
@@ -1,0 +1,42 @@
+<!--
+  SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+
+  SPDX-License-Identifier: AGPL-3.0-only
+-->
+
+<div class="closure-page">
+  @if (loading()) {
+    <div class="full-loading">
+      <app-loading-spinner message="Loading closure…" />
+    </div>
+  } @else if (errorMsg()) {
+    <div class="error-state">
+      <span class="material-symbols-outlined">error</span>
+      <p>{{ errorMsg() }}</p>
+      <button pButton label="Go Back" severity="secondary" (click)="goBack()"></button>
+    </div>
+  } @else {
+    <div class="closure-header">
+      <div class="header-left">
+        <button class="icon-btn" (click)="goBack()" title="Back">
+          <span class="material-symbols-outlined">arrow_back</span>
+        </button>
+        <div class="header-info">
+          <div class="header-title">
+            <span class="header-name">{{ rootName() }}</span>
+            <span class="total-badge">{{ totalLabel() }}</span>
+          </div>
+          <div class="header-meta">
+            <span>{{ nodeCount() }} packages in closure</span>
+            @if (truncated()) {
+              <span class="sep">·</span>
+              <span class="warn">large closure — node list truncated</span>
+            }
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div #sankeyEl class="sankey-canvas"></div>
+  }
+</div>

--- a/frontend/src/app/features/evaluations/closure-graph/closure-graph.component.scss
+++ b/frontend/src/app/features/evaluations/closure-graph/closure-graph.component.scss
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+.closure-page {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  background: #0d1118;
+  color: #e5e7eb;
+}
+
+.full-loading,
+.error-state {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+
+.closure-header {
+  display: flex;
+  align-items: center;
+  padding: 12px 16px;
+  border-bottom: 1px solid #2d3748;
+}
+
+.header-left { display: flex; align-items: center; gap: 12px; }
+
+.icon-btn {
+  background: none;
+  border: none;
+  color: #abb0b4;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+}
+
+.header-title { display: flex; align-items: center; gap: 10px; }
+.header-name { font-weight: 600; font-family: monospace; }
+
+.total-badge {
+  background: #fd7e14;
+  color: #0d1118;
+  font-weight: 700;
+  padding: 2px 10px;
+  border-radius: 12px;
+  font-size: 13px;
+}
+
+.header-meta { font-size: 12px; color: #6b7280; display: flex; gap: 8px; }
+.header-meta .warn { color: #eab308; }
+.sep { color: #374151; }
+
+.sankey-canvas {
+  flex: 1;
+  overflow: auto;
+  padding: 16px;
+}

--- a/frontend/src/app/features/evaluations/closure-graph/closure-graph.component.ts
+++ b/frontend/src/app/features/evaluations/closure-graph/closure-graph.component.ts
@@ -1,0 +1,124 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import {
+  Component, OnInit, inject, signal, ViewChild, ElementRef, NgZone,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute, Router } from '@angular/router';
+import { ButtonModule } from 'primeng/button';
+import { EvaluationsService, ClosureGraph } from '@core/services/evaluations.service';
+import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
+import { aggregateTopN } from './closure-aggregate';
+
+const TOP_N = 30;
+
+@Component({
+  selector: 'app-closure-graph',
+  standalone: true,
+  imports: [CommonModule, ButtonModule, LoadingSpinnerComponent],
+  templateUrl: './closure-graph.component.html',
+  styleUrl: './closure-graph.component.scss',
+})
+export class ClosureGraphComponent implements OnInit {
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private evalService = inject(EvaluationsService);
+  private zone = inject(NgZone);
+
+  @ViewChild('sankeyEl') sankeyRef!: ElementRef<HTMLDivElement>;
+
+  loading = signal(true);
+  errorMsg = signal<string | null>(null);
+  truncated = signal(false);
+  rootName = signal('');
+  totalLabel = signal('');
+  nodeCount = signal(0);
+
+  orgName = '';
+  kind = '';
+  id = '';
+
+  ngOnInit(): void {
+    this.orgName = this.route.snapshot.paramMap.get('org') || '';
+    this.kind = this.route.snapshot.paramMap.get('kind') || 'build';
+    this.id = this.route.snapshot.paramMap.get('id') || '';
+    this.load();
+  }
+
+  private load(): void {
+    const req = this.kind === 'eval'
+      ? this.evalService.getEvalClosure(this.id)
+      : this.evalService.getBuildClosure(this.id);
+    req.subscribe({
+      next: (g) => {
+        this.nodeCount.set(g.node_count);
+        this.truncated.set(g.truncated);
+        this.totalLabel.set(this.formatBytes(g.total_size_bytes ?? 0));
+        const rootNode = g.nodes.find((n) => g.roots.includes(n.id));
+        this.rootName.set(rootNode?.name ?? '');
+        this.loading.set(false);
+        setTimeout(() => this.render(g), 0);
+      },
+      error: () => {
+        this.loading.set(false);
+        this.errorMsg.set('Failed to load closure');
+      },
+    });
+  }
+
+  private async render(graph: ClosureGraph): Promise<void> {
+    const el = this.sankeyRef?.nativeElement;
+    if (!el || !graph.nodes.length) return;
+    const agg = aggregateTopN(graph, TOP_N);
+    const sizeById = new Map(agg.nodes.map((n) => [n.id, n.nar_size ?? 0]));
+
+    const { default: ApexSankey } = await import('apexsankey');
+
+    const nodes = agg.nodes.map((n) => ({
+      id: n.id,
+      title: `${this.shortName(n.name)} · ${this.formatBytes(n.nar_size ?? 0)}`,
+    }));
+    const edges = agg.edges.map((e) => ({
+      source: e.source,
+      target: e.target,
+      value: Math.max(1, sizeById.get(e.source) ?? 1),
+      type: 'closure',
+    }));
+
+    this.zone.runOutsideAngular(() => {
+      el.innerHTML = '';
+      try {
+        const chart = new ApexSankey(el, {
+          width: el.clientWidth || 1000,
+          height: Math.max(420, agg.nodes.length * 24),
+          nodeWidth: 16,
+          fontColor: '#e5e7eb',
+          canvasStyle: 'background:#0d1118;',
+          tooltipTheme: 'dark',
+        });
+        chart.render({ nodes, edges, options: chart.options });
+      } catch {
+        this.zone.run(() => this.errorMsg.set('Unable to render closure diagram'));
+      }
+    });
+  }
+
+  private shortName(name: string): string {
+    return name.length > 28 ? name.slice(0, 27) + '…' : name;
+  }
+
+  formatBytes(bytes: number): string {
+    if (!bytes || bytes <= 0) return '0 B';
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(1024));
+    return `${(bytes / Math.pow(1024, i)).toFixed(1)} ${units[Math.min(i, units.length - 1)]}`;
+  }
+
+  goBack(): void {
+    this.router.navigate(['/organization', this.orgName]);
+  }
+}

--- a/frontend/src/app/features/evaluations/dependency-graph/dependency-graph.component.ts
+++ b/frontend/src/app/features/evaluations/dependency-graph/dependency-graph.component.ts
@@ -83,17 +83,18 @@ export class DependencyGraphComponent implements OnInit, OnDestroy {
   hoveredNode = signal<LayoutNode | null>(null);
   tooltipX = signal(0);
   tooltipY = signal(0);
+  private hoveredId: string | null = null;
 
   private layoutNodes: LayoutNode[] = [];
   private layoutEdges: LayoutEdge[] = [];
   private nodeMap = new Map<string, LayoutNode>();
-  private nodeDepths = new Map<string, number>();
-  private graphBounds = { minX: 0, maxX: 0 };
 
   // DOM refs (imperative)
   private nodeEls = new Map<string, SVGGElement>();
-  private edgeEls: { el: SVGPathElement; source: string; target: string; idx: number }[] = [];
+  private edgeEls: { el: SVGPathElement; source: string; target: string }[] = [];
   private durationEls = new Map<string, SVGTextElement>();
+  private incident = new Map<string, Set<number>>(); // nodeId -> indices into edgeEls
+  private neighbours = new Map<string, Set<string>>();
 
   // Interaction
   private isPanning = false;
@@ -188,8 +189,6 @@ export class DependencyGraphComponent implements OnInit, OnDestroy {
       }
     }
 
-    this.nodeDepths = depth;
-
     // Group nodes by level
     const byLevel = new Map<number, LayoutNode[]>();
     for (const n of nodes) {
@@ -221,13 +220,6 @@ export class DependencyGraphComponent implements OnInit, OnDestroy {
         posX.set(n.id, n.x + CARD_W / 2);
       });
     }
-
-    // Overall graph bounds (used for side-lane routing of multi-level edges)
-    this.graphBounds = { minX: Infinity, maxX: -Infinity };
-    for (const n of nodes) {
-      if (n.x < this.graphBounds.minX) this.graphBounds.minX = n.x;
-      if (n.x + CARD_W > this.graphBounds.maxX) this.graphBounds.maxX = n.x + CARD_W;
-    }
   }
 
   private avgX(nodeId: string, dependents: Map<string, string[]>, posX: Map<string, number>): number {
@@ -249,13 +241,13 @@ export class DependencyGraphComponent implements OnInit, OnDestroy {
     this.edgeEls = [];
 
     // Edges first (rendered under cards)
-    this.layoutEdges.forEach((edge, idx) => {
+    this.layoutEdges.forEach((edge) => {
       const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
       path.setAttribute('fill', 'none');
       path.setAttribute('stroke-width', '1.5');
       path.setAttribute('marker-end', 'url(#arrowhead)');
       g.appendChild(path);
-      this.edgeEls.push({ el: path, source: edge.source, target: edge.target, idx });
+      this.edgeEls.push({ el: path, source: edge.source, target: edge.target });
     });
 
     // Cards
@@ -264,6 +256,19 @@ export class DependencyGraphComponent implements OnInit, OnDestroy {
       g.appendChild(cardG);
       this.nodeEls.set(node.id, cardG);
     }
+
+    // Incidence index: which edges + neighbours touch each node, for hover highlight.
+    this.incident.clear();
+    this.neighbours.clear();
+    this.edgeEls.forEach((e, i) => {
+      for (const id of [e.source, e.target]) {
+        if (!this.incident.has(id)) this.incident.set(id, new Set());
+        this.incident.get(id)!.add(i);
+        if (!this.neighbours.has(id)) this.neighbours.set(id, new Set());
+      }
+      this.neighbours.get(e.source)!.add(e.target);
+      this.neighbours.get(e.target)!.add(e.source);
+    });
 
     this.updateSvgPositions();
   }
@@ -347,6 +352,7 @@ export class DependencyGraphComponent implements OnInit, OnDestroy {
 
     // Hover events for tooltip
     g.addEventListener('mouseenter', (e: MouseEvent) => {
+      this.highlightNode(node.id);
       this.zone.run(() => {
         this.hoveredNode.set(node);
         this.tooltipX.set(e.clientX + 14);
@@ -354,6 +360,7 @@ export class DependencyGraphComponent implements OnInit, OnDestroy {
       });
     });
     g.addEventListener('mouseleave', () => {
+      this.resetHighlight();
       this.zone.run(() => this.hoveredNode.set(null));
     });
     // Click navigates to build log
@@ -372,8 +379,6 @@ export class DependencyGraphComponent implements OnInit, OnDestroy {
   }
 
   private updateSvgPositions(): void {
-    const LANE_MARGIN = 50;
-
     // Update card transforms and live status visuals
     for (const node of this.layoutNodes) {
       const el = this.nodeEls.get(node.id);
@@ -393,51 +398,46 @@ export class DependencyGraphComponent implements OnInit, OnDestroy {
       }
     }
 
-    // Update edge paths
+    // Update edge paths — every edge uses a smooth bottom→top bezier; hovering a
+    // node (highlightNode) makes its incident edges legible on demand.
     for (const edge of this.edgeEls) {
-      const child  = this.nodeMap.get(edge.source); // dependency  (lower level)
-      const parent = this.nodeMap.get(edge.target); // dependent   (higher level)
+      const child = this.nodeMap.get(edge.source);
+      const parent = this.nodeMap.get(edge.target);
       if (!child || !parent) continue;
-
-      const pd = this.nodeDepths.get(edge.target) ?? 0;
-      const cd = this.nodeDepths.get(edge.source) ?? 0;
-      const dd = cd - pd;
-
-      const pCX = parent.x + CARD_W / 2;
-      const cCX = child.x + CARD_W / 2;
-
-      if (dd <= 1) {
-        // Single-level: smooth bezier bottom-center → top-center
-        const px = pCX, py = parent.y + CARD_H;
-        const cx = cCX, cy = child.y;
-        const midY = (py + cy) / 2;
-        edge.el.setAttribute('d', `M ${px} ${py} C ${px} ${midY} ${cx} ${midY} ${cx} ${cy}`);
-        edge.el.setAttribute('stroke', '#374151');
-      } else {
-        // Multi-level: route through a side-lane to avoid crossing intermediate cards.
-        // Determine which side based on horizontal direction; use edge index as tiebreaker.
-        const dx = cCX - pCX;
-        const useRight = dx > 5 ? true : dx < -5 ? false : edge.idx % 2 === 0;
-        const laneX = useRight
-          ? this.graphBounds.maxX + LANE_MARGIN + (dd - 2) * 15
-          : this.graphBounds.minX - LANE_MARGIN - (dd - 2) * 15;
-
-        // Exit from the card's left/right side mid-height, re-enter child top-center vertically.
-        const exitX = useRight ? parent.x + CARD_W : parent.x;
-        const exitY = parent.y + CARD_H / 2;
-        const TURN = 22;
-
-        // Compound path: curve to lane → straight down → curve back to child top-center
-        const d = [
-          `M ${exitX} ${exitY}`,
-          `C ${laneX} ${exitY} ${laneX} ${exitY + TURN} ${laneX} ${exitY + TURN}`,
-          `L ${laneX} ${child.y - TURN}`,
-          `C ${laneX} ${child.y} ${cCX} ${child.y - TURN} ${cCX} ${child.y}`,
-        ].join(' ');
-        edge.el.setAttribute('d', d);
-        edge.el.setAttribute('stroke', '#2d3748');
-      }
+      const px = parent.x + CARD_W / 2, py = parent.y + CARD_H;
+      const cx = child.x + CARD_W / 2, cy = child.y;
+      const midY = (py + cy) / 2;
+      edge.el.setAttribute('d', `M ${px} ${py} C ${px} ${midY} ${cx} ${midY} ${cx} ${cy}`);
+      edge.el.setAttribute('stroke', '#374151');
     }
+
+    // Re-apply hover highlight if a node is still hovered after a live update.
+    if (this.hoveredId) this.highlightNode(this.hoveredId);
+  }
+
+  private highlightNode(nodeId: string): void {
+    this.hoveredId = nodeId;
+    const inc = this.incident.get(nodeId) ?? new Set<number>();
+    const near = this.neighbours.get(nodeId) ?? new Set<string>();
+    this.edgeEls.forEach((e, i) => {
+      const on = inc.has(i);
+      e.el.setAttribute('stroke', on ? '#9ca3af' : '#1f2733');
+      e.el.setAttribute('stroke-width', on ? '2.5' : '1');
+      e.el.setAttribute('opacity', on ? '1' : '0.25');
+    });
+    for (const [id, el] of this.nodeEls) {
+      el.setAttribute('opacity', id === nodeId || near.has(id) ? '1' : '0.35');
+    }
+  }
+
+  private resetHighlight(): void {
+    this.hoveredId = null;
+    for (const e of this.edgeEls) {
+      e.el.setAttribute('stroke', '#374151');
+      e.el.setAttribute('stroke-width', '1.5');
+      e.el.setAttribute('opacity', '1');
+    }
+    for (const [, el] of this.nodeEls) el.setAttribute('opacity', '1');
   }
 
   private centerViewport(): void {
@@ -464,16 +464,17 @@ export class DependencyGraphComponent implements OnInit, OnDestroy {
 
   onWheel(event: WheelEvent): void {
     event.preventDefault();
-    const factor = event.deltaY > 0 ? 0.9 : 1.1;
-    const newScale = Math.max(0.08, Math.min(4, this.scale() * factor));
     const rect = this.svgRef.nativeElement.getBoundingClientRect();
     const mx = event.clientX - rect.left;
     const my = event.clientY - rect.top;
-    const dx = (mx - this.tx()) * (1 - factor);
-    const dy = (my - this.ty()) * (1 - factor);
+    const oldScale = this.scale();
+    const target = oldScale * (event.deltaY > 0 ? 0.9 : 1.1);
+    const newScale = Math.max(0.08, Math.min(4, target));
+    const effFactor = newScale / oldScale;
+    if (effFactor === 1) return;
     this.scale.set(newScale);
-    this.tx.update((v) => v + dx);
-    this.ty.update((v) => v + dy);
+    this.tx.update((v) => mx - effFactor * (mx - v));
+    this.ty.update((v) => my - effFactor * (my - v));
   }
 
   onSvgMousedown(event: MouseEvent): void {
@@ -503,25 +504,21 @@ export class DependencyGraphComponent implements OnInit, OnDestroy {
     this.isPanning = false;
   }
 
-  zoomIn(): void {
+  private zoomBy(factor: number): void {
     const rect = this.svgRef?.nativeElement.getBoundingClientRect();
     if (!rect) return;
-    const factor = 1.3;
     const cx = rect.width / 2, cy = rect.height / 2;
-    this.scale.update((s) => Math.min(s * factor, 4));
-    this.tx.update((v) => v + (cx - v) * (1 - 1 / factor));
-    this.ty.update((v) => v + (cy - v) * (1 - 1 / factor));
+    const oldScale = this.scale();
+    const newScale = Math.max(0.08, Math.min(4, oldScale * factor));
+    const eff = newScale / oldScale;
+    if (eff === 1) return;
+    this.scale.set(newScale);
+    this.tx.update((v) => cx - eff * (cx - v));
+    this.ty.update((v) => cy - eff * (cy - v));
   }
 
-  zoomOut(): void {
-    const rect = this.svgRef?.nativeElement.getBoundingClientRect();
-    if (!rect) return;
-    const factor = 1 / 1.3;
-    const cx = rect.width / 2, cy = rect.height / 2;
-    this.scale.update((s) => Math.max(s * factor, 0.08));
-    this.tx.update((v) => v + (cx - v) * (1 - 1 / factor));
-    this.ty.update((v) => v + (cy - v) * (1 - 1 / factor));
-  }
+  zoomIn(): void { this.zoomBy(1.3); }
+  zoomOut(): void { this.zoomBy(1 / 1.3); }
 
   fitToScreen(): void {
     this.centerViewport();

--- a/frontend/src/app/features/organizations/integrations/integrations.component.spec.ts
+++ b/frontend/src/app/features/organizations/integrations/integrations.component.spec.ts
@@ -25,6 +25,7 @@ const baseIntegration: Integration = {
   endpoint_url: null,
   has_secret: true,
   has_access_token: false,
+  allowed_ips: [],
   created_by: 'u',
   created_at: '2026-01-01T00:00:00Z',
 };

--- a/frontend/src/app/features/projects/entry-point-metrics/entry-point-metrics.component.html
+++ b/frontend/src/app/features/projects/entry-point-metrics/entry-point-metrics.component.html
@@ -17,6 +17,14 @@
       <h1>{{ evalAttr() }}</h1>
       <p class="text-secondary">Build history over the last {{ keepEvaluations() }} completed evaluations.</p>
     </div>
+    @if (latestBuildId()) {
+      <a class="closure-link"
+         [routerLink]="['/organization', orgName, 'closure', 'build', latestBuildId()]"
+         title="View closure size breakdown">
+        <span class="material-symbols-outlined">account_tree</span>
+        View Closure
+      </a>
+    }
   </div>
 
   @if (loading()) {

--- a/frontend/src/app/features/projects/entry-point-metrics/entry-point-metrics.component.scss
+++ b/frontend/src/app/features/projects/entry-point-metrics/entry-point-metrics.component.scss
@@ -14,6 +14,28 @@
 
 .page-header {
   margin-bottom: $spacing-xl;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: $spacing-lg;
+
+  .closure-link {
+    display: inline-flex;
+    align-items: center;
+    gap: $spacing-xs;
+    padding: $spacing-sm $spacing-md;
+    border: 1px solid $color-border;
+    border-radius: $border-radius-md;
+    color: $text-secondary;
+    text-decoration: none;
+    font-size: $font-size-sm;
+    white-space: nowrap;
+
+    &:hover {
+      border-color: #fd7e14;
+      color: #fd7e14;
+    }
+  }
 
   .breadcrumb {
     display: flex;

--- a/frontend/src/app/features/projects/entry-point-metrics/entry-point-metrics.component.ts
+++ b/frontend/src/app/features/projects/entry-point-metrics/entry-point-metrics.component.ts
@@ -166,6 +166,11 @@ export class EntryPointMetricsComponent implements OnInit {
     return opts;
   });
 
+  latestBuildId = computed(() => {
+    const pts = this.points();
+    return pts.length ? pts[pts.length - 1].build_id : '';
+  });
+
   completedCount = computed(() => this.points().filter((p) => p.build_status === 'Completed').length);
   failedCount = computed(() => this.points().filter((p) => p.build_status === 'FailedPermanent' || p.build_status === 'FailedTimeout').length);
   substitutedCount = computed(() => this.points().filter((p) => p.build_status === 'Substituted').length);

--- a/frontend/src/app/features/settings/api-keys/api-keys.component.spec.ts
+++ b/frontend/src/app/features/settings/api-keys/api-keys.component.spec.ts
@@ -20,10 +20,12 @@ const unmanagedKey: ApiKey = {
   managed: false,
   permissions: ['viewOrg'],
   organization: null,
+  cache: null,
   created_at: '2026-01-01T00:00:00',
   last_used_at: null,
   expires_at: null,
   revoked_at: null,
+  allowed_ips: [],
 };
 
 const managedKey: ApiKey = {
@@ -32,10 +34,12 @@ const managedKey: ApiKey = {
   managed: true,
   permissions: ['viewOrg'],
   organization: null,
+  cache: null,
   created_at: '2026-01-01T00:00:00',
   last_used_at: null,
   expires_at: null,
   revoked_at: null,
+  allowed_ips: [],
 };
 
 function setup(keys: ApiKey[]): ComponentFixture<ApiKeysComponent> {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
     - Forge Integration: usage/integration.md
     - Actions: usage/actions.md
     - Cache NARs: usage/cache-nars.md
+    - Closure View: usage/closure-view.md
   - Development:
     - Architecture: development/architecture.md
     - Internals: development/internals.md

--- a/nix/packages/gradient-frontend.nix
+++ b/nix/packages/gradient-frontend.nix
@@ -29,7 +29,7 @@ in stdenv.mkDerivation rec {
   pnpmDeps = fetchPnpmDeps {
     inherit pnpm pname version src;
     fetcherVersion = 3;
-    hash = "sha256-EHu31lqcib3JrHk5JWHcz+0zQDfSDWAxIaZ/g+Z4Khw=";
+    hash = "sha256-pRuwdfbXIj7O44V1lNafGIKAv8+gQlFiV0MUL9oup54=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Implements the remaining scope from #242 (the maintainer's last comment). The original issue title — a button from build-log to build-graph — already shipped (graph link in the evaluation-log sidebar), so this PR delivers the two follow-up deliverables.

## Closure size view + API
- New per-derivation **closure graph** builder with coalesced NAR sizes (`derivation_output.nar_size` → `cached_path` fallback). The existing `derivation_closure_reachable` / `sum_output_sizes` helpers were lifted out of `projects/metrics.rs` into a shared `builds/closure.rs` (no duplicated BFS).
- New endpoints: `GET /builds/{build}/closure` and `GET /evals/{evaluation}/closure`. Both return full per-node sizes plus an **exact** `total_size_bytes` (also handy for custom tooling), with a `truncated` flag when the node list is capped (largest-first).
- New **closure Sankey page** (`/organization/:org/closure/:kind/:id`) rendered with **ApexSankey** (lazy-loaded into its own chunk). Large closures show the top-N packages with the long tail aggregated into an exact-sized "others" node.
- **View Closure** button on the entry-point metrics page → that entry point's latest build. `build_id` was added to `EntryPointMetricPoint` to support this.

## Build-graph rework (`dependency-graph.component.ts`)
- **Zoom-to-cursor** fixed: wheel/buttons now use the *effective* (post-clamp) factor, eliminating drift at the zoom limits.
- **Hover edge highlight**: hovering a node highlights its incident edges + neighbours and dims the rest.
- **Removed the multi-level side-lane edge routing** — all edges route directly now that hover makes them legible; dropped the dead `graphBounds`/`nodeDepths`/`idx` plumbing.

## Docs & tests
- `docs/gradient-api.yaml`: both closure endpoints + `ClosureGraph`/`ClosureNode`/`ClosureEdge` schemas + `build_id` on entry-point metric points.
- `docs/src/usage/closure-view.md` (+ mkdocs nav) and `docs/src/tests.md` notes.
- Backend `build_closure_graph` unit test (MockDatabase) and frontend `closure-aggregate.spec.ts` (Top-N aggregation, 3 cases).
- Also fixed pre-existing red specs (`integrations`/`api-keys`) whose fixtures had drifted from the `allowed_ips`/`cache` model fields, so the full frontend suite is green again.

## Verification
- `cargo check --workspace`: clean · `cargo clippy -p web --all-targets`: clean
- `ng test` (full suite): **141/141 pass across 36 files** · `pnpm run build`: succeeds (ApexSankey code-split)

## Notes
- Backend tests run in CI per repo convention (not locally).
- No live UI smoke yet (needs a running server+DB); verification was build + unit tests + typecheck. Happy to run a manual smoke if you want.

Closes #242