### PR TITLE
fix(worker): stop the running build on cancel (#309) + preserve queued/waiting work across restart

### DIFF
--- a/backend/core/src/db/connection.rs
+++ b/backend/core/src/db/connection.rs
@@ -131,18 +131,50 @@ pub async fn connect_web_db(cli: &Cli) -> Result<DatabaseConnection> {
     .context("Failed to connect web database pool")
 }
 
+/// Evaluations the scheduler re-dispatches on its own after a restart, so
+/// startup recovery must leave them alone: `Queued` is re-offered by the eval
+/// dispatcher, `Waiting` (evaluated, builds queued for a free worker) is
+/// re-driven by build reconcile. Every other active status was running on a
+/// now-disconnected worker and is genuinely lost.
+fn eval_survives_restart(status: EvaluationStatus) -> bool {
+    matches!(status, EvaluationStatus::Queued | EvaluationStatus::Waiting)
+}
+
+/// A build survives a restart only if it had not started running
+/// (`Created`/`Queued`) *and* its evaluation survives too. A `Building` build
+/// was on a lost worker; a queued build under an aborted evaluation goes with
+/// it.
+fn build_survives_restart(status: BuildStatus, eval_survives: bool) -> bool {
+    eval_survives && matches!(status, BuildStatus::Created | BuildStatus::Queued)
+}
+
 async fn update_db(db: &DatabaseConnection) -> Result<(), DbErr> {
+    // Recover work interrupted by the restart. Only abort what was genuinely
+    // lost (mid-fetch/eval/build evaluations, mid-compile builds); leave
+    // queued/waiting evaluations and their not-yet-dispatched builds so the
+    // scheduler re-offers them on its next tick.
+    let surviving_eval_ids: Vec<EvaluationId> = EEvaluation::find()
+        .filter(CEvaluation::Status.is_in(EvaluationStatus::ACTIVE))
+        .all(db)
+        .await?
+        .into_iter()
+        .filter(|e| eval_survives_restart(e.status))
+        .map(|e| e.id)
+        .collect();
+
     let builds = EBuild::find()
-        .filter(
-            Condition::any()
-                .add(CBuild::Status.eq(BuildStatus::Created))
-                .add(CBuild::Status.eq(BuildStatus::Queued))
-                .add(CBuild::Status.eq(BuildStatus::Building)),
-        )
+        .filter(CBuild::Status.is_in([
+            BuildStatus::Created,
+            BuildStatus::Queued,
+            BuildStatus::Building,
+        ]))
         .all(db)
         .await?;
 
     for build in builds {
+        if build_survives_restart(build.status, surviving_eval_ids.contains(&build.evaluation)) {
+            continue;
+        }
         let mut abuild: ABuild = build.into();
         abuild.status = Set(BuildStatus::Aborted);
         abuild.via = Set(None);
@@ -155,6 +187,10 @@ async fn update_db(db: &DatabaseConnection) -> Result<(), DbErr> {
         .await?;
 
     for evaluation in evaluations {
+        if eval_survives_restart(evaluation.status) {
+            continue;
+        }
+
         // Direct-build evaluations have no project; skip force_evaluation for those.
         if let Some(project_id) = evaluation.project
             && let Some(project) = EProject::find_by_id(project_id).one(db).await?
@@ -398,4 +434,49 @@ pub async fn get_any_cache_by_name(
         .one(&state.web_db)
         .await
         .context("Failed to query cache")
+}
+
+#[cfg(test)]
+mod startup_recovery_tests {
+    use super::{build_survives_restart, eval_survives_restart};
+    use entity::build::BuildStatus;
+    use entity::evaluation::EvaluationStatus;
+
+    #[test]
+    fn queued_and_waiting_evaluations_survive_restart() {
+        assert!(eval_survives_restart(EvaluationStatus::Queued));
+        assert!(eval_survives_restart(EvaluationStatus::Waiting));
+    }
+
+    #[test]
+    fn actively_running_evaluations_are_aborted_on_restart() {
+        for status in [
+            EvaluationStatus::Fetching,
+            EvaluationStatus::EvaluatingFlake,
+            EvaluationStatus::EvaluatingDerivation,
+            EvaluationStatus::Building,
+        ] {
+            assert!(!eval_survives_restart(status), "{status:?} must not survive");
+        }
+    }
+
+    #[test]
+    fn queued_builds_of_a_surviving_evaluation_survive_restart() {
+        // The "eval waiting case": builds queued for a free worker must not be
+        // aborted just because the server restarted.
+        assert!(build_survives_restart(BuildStatus::Queued, true));
+        assert!(build_survives_restart(BuildStatus::Created, true));
+    }
+
+    #[test]
+    fn running_builds_are_aborted_even_under_a_surviving_evaluation() {
+        // A `Building` build was on a now-disconnected worker - genuinely lost.
+        assert!(!build_survives_restart(BuildStatus::Building, true));
+    }
+
+    #[test]
+    fn builds_of_an_aborted_evaluation_are_aborted() {
+        assert!(!build_survives_restart(BuildStatus::Queued, false));
+        assert!(!build_survives_restart(BuildStatus::Created, false));
+    }
 }

--- a/backend/worker/src/executor/build.rs
+++ b/backend/worker/src/executor/build.rs
@@ -38,6 +38,7 @@ use harmonia_utils_hash::{Algorithm, Hash};
 use proto::messages::{BuildFailureKind, BuildOutput, BuildProduct, BuildTask};
 use std::collections::BTreeMap;
 use std::pin::{Pin, pin};
+use tokio::sync::watch;
 use tracing::{debug, info, warn};
 
 use crate::nix::store::{LocalNixStore, strip_store_prefix};
@@ -77,6 +78,14 @@ impl BuildError {
         Self {
             kind: BuildFailureKind::Timeout,
             source: e.into(),
+        }
+    }
+    /// The server sent `AbortJob` while the daemon was building. Terminal: the
+    /// build is already in a terminal state server-side, so retrying is wrong.
+    pub(crate) fn aborted(drv_path: &str) -> Self {
+        Self {
+            kind: BuildFailureKind::Permanent,
+            source: anyhow::anyhow!("build aborted by server: {}", drv_path),
         }
     }
 }
@@ -152,6 +161,7 @@ impl ParsedDerivation {
         updater: &mut JobUpdater,
         drv_path: &str,
         max_silent_secs: Option<u64>,
+        abort: &mut watch::Receiver<bool>,
     ) -> Result<Vec<BuildOutput>, BuildError> {
         let mut guard = store.scoped().await.map_err(BuildError::transient)?;
 
@@ -183,6 +193,11 @@ impl ParsedDerivation {
 
         // `build_derivation` returns `impl ResultLog = Stream<Item=LogMessage> + Future`.
         // Drain the stream first, then await the future for the BuildResult.
+        //
+        // On abort we return early *without* `mark_ok`: dropping `logs` and
+        // then `guard` discards the daemon connection (see `ScopedGuard`),
+        // which closes the socket and makes the nix-daemon kill the in-flight
+        // build instead of leaving it compiling after the server cancelled.
         let silent = max_silent_secs.map(std::time::Duration::from_secs);
         let outcome = {
             let logs = guard.client().build_derivation(
@@ -191,8 +206,11 @@ impl ParsedDerivation {
                 BuildMode::Normal,
             );
             let mut logs = pin!(logs);
-            match drain_build_logs_with_timeout(logs.as_mut(), updater, task_index, silent).await {
-                Ok(stats) => log_stream_summary(&stats, drv_path),
+            match drain_build_logs_with_timeout(logs.as_mut(), updater, task_index, silent, abort)
+                .await
+            {
+                Ok(DrainOutcome::Completed(stats)) => log_stream_summary(&stats, drv_path),
+                Ok(DrainOutcome::Aborted) => return Err(BuildError::aborted(drv_path)),
                 Err(e) => return Err(BuildError::timeout(e)),
             }
             logs.await
@@ -343,6 +361,7 @@ pub async fn build_derivation(
     task: &BuildTask,
     task_index: u32,
     updater: &mut JobUpdater,
+    abort: &mut watch::Receiver<bool>,
 ) -> Result<Vec<BuildOutput>, BuildError> {
     // `report_building` is sent by the caller (`execute_build_job`) before the
     // prefetch step, so a `JobFailed` after a prefetch error finds the build
@@ -358,6 +377,7 @@ pub async fn build_derivation(
         updater,
         &task.drv_path,
         task.max_silent_secs,
+        abort,
     );
 
     let outputs = match task.timeout_secs.map(std::time::Duration::from_secs) {
@@ -389,36 +409,84 @@ struct LogStreamStats {
     send_failures: u64,
 }
 
-/// Drain every [`LogMessage`] from `logs`, forwarding text lines to `updater`,
-/// aborting with an error if no log line arrives within `silent` (the build's
-/// `maxSilent` budget). `None` disables the silent timeout.
+/// Why the build log drain stopped.
+enum DrainOutcome {
+    /// The daemon finished the build and closed the log stream normally.
+    Completed(LogStreamStats),
+    /// The server signalled `AbortJob` mid-build; the caller must drop the
+    /// daemon connection so the build is killed.
+    Aborted,
+}
+
+/// One step of the build log stream: the next message, end-of-stream, or a
+/// server abort.
+enum NextLog {
+    Message(LogMessage),
+    StreamEnd,
+    Aborted,
+}
+
+/// Resolve the next event on the build log stream, racing it against the
+/// server abort signal and the `maxSilent` budget.
 ///
-/// Returns aggregate counters; callers should pass them to
-/// [`log_stream_summary`] for tracing.
+/// Returns [`NextLog::Aborted`] the instant `abort` is set so the caller can
+/// tear down the daemon connection and let the daemon kill the running build.
+/// Returns `Err` only when `silent` elapses with no new log line.
+async fn next_log_event<S>(
+    mut logs: Pin<&mut S>,
+    silent: Option<std::time::Duration>,
+    abort: &mut watch::Receiver<bool>,
+) -> Result<NextLog>
+where
+    S: futures::Stream<Item = LogMessage>,
+{
+    if *abort.borrow() {
+        return Ok(NextLog::Aborted);
+    }
+    tokio::select! {
+        biased;
+        _ = abort.changed() => Ok(NextLog::Aborted),
+        item = logs.next() => Ok(match item {
+            Some(msg) => NextLog::Message(msg),
+            None => NextLog::StreamEnd,
+        }),
+        _ = maybe_silent_timeout(silent) => Err(anyhow::anyhow!(
+            "build produced no output for {}s (maxSilent exceeded)",
+            silent.map(|d| d.as_secs()).unwrap_or_default()
+        )),
+    }
+}
+
+/// Sleep for the `maxSilent` budget, or never resolve when no budget is set.
+async fn maybe_silent_timeout(silent: Option<std::time::Duration>) {
+    match silent {
+        Some(d) => tokio::time::sleep(d).await,
+        None => std::future::pending().await,
+    }
+}
+
+/// Drain every [`LogMessage`] from `logs`, forwarding text lines to `updater`.
+///
+/// Stops early with [`DrainOutcome::Aborted`] when the server cancels the job,
+/// or with `Err` when no log line arrives within `silent` (the build's
+/// `maxSilent` budget; `None` disables it).
 async fn drain_build_logs_with_timeout<S>(
     mut logs: Pin<&mut S>,
     updater: &mut JobUpdater,
     task_index: u32,
     silent: Option<std::time::Duration>,
-) -> Result<LogStreamStats>
+    abort: &mut watch::Receiver<bool>,
+) -> Result<DrainOutcome>
 where
     S: futures::Stream<Item = LogMessage>,
 {
     let mut stats = LogStreamStats::default();
     loop {
-        let next = match silent {
-            Some(d) => match tokio::time::timeout(d, logs.next()).await {
-                Ok(item) => item,
-                Err(_) => {
-                    return Err(anyhow::anyhow!(
-                        "build produced no output for {}s (maxSilent exceeded)",
-                        d.as_secs()
-                    ));
-                }
-            },
-            None => logs.next().await,
+        let msg = match next_log_event(logs.as_mut(), silent, abort).await? {
+            NextLog::Message(msg) => msg,
+            NextLog::StreamEnd => break,
+            NextLog::Aborted => return Ok(DrainOutcome::Aborted),
         };
-        let Some(msg) = next else { break };
         stats.total_msgs += 1;
         if let Some(line) = log_message_to_text(&msg) {
             let len = line.len();
@@ -437,7 +505,7 @@ where
             }
         }
     }
-    Ok(stats)
+    Ok(DrainOutcome::Completed(stats))
 }
 
 /// Emit a tracing summary after [`drain_build_logs_with_timeout`] completes.
@@ -878,6 +946,53 @@ mod tests {
 
         let pairs = output_pairs_from_built_or_drv(&built, &drv);
         assert!(pairs.is_empty());
+    }
+
+    use tokio::sync::watch;
+
+    #[tokio::test]
+    async fn next_log_event_returns_aborted_when_already_set() {
+        let (tx, mut rx) = watch::channel(false);
+        tx.send(true).unwrap();
+        let stream = futures::stream::pending::<LogMessage>();
+        let mut stream = std::pin::pin!(stream);
+        let out = next_log_event(stream.as_mut(), None, &mut rx).await;
+        assert!(matches!(out, Ok(NextLog::Aborted)));
+    }
+
+    #[tokio::test]
+    async fn next_log_event_aborts_while_waiting_on_stalled_stream() {
+        let (tx, mut rx) = watch::channel(false);
+        let stream = futures::stream::pending::<LogMessage>();
+        let mut stream = std::pin::pin!(stream);
+        let mut fut = std::pin::pin!(next_log_event(stream.as_mut(), None, &mut rx));
+        assert!(futures::poll!(fut.as_mut()).is_pending());
+        tx.send(true).unwrap();
+        assert!(matches!(fut.await, Ok(NextLog::Aborted)));
+    }
+
+    #[tokio::test]
+    async fn next_log_event_reports_stream_end() {
+        let (_tx, mut rx) = watch::channel(false);
+        let stream = futures::stream::empty::<LogMessage>();
+        let mut stream = std::pin::pin!(stream);
+        let out = next_log_event(stream.as_mut(), None, &mut rx).await;
+        assert!(matches!(out, Ok(NextLog::StreamEnd)));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn next_log_event_errors_on_silent_timeout() {
+        let (_tx, mut rx) = watch::channel(false);
+        let stream = futures::stream::pending::<LogMessage>();
+        let mut stream = std::pin::pin!(stream);
+        let mut fut = std::pin::pin!(next_log_event(
+            stream.as_mut(),
+            Some(std::time::Duration::from_secs(5)),
+            &mut rx,
+        ));
+        assert!(futures::poll!(fut.as_mut()).is_pending());
+        tokio::time::advance(std::time::Duration::from_secs(6)).await;
+        assert!(fut.await.is_err());
     }
 
     #[tokio::test]

--- a/backend/worker/src/executor/mod.rs
+++ b/backend/worker/src/executor/mod.rs
@@ -362,7 +362,8 @@ impl JobExecutor {
                     crate::executor::build::BuildError::transient(e)
                 })?;
             let outputs =
-                build::build_derivation(&self.store, build_task, index as u32, updater).await?;
+                build::build_derivation(&self.store, build_task, index as u32, updater, &mut abort)
+                    .await?;
             for o in &outputs {
                 gc_handles.push(self.gcroots.add(&o.store_path).await);
             }

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -1645,6 +1645,36 @@ SET NULL`, so a delete would silently drop the link plus the
 `cached_path_signature` placeholders, while a demote keeps the row's
 identity and lets a subsequent successful upload re-fill the metadata.
 
+## Worker aborts the running build, not just the upload (#309)
+
+Abort propagation reached the `compress`/`push` loop (above), but **not the
+derivation build itself**. `execute_build_job` only checked `abort` at the top
+of each task iteration; the long-running `build_derivation` never observed it.
+So cancelling a build server-side left the worker's nix-daemon compiling the
+derivation to completion - high memory, build still running, `LogChunk`s still
+streaming - while the server already showed no running build.
+
+Fix in `worker/src/executor/build.rs`: the build log drain races the daemon's
+log stream against the `abort` watch (`next_log_event`). When the server
+signals `AbortJob`, `drain_build_logs_with_timeout` returns
+`DrainOutcome::Aborted` and `realize` returns early *without* `mark_ok`.
+Dropping the `ScopedGuard` discards the daemon connection (closes the socket),
+which makes the nix-daemon kill the in-flight build. Because the build errors
+out before the compress/push stage, no NAR is uploaded for a cancelled build.
+
+Tests (`cargo test -p worker executor::build::tests`):
+
+- `next_log_event_returns_aborted_when_already_set` - abort already signalled
+  before the first poll yields `NextLog::Aborted` immediately, even against a
+  stalled stream.
+- `next_log_event_aborts_while_waiting_on_stalled_stream` - a stream that never
+  yields stays `Pending` until `abort` fires, then resolves to
+  `NextLog::Aborted` (proves a running build is interruptible, not hung).
+- `next_log_event_reports_stream_end` - an exhausted log stream maps to
+  `NextLog::StreamEnd` so a normal build still completes.
+- `next_log_event_errors_on_silent_timeout` - with `maxSilent` set and no log
+  output, the drain errors once the budget elapses (paused-time test).
+
 ## Cache GC - guard shared-hash NARs and purge zombie cached_path rows
 
 Two bugs together inflated cache stats and over-deleted shared NARs:

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -1675,6 +1675,34 @@ Tests (`cargo test -p worker executor::build::tests`):
 - `next_log_event_errors_on_silent_timeout` - with `maxSilent` set and no log
   output, the drain errors once the budget elapses (paused-time test).
 
+## Startup recovery preserves queued/waiting work
+
+`core/src/db/connection.rs::update_db` runs once on boot to reconcile work
+left behind by the previous process. It used to abort **everything** active -
+every `Created`/`Queued`/`Building` build and every `ACTIVE` evaluation - which
+needlessly threw away queued evaluations and builds that were only waiting for
+a free worker.
+
+The policy is now two pure predicates the recovery loop applies per row:
+
+- `eval_survives_restart` - `Queued` and `Waiting` evaluations survive (the
+  eval dispatcher re-offers `Queued`; build reconcile re-drives `Waiting`).
+  `Fetching` / `EvaluatingFlake` / `EvaluatingDerivation` / `Building` were
+  running on a now-disconnected worker, so they are aborted (and their project
+  is flagged `force_evaluation`).
+- `build_survives_restart` - a build survives only if it is `Created`/`Queued`
+  **and** its evaluation survives. A `Building` build was mid-compile on a lost
+  worker; a queued build under an aborted evaluation goes with it.
+
+Tests (`cargo test -p core startup_recovery_tests`):
+
+- `queued_and_waiting_evaluations_survive_restart`
+- `actively_running_evaluations_are_aborted_on_restart`
+- `queued_builds_of_a_surviving_evaluation_survive_restart` - the "eval waiting
+  case" from the bug report: builds queued for a free worker are kept.
+- `running_builds_are_aborted_even_under_a_surviving_evaluation`
+- `builds_of_an_aborted_evaluation_are_aborted`
+
 ## Cache GC - guard shared-hash NARs and purge zombie cached_path rows
 
 Two bugs together inflated cache stats and over-deleted shared NARs:


### PR DESCRIPTION
Fixes #309.

## 1. Worker aborts the running build, not just the upload (#309)

When a build was cancelled server-side, the server marked it not-running but the worker's nix-daemon kept compiling the derivation to completion (high memory, build still running, build-log uploads still failing).

**Root cause:** abort was only checked at *task boundaries* in `execute_build_job`. The long-running `build_derivation` call never observed the `abort` watch, so a server `AbortJob` had no effect until the build finished on its own.

**Fix** (`backend/worker/src/executor/build.rs`): the build-log drain now races the daemon's log stream against the `abort` watch (`next_log_event`). On `AbortJob`, `drain_build_logs_with_timeout` returns `DrainOutcome::Aborted` and `realize` returns early **without** `mark_ok`. Dropping the `ScopedGuard` discards the daemon connection (closes the socket), which makes the nix-daemon kill the in-flight build — the same mechanism as Ctrl-C'ing a `nix build`. Because the build errors out before the compress/push stage, no NAR is uploaded for a cancelled build.

Tests: four cases on `next_log_event` (already-aborted, abort-while-stalled → proves interruptible not hung, normal stream-end, silent-timeout).

## 2. Startup recovery preserves queued/waiting work

`core/src/db/connection.rs::update_db` ran on boot and aborted **everything** active — every `Created`/`Queued`/`Building` build and every `ACTIVE` evaluation — throwing away work that was only waiting for a free worker.

The policy is now two pure predicates applied per row:

- `eval_survives_restart` — `Queued`/`Waiting` evaluations survive (the scheduler re-offers/reconciles them). `Fetching`/`EvaluatingFlake`/`EvaluatingDerivation`/`Building` were running on a now-disconnected worker → aborted (+ `force_evaluation`).
- `build_survives_restart` — a build survives only if it is `Created`/`Queued` **and** its evaluation survives. A `Building` build was mid-compile on a lost worker; a queued build under an aborted evaluation goes with it.

This is the "eval waiting case": an evaluation that finished evaluating with builds queued for a free worker now survives a restart intact.

Tests: five `startup_recovery_tests` covering every state class.

## Notes
- Policy is encoded as pure predicates (not a SQL `WHERE`) because the repo only has `MockDatabase` — a predicate is the only unit-testable form.
- `cargo check --tests` + `cargo clippy` green for `worker` and `core`; full suite runs in CI.
- Docs updated in `docs/src/tests.md`. No API / env-var / nix-module changes.