### PR TITLE
fix(oidc): PKCE, account claiming, and group-to-role mapping (#319, #318, #322)

### DIFF
--- a/backend/cache/src/cacher/cleanup.rs
+++ b/backend/cache/src/cacher/cleanup.rs
@@ -437,6 +437,7 @@ mod tests {
             jwt_secret: gradient_core::types::SecretString::new("test-jwt-secret".to_string()),
             started_at: chrono::Utc::now(),
             pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+            oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
         })
     }
 
@@ -527,6 +528,7 @@ mod tests {
             jwt_secret: gradient_core::types::SecretString::new("test-jwt-secret".to_string()),
             started_at: chrono::Utc::now(),
             pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+            oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
         });
 
         cleanup_stale_cached_nars(state).await.unwrap();
@@ -618,6 +620,7 @@ mod tests {
             jwt_secret: gradient_core::types::SecretString::new("test-jwt-secret".to_string()),
             started_at: chrono::Utc::now(),
             pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+            oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
         });
 
         cleanup_orphaned_cache_files(Arc::clone(&state))
@@ -649,6 +652,7 @@ mod tests {
             jwt_secret: gradient_core::types::SecretString::new("test-jwt-secret".to_string()),
             started_at: chrono::Utc::now(),
             pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+            oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
         })
     }
 
@@ -724,6 +728,7 @@ mod tests {
             jwt_secret: gradient_core::types::SecretString::new("test-jwt-secret".to_string()),
             started_at: chrono::Utc::now(),
             pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+            oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
         });
 
         cleanup_stale_build_request_blobs(state).await.unwrap();

--- a/backend/cache/src/cacher/deep_gc.rs
+++ b/backend/cache/src/cacher/deep_gc.rs
@@ -224,6 +224,7 @@ mod tests {
             jwt_secret: gradient_core::types::SecretString::new("test-jwt-secret".to_string()),
             started_at: chrono::Utc::now(),
             pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+            oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
         })
     }
 

--- a/backend/core/src/ci/actions.rs
+++ b/backend/core/src/ci/actions.rs
@@ -1039,6 +1039,7 @@ mod tests {
             jwt_secret: SecretString::new("test-jwt-secret".to_string()),
             started_at: chrono::Utc::now(),
             pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+            oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
         })
     }
 

--- a/backend/core/src/db/status.rs
+++ b/backend/core/src/db/status.rs
@@ -891,6 +891,7 @@ mod reelect_leader_tests {
             jwt_secret: SecretString::new("test-jwt-secret".to_string()),
             started_at: chrono::Utc::now(),
             pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+            oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
         })
     }
 

--- a/backend/core/src/lib.rs
+++ b/backend/core/src/lib.rs
@@ -65,7 +65,7 @@ pub async fn init_state(cli: Cli) -> Arc<ServerState> {
         }
     };
 
-    let pending_org_memberships = match load_and_apply_state(
+    let (pending_org_memberships, oidc_group_roles) = match load_and_apply_state(
         &db,
         cli.storage.state_file.as_deref(),
         &cli.secrets.crypt_secret_file,
@@ -74,7 +74,7 @@ pub async fn init_state(cli: Cli) -> Arc<ServerState> {
     )
     .await
     {
-        Ok(p) => Arc::new(p),
+        Ok(r) => (Arc::new(r.pending), Arc::new(r.oidc_group_roles)),
         Err(e) => {
             tracing::error!(error = %e, "Failed to load state configuration");
             std::process::exit(1);
@@ -225,5 +225,6 @@ pub async fn init_state(cli: Cli) -> Arc<ServerState> {
         jwt_secret,
         started_at: chrono::Utc::now(),
         pending_org_memberships,
+        oidc_group_roles,
     })
 }

--- a/backend/core/src/state/export.rs
+++ b/backend/core/src/state/export.rs
@@ -242,6 +242,7 @@ pub async fn export_state<C: ConnectionTrait>(db: &C) -> Result<StateConfigurati
                     .into_iter()
                     .map(|p| p.as_wire_name().to_string())
                     .collect(),
+                oidc_group: Vec::new(),
             },
         );
     }

--- a/backend/core/src/state/mod.rs
+++ b/backend/core/src/state/mod.rs
@@ -1441,6 +1441,6 @@ mod tests {
         let resolved = resolve_oidc_group_roles(&cfg, &role_ids);
         assert_eq!(resolved.get("platform-team"), Some(&vec![(org, role)]));
         assert_eq!(resolved.get("ops"), Some(&vec![(org, role)]));
-        assert!(resolved.get("unmapped").is_none());
+        assert!(!resolved.contains_key("unmapped"));
     }
 }

--- a/backend/core/src/state/mod.rs
+++ b/backend/core/src/state/mod.rs
@@ -9,8 +9,41 @@ mod provisioning;
 
 pub use export::export_state;
 pub use provisioning::{
-    PendingOrgMembership, PendingOrgMemberships, apply_pending_org_memberships,
+    PendingOrgMembership, PendingOrgMemberships, StateApplyResult, apply_pending_org_memberships,
 };
+
+use crate::types::{OrganizationId, RoleId};
+
+/// Resolved at startup from [`StateRole::oidc_group`]: OIDC group name → the
+/// `(organization, role)` grants a user presenting that group receives on login.
+pub type OidcGroupRoles = HashMap<String, Vec<(OrganizationId, RoleId)>>;
+
+/// Build the OIDC group → grants map from declared roles. `role_ids` maps
+/// `(organization_name, role_name)` to the provisioned `(OrganizationId, RoleId)`.
+pub fn resolve_oidc_group_roles(
+    config: &StateConfiguration,
+    role_ids: &HashMap<(String, String), (OrganizationId, RoleId)>,
+) -> OidcGroupRoles {
+    let mut map: OidcGroupRoles = HashMap::new();
+    for role in config.roles.values() {
+        if role.oidc_group.is_empty() {
+            continue;
+        }
+        let key = (role.organization.clone(), role.name.clone());
+        let Some(&grant) = role_ids.get(&key) else {
+            tracing::warn!(
+                organization = %role.organization,
+                role = %role.name,
+                "oidc_group references a role that was not provisioned; skipping",
+            );
+            continue;
+        };
+        for group in &role.oidc_group {
+            map.entry(group.clone()).or_default().push(grant);
+        }
+    }
+    map
+}
 
 use crate::types::triggers::{ConcurrencyPolicy, TriggerType};
 use entity::organization_cache::CacheSubscriptionMode;
@@ -260,6 +293,10 @@ pub struct StateRole {
     /// Capability identifiers (matching `Permission::as_wire_name`) the role
     /// grants. Required - there is no safe default.
     pub permissions: Vec<String>,
+    /// OIDC group claims that grant this role on login. Resolved at startup
+    /// into [`OidcGroupRoles`] and applied additively per OIDC login.
+    #[serde(default)]
+    pub oidc_group: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -680,10 +717,13 @@ pub async fn load_and_apply_state(
     crypt_secret_file: &str,
     delete_state: bool,
     email_enabled: bool,
-) -> Result<PendingOrgMemberships, Box<dyn std::error::Error>> {
+) -> Result<StateApplyResult, Box<dyn std::error::Error>> {
     let Some(path) = state_file_path else {
         tracing::info!("No state file configured, skipping state management");
-        return Ok(PendingOrgMemberships::new());
+        return Ok(StateApplyResult {
+            pending: PendingOrgMemberships::new(),
+            oidc_group_roles: OidcGroupRoles::new(),
+        });
     };
 
     tracing::info!(path, "Loading state configuration");
@@ -707,7 +747,7 @@ pub async fn load_and_apply_state(
 
     tracing::info!("State configuration validated successfully");
 
-    let pending = provisioning::apply_state_to_database(
+    let result = provisioning::apply_state_to_database(
         db,
         &config,
         crypt_secret_file,
@@ -716,7 +756,7 @@ pub async fn load_and_apply_state(
     )
     .await?;
 
-    Ok(pending)
+    Ok(result)
 }
 
 #[cfg(test)]
@@ -1368,5 +1408,39 @@ mod tests {
             "expected unknown-org error mentioning 'ghost', got: {:?}",
             v.errors
         );
+    }
+
+    #[test]
+    fn resolves_group_to_org_role_grants() {
+        let json = r#"{
+            "roles": {
+                "platform": {
+                    "name": "platform-admin",
+                    "organization": "acme",
+                    "permissions": ["create_project"],
+                    "oidc_group": ["platform-team", "ops"]
+                },
+                "unmapped": {
+                    "name": "viewer",
+                    "organization": "acme",
+                    "permissions": ["view_project"]
+                }
+            }
+        }"#;
+        let cfg: StateConfiguration = serde_json::from_str(json).unwrap();
+
+        let org = OrganizationId::now_v7();
+        let role = RoleId::now_v7();
+        let mut role_ids = HashMap::new();
+        role_ids.insert(("acme".to_string(), "platform-admin".to_string()), (org, role));
+        role_ids.insert(
+            ("acme".to_string(), "viewer".to_string()),
+            (org, RoleId::now_v7()),
+        );
+
+        let resolved = resolve_oidc_group_roles(&cfg, &role_ids);
+        assert_eq!(resolved.get("platform-team"), Some(&vec![(org, role)]));
+        assert_eq!(resolved.get("ops"), Some(&vec![(org, role)]));
+        assert!(resolved.get("unmapped").is_none());
     }
 }

--- a/backend/core/src/state/provisioning.rs
+++ b/backend/core/src/state/provisioning.rs
@@ -44,6 +44,13 @@ pub struct PendingOrgMembership {
 
 pub type PendingOrgMemberships = HashMap<String, Vec<PendingOrgMembership>>;
 
+/// Outcome of applying declarative state: memberships deferred until their user
+/// exists, and the OIDC group → role grants resolved from `StateRole.oidc_group`.
+pub struct StateApplyResult {
+    pub pending: PendingOrgMemberships,
+    pub oidc_group_roles: crate::state::OidcGroupRoles,
+}
+
 // ── Entry point ───────────────────────────────────────────────────────────────
 
 pub(super) async fn apply_state_to_database(
@@ -52,7 +59,7 @@ pub(super) async fn apply_state_to_database(
     crypt_secret_file: &str,
     delete_state: bool,
     email_enabled: bool,
-) -> Result<PendingOrgMemberships, DynError> {
+) -> Result<StateApplyResult, DynError> {
     tracing::info!("Applying state to database");
 
     let app = StateApplicator {
@@ -66,7 +73,7 @@ pub(super) async fn apply_state_to_database(
     app.apply_users(&config.users).await?;
     app.apply_organizations_without_members(&config.organizations)
         .await?;
-    app.apply_roles(&config.roles).await?;
+    let role_ids = app.apply_roles(&config.roles).await?;
     app.apply_organization_members(&config.organizations, &mut pending)
         .await?;
     app.apply_projects(&config.projects).await?;
@@ -76,8 +83,13 @@ pub(super) async fn apply_state_to_database(
     app.apply_workers(&config.workers).await?;
     app.unmark_removed_entities(config, delete_state).await?;
 
+    let oidc_group_roles = super::resolve_oidc_group_roles(config, &role_ids);
+
     tracing::info!("State applied successfully");
-    Ok(pending)
+    Ok(StateApplyResult {
+        pending,
+        oidc_group_roles,
+    })
 }
 
 // ── Credential / lookup helpers ───────────────────────────────────────────────
@@ -1269,8 +1281,12 @@ impl<'a> StateApplicator<'a> {
 
     // ── apply_roles ───────────────────────────────────────────────────────────
 
-    async fn apply_roles(&self, state_roles: &HashMap<String, StateRole>) -> Result<(), DynError> {
+    async fn apply_roles(
+        &self,
+        state_roles: &HashMap<String, StateRole>,
+    ) -> Result<HashMap<(String, String), (OrganizationId, RoleId)>, DynError> {
         let org_lookup = self.org_lookup().await?;
+        let mut role_ids: HashMap<(String, String), (OrganizationId, RoleId)> = HashMap::new();
 
         for state_role in state_roles.values() {
             let org_id = lookup_id(&org_lookup, &state_role.organization, "Organization")?;
@@ -1300,15 +1316,18 @@ impl<'a> StateApplicator<'a> {
                 .one(self.db)
                 .await?;
 
-            if let Some(existing) = existing {
+            let role_id = if let Some(existing) = existing {
+                let id = existing.id;
                 let mut active: role::ActiveModel = existing.into();
                 active.permission = Set(mask);
                 active.managed = Set(true);
                 active.update(self.db).await?;
                 tracing::info!(name = %state_role.name, "Updated managed role");
+                id
             } else {
+                let id = RoleId::now_v7();
                 let active = role::ActiveModel {
-                    id: Set(RoleId::now_v7()),
+                    id: Set(id),
                     name: Set(state_role.name.clone()),
                     organization: Set(Some(org_id)),
                     permission: Set(mask),
@@ -1316,10 +1335,16 @@ impl<'a> StateApplicator<'a> {
                 };
                 active.insert(self.db).await?;
                 tracing::info!(name = %state_role.name, "Created managed role");
-            }
+                id
+            };
+
+            role_ids.insert(
+                (state_role.organization.clone(), state_role.name.clone()),
+                (org_id, role_id),
+            );
         }
 
-        Ok(())
+        Ok(role_ids)
     }
 
     // ── apply_api_keys ────────────────────────────────────────────────────────

--- a/backend/core/src/types/mod.rs
+++ b/backend/core/src/types/mod.rs
@@ -138,6 +138,10 @@ pub struct ServerState {
     /// signs in via OIDC for the first time. Empty when no state file is
     /// configured or when every declared member already existed.
     pub pending_org_memberships: Arc<crate::state::PendingOrgMemberships>,
+    /// OIDC group → (organization, role) grants resolved from state at startup
+    /// (`StateRole.oidc_group`). Applied additively on every OIDC login. Empty
+    /// when no state file is configured.
+    pub oidc_group_roles: Arc<crate::state::OidcGroupRoles>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/backend/migration/src/lib.rs
+++ b/backend/migration/src/lib.rs
@@ -125,6 +125,7 @@ mod m20260529_000000_add_cache_upstream_kind;
 mod m20260603_000000_add_build_failure_retry_fields;
 mod m20260604_000001_add_derivation_scoring_columns;
 mod m20260604_000002_create_derivation_metric;
+mod m20260605_000000_index_hot_lookups;
 
 pub struct Migrator;
 
@@ -251,6 +252,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260603_000000_add_build_failure_retry_fields::Migration),
             Box::new(m20260604_000001_add_derivation_scoring_columns::Migration),
             Box::new(m20260604_000002_create_derivation_metric::Migration),
+            Box::new(m20260605_000000_index_hot_lookups::Migration),
         ]
     }
 }

--- a/backend/migration/src/m20260605_000000_index_hot_lookups.rs
+++ b/backend/migration/src/m20260605_000000_index_hot_lookups.rs
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Indexes the hash/derivation columns that the cache write path filters on but
+//! that were previously only sequential-scanned:
+//!
+//! 1. `idx-derivation_output-hash` - NAR ingest (`proto::handler::nar`) and the
+//!    sign sweep both look up `derivation_output` by `hash`; without this index
+//!    every NAR push and every sweep degenerated into a full table scan.
+//! 2. `idx-build-derivation` - the sign-sweep join `build.derivation =
+//!    derivation.id` could not use the composite `(evaluation, derivation)`
+//!    index (derivation is the trailing column), so it scanned all of `build`.
+//! 3. `idx-cached_path-hash` - cache invalidation and cleanup look up
+//!    `cached_path` by `hash`.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx-derivation_output-hash")
+                    .table(DerivationOutput::Table)
+                    .col(DerivationOutput::Hash)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx-build-derivation")
+                    .table(Build::Table)
+                    .col(Build::Derivation)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx-cached_path-hash")
+                    .table(CachedPath::Table)
+                    .col(CachedPath::Hash)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx-cached_path-hash")
+                    .table(CachedPath::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx-build-derivation")
+                    .table(Build::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx-derivation_output-hash")
+                    .table(DerivationOutput::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum DerivationOutput {
+    Table,
+    Hash,
+}
+
+#[derive(DeriveIden)]
+enum Build {
+    Table,
+    Derivation,
+}
+
+#[derive(DeriveIden)]
+enum CachedPath {
+    Table,
+    Hash,
+}

--- a/backend/test-support/src/cache_fixture.rs
+++ b/backend/test-support/src/cache_fixture.rs
@@ -165,6 +165,7 @@ pub async fn public_cache_with_narinfo() -> Arc<ServerState> {
         jwt_secret: SecretString::new("test-jwt-secret".to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     })
 }
 
@@ -210,6 +211,7 @@ pub async fn public_cache_state() -> Arc<ServerState> {
         jwt_secret: SecretString::new("test-jwt-secret".to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     })
 }
 
@@ -260,6 +262,7 @@ pub async fn public_cache_with_nar() -> Arc<ServerState> {
         jwt_secret: SecretString::new("test-jwt-secret".to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     });
 
     let compressed = synthetic_nar_zst().await;
@@ -369,6 +372,7 @@ fn make_state(
         jwt_secret: SecretString::new("test-jwt-secret".to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     })
 }
 
@@ -440,6 +444,7 @@ pub async fn private_cache_state() -> Arc<ServerState> {
         jwt_secret: SecretString::new("test-jwt-secret".to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     })
 }
 
@@ -496,6 +501,7 @@ pub async fn private_cache_with_nar() -> Arc<ServerState> {
         jwt_secret: SecretString::new("test-jwt-secret".to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     });
 
     let compressed = synthetic_nar_zst().await;

--- a/backend/test-support/src/state.rs
+++ b/backend/test-support/src/state.rs
@@ -37,6 +37,7 @@ pub fn test_state(db: DatabaseConnection) -> Arc<ServerState> {
         jwt_secret: SecretString::new("test-jwt-secret".to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: Arc::new(std::collections::HashMap::new()),
     })
 }
 
@@ -62,5 +63,6 @@ pub fn test_state_with_log_storage(
         jwt_secret: SecretString::new("test-jwt-secret".to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: Arc::new(std::collections::HashMap::new()),
     })
 }

--- a/backend/test-support/src/web.rs
+++ b/backend/test-support/src/web.rs
@@ -117,6 +117,7 @@ pub fn make_test_server_with(
         jwt_secret: SecretString::new(TEST_JWT_SECRET.to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     });
     TestServer::new(web::create_router(state))
 }

--- a/backend/web/src/access.rs
+++ b/backend/web/src/access.rs
@@ -630,6 +630,7 @@ mod tests {
             jwt_secret: gradient_core::types::SecretString::new("test-jwt-secret".to_string()),
             started_at: chrono::Utc::now(),
             pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+            oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
         })
     }
 

--- a/backend/web/src/authorization/oidc.rs
+++ b/backend/web/src/authorization/oidc.rs
@@ -56,12 +56,71 @@ struct IdTokenClaims {
     name: Option<String>,
     #[serde(default)]
     preferred_username: Option<String>,
+    #[serde(default)]
+    groups: Vec<String>,
 }
 
 /// A provisioned/managed placeholder is claimable by the first matching OIDC
 /// login: no local password set and not yet bound to an OIDC identity.
 fn is_claimable(password: &Option<String>, oidc_subject: &Option<String>) -> bool {
     password.is_none() && oidc_subject.is_none()
+}
+
+/// Distinct `(org, role)` grants for the groups a user presents on login.
+fn grants_for_groups(
+    map: &gradient_core::state::OidcGroupRoles,
+    groups: &[String],
+) -> Vec<(OrganizationId, RoleId)> {
+    let mut out: Vec<(OrganizationId, RoleId)> = Vec::new();
+    for group in groups {
+        for &grant in map.get(group).into_iter().flatten() {
+            if !out.contains(&grant) {
+                out.push(grant);
+            }
+        }
+    }
+    out
+}
+
+/// Apply OIDC group → role grants additively: insert the membership when
+/// missing, upgrade the role when it differs. Never removes a membership.
+async fn apply_oidc_group_grants<C: sea_orm::ConnectionTrait>(
+    tx: &C,
+    map: &gradient_core::state::OidcGroupRoles,
+    groups: &[String],
+    user_id: UserId,
+) -> Result<()> {
+    for (org_id, role_id) in grants_for_groups(map, groups) {
+        let existing = EOrganizationUser::find()
+            .filter(COrganizationUser::Organization.eq(org_id))
+            .filter(COrganizationUser::User.eq(user_id))
+            .one(tx)
+            .await
+            .context("query org membership for OIDC group grant")?;
+        match existing {
+            Some(row) if row.role == role_id => {}
+            Some(row) => {
+                let mut active: AOrganizationUser = row.into();
+                active.role = Set(role_id);
+                active
+                    .update(tx)
+                    .await
+                    .context("update org role from OIDC group")?;
+            }
+            None => {
+                AOrganizationUser {
+                    id: Set(OrganizationUserId::now_v7()),
+                    organization: Set(org_id),
+                    user: Set(user_id),
+                    role: Set(role_id),
+                }
+                .insert(tx)
+                .await
+                .context("insert org membership from OIDC group")?;
+            }
+        }
+    }
+    Ok(())
 }
 
 fn random_url_safe(bytes: usize) -> String {
@@ -303,6 +362,7 @@ async fn create_or_update_user(
         .preferred_username
         .clone()
         .unwrap_or_else(|| claims.sub.clone());
+    let groups = claims.groups.clone();
 
     let tx = state
         .web_db
@@ -338,6 +398,13 @@ async fn create_or_update_user(
             .update(&tx)
             .await
             .context("Failed to update OIDC user")?;
+
+        if let Err(e) =
+            apply_oidc_group_grants(&tx, &state.oidc_group_roles, &groups, user.id).await
+        {
+            tracing::warn!(error = %e, username = %user.username,
+                "Failed to apply OIDC group role grants");
+        }
 
         tx.commit()
             .await
@@ -391,6 +458,13 @@ async fn create_or_update_user(
             );
         }
 
+        if let Err(e) =
+            apply_oidc_group_grants(&tx, &state.oidc_group_roles, &groups, user_id).await
+        {
+            tracing::warn!(error = %e, username = %user.username,
+                "Failed to apply OIDC group role grants");
+        }
+
         tx.commit()
             .await
             .context("Failed to commit OIDC account claim")?;
@@ -430,6 +504,11 @@ async fn create_or_update_user(
             username = %user.username,
             "Failed to apply pending state-managed org memberships for new OIDC user"
         );
+    }
+
+    if let Err(e) = apply_oidc_group_grants(&tx, &state.oidc_group_roles, &groups, user.id).await {
+        tracing::warn!(error = %e, username = %user.username,
+            "Failed to apply OIDC group role grants");
     }
 
     tx.commit()
@@ -531,6 +610,24 @@ mod tests {
             &Some("$argon2id$...".into()),
             &Some("existing-subject".into())
         ));
+    }
+
+    #[test]
+    fn collects_distinct_grants_for_presented_groups() {
+        use std::collections::HashMap;
+        let org = OrganizationId::now_v7();
+        let role = RoleId::now_v7();
+        let mut map: gradient_core::state::OidcGroupRoles = HashMap::new();
+        map.insert("platform-team".into(), vec![(org, role)]);
+        map.insert("ops".into(), vec![(org, role)]);
+
+        let grants = super::grants_for_groups(
+            &map,
+            &["platform-team".into(), "ops".into(), "irrelevant".into()],
+        );
+        assert_eq!(grants, vec![(org, role)]);
+
+        assert!(super::grants_for_groups(&map, &["nobody".into()]).is_empty());
     }
 
     #[test]

--- a/backend/web/src/authorization/oidc.rs
+++ b/backend/web/src/authorization/oidc.rs
@@ -19,6 +19,7 @@ use sea_orm::{
     ActiveModelTrait, ActiveValue::Set, ColumnTrait, EntityTrait, QueryFilter, TransactionTrait,
 };
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::sync::Arc;
 use subtle::ConstantTimeEq;
 use url::Url;
@@ -39,6 +40,7 @@ struct CsrfClaims {
     iat: i64,
     state: String,
     nonce: String,
+    pkce_verifier: String,
 }
 
 /// Subset of ID-token claims we trust as identity.
@@ -125,6 +127,8 @@ pub async fn oidc_login_create(state: State<Arc<ServerState>>) -> Result<OidcAut
 
     let csrf_state = random_url_safe(32);
     let nonce = random_url_safe(32);
+    let pkce_verifier = random_url_safe(32);
+    let pkce_challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(pkce_verifier.as_bytes()));
 
     let now = Utc::now();
     let claims = CsrfClaims {
@@ -132,6 +136,7 @@ pub async fn oidc_login_create(state: State<Arc<ServerState>>) -> Result<OidcAut
         exp: (now + Duration::minutes(10)).timestamp(),
         state: csrf_state.clone(),
         nonce: nonce.clone(),
+        pkce_verifier,
     };
     let cookie_value = encode(
         &Header::default(),
@@ -147,6 +152,8 @@ pub async fn oidc_login_create(state: State<Arc<ServerState>>) -> Result<OidcAut
         ("scope", scope.as_str()),
         ("state", csrf_state.as_str()),
         ("nonce", nonce.as_str()),
+        ("code_challenge", pkce_challenge.as_str()),
+        ("code_challenge_method", "S256"),
     ];
 
     let auth_url = Url::parse_with_params(auth_endpoint, &params)
@@ -189,6 +196,7 @@ pub async fn oidc_login_verify(
     }
 
     let expected_nonce = csrf_data.claims.nonce;
+    let pkce_verifier = csrf_data.claims.pkce_verifier;
 
     let metadata = get_oidc_metadata(&state.http, &oidc.discovery_url).await?;
 
@@ -220,6 +228,7 @@ pub async fn oidc_login_verify(
             ("redirect_uri", redirect_uri.as_str()),
             ("client_id", oidc.client_id.as_str()),
             ("client_secret", client_secret.expose()),
+            ("code_verifier", pkce_verifier.as_str()),
         ])
         .send()
         .await
@@ -418,6 +427,7 @@ mod tests {
             exp: (now + Duration::minutes(5)).timestamp(),
             state: "abc".into(),
             nonce: "xyz".into(),
+            pkce_verifier: "verifier".into(),
         };
         let token = jwt_with_secret(&claims, "shh");
         let decoded = decode::<CsrfClaims>(
@@ -438,6 +448,7 @@ mod tests {
             exp: (now + Duration::minutes(5)).timestamp(),
             state: "abc".into(),
             nonce: "xyz".into(),
+            pkce_verifier: "verifier".into(),
         };
         let token = jwt_with_secret(&claims, "secret-a");
         let decoded = decode::<CsrfClaims>(
@@ -456,6 +467,7 @@ mod tests {
             exp: past.timestamp(),
             state: "abc".into(),
             nonce: "xyz".into(),
+            pkce_verifier: "verifier".into(),
         };
         let token = jwt_with_secret(&claims, "shh");
         let decoded = decode::<CsrfClaims>(

--- a/backend/web/src/authorization/oidc.rs
+++ b/backend/web/src/authorization/oidc.rs
@@ -58,6 +58,12 @@ struct IdTokenClaims {
     preferred_username: Option<String>,
 }
 
+/// A provisioned/managed placeholder is claimable by the first matching OIDC
+/// login: no local password set and not yet bound to an OIDC identity.
+fn is_claimable(password: &Option<String>, oidc_subject: &Option<String>) -> bool {
+    password.is_none() && oidc_subject.is_none()
+}
+
 fn random_url_safe(bytes: usize) -> String {
     let mut buf = vec![0u8; bytes];
     rand::rng().fill(buf.as_mut_slice());
@@ -349,8 +355,46 @@ async fn create_or_update_user(
         .await
         .context("Database error while checking for OIDC username/email collision")?;
 
-    if collision.is_some() {
-        bail!("An account already exists with this username or email.");
+    if let Some(existing) = collision {
+        if !is_claimable(&existing.password, &existing.oidc_subject) {
+            bail!("An account already exists with this username or email.");
+        }
+
+        let user_id = existing.id;
+        let mut auser: AUser = existing.into();
+        auser.oidc_issuer = Set(Some(claims.iss));
+        auser.oidc_subject = Set(Some(claims.sub));
+        auser.last_login_at = Set(gradient_core::types::now());
+        if let Some(ref new_email) = claims.email {
+            auser.email = Set(new_email.clone());
+        }
+        if let Some(ref new_name) = claims.name {
+            auser.name = Set(new_name.clone());
+        }
+        let user = auser
+            .update(&tx)
+            .await
+            .context("Failed to claim OIDC account")?;
+
+        if let Err(e) = gradient_core::state::apply_pending_org_memberships(
+            &tx,
+            &state.pending_org_memberships,
+            &user.username,
+            user_id,
+        )
+        .await
+        {
+            tracing::warn!(
+                error = %e,
+                username = %user.username,
+                "Failed to apply pending state-managed org memberships for claimed OIDC user"
+            );
+        }
+
+        tx.commit()
+            .await
+            .context("Failed to commit OIDC account claim")?;
+        return Ok(user);
     }
 
     let user = AUser {
@@ -476,6 +520,17 @@ mod tests {
             &Validation::new(Algorithm::HS256),
         );
         assert!(decoded.is_err());
+    }
+
+    #[test]
+    fn claimable_only_when_passwordless_and_unbound() {
+        assert!(super::is_claimable(&None, &None));
+        assert!(!super::is_claimable(&Some("$argon2id$...".into()), &None));
+        assert!(!super::is_claimable(&None, &Some("existing-subject".into())));
+        assert!(!super::is_claimable(
+            &Some("$argon2id$...".into()),
+            &Some("existing-subject".into())
+        ));
     }
 
     #[test]

--- a/backend/web/tests/actions.rs
+++ b/backend/web/tests/actions.rs
@@ -166,6 +166,7 @@ fn server_with_email(
         jwt_secret: SecretString::new(TEST_JWT_SECRET.to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     });
     TestServer::new(create_router(state))
 }

--- a/backend/web/tests/auth_hardening.rs
+++ b/backend/web/tests/auth_hardening.rs
@@ -86,6 +86,7 @@ fn server_with(web_db_setup: impl FnOnce(MockDatabase) -> MockDatabase) -> TestS
         jwt_secret: SecretString::new(JWT_SECRET.to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     });
     TestServer::new(create_router(state))
 }

--- a/backend/web/tests/auth_middleware.rs
+++ b/backend/web/tests/auth_middleware.rs
@@ -49,6 +49,7 @@ fn server() -> TestServer {
         jwt_secret: gradient_core::types::SecretString::new("test-jwt-secret".to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     });
     TestServer::new(create_router(state))
 }

--- a/backend/web/tests/body_size_limit.rs
+++ b/backend/web/tests/body_size_limit.rs
@@ -46,6 +46,7 @@ fn make_state_with_limits(max_request_size: usize) -> Arc<ServerState> {
         jwt_secret: gradient_core::types::SecretString::new("test-jwt-secret".to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     })
 }
 

--- a/backend/web/tests/builds_download.rs
+++ b/backend/web/tests/builds_download.rs
@@ -273,6 +273,7 @@ fn listing_returns_products_from_db() {
             jwt_secret: gradient_core::types::SecretString::new("test-jwt-secret".to_string()),
             started_at: chrono::Utc::now(),
             pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+            oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
         });
 
         let router = create_router(state);
@@ -352,6 +353,7 @@ fn download_streams_file_from_nar() {
             jwt_secret: gradient_core::types::SecretString::new("test-jwt-secret".to_string()),
             started_at: chrono::Utc::now(),
             pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+            oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
         });
 
         let router = create_router(state);

--- a/backend/web/tests/cache_local_priority.rs
+++ b/backend/web/tests/cache_local_priority.rs
@@ -77,6 +77,7 @@ fn build_server(cache: entity::cache::Model, peer: &str) -> TestServer {
         jwt_secret: gradient_core::types::SecretString::new("test-jwt-secret".to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     });
 
     let peer_addr: SocketAddr = format!("{peer}:0").parse().expect("valid peer addr");

--- a/backend/web/tests/cli_device_authorization.rs
+++ b/backend/web/tests/cli_device_authorization.rs
@@ -113,6 +113,7 @@ fn server_with(web_db_setup: impl FnOnce(MockDatabase) -> MockDatabase) -> TestS
         jwt_secret: SecretString::new(JWT_SECRET.to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     });
     TestServer::new(create_router(state))
 }

--- a/backend/web/tests/commits_authorization.rs
+++ b/backend/web/tests/commits_authorization.rs
@@ -171,6 +171,7 @@ fn make_server(db: sea_orm::DatabaseConnection) -> TestServer {
         jwt_secret: SecretString::new(JWT_SECRET.to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     });
     TestServer::new(create_router(state))
 }

--- a/backend/web/tests/cross_org_follower_log_visible.rs
+++ b/backend/web/tests/cross_org_follower_log_visible.rs
@@ -214,6 +214,7 @@ fn make_server(db: sea_orm::DatabaseConnection) -> TestServer {
         jwt_secret: SecretString::new(TEST_JWT_SECRET.to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     });
     TestServer::new(create_router(state))
 }

--- a/backend/web/tests/entry_point_download.rs
+++ b/backend/web/tests/entry_point_download.rs
@@ -173,6 +173,7 @@ fn make_state(db: sea_orm::DatabaseConnection) -> Arc<ServerState> {
         jwt_secret: gradient_core::types::SecretString::new("test-jwt-secret".to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     })
 }
 

--- a/backend/web/tests/entry_point_metrics.rs
+++ b/backend/web/tests/entry_point_metrics.rs
@@ -172,6 +172,7 @@ fn make_state(db: sea_orm::DatabaseConnection) -> Arc<ServerState> {
         jwt_secret: gradient_core::types::SecretString::new("test-jwt-secret".to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     })
 }
 

--- a/backend/web/tests/evals_artefacts.rs
+++ b/backend/web/tests/evals_artefacts.rs
@@ -242,6 +242,7 @@ fn make_state(db: sea_orm::DatabaseConnection) -> Arc<ServerState> {
         jwt_secret: gradient_core::types::SecretString::new("test-jwt-secret".to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     })
 }
 

--- a/backend/web/tests/evaluation_builds_via.rs
+++ b/backend/web/tests/evaluation_builds_via.rs
@@ -201,6 +201,7 @@ fn make_state(db: sea_orm::DatabaseConnection) -> Arc<ServerState> {
         jwt_secret: gradient_core::types::SecretString::new("test-jwt-secret".to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     })
 }
 

--- a/backend/web/tests/evaluation_builds_via_cross_org.rs
+++ b/backend/web/tests/evaluation_builds_via_cross_org.rs
@@ -218,6 +218,7 @@ fn make_server(db: sea_orm::DatabaseConnection) -> TestServer {
         jwt_secret: SecretString::new(TEST_JWT_SECRET.to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     });
     TestServer::new(create_router(state))
 }

--- a/backend/web/tests/evaluations.rs
+++ b/backend/web/tests/evaluations.rs
@@ -176,6 +176,7 @@ fn make_server(db: sea_orm::DatabaseConnection) -> TestServer {
         jwt_secret: SecretString::new(JWT_SECRET.to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     });
     TestServer::new(create_router(state))
 }

--- a/backend/web/tests/forge_hooks.rs
+++ b/backend/web/tests/forge_hooks.rs
@@ -84,6 +84,7 @@ fn make_state(
         jwt_secret: gradient_core::types::SecretString::new("test-jwt-secret".to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     })
 }
 

--- a/backend/web/tests/metrics.rs
+++ b/backend/web/tests/metrics.rs
@@ -63,6 +63,7 @@ fn state_with_metrics(enabled: bool, db: DatabaseConnection) -> Arc<ServerState>
         jwt_secret: SecretString::new("test-jwt-secret".into()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     })
 }
 

--- a/backend/web/tests/narinfo.rs
+++ b/backend/web/tests/narinfo.rs
@@ -188,6 +188,7 @@ async fn narinfo_served_from_db_inner() {
         jwt_secret: gradient_core::types::SecretString::new("test-jwt-secret".to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     });
 
     let router = create_router(state);
@@ -334,6 +335,7 @@ async fn narinfo_unsigned_inner() {
         jwt_secret: gradient_core::types::SecretString::new("test-jwt-secret".to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     });
 
     let router = create_router(state);

--- a/backend/web/tests/oidc_errors.rs
+++ b/backend/web/tests/oidc_errors.rs
@@ -62,6 +62,7 @@ fn server_with_broken_oidc() -> TestServer {
         jwt_secret: gradient_core::types::SecretString::new("test-jwt-secret".to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     });
     TestServer::new(create_router(state))
 }

--- a/backend/web/tests/oidc_pkce.rs
+++ b/backend/web/tests/oidc_pkce.rs
@@ -106,6 +106,7 @@ async fn authorize_redirect_carries_pkce_and_cookie_holds_verifier() {
         jwt_secret: gradient_core::types::SecretString::new("test-jwt-secret".to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: Arc::new(std::collections::HashMap::new()),
     });
 
     let server = axum_test::TestServer::new(create_router(state));

--- a/backend/web/tests/oidc_pkce.rs
+++ b/backend/web/tests/oidc_pkce.rs
@@ -1,0 +1,132 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! PKCE regression tests (issue #318): the authorization redirect must carry
+//! `code_challenge` + `code_challenge_method=S256`, and the verifier stored in
+//! the signed `oidc_csrf` cookie must hash to that challenge.
+
+use axum::extract::State;
+use axum::routing::get;
+use axum::{Json, Router};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use gradient_core::storage::{EmailSender, NarStore};
+use gradient_core::types::cli::OidcArgs;
+use gradient_core::types::{RuntimeConfig, ServerState, WebDb, WorkerDb};
+use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
+use sea_orm::{DatabaseBackend, MockDatabase};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::sync::Arc;
+use test_support::cli::test_cli;
+use test_support::fakes::email::InMemoryEmailSender;
+use test_support::log_storage::NoopLogStorage;
+use url::Url;
+use uuid::Uuid;
+use web::create_router;
+
+#[derive(Deserialize)]
+struct CsrfClaims {
+    state: String,
+    nonce: String,
+    pkce_verifier: String,
+}
+
+async fn metadata(State(base): State<String>) -> Json<serde_json::Value> {
+    Json(serde_json::json!({
+        "issuer": base,
+        "authorization_endpoint": format!("{base}/authorize"),
+        "token_endpoint": format!("{base}/token"),
+        "jwks_uri": format!("{base}/jwks"),
+    }))
+}
+
+async fn spawn_idp() -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    let app = Router::new()
+        .route("/.well-known/openid-configuration", get(metadata))
+        .with_state(base.clone());
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    base
+}
+
+fn jwt_decode(cookie: &str) -> CsrfClaims {
+    let jwt = cookie
+        .split("oidc_csrf=")
+        .nth(1)
+        .and_then(|rest| rest.split(';').next())
+        .expect("oidc_csrf cookie present");
+    decode::<CsrfClaims>(
+        jwt,
+        &DecodingKey::from_secret(b"test-jwt-secret"),
+        &Validation::new(Algorithm::HS256),
+    )
+    .expect("decode CSRF cookie")
+    .claims
+}
+
+#[tokio::test]
+async fn authorize_redirect_carries_pkce_and_cookie_holds_verifier() {
+    let base = spawn_idp().await;
+
+    let tmp = std::env::temp_dir();
+    let suffix = Uuid::now_v7();
+    let jwt_path = tmp.join(format!("gradient-pkce-jwt-{suffix}"));
+    std::fs::write(&jwt_path, "test-jwt-secret").unwrap();
+    let secret_path = tmp.join(format!("gradient-pkce-secret-{suffix}"));
+    std::fs::write(&secret_path, "test-client-secret").unwrap();
+
+    let mut cli = test_cli();
+    cli.secrets.jwt_secret_file = jwt_path.to_string_lossy().into_owned();
+    cli.oidc = OidcArgs {
+        oidc_enabled: true,
+        oidc_required: false,
+        oidc_client_id: Some("test-client".into()),
+        oidc_client_secret_file: Some(secret_path.to_string_lossy().into_owned()),
+        oidc_scopes: None,
+        oidc_discovery_url: Some(base.clone()),
+    };
+
+    let config = Arc::new(RuntimeConfig::from_cli(&cli).expect("valid test config"));
+    let nar_storage = NarStore::local(&config.storage.base_path).expect("create test NarStore");
+    let state = Arc::new(ServerState {
+        web_db: WebDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
+        worker_db: WorkerDb::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
+        config,
+        log_storage: Arc::new(NoopLogStorage),
+        email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,
+        nar_storage,
+        manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        http: gradient_core::http::build_client().expect("http client"),
+        shutdown: gradient_core::shutdown::Shutdown::new(),
+        jwt_secret: gradient_core::types::SecretString::new("test-jwt-secret".to_string()),
+        started_at: chrono::Utc::now(),
+        pending_org_memberships: Arc::new(std::collections::HashMap::new()),
+    });
+
+    let server = axum_test::TestServer::new(create_router(state));
+    let res = server.get("/api/v1/auth/oidc/login").await;
+    res.assert_status(axum::http::StatusCode::FOUND);
+
+    let location = res.header("location");
+    let auth_url = Url::parse(location.to_str().unwrap()).unwrap();
+    let params: std::collections::HashMap<_, _> =
+        auth_url.query_pairs().into_owned().collect();
+
+    assert_eq!(
+        params.get("code_challenge_method").map(String::as_str),
+        Some("S256")
+    );
+    let challenge = params.get("code_challenge").expect("code_challenge present");
+
+    let cookie = res.header("set-cookie");
+    let csrf = jwt_decode(cookie.to_str().unwrap());
+
+    let expected = URL_SAFE_NO_PAD.encode(Sha256::digest(csrf.pkce_verifier.as_bytes()));
+    assert_eq!(&expected, challenge, "challenge must be S256(verifier)");
+    assert!(!csrf.state.is_empty() && !csrf.nonce.is_empty());
+}

--- a/backend/web/tests/old_direct_build_gone.rs
+++ b/backend/web/tests/old_direct_build_gone.rs
@@ -41,6 +41,7 @@ fn make_state() -> Arc<ServerState> {
         jwt_secret: gradient_core::types::SecretString::new("test-jwt-secret".to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     })
 }
 

--- a/backend/web/tests/projects_sign_cache.rs
+++ b/backend/web/tests/projects_sign_cache.rs
@@ -87,6 +87,7 @@ fn make_server(db: sea_orm::DatabaseConnection) -> TestServer {
         jwt_secret: SecretString::new(JWT_SECRET.to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     });
     TestServer::new(create_router(state))
 }

--- a/backend/web/tests/rate_limit.rs
+++ b/backend/web/tests/rate_limit.rs
@@ -40,6 +40,7 @@ fn make_state() -> Arc<ServerState> {
         jwt_secret: gradient_core::types::SecretString::new("test-jwt-secret".to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     })
 }
 

--- a/backend/web/tests/request_id.rs
+++ b/backend/web/tests/request_id.rs
@@ -43,6 +43,7 @@ fn make_state() -> Arc<ServerState> {
         jwt_secret: gradient_core::types::SecretString::new("test-jwt-secret".to_string()),
         started_at: chrono::Utc::now(),
         pending_org_memberships: std::sync::Arc::new(std::collections::HashMap::new()),
+        oidc_group_roles: std::sync::Arc::new(std::collections::HashMap::new()),
     })
 }
 

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -454,9 +454,9 @@ paths:
       tags: [auth]
       summary: OIDC login redirect
       description: |-
-        Redirects the browser to the OIDC provider's authorization endpoint (HTTP 302) and
-        sets a short-lived `oidc_csrf` cookie carrying the signed `state` and `nonce` values
-        that must be returned on the callback.
+        Redirects the browser to the OIDC provider's authorization endpoint (HTTP 302) using
+        PKCE (S256), and sets a short-lived `oidc_csrf` cookie carrying the signed `state`,
+        `nonce`, and PKCE verifier that must be returned on the callback.
       security: []
       operationId: oidcLogin
       responses:

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -155,7 +155,7 @@ services.gradient.oidc = {
 
 Gradient uses PKCE (S256) and discovers all provider endpoints from `discoveryUrl/.well-known/openid-configuration` and callback url is at `https://$domain/api/v1/auth/oidc/callback`. Set `required` to `true` to disable basic auth and require OIDC for all users. Because PKCE is sent on every request, providers that gate it (e.g. kanidm) do not need `allowInsecureClientDisablePkce`.
 
-To map OIDC groups to organization roles, request the `groups` scope (add `"groups"` to `scopes`) so the ID token carries the user's group claims, then attach `oidcGroup` lists to state-managed roles (see [Declarative State](usage/state.md)).
+To map OIDC groups to organization roles, request the `groups` scope (add `"groups"` to `scopes`) so the ID token carries the user's group claims, then attach `oidc_group` lists to state-managed roles (see [Declarative State](usage/state.md)).
 
 ## Email
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -153,7 +153,9 @@ services.gradient.oidc = {
 };
 ```
 
-Gradient uses PKCE and discovers all provider endpoints from `discoveryUrl/.well-known/openid-configuration` and callback url is at `https://$domain/api/v1/auth/oidc/callback`. Set `required` to `true` to disable basic auth and require OIDC for all users.
+Gradient uses PKCE (S256) and discovers all provider endpoints from `discoveryUrl/.well-known/openid-configuration` and callback url is at `https://$domain/api/v1/auth/oidc/callback`. Set `required` to `true` to disable basic auth and require OIDC for all users. Because PKCE is sent on every request, providers that gate it (e.g. kanidm) do not need `allowInsecureClientDisablePkce`.
+
+To map OIDC groups to organization roles, request the `groups` scope (add `"groups"` to `scopes`) so the ID token carries the user's group claims, then attach `oidcGroup` lists to state-managed roles (see [Declarative State](usage/state.md)).
 
 ## Email
 

--- a/docs/src/development/internals.md
+++ b/docs/src/development/internals.md
@@ -154,7 +154,7 @@ Batching the BFS (one DB round-trip per level) keeps the query count proportiona
 
 **API keys** - 32 random bytes encoded as hex, stored hashed in `api.key`, prefixed with `GRAD` when returned to the user. The `authorization::authorize` middleware accepts both token types in the `Authorization: Bearer` header.
 
-**OIDC** - `oidc_login_create` starts the PKCE flow and stores the verifier in the database. `oidc_login_verify` exchanges the code, fetches user info, upserts the user row, and returns a JWT. Endpoint discovery is automatic from `GRADIENT_OIDC_DISCOVERY_URL/.well-known/openid-configuration`.
+**OIDC** - `oidc_login_create` builds the authorization URL with PKCE (S256), storing `state`, `nonce`, and the PKCE verifier in a short-lived signed `oidc_csrf` cookie. `oidc_login_verify` validates `state`, exchanges the code (sending `code_verifier`), verifies the ID token against the provider JWKS, then upserts the user row and returns a JWT. Endpoint discovery is automatic from `GRADIENT_OIDC_DISCOVERY_URL/.well-known/openid-configuration`.
 
 ---
 

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -21,6 +21,11 @@ JWKS, `iss`/`aud`/`exp`/`nonce` checks, identity bound to
 `(oidc_issuer, oidc_subject)` rather than email) is enforced in
 `oidc_login_verify` and exercised end-to-end via the
 `/auth/oauth/authorize` and `/auth/oidc/callback` endpoints.
+
+`backend/web/tests/oidc_pkce.rs::authorize_redirect_carries_pkce_and_cookie_holds_verifier`
+asserts the login redirect carries `code_challenge` + `code_challenge_method=S256`
+and that the verifier stored in the signed `oidc_csrf` cookie hashes to that
+challenge (issue #318).
 ## Unified resource access - `crate::access` and `crate::permissions`
 
 All "load resource by name and check the caller may use it" logic lives in

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -26,6 +26,11 @@ JWKS, `iss`/`aud`/`exp`/`nonce` checks, identity bound to
 asserts the login redirect carries `code_challenge` + `code_challenge_method=S256`
 and that the verifier stored in the signed `oidc_csrf` cookie hashes to that
 challenge (issue #318).
+
+`oidc.rs::tests::claimable_only_when_passwordless_and_unbound` covers account
+claiming (issue #319): a provisioned password-less, OIDC-unbound account is
+claimed on first login, while password-bearing or already-bound accounts are
+not.
 ## Unified resource access - `crate::access` and `crate::permissions`
 
 All "load resource by name and check the caller may use it" logic lives in

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -31,6 +31,12 @@ challenge (issue #318).
 claiming (issue #319): a provisioned password-less, OIDC-unbound account is
 claimed on first login, while password-bearing or already-bound accounts are
 not.
+
+OIDC group → role mapping (issue #322) is covered by
+`core` `state::tests::resolves_group_to_org_role_grants` (declared `oidc_group`
+lists resolve to `(organization, role)` grants) and
+`oidc.rs::tests::collects_distinct_grants_for_presented_groups` (a user's group
+claims collect the distinct grants applied additively on login).
 ## Unified resource access - `crate::access` and `crate::permissions`
 
 All "load resource by name and check the caller may use it" logic lives in

--- a/docs/src/usage/state.md
+++ b/docs/src/usage/state.md
@@ -350,6 +350,26 @@ Role names must not collide with the built-in roles (`Admin`, `Write`,
 `View`) or with another state-managed role in the same organization -
 startup fails on collision.
 
+### Mapping OIDC groups to roles
+
+A role may list `oidc_group` values. On each OIDC login, a user whose
+`groups` claim contains any listed group is granted that role in the role's
+organization (creating the membership if missing, upgrading the role if it
+differs). Grants are **additive**: OIDC groups only ever add or upgrade a
+membership, never remove one - removal stays with explicit `members` lists
+and the API. This targets state-managed custom roles only; to grant
+admin-level access via a group, declare a custom role with those permissions
+and an `oidc_group`. Requires the `groups` scope on the OIDC client (add
+`"groups"` to `services.gradient.oidc.scopes`).
+
+```nix
+services.gradient.state.roles.platform-admin = {
+  organization = "acme";
+  permissions  = [ "viewOrg" "triggerEvaluation" ];
+  oidc_group   = [ "platform-team" "ops" ];
+};
+```
+
 ### Role options
 
 | Option | Default | Description |
@@ -357,6 +377,7 @@ startup fails on collision.
 | `name` | `<attrset key>` | Role name. Must be unique within the organization and must not collide with a built-in role |
 | `organization` | - | Owning organization name (required) |
 | `permissions` | - | List of capability identifiers granted by the role (required, see `GET /user/keys/permissions` for the catalogue) |
+| `oidc_group` | `[]` | OIDC group claims that grant this role on login (additive). Requires the `groups` scope |
 
 ## API Keys
 

--- a/docs/src/usage/state.md
+++ b/docs/src/usage/state.md
@@ -78,6 +78,13 @@ attempting to sign in as that user via OIDC is rejected by the server
 (`User already exists with password authentication`), so OIDC-only users
 must be declared without one.
 
+A *claimable* account is one provisioned without a password that has not yet
+been bound to an OIDC identity. On the first OIDC login whose username or email
+matches it, the server records its `(iss, sub)` and binds the account;
+`superuser` and the other provisioned fields are preserved. This is the
+supported way to **bootstrap an OIDC superuser**: declare the user with
+`superuser = true` and `password_file = null`, then sign in via OIDC.
+
 ### User options
 
 | Option | Default | Description |

--- a/nix/modules/gradient-state.nix
+++ b/nix/modules/gradient-state.nix
@@ -878,6 +878,18 @@
         '';
         example = [ "viewOrg" "triggerEvaluation" ];
       };
+
+      oidc_group = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = ''
+          OIDC group claims that grant this role on login. A user whose
+          `groups` claim contains any listed group is granted this role in
+          the role's organization. Grants are additive - they never remove a
+          membership. Requires the `groups` scope on the OIDC client.
+        '';
+        example = [ "platform-team" "ops" ];
+      };
     };
   });
 


### PR DESCRIPTION
Resolves the OIDC onboarding friction reported in #319 and closes both sub-issues.

## #318 Implement PKCE (S256)
The docs claimed PKCE was used but no PKCE parameters were ever sent, forcing providers like kanidm to set `allowInsecureClientDisablePkce = true`. `oidc_login_create` now generates a `code_verifier`, sends `code_challenge` + `code_challenge_method=S256`, and stores the verifier in the existing signed `oidc_csrf` cookie; `oidc_login_verify` returns it as `code_verifier` on the token exchange. The confidential `client_secret` is unchanged. Docs/API spec updated to match reality.

## #317 Claim provisioned password-less accounts on first OIDC login
`create_or_update_user` rejected any username/email collision, so a provisioned `superuser = true, password_file = null` admin could never log in, contradicting the docs. It now **claims** a collision when the row is a provisioned placeholder (`password IS NULL` and not yet bound to an OIDC identity): it binds `(iss, sub)`, refreshes login/name/email, applies pending memberships, and **preserves `superuser`/`managed`**. Password-bearing or already-bound accounts still reject. This makes declarative state the supported OIDC-superuser bootstrap/recovery path, no separate admin CLI, fail-fast startup unchanged.

## #322 Map OIDC group claims to org roles
`StateRole` gains an `oidc_group` list. At startup (after roles are provisioned) the declared `oidc_group` entries resolve into an in-memory `group -> [(org, role)]` map carried on `ServerState`. On every OIDC login the user's `groups` claim is matched and memberships are upserted **additively** (grant/upgrade only, never revoke). Targets state-managed custom roles by design; superuser stays with the state-bootstrap path above. Requires the `groups` scope.

Closes #319
Closes #318
Closes #322
