### PR TITLE
fix(web): let subscribed-org members view private caches (#327)

### DIFF
--- a/backend/scheduler/src/jobs.rs
+++ b/backend/scheduler/src/jobs.rs
@@ -216,6 +216,14 @@ impl JobTracker {
 
     pub fn add_pending(&mut self, job_id: String, job: PendingJob) -> JobCandidate {
         let candidate = job.as_candidate(&job_id);
+        // Idempotent under the tracker write lock: two concurrent
+        // `dispatch_ready_builds` passes can both clear the `contains_job`
+        // filter before either enqueues, so a job already pending or in-flight
+        // (active) must not be re-queued - otherwise the same build is
+        // dispatched to the worker twice and the duplicate fails the eval.
+        if self.pending.contains_key(&job_id) || self.active.contains_key(&job_id) {
+            return candidate;
+        }
         self.pending.insert(job_id, job);
         candidate
     }
@@ -582,6 +590,28 @@ mod tests {
         assert!(caps.can_build("x86_64-linux", &["kvm".into()]));
         // kvm is provided but big-parallel is not → must reject.
         assert!(!caps.can_build("x86_64-linux", &["kvm".into(), "big-parallel".into()],));
+    }
+
+    #[test]
+    fn add_pending_does_not_requeue_active_job() {
+        // Regression: two concurrent dispatch passes can both pass the
+        // `contains_job` filter before either enqueues. Once a job is assigned
+        // (active), re-adding the same id must not put it back in pending, or it
+        // gets dispatched to the worker a second time and the duplicate build is
+        // aborted by the daemon - failing the whole evaluation.
+        let mut tracker = JobTracker::new();
+        let peer = OrganizationId::now_v7();
+        tracker.add_pending("build:1".into(), build_job(peer, vec![]));
+        assert!(
+            tracker.assign_pending("worker", "build:1").is_some(),
+            "job should assign"
+        );
+        assert_eq!(tracker.pending_count(), 0);
+        assert_eq!(tracker.active_count(), 1);
+
+        tracker.add_pending("build:1".into(), build_job(peer, vec![]));
+        assert_eq!(tracker.pending_count(), 0, "active job must not be re-queued");
+        assert_eq!(tracker.active_count(), 1);
     }
 
     #[test]

--- a/backend/web/src/access.rs
+++ b/backend/web/src/access.rs
@@ -30,9 +30,9 @@ use gradient_core::db::{
 };
 use gradient_core::types::ids::{CacheId, IntegrationId, OrganizationId, UserId};
 use gradient_core::types::{
-    CCacheUser, CIntegration, COrganizationUser, ECacheRole, ECacheUser, EIntegration,
-    EOrganizationUser, ERole, MCache, MIntegration, MOrganization, MOrganizationUser, MProject,
-    MUser, ServerState,
+    CCacheUser, CIntegration, COrganizationCache, COrganizationUser, ECacheRole, ECacheUser,
+    EIntegration, EOrganizationCache, EOrganizationUser, ERole, MCache, MIntegration, MOrganization,
+    MOrganizationUser, MProject, MUser, ServerState,
 };
 use sea_orm::{ColumnTrait, Condition, EntityTrait, QueryFilter};
 use std::sync::Arc;
@@ -262,7 +262,10 @@ pub async fn load_cache(
         CacheAccess::Readable => {
             if !cache.public {
                 let visible = match caller.user_id() {
-                    Some(uid) => is_cache_member(state, uid, cache.id, api_key).await?,
+                    Some(uid) => {
+                        is_cache_member(state, uid, cache.id, api_key).await?
+                            || is_cache_org_subscriber(state, uid, cache.id, api_key).await?
+                    }
                     None => false,
                 };
                 if !visible {
@@ -443,6 +446,39 @@ async fn is_cache_member(
         .one(&state.web_db)
         .await?;
     Ok(row.is_some())
+}
+
+/// True when `user_id` belongs to an organization that subscribes to `cache_id`.
+/// Mirrors `GET /caches` visibility so a cache the user can list is also
+/// readable, even without a direct `cache_user` membership row.
+async fn is_cache_org_subscriber(
+    state: &Arc<ServerState>,
+    user_id: UserId,
+    cache_id: CacheId,
+    api_key: Option<&ApiKeyContext>,
+) -> WebResult<bool> {
+    let subscriber_orgs: Vec<OrganizationId> = EOrganizationCache::find()
+        .filter(COrganizationCache::Cache.eq(cache_id))
+        .all(&state.web_db)
+        .await?
+        .into_iter()
+        .map(|oc| oc.organization)
+        .collect();
+
+    let allowed: Vec<OrganizationId> = match api_key.and_then(|k| k.organization) {
+        Some(pinned) => subscriber_orgs.into_iter().filter(|o| *o == pinned).collect(),
+        None => subscriber_orgs,
+    };
+    if allowed.is_empty() {
+        return Ok(false);
+    }
+
+    let member = EOrganizationUser::find()
+        .filter(COrganizationUser::User.eq(user_id))
+        .filter(COrganizationUser::Organization.is_in(allowed))
+        .one(&state.web_db)
+        .await?;
+    Ok(member.is_some())
 }
 
 async fn cache_role_mask(

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -4324,6 +4324,11 @@ paths:
     get:
       tags: [caches]
       summary: Get cache
+      description: >-
+        Returns cache details. Public caches are visible to anyone. A private
+        cache is visible to its cache members and to members of any organization
+        subscribed to it (matching the visibility of `GET /caches`); other
+        callers receive `404`.
       operationId: getCache
       responses:
         '200':

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -601,6 +601,20 @@ Backend (`cargo test -p core --lib state::provisioning::trigger_helper_tests`):
   otherwise persist an id no webhook ever resolves to and the trigger would
   silently never fire.
 
+## Org members can view subscribed caches (#327)
+
+NixOS VM (`nix/tests/gradient/state`):
+- `org member can view subscribed caches they do not own` - a state-provisioned
+  cache appears in `GET /caches` for any member of a subscribed organization,
+  so viewing it by name (`GET /caches/{cache}`, `gradient cache show`) must
+  succeed too. `bob` (a plain `corp` member who created none of the caches and
+  holds no cache membership) lists and shows both the active `main` and inactive
+  `dev` caches. Regression: detail lookups previously required a direct
+  `cache_user` row, so org members got a 404 via the API, CLI and WebUI.
+- `non-members cannot see private caches` - `charlie`, who belongs to no
+  subscribing org, neither lists nor can show the private caches, pinning the
+  broadened read access so it does not leak caches to unrelated users.
+
 ## Hashed API keys at rest
 
 Backend (`cargo test -p core --lib state::provisioning::api_key_hash_tests`):

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -601,6 +601,17 @@ Backend (`cargo test -p core --lib state::provisioning::trigger_helper_tests`):
   otherwise persist an id no webhook ever resolves to and the trigger would
   silently never fire.
 
+## Scheduler does not double-dispatch a build
+
+Backend (`cargo test -p scheduler --lib jobs::tests::add_pending_does_not_requeue_active_job`):
+- `add_pending_does_not_requeue_active_job` - once a build is assigned (moved to
+  `active`), re-adding the same job id must not put it back in `pending`. Two
+  concurrent `dispatch_ready_builds` passes can both clear the `contains_job`
+  filter before either enqueues; without the idempotency guard the same build is
+  dispatched to the worker twice, the duplicate is aborted by the nix daemon
+  ("build aborted by server"), and the spurious failure fails the whole
+  evaluation (observed flaking the `gradient-cache` NixOS VM test).
+
 ## Org members can view subscribed caches (#327)
 
 NixOS VM (`nix/tests/gradient/state`):

--- a/nix/tests/gradient/state/default.nix
+++ b/nix/tests/gradient/state/default.nix
@@ -16,6 +16,13 @@
         networking.hosts = {
           "127.0.0.1" = [ "gradient.local" ];
         };
+
+        environment.systemPackages = with pkgs; [
+          curl
+          jq
+          gradient-cli
+        ];
+
         environment.etc = {
           "gradient/secrets/alice_password" = {
             mode = "0600";
@@ -96,7 +103,7 @@
                   name = "Bob Smith";
                   email = "bob@example.com";
                   password_file = "/etc/gradient/secrets/bob_password";
-                  email_verified = false;
+                  email_verified = true;
                 };
               };
 
@@ -106,6 +113,10 @@
                   description = "Main development organization";
                   private_key_file = "/etc/gradient/secrets/corp_ssh_key";
                   created_by = "alice";
+                  members = [
+                    { user = "alice"; role = "Admin"; }
+                    { user = "bob"; role = "View"; }
+                  ];
                 };
               };
 

--- a/nix/tests/gradient/state/test.py
+++ b/nix/tests/gradient/state/test.py
@@ -2,103 +2,116 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-import time
+# Exercises declarative `services.gradient.state` provisioning end to end:
+# resources are created from the Nix config at startup and then read back over
+# the REST API and the `gradient` CLI as the provisioned users.
+
 import json
+
+API = "http://gradient.local/api/v1"
+
+# Alice's state-provisioned API key (bearer = "GRAD" + the key file contents).
+ALICE = "GRADa1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6A7B8C9D0E1F2G3"
+
+
+def curl(method, path, token=None, body=None):
+    cmd = f"curl -sS -X {method} {API}/{path} -H 'Content-Type: application/json'"
+    if token:
+        cmd += f" -H 'Authorization: Bearer {token}'"
+    if body is not None:
+        cmd += f" -d '{json.dumps(body)}'"
+    return machine.succeed(cmd)
+
+
+def api(method, path, token=None, body=None, expect_error=False):
+    j = json.loads(curl(method, path, token=token, body=body))
+    if expect_error:
+        assert j.get("error") is True, f"{method} {path}: expected error, got {j}"
+    else:
+        assert j.get("error") is False, f"{method} {path}: {j.get('message')}"
+    return j.get("message")
+
+
+def login(loginname, password):
+    return api("POST", "auth/basic/login", body={"loginname": loginname, "password": password})
+
+
+def names(items):
+    return [i.get("name") for i in items]
+
+
+def gradient(args):
+    return machine.succeed(f"gradient {args}")
+
 
 start_all()
 machine.wait_for_unit("gradient-server.service")
 machine.wait_for_unit("nginx.service")
+machine.wait_for_open_port(3000)
 machine.wait_for_open_port(80)
 
-with subtest("check service started successfully with state"):
+with subtest("state applied at startup"):
     machine.succeed("systemctl is-active gradient-server.service")
-    time.sleep(2)
-
     logs = machine.succeed("journalctl -u gradient-server.service --no-pager")
     assert "Loading state configuration" in logs, "Should load state configuration"
     assert "State configuration validated successfully" in logs, "Should validate state"
     assert "State applied successfully" in logs, "Should apply state successfully"
 
-with subtest("check state-managed API keys work"):
-    alice_token = "GRADa1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6A7B8C9D0E1F2G3"
+with subtest("state-managed API key authenticates"):
+    api("GET", "orgs", token=ALICE)
 
-    req = json.loads(machine.succeed("""
-        curl -XGET http://gradient.local/api/v1/orgs -H 'Authorization: Bearer alice_token' -H 'Content-Type: application/json'
-    """.replace("alice_token", alice_token)))
+with subtest("state-managed organizations exist"):
+    orgs = api("GET", "orgs", token=ALICE).get("items")
+    assert "corp" in names(orgs), f"corp organization missing. Found: {names(orgs)}"
 
-    assert req.get("error") == False, f"API key authentication failed: {req.get('message')}"
-    alice_token_to_use = alice_token
+with subtest("state-managed projects exist"):
+    projects = api("GET", "projects/corp", token=ALICE).get("items")
+    assert "web-app" in names(projects), f"web-app missing. Found: {names(projects)}"
+    assert "mobile-app" in names(projects), f"mobile-app missing. Found: {names(projects)}"
 
-with subtest("check state-managed organizations exist"):
-    req = json.loads(machine.succeed("""
-        curl -XGET http://gradient.local/api/v1/orgs -H 'Authorization: Bearer alice_token' -H 'Content-Type: application/json'
-    """.replace("alice_token", alice_token_to_use)))
+with subtest("state-managed caches exist"):
+    caches = api("GET", "caches", token=ALICE)
+    assert "main" in names(caches), f"main missing. Found: {names(caches)}"
+    assert "dev" in names(caches), f"dev missing. Found: {names(caches)}"
 
-    assert req.get("error") == False, f"Failed to get organizations: {req.get('message')}"
-    orgs = req.get("message").get("items")
+with subtest("org member can view subscribed caches they do not own"):
+    # bob is a plain 'corp' member who created none of the caches and holds no
+    # cache membership. 'corp' subscribes to both caches, so they must be both
+    # listable and viewable by name - active ('main') and inactive ('dev') alike.
+    # Regression: detail lookups used to demand a direct cache membership, so an
+    # org member got a 404 from the API, the `gradient` CLI and the WebUI.
+    bob = login("bob", "bob_password")
+    listed = names(api("GET", "caches", token=bob))
+    for name in ["main", "dev"]:
+        assert name in listed, f"org member should list '{name}'. Found: {listed}"
+        shown = api("GET", f"caches/{name}", token=bob)
+        assert shown.get("name") == name, f"show returned wrong cache: {shown}"
 
-    corp_org = None
-    for org in orgs:
-        if org.get("name") == "corp":
-            corp_org = org
-            break
+    # The reporter's exact reproduction path: `gradient cache show <name>`.
+    gradient("config Server http://gradient.local")
+    gradient(f"config AuthToken {bob}")
+    gradient("organization select corp")
+    assert "main" in gradient("cache show main"), "`gradient cache show main` should succeed"
 
-    assert corp_org is not None, "corp organization should exist"
-    assert corp_org.get("name") == "corp", f"Wrong organization name: {corp_org.get('name')}"
+with subtest("non-members cannot see private caches"):
+    # charlie belongs to no organization that subscribes to the caches, so the
+    # broadened read access must not leak them - neither listed nor viewable.
+    api("POST", "auth/basic/register", body={
+        "username": "charlie", "name": "Charlie Brown",
+        "email": "charlie@example.com", "password": "SecureAuth456$",
+    })
+    charlie = login("charlie", "SecureAuth456$")
+    assert "main" not in names(api("GET", "caches", token=charlie)), "private cache leaked in list"
+    api("GET", "caches/main", token=charlie, expect_error=True)
 
-with subtest("check state-managed projects exist"):
-    req = json.loads(machine.succeed("""
-        curl -XGET http://gradient.local/api/v1/projects/corp -H 'Authorization: Bearer alice_token' -H 'Content-Type: application/json'
-    """.replace("alice_token", alice_token_to_use)))
+with subtest("managed entities are read-only"):
+    api("POST", "auth/basic/register", expect_error=True, body={
+        "username": "alice", "name": "Alice Modified",
+        "email": "alice.modified@example.com", "password": "StrongSecret123!",
+    })
 
-    assert req.get("error") == False, f"Failed to get projects: {req.get('message')}"
-    projects = req.get("message").get("items")
-
-    project_names = [p.get("name") for p in projects]
-    assert "web-app" in project_names, f"web-app project missing. Found: {project_names}"
-    assert "mobile-app" in project_names, f"mobile-app project missing. Found: {project_names}"
-
-with subtest("check state-managed caches exist"):
-    req = json.loads(machine.succeed("""
-        curl -XGET http://gradient.local/api/v1/caches -H 'Authorization: Bearer alice_token' -H 'Content-Type: application/json'
-    """.replace("alice_token", alice_token_to_use)))
-
-    assert req.get("error") == False, f"Failed to get caches: {req.get('message')}"
-    caches = req.get("message")
-
-    cache_names = [c.get("name") for c in caches]
-    assert "main" in cache_names, f"main missing. Found: {cache_names}"
-    assert "dev" in cache_names, f"dev missing. Found: {cache_names}"
-
-with subtest("check managed entities are read-only"):
-    # Try to register with an existing state-managed username
-    req = json.loads(machine.succeed("""
-        curl -XPOST http://gradient.local/api/v1/auth/basic/register -H 'Content-Type: application/json' -d '{"username": "alice", "name": "Alice Modified", "email": "alice.modified@example.com", "password": "StrongSecret123!"}'
-    """))
-
-    assert req.get("error") == True, "Should not be able to register with a state-managed username"
-
-with subtest("check non-managed users can still be created"):
-    req = json.loads(machine.succeed("""
-        curl -XPOST http://gradient.local/api/v1/auth/basic/register -H 'Content-Type: application/json' -d '{"username": "charlie", "name": "Charlie Brown", "email": "charlie@example.com", "password": "SecureAuth456$"}'
-    """))
-
-    assert req.get("error") == False, f"Should be able to create non-managed user: {req.get('message')}"
-
-    req = json.loads(machine.succeed("""
-        curl -XPOST http://gradient.local/api/v1/auth/basic/login -H 'Content-Type: application/json' -d '{"loginname": "charlie", "password": "SecureAuth456$"}'
-    """))
-
-    assert req.get("error") == False, f"Charlie login failed: {req.get('message')}"
-
-with subtest("check organization SSH keys work"):
-    req = json.loads(machine.succeed("""
-        curl -XGET http://gradient.local/api/v1/orgs/corp/ssh -H 'Authorization: Bearer alice_token' -H 'Content-Type: application/json'
-    """.replace("alice_token", alice_token_to_use)))
-
-    assert req.get("error") == False, f"Failed to get SSH key: {req.get('message')}"
-    ssh_key = req.get("message")
-
+with subtest("organization SSH keys work"):
+    ssh_key = api("GET", "orgs/corp/ssh", token=ALICE)
     assert ssh_key.startswith("ssh-ed25519 "), f"Invalid SSH key format: {ssh_key[:50]}..."
 
 print("All state management tests passed successfully!")


### PR DESCRIPTION
Fixes #327.

## Problem

A cache created via `services.gradient.state` is usable through its subscribed organizations and shows up in `gradient cache list`, but `gradient cache show <name>` (and the WebUI / `GET /caches/{cache}`) returns `404 Cache not found`.

The two endpoints used inconsistent visibility rules:

- **`GET /caches` (list)** returns caches the user created **or** that are subscribed by an org the user belongs to.
- **`GET /caches/{cache}` (show)** via `load_cache(Readable)` only allowed **public** caches or **direct `cache_user` members**.

State provisioning subscribes the listed orgs to the cache but only adds the `created_by` user as a `cache_user`. So any other member of a subscribed org can *list* the cache but gets a 404 on *show*.

## Fix

`load_cache` (Readable) now also grants read access to members of any organization subscribed to the cache, mirroring `GET /caches`. The inbound/outbound API-key org pin is respected. Edit/management paths are unchanged, `can_edit` and `Require`/`Member` access still demand a real cache role.

## Tests

Extended the state NixOS integration test (`nix/tests/gradient/state`), the documented home for full state round-trips, and refactored it to use small `api`/`login`/`gradient` helpers:

- **org member can view subscribed caches they do not own**: `bob` (a plain `corp` member who created none of the caches) lists *and* shows both the active `main` and inactive `dev` caches, including via `gradient cache show` (the reporter's exact path).
- **non-members cannot see private caches**: `charlie` (no subscribing org) neither lists nor can show the private caches, pinning that the broadened access doesn't leak.