### PR TITLE
feat(cli): background build dispatch and live watch dashboard (#314)

### DIFF
--- a/cli/src/commands/base.rs
+++ b/cli/src/commands/base.rs
@@ -95,11 +95,16 @@ enum MainCommands {
         system: Option<String>,
         #[arg(short, long)]
         organization: Option<String>,
-        /// Skip log streaming and exit after dispatch
-        #[arg(long)]
-        no_stream: bool,
+        /// Dispatch and return the evaluation UUID without streaming logs
+        #[arg(short, long)]
+        background: bool,
         #[arg(short, long)]
         quiet: bool,
+    },
+    /// Watch a running evaluation's live build logs and status
+    Watch {
+        /// Evaluation UUID to watch
+        evaluation: String,
     },
     /// Download evaluation artefacts
     Download {
@@ -291,9 +296,10 @@ pub async fn run_cli() -> std::io::Result<()> {
             target,
             system,
             organization,
-            no_stream,
+            background,
             quiet,
-        } => build::handle_build(target, system, organization, no_stream, quiet, out).await,
+        } => build::handle_build(target, system, organization, background, quiet, out).await,
+        MainCommands::Watch { evaluation } => watch::handle_watch(&evaluation, out).await,
         MainCommands::Download {
             flake_ref,
             evaluation,

--- a/cli/src/commands/build.rs
+++ b/cli/src/commands/build.rs
@@ -18,7 +18,7 @@ pub async fn handle_build(
     target: Option<String>,
     system: Option<String>,
     organization: Option<String>,
-    no_stream: bool,
+    background: bool,
     quiet: bool,
     out: Output,
 ) {
@@ -181,6 +181,12 @@ pub async fn handle_build(
         }
     };
 
+    if background {
+        out.ok(&dispatch);
+        out.human(dispatch.evaluation.clone());
+        return;
+    }
+
     if quiet {
         out.human(dispatch.evaluation.clone());
     } else {
@@ -188,10 +194,6 @@ pub async fn handle_build(
         out.human(format!("Evaluation: {}", dispatch.evaluation));
         out.human(format!("Project:    {}", dispatch.project));
         out.human(format!("Commit:     {}", dispatch.commit));
-    }
-
-    if no_stream {
-        return;
     }
 
     if !quiet {

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -19,4 +19,5 @@ pub mod download;
 pub mod generate;
 pub mod organization;
 pub mod project;
+pub mod watch;
 pub mod worker;

--- a/cli/src/commands/watch.rs
+++ b/cli/src/commands/watch.rs
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use crate::input::client_from_config;
+use crate::output::{ExitKind, Output, to_exit_kind};
+use crate::tui::watch::{Dashboard, WatchEvent, eval_is_terminal};
+use connector::Client;
+use futures::{StreamExt, pin_mut};
+use std::time::Duration;
+use tokio::sync::mpsc::UnboundedSender;
+
+pub async fn handle_watch(eval_id: &str, out: Output) {
+    let client = client_from_config(out);
+
+    if client.evals().get(eval_id).await.is_err() {
+        out.err(ExitKind::Api, format!("Unknown evaluation: {eval_id}"));
+    }
+
+    if out.is_json() {
+        return stream_plain(&client, eval_id, out).await;
+    }
+
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<WatchEvent>();
+    tokio::spawn(poll_metadata(client.clone(), eval_id.to_string(), tx.clone()));
+    tokio::spawn(stream_logs(client.clone(), eval_id.to_string(), tx));
+
+    crate::tui::run(Dashboard::new(eval_id.to_string(), rx))
+        .unwrap_or_else(|e| out.err(ExitKind::Api, format!("tui error: {e}")));
+}
+
+async fn poll_metadata(client: Client, eval_id: String, tx: UnboundedSender<WatchEvent>) {
+    loop {
+        let evals = client.evals();
+        let terminal = match evals.get(&eval_id).await {
+            Ok(eval) => {
+                let terminal = eval_is_terminal(&eval.status);
+                let _ = tx.send(WatchEvent::Eval(eval));
+                terminal
+            }
+            Err(_) => false,
+        };
+        if let Ok(builds) = evals.builds(&eval_id).await {
+            let _ = tx.send(WatchEvent::Builds(builds.builds));
+        }
+        if let Ok(messages) = evals.messages(&eval_id).await {
+            for m in messages {
+                let _ = tx.send(WatchEvent::Message(m));
+            }
+        }
+        if terminal || tx.is_closed() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}
+
+async fn stream_logs(client: Client, eval_id: String, tx: UnboundedSender<WatchEvent>) {
+    let evals = client.evals();
+    let stream = match evals.stream_builds(&eval_id).await {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    pin_mut!(stream);
+    while let Some(Ok(line)) = stream.next().await {
+        if tx.send(WatchEvent::Log(line)).is_err() {
+            break;
+        }
+    }
+}
+
+async fn stream_plain(client: &Client, eval_id: &str, out: Output) {
+    let evals = client.evals();
+    let stream = match evals.stream_builds(eval_id).await {
+        Ok(s) => s,
+        Err(e) => out.err(to_exit_kind(&e), e),
+    };
+    pin_mut!(stream);
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(line) => println!("{}", serde_json::json!({"error": false, "message": line})),
+            Err(e) => out.err(to_exit_kind(&e), e),
+        }
+    }
+}

--- a/cli/src/tui/mod.rs
+++ b/cli/src/tui/mod.rs
@@ -6,6 +6,7 @@
 pub mod graph;
 pub mod log_view;
 pub mod nar_browser;
+pub mod watch;
 
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;

--- a/cli/src/tui/watch.rs
+++ b/cli/src/tui/watch.rs
@@ -1,0 +1,472 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use crate::tui::View;
+use connector::evals::{BuildItem, EvalMessage, EvaluationResponse};
+use ratatui::crossterm::event::{KeyCode, KeyEvent};
+use ratatui::style::{Color, Modifier, Style};
+use std::collections::HashSet;
+use std::time::Instant;
+use tokio::sync::mpsc::UnboundedReceiver;
+
+pub enum WatchEvent {
+    Eval(EvaluationResponse),
+    Builds(Vec<BuildItem>),
+    Message(EvalMessage),
+    Log(String),
+}
+
+#[derive(Default, Debug, PartialEq, Eq)]
+pub struct BuildSummary {
+    pub total: usize,
+    pub succeeded: usize,
+    pub failed: usize,
+    pub building: usize,
+    pub queued: usize,
+}
+
+impl BuildSummary {
+    pub fn of(builds: &[BuildItem]) -> Self {
+        let mut s = BuildSummary {
+            total: builds.len(),
+            ..Default::default()
+        };
+        for b in builds {
+            match build_class(&b.status) {
+                BuildClass::Succeeded => s.succeeded += 1,
+                BuildClass::Failed => s.failed += 1,
+                BuildClass::Building => s.building += 1,
+                BuildClass::Queued => s.queued += 1,
+            }
+        }
+        s
+    }
+
+    pub fn done(&self) -> usize {
+        self.succeeded + self.failed
+    }
+}
+
+enum BuildClass {
+    Succeeded,
+    Failed,
+    Building,
+    Queued,
+}
+
+fn build_class(status: &str) -> BuildClass {
+    match status {
+        "Completed" | "Substituted" => BuildClass::Succeeded,
+        "Building" => BuildClass::Building,
+        "Queued" | "Created" => BuildClass::Queued,
+        _ => BuildClass::Failed,
+    }
+}
+
+pub fn build_icon(status: &str) -> &'static str {
+    match build_class(status) {
+        BuildClass::Succeeded => "✔",
+        BuildClass::Failed => "✗",
+        BuildClass::Building => "▶",
+        BuildClass::Queued => "·",
+    }
+}
+
+fn build_style(status: &str) -> Style {
+    let color = match build_class(status) {
+        BuildClass::Succeeded => Color::Green,
+        BuildClass::Failed => Color::Red,
+        BuildClass::Building => Color::Yellow,
+        BuildClass::Queued => Color::DarkGray,
+    };
+    Style::default().fg(color)
+}
+
+pub fn eval_is_terminal(status: &str) -> bool {
+    matches!(status, "Completed" | "Failed" | "Aborted")
+}
+
+fn eval_style(status: &str) -> Style {
+    let color = match status {
+        "Completed" => Color::Green,
+        "Failed" | "Aborted" => Color::Red,
+        _ => Color::Yellow,
+    };
+    Style::default().fg(color).add_modifier(Modifier::BOLD)
+}
+
+pub fn format_duration(total_secs: u64) -> String {
+    let h = total_secs / 3600;
+    let m = (total_secs % 3600) / 60;
+    let s = total_secs % 60;
+    if h > 0 {
+        format!("{h}:{m:02}:{s:02}")
+    } else {
+        format!("{m:02}:{s:02}")
+    }
+}
+
+pub fn format_build_time(ms: Option<i64>) -> String {
+    match ms {
+        Some(ms) if ms >= 1000 => format!("{:.1}s", ms as f64 / 1000.0),
+        Some(ms) => format!("{ms}ms"),
+        None => "—".to_string(),
+    }
+}
+
+pub struct Dashboard {
+    eval_id: String,
+    eval: Option<EvaluationResponse>,
+    builds: Vec<BuildItem>,
+    seen_messages: HashSet<String>,
+    log: Vec<String>,
+    pending: String,
+    offset: usize,
+    viewport: usize,
+    follow: bool,
+    started: Instant,
+    rx: Option<UnboundedReceiver<WatchEvent>>,
+}
+
+impl Dashboard {
+    pub fn new(eval_id: String, rx: UnboundedReceiver<WatchEvent>) -> Self {
+        Self {
+            rx: Some(rx),
+            ..Self::bare(eval_id)
+        }
+    }
+
+    fn bare(eval_id: String) -> Self {
+        Self {
+            eval_id,
+            eval: None,
+            builds: Vec::new(),
+            seen_messages: HashSet::new(),
+            log: Vec::new(),
+            pending: String::new(),
+            offset: 0,
+            viewport: 1,
+            follow: true,
+            started: Instant::now(),
+            rx: None,
+        }
+    }
+
+    pub fn apply(&mut self, ev: WatchEvent) {
+        match ev {
+            WatchEvent::Eval(e) => self.eval = Some(e),
+            WatchEvent::Builds(b) => self.builds = b,
+            WatchEvent::Message(m) => {
+                if self.seen_messages.insert(m.id.clone()) {
+                    self.push_line(format!("[eval/{}] {}", m.level, m.message));
+                }
+            }
+            WatchEvent::Log(chunk) => self.push_chunk(chunk),
+        }
+    }
+
+    fn push_chunk(&mut self, chunk: String) {
+        self.pending.push_str(&chunk);
+        while let Some(nl) = self.pending.find('\n') {
+            let line: String = self.pending.drain(..=nl).collect();
+            self.push_line(line.trim_end_matches('\n').to_string());
+        }
+    }
+
+    fn push_line(&mut self, line: String) {
+        self.log.push(line);
+        if self.follow {
+            self.scroll_to_bottom();
+        }
+    }
+
+    fn scroll_to_bottom(&mut self) {
+        self.offset = self.log.len().saturating_sub(self.viewport);
+    }
+
+    fn clamp(&mut self) {
+        let max = self.log.len().saturating_sub(self.viewport);
+        if self.offset > max {
+            self.offset = max;
+        }
+    }
+
+    fn scroll_down(&mut self) {
+        let max = self.log.len().saturating_sub(self.viewport);
+        if self.offset < max {
+            self.offset += 1;
+        }
+        if self.offset >= max {
+            self.follow = true;
+        }
+    }
+
+    fn scroll_up(&mut self) {
+        self.offset = self.offset.saturating_sub(1);
+        self.follow = false;
+    }
+
+    fn status(&self) -> &str {
+        self.eval.as_ref().map(|e| e.status.as_str()).unwrap_or("…")
+    }
+
+    #[cfg(test)]
+    fn offset(&self) -> usize {
+        self.offset
+    }
+    #[cfg(test)]
+    fn log_len(&self) -> usize {
+        self.log.len()
+    }
+    #[cfg(test)]
+    fn set_viewport(&mut self, n: usize) {
+        self.viewport = n.max(1);
+        self.clamp();
+    }
+}
+
+impl View for Dashboard {
+    fn render(&mut self, frame: &mut ratatui::Frame) {
+        use ratatui::layout::{Constraint, Direction, Layout};
+        use ratatui::text::{Line, Span, Text};
+        use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
+
+        let area = frame.area();
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(5),
+                Constraint::Percentage(45),
+                Constraint::Min(3),
+            ])
+            .split(area);
+
+        let summary = BuildSummary::of(&self.builds);
+        let status = self.status().to_string();
+        let elapsed = format_duration(self.started.elapsed().as_secs());
+        let mut header: Vec<Line> = vec![
+            Line::from(vec![
+                Span::raw("Status "),
+                Span::styled(status.clone(), eval_style(&status)),
+                Span::raw(format!(
+                    "   Elapsed {elapsed}   Builds {}/{} ",
+                    summary.done(),
+                    summary.total
+                )),
+                Span::styled(format!("✔{}", summary.succeeded), build_style("Completed")),
+                Span::raw(" "),
+                Span::styled(format!("✗{}", summary.failed), build_style("Failed")),
+                Span::raw(" "),
+                Span::styled(format!("▶{}", summary.building), build_style("Building")),
+                Span::raw(" "),
+                Span::styled(format!("·{}", summary.queued), build_style("Queued")),
+            ]),
+        ];
+        if let Some(e) = &self.eval {
+            header.push(Line::raw(format!(
+                "Project {}   Commit {}   Target {}",
+                e.project.as_deref().unwrap_or("—"),
+                short_commit(&e.commit),
+                e.wildcard
+            )));
+            if let Some(err) = e.error.as_ref().filter(|s| !s.is_empty()) {
+                header.push(Line::styled(
+                    format!("Error: {err}"),
+                    Style::default().fg(Color::Red),
+                ));
+            }
+        }
+        let header_block = Paragraph::new(Text::from(header)).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(format!("Evaluation {}", self.eval_id)),
+        );
+        frame.render_widget(header_block, chunks[0]);
+
+        let rows: Vec<ListItem> = self
+            .builds
+            .iter()
+            .map(|b| {
+                ListItem::new(Line::from(vec![
+                    Span::styled(format!("{} ", build_icon(&b.status)), build_style(&b.status)),
+                    Span::raw(format!("{:<40} ", truncate(&b.name, 40))),
+                    Span::styled(format!("{:<12}", b.status), build_style(&b.status)),
+                    Span::raw(format_build_time(b.build_time_ms)),
+                ]))
+            })
+            .collect();
+        let builds_list = List::new(rows).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(format!("Builds ({})", self.builds.len())),
+        );
+        frame.render_widget(builds_list, chunks[1]);
+
+        self.viewport = (chunks[2].height.saturating_sub(2)).max(1) as usize;
+        self.clamp();
+        if self.follow {
+            self.scroll_to_bottom();
+        }
+        let end = (self.offset + self.viewport).min(self.log.len());
+        let body = self.log.get(self.offset..end).unwrap_or(&[]).join("\n");
+        let log_title = format!(
+            "Logs ({} lines){}  [↑/↓ scroll, f follow, q quit]",
+            self.log.len(),
+            if self.follow { " FOLLOW" } else { "" }
+        );
+        let log_widget = Paragraph::new(Text::raw(body))
+            .block(Block::default().borders(Borders::ALL).title(log_title));
+        frame.render_widget(log_widget, chunks[2]);
+    }
+
+    fn on_key(&mut self, key: KeyEvent) -> bool {
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => return true,
+            KeyCode::Down => self.scroll_down(),
+            KeyCode::Up => self.scroll_up(),
+            KeyCode::Char('f') => self.follow = !self.follow,
+            _ => {}
+        }
+        false
+    }
+
+    fn on_tick(&mut self) {
+        let mut drained = Vec::new();
+        if let Some(rx) = self.rx.as_mut() {
+            while let Ok(ev) = rx.try_recv() {
+                drained.push(ev);
+            }
+        }
+        for ev in drained {
+            self.apply(ev);
+        }
+    }
+}
+
+fn short_commit(commit: &str) -> &str {
+    commit.get(..8).unwrap_or(commit)
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let kept: String = s.chars().take(max.saturating_sub(1)).collect();
+        format!("{kept}…")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build(name: &str, status: &str, ms: Option<i64>) -> BuildItem {
+        BuildItem {
+            id: name.to_string(),
+            name: name.to_string(),
+            status: status.to_string(),
+            updated_at: String::new(),
+            build_time_ms: ms,
+        }
+    }
+
+    fn msg(id: &str, level: &str, text: &str) -> EvalMessage {
+        EvalMessage {
+            id: id.to_string(),
+            level: level.to_string(),
+            message: text.to_string(),
+            source: None,
+            created_at: String::new(),
+            entry_points: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn summary_classifies_statuses() {
+        let builds = vec![
+            build("a", "Completed", Some(10)),
+            build("b", "Substituted", None),
+            build("c", "Building", None),
+            build("d", "Queued", None),
+            build("e", "FailedPermanent", Some(5)),
+            build("f", "DependencyFailed", None),
+        ];
+        let s = BuildSummary::of(&builds);
+        assert_eq!(
+            s,
+            BuildSummary {
+                total: 6,
+                succeeded: 2,
+                failed: 2,
+                building: 1,
+                queued: 1,
+            }
+        );
+        assert_eq!(s.done(), 4);
+    }
+
+    #[test]
+    fn eval_terminal_detection() {
+        assert!(eval_is_terminal("Completed"));
+        assert!(eval_is_terminal("Failed"));
+        assert!(eval_is_terminal("Aborted"));
+        assert!(!eval_is_terminal("Building"));
+        assert!(!eval_is_terminal("EvaluatingFlake"));
+    }
+
+    #[test]
+    fn duration_formats_minutes_and_hours() {
+        assert_eq!(format_duration(83), "01:23");
+        assert_eq!(format_duration(3723), "1:02:03");
+    }
+
+    #[test]
+    fn build_time_formats_units() {
+        assert_eq!(format_build_time(Some(1500)), "1.5s");
+        assert_eq!(format_build_time(Some(250)), "250ms");
+        assert_eq!(format_build_time(None), "—");
+    }
+
+    #[test]
+    fn chunk_splits_into_lines_and_buffers_partial() {
+        let mut d = Dashboard::bare("e1".into());
+        d.set_viewport(5);
+        d.apply(WatchEvent::Log("a> hello\nb> wor".into()));
+        assert_eq!(d.log_len(), 1);
+        d.apply(WatchEvent::Log("ld\n".into()));
+        assert_eq!(d.log_len(), 2);
+    }
+
+    #[test]
+    fn messages_are_deduplicated() {
+        let mut d = Dashboard::bare("e1".into());
+        d.set_viewport(5);
+        d.apply(WatchEvent::Message(msg("m1", "error", "boom")));
+        d.apply(WatchEvent::Message(msg("m1", "error", "boom")));
+        d.apply(WatchEvent::Message(msg("m2", "warn", "careful")));
+        assert_eq!(d.log_len(), 2);
+    }
+
+    #[test]
+    fn follow_keeps_bottom_then_scroll_up_detaches() {
+        let mut d = Dashboard::bare("e1".into());
+        d.set_viewport(5);
+        for i in 0..20 {
+            d.push_line(format!("line {i}"));
+        }
+        assert_eq!(d.offset(), 15);
+        d.scroll_up();
+        assert_eq!(d.offset(), 14);
+        assert!(!d.follow);
+    }
+
+    #[test]
+    fn icons_map_to_class() {
+        assert_eq!(build_icon("Completed"), "✔");
+        assert_eq!(build_icon("FailedTimeout"), "✗");
+        assert_eq!(build_icon("Building"), "▶");
+        assert_eq!(build_icon("Queued"), "·");
+    }
+}

--- a/cli/tests/build_watch.rs
+++ b/cli/tests/build_watch.rs
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use assert_cmd::Command;
+
+fn help(args: &[&str]) -> String {
+    let output = Command::cargo_bin("gradient")
+        .unwrap()
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "command failed: {args:?}");
+    String::from_utf8(output.stdout).unwrap()
+}
+
+#[test]
+fn build_exposes_background_flag_not_no_stream() {
+    let text = help(&["build", "--help"]);
+    assert!(text.contains("--background"), "missing --background:\n{text}");
+    assert!(text.contains("-b"), "missing -b short flag:\n{text}");
+    assert!(
+        !text.contains("--no-stream"),
+        "--no-stream should be replaced by --background:\n{text}"
+    );
+}
+
+#[test]
+fn watch_command_takes_an_evaluation() {
+    let text = help(&["watch", "--help"]);
+    assert!(text.contains("evaluation"), "missing evaluation arg:\n{text}");
+}
+
+#[test]
+fn watch_requires_an_evaluation_argument() {
+    let output = Command::cargo_bin("gradient")
+        .unwrap()
+        .arg("watch")
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "watch without an evaluation argument must fail"
+    );
+}

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -2611,6 +2611,7 @@ loading degrades silently when `/etc/ssl/certs` is missing.
 CLI integration tests in `cli/tests/`:
 
 - `download_attr.rs` - `gradient download '#attr' --json` writes the right files; `--json` without args returns a structured missing-argument envelope and exits 2.
+- `build_watch.rs` (#314) - `gradient build --help` exposes `-b`/`--background` and no longer advertises the removed `--no-stream`; `gradient watch --help` documents the required `<EVALUATION>` argument; `gradient watch` with no argument exits non-zero.
 - `completion.rs` - regression for the broken completion bin name: `gradient completion {bash,zsh}` must emit a script that registers against the real `gradient` binary (`-F _clap_complete_gradient gradient`) and never the capitalised `Gradient` app name, which silently disabled `gradient <TAB>`. Also asserts the zsh script appends the autoload bridge (`[[ ${funcstack[1]} = _gradient ]] && _clap_dynamic_completer_gradient "$@"`) so the fpath autoload file the Nix package installs completes on the first TAB instead of only after a second.
 
 Dynamic completer unit tests live in `cli/src/commands/completion.rs` (`#[cfg(test)]`,
@@ -2990,6 +2991,13 @@ Run with: `cargo test -p gradient-cli`
   triggers quit.
 - `tui::log_view` — `↑`/`↓` scroll adjusts the offset; enabling follow-tail
   pins the view to the last line; `/` search highlights matching lines.
+- `tui::watch` (#314) — the `gradient watch` dashboard view-model:
+  `BuildSummary::of` classifies build statuses into succeeded/failed/building/
+  queued counts; `eval_is_terminal` recognises `Completed`/`Failed`/`Aborted`;
+  `format_duration`/`format_build_time` render elapsed and per-build times;
+  streamed log chunks split on newlines and buffer partial lines; evaluation
+  messages are de-duplicated by id; follow-tail pins to the bottom until an
+  `↑` scroll detaches it.
 
 ## REST API endpoint surface (NixOS integration)
 

--- a/docs/src/usage/cli.md
+++ b/docs/src/usage/cli.md
@@ -151,7 +151,7 @@ an evaluation under a per-org reserved `build-request` project.
 gradient build                          # eval the project's wildcard target
 gradient build checks.x86_64-linux.foo  # eval a specific attribute path
 gradient build --system x86_64-linux    # override target system (default: org preference)
-gradient build --no-stream              # dispatch and exit without tailing logs
+gradient build -b                       # dispatch and print the evaluation UUID, then exit
 ```
 
 Requirements and limits:
@@ -160,7 +160,24 @@ Requirements and limits:
 - Only files git tracks are uploaded; untracked files and `.git/` are skipped.
 - Combined upload size must not exceed **20 MiB** (`MAX_BUILD_REQUEST_SIZE`).
 - The default flow streams logs from all queued builds until they complete;
-  pass `--no-stream` to return immediately after dispatch.
+  pass `-b`/`--background` to print only the evaluation UUID and return
+  immediately. Pair it with [`gradient watch`](#watching-an-evaluation) to
+  follow the build later: `eval=$(gradient build -b); gradient watch "$eval"`.
+
+### Watching an evaluation
+
+`gradient watch <evaluation>` opens a live full-screen dashboard for any
+evaluation UUID. It shows the evaluation status and elapsed time, a per-build
+list with statuses and build times, evaluation messages and errors as they
+appear, and a follow-tail log pane that merges every build's output.
+
+```sh
+gradient watch 0190f3c2-...   # live dashboard for an evaluation
+```
+
+Key bindings: `↑`/`↓` scroll the log, `f` toggle follow-tail, `q`/`Esc` quit.
+In `--json` mode the dashboard is skipped and the merged build logs are streamed
+as JSON envelopes to stdout instead.
 
 ### Builds
 


### PR DESCRIPTION
Closes #314.

## What

Two CLI ergonomics for fire-and-forget builds:

- **`gradient build -b` / `--background`** — dispatches the job and prints
  **only the evaluation UUID**, then exits without streaming. Scriptable:
  `eval=$(gradient build -b)`. This replaces the old `--no-stream` flag
  (clean break — `--no-stream` did the same "dispatch and exit" job but
  printed the full project/commit block and lacked a short flag).
- **`gradient watch <evaluation>`** — a live full-screen dashboard for any
  evaluation UUID:
  - evaluation status + elapsed time + build progress counts
  - per-build list with status icons/colors and build times
  - evaluation messages and errors surfaced inline as they appear
  - follow-tail log pane merging every build's output

  Keys: `↑`/`↓` scroll, `f` toggle follow, `q`/`Esc` quit. In `--json` mode
  the dashboard is skipped and merged logs stream as JSON envelopes.

Together: `eval=$(gradient build -b); gradient watch "$eval"`.

## How

- No new server endpoints — `watch` reuses `GET /evals/{id}`,
  `/evals/{id}/builds`, `/evals/{id}/messages`, and the existing
  `POST /evals/{id}/builds` log stream. Two background tokio tasks
  (1 s metadata poll + log stream) feed an `mpsc` channel that the
  ratatui `Dashboard` view drains on tick, matching the existing
  `tui::log_view` streaming pattern.
- The poll loop stops on terminal eval status or when the TUI closes.

## Tests (TDD)

- `cli/src/tui/watch.rs` unit tests: status classification, terminal
  detection, duration/build-time formatting, log-chunk line splitting +
  partial buffering, message de-dup, follow-tail scroll behavior.
- `cli/tests/build_watch.rs`: `build --help` exposes `-b`/`--background`
  and no longer advertises `--no-stream`; `watch --help` documents the
  required `<EVALUATION>`; bare `watch` exits non-zero.
- Docs updated: `docs/src/usage/cli.md`, `docs/src/tests.md`.

Verified locally with `cargo clippy --all-targets` (clean) and by running
the built binary's `--help` for both commands. Per repo convention the full
test suite runs in CI.