### PR TITLE
Fix issue #303: minor frontend issues

### DIFF
--- a/backend/core/src/db/status.rs
+++ b/backend/core/src/db/status.rs
@@ -156,6 +156,7 @@ pub async fn update_build_status(
             if matches!(
                 updated_build.status,
                 BuildStatus::Completed
+                    | BuildStatus::Substituted
                     | BuildStatus::FailedPermanent
                     | BuildStatus::FailedTimeout
                     | BuildStatus::Aborted

--- a/backend/core/src/state_machine/build.rs
+++ b/backend/core/src/state_machine/build.rs
@@ -31,7 +31,7 @@ impl std::error::Error for InvalidBuildTransition {}
 /// ```text
 /// Created → Queued
 /// Queued  → Building
-/// Building → Completed | FailedPermanent | FailedTransient | FailedTimeout
+/// Building → Completed | Substituted | FailedPermanent | FailedTransient | FailedTimeout
 /// FailedTransient → Queued | FailedPermanent
 /// * → Aborted          (except terminal states)
 /// * → DependencyFailed (except terminal states)
@@ -73,6 +73,7 @@ impl BuildStateMachine {
             (_, BuildStatus::FailedTransient) => Ok(to),
             (_, BuildStatus::FailedTimeout) => Ok(to),
             (_, BuildStatus::Completed) => Ok(to),
+            (_, BuildStatus::Substituted) => Ok(to),
             (_, BuildStatus::Aborted) => Ok(to),
             (_, BuildStatus::DependencyFailed) => Ok(to),
 
@@ -111,6 +112,13 @@ mod tests {
     #[test]
     fn build_sm_building_to_completed() {
         assert!(BuildStateMachine::validate(BuildStatus::Building, BuildStatus::Completed).is_ok());
+    }
+
+    #[test]
+    fn build_sm_building_to_substituted() {
+        assert!(
+            BuildStateMachine::validate(BuildStatus::Building, BuildStatus::Substituted).is_ok()
+        );
     }
 
     #[test]

--- a/backend/core/src/types/proto.rs
+++ b/backend/core/src/types/proto.rs
@@ -170,6 +170,9 @@ pub enum JobUpdateKind {
         /// disabled. A multi-build job yields one `BuildOutput` (and thus one
         /// metrics record) per build.
         metrics: Option<BuildMetrics>,
+        /// True when the daemon reported the outputs as already valid (no work
+        /// performed) - the build is finalized as `Substituted`, not `Completed`.
+        substituted: bool,
     },
     Compressing,
 }

--- a/backend/proto/src/handler/dispatch.rs
+++ b/backend/proto/src/handler/dispatch.rs
@@ -549,10 +549,11 @@ impl<'a> DispatchContext<'a> {
                 build_id,
                 outputs,
                 metrics,
+                substituted,
             } => {
                 if let Err(e) = self
                     .scheduler
-                    .handle_build_output(&job_id, &build_id, outputs, metrics)
+                    .handle_build_output(&job_id, &build_id, outputs, metrics, substituted)
                     .await
                 {
                     error!(peer_id = %self.peer_id, %job_id, error = %e, "handle_build_output failed");

--- a/backend/proto/src/tests.rs
+++ b/backend/proto/src/tests.rs
@@ -294,6 +294,7 @@ fn build_output_with_metrics_roundtrip() {
                 oom_killed: true,
                 build_time_ms: Some(120_000),
             }),
+            substituted: false,
         },
     };
     let bytes = rkyv::to_bytes::<RkyvError>(&original).unwrap();
@@ -309,6 +310,7 @@ fn build_output_no_metrics_roundtrip() {
             build_id: "build-2".to_string(),
             outputs: vec![],
             metrics: None,
+            substituted: true,
         },
     };
     let bytes = rkyv::to_bytes::<RkyvError>(&original).unwrap();

--- a/backend/proto/src/traits.rs
+++ b/backend/proto/src/traits.rs
@@ -83,6 +83,7 @@ pub trait JobReporter: Send {
         build_id: String,
         outputs: Vec<BuildOutput>,
         metrics: Option<BuildMetrics>,
+        substituted: bool,
     ) -> Result<()>;
     async fn report_compressing(&mut self) -> Result<()>;
     async fn send_log_chunk(&mut self, task_index: u32, data: Vec<u8>) -> Result<()>;

--- a/backend/scheduler/src/build.rs
+++ b/backend/scheduler/src/build.rs
@@ -85,6 +85,7 @@ impl<'a> BuildStateHandler<'a> {
         build_id: BuildId,
         outputs: Vec<BuildOutput>,
         metrics: Option<BuildMetrics>,
+        substituted: bool,
     ) -> Result<()> {
         let mut build = EBuild::find_by_id(build_id)
             .one(&self.state.worker_db)
@@ -155,6 +156,14 @@ impl<'a> BuildStateHandler<'a> {
         }
 
         info!(%build_id, output_count = outputs.len(), "build outputs recorded");
+
+        // The daemon found the outputs already valid - no build ran. Mark the
+        // build `Substituted` here so the later `JobCompleted` finalizes it as
+        // such instead of `Completed` (issue #303).
+        if substituted {
+            update_build_status(Arc::clone(self.state), build, BuildStatus::Substituted).await;
+        }
+
         Ok(())
     }
 
@@ -173,8 +182,15 @@ impl<'a> BuildStateHandler<'a> {
         let derivation_id = build.derivation;
         let was_external_cached = build.external_cached;
 
-        let leader =
-            update_build_status(Arc::clone(self.state), build, BuildStatus::Completed).await;
+        // `handle_build_output` already moved the build to `Substituted` when the
+        // outputs were found already valid; preserve that terminal state instead
+        // of overwriting it with `Completed`.
+        let terminal = if build.status == BuildStatus::Substituted {
+            BuildStatus::Substituted
+        } else {
+            BuildStatus::Completed
+        };
+        let leader = update_build_status(Arc::clone(self.state), build, terminal).await;
         self.propagate_to_followers(&leader).await?;
 
         if was_external_cached {
@@ -791,9 +807,10 @@ pub async fn handle_build_output(
     build_id: BuildId,
     outputs: Vec<BuildOutput>,
     metrics: Option<BuildMetrics>,
+    substituted: bool,
 ) -> Result<()> {
     BuildStateHandler::new(state)
-        .handle_build_output(job, build_id, outputs, metrics)
+        .handle_build_output(job, build_id, outputs, metrics, substituted)
         .await
 }
 

--- a/backend/scheduler/src/handler_tests.rs
+++ b/backend/scheduler/src/handler_tests.rs
@@ -777,6 +777,44 @@ async fn build_completed_last_build_completes_eval() {
     assert!(result.is_ok());
 }
 
+/// A build already moved to `Substituted` by `handle_build_output` keeps that
+/// terminal status on completion instead of being overwritten with `Completed`.
+#[tokio::test]
+async fn build_completed_preserves_substituted_status() {
+    let eval_id = EvaluationId::now_v7();
+    let drv_id = DerivationId::now_v7();
+    let build_id = BuildId::now_v7();
+
+    let build = make_build(build_id, eval_id, drv_id, BuildStatus::Substituted);
+
+    let db = MockDatabase::new(DatabaseBackend::Postgres)
+        // 1. find_by_id(build) → Substituted (already terminal)
+        .append_query_results([vec![build]])
+        // update_build_status sees from == to and skips the UPDATE entirely.
+        // 2. propagate_to_followers: find via=leader.id → empty
+        .append_query_results([Vec::<MBuild>::new()])
+        // 3. find active builds → empty
+        .append_query_results([Vec::<MBuild>::new()])
+        // 4. find_by_id(eval) → Building
+        .append_query_results([vec![make_eval(eval_id, EvaluationStatus::Building)]])
+        // 5. find failed builds → empty
+        .append_query_results([Vec::<MBuild>::new()])
+        // 6. find eval error messages → empty
+        .append_query_results([Vec::<MEvaluationMessage>::new()])
+        // 7. update_many eval → Completed
+        .append_exec_results([MockExecResult {
+            last_insert_id: 0,
+            rows_affected: 1,
+        }])
+        // 8. find_by_id(eval) → Completed
+        .append_query_results([vec![make_eval(eval_id, EvaluationStatus::Completed)]])
+        .into_connection();
+
+    let state = make_state(db);
+    let result = build_handler::handle_build_job_completed(&state, build_id).await;
+    assert!(result.is_ok());
+}
+
 /// When active builds remain, check_evaluation_done returns early (eval stays Building).
 #[tokio::test]
 async fn build_completed_with_remaining_active() {
@@ -1249,7 +1287,7 @@ async fn build_output_updates_derivation_output() {
     let state = make_state(db);
     let job = make_build_job(build_id, eval_id, org_id);
 
-    let result = build_handler::handle_build_output(&state, &job, build_id, outputs, None).await;
+    let result = build_handler::handle_build_output(&state, &job, build_id, outputs, None, false).await;
     assert!(result.is_ok());
 }
 
@@ -1327,7 +1365,7 @@ async fn build_output_with_metrics_records_one_metric_row() {
     let state = make_state(db);
     let job = make_build_job(build_id, eval_id, org_id);
 
-    let result = build_handler::handle_build_output(&state, &job, build_id, outputs, metrics).await;
+    let result = build_handler::handle_build_output(&state, &job, build_id, outputs, metrics, false).await;
     assert!(result.is_ok(), "expected Ok, got: {:?}", result.err());
 }
 
@@ -1361,7 +1399,7 @@ async fn build_output_missing_row_warns_not_errors() {
     let state = make_state(db);
     let job = make_build_job(build_id, eval_id, org_id);
 
-    let result = build_handler::handle_build_output(&state, &job, build_id, outputs, None).await;
+    let result = build_handler::handle_build_output(&state, &job, build_id, outputs, None, false).await;
     assert!(result.is_ok());
 }
 
@@ -1440,7 +1478,7 @@ async fn build_output_inserts_build_product_rows() {
     let state = make_state(db);
     let job = make_build_job(build_id, eval_id, org_id);
 
-    let result = build_handler::handle_build_output(&state, &job, build_id, outputs, None).await;
+    let result = build_handler::handle_build_output(&state, &job, build_id, outputs, None, false).await;
     assert!(result.is_ok(), "expected Ok, got: {:?}", result.err());
 }
 
@@ -1458,7 +1496,7 @@ async fn build_output_unknown_build_errors() {
     let state = make_state(db);
     let job = make_build_job(build_id, eval_id, org_id);
 
-    let result = build_handler::handle_build_output(&state, &job, build_id, vec![], None).await;
+    let result = build_handler::handle_build_output(&state, &job, build_id, vec![], None, false).await;
     assert!(result.is_err());
 }
 

--- a/backend/scheduler/src/job_handlers.rs
+++ b/backend/scheduler/src/job_handlers.rs
@@ -337,6 +337,7 @@ impl Scheduler {
         build_id_str: &str,
         outputs: Vec<BuildOutput>,
         metrics: Option<BuildMetrics>,
+        substituted: bool,
     ) -> Result<()> {
         let build_id: BuildId = build_id_str
             .parse()
@@ -353,7 +354,7 @@ impl Scheduler {
                 }
             }
         };
-        build::handle_build_output(&self.state, &job, build_id, outputs, metrics).await
+        build::handle_build_output(&self.state, &job, build_id, outputs, metrics, substituted).await
     }
 
     // ── Job completion ────────────────────────────────────────────────────────

--- a/backend/test-support/src/fakes/job_reporter.rs
+++ b/backend/test-support/src/fakes/job_reporter.rs
@@ -34,6 +34,7 @@ pub enum ReportedEvent {
         build_id: String,
         outputs: Vec<BuildOutput>,
         metrics: Option<BuildMetrics>,
+        substituted: bool,
     },
     Compressing,
     LogChunk {
@@ -200,11 +201,13 @@ impl JobReporter for RecordingJobReporter {
         build_id: String,
         outputs: Vec<BuildOutput>,
         metrics: Option<BuildMetrics>,
+        substituted: bool,
     ) -> Result<()> {
         self.events.push(ReportedEvent::BuildOutput {
             build_id,
             outputs,
             metrics,
+            substituted,
         });
         Ok(())
     }

--- a/backend/web/src/endpoints/evals/query.rs
+++ b/backend/web/src/endpoints/evals/query.rs
@@ -195,12 +195,17 @@ pub async fn get_evaluation_builds(
             leaders.insert(row.id, row);
         }
     }
+    // Multiple followers can share one leader; after substituting leaders for
+    // followers the same leader row would appear several times. Dedup by id so
+    // the sidebar never renders a build twice (issue #303).
+    let mut seen_ids: HashSet<BuildId> = HashSet::new();
     let builds: Vec<MBuild> = raw_builds
         .into_iter()
         .map(|b| match b.via.and_then(|id| leaders.get(&id)) {
             Some(leader) => leader.clone(),
             None => b,
         })
+        .filter(|b| seen_ids.insert(b.id))
         .collect();
 
     // Distinct derivations referenced by builds. Deduping cuts the IN-list down

--- a/backend/worker/src/executor/build.rs
+++ b/backend/worker/src/executor/build.rs
@@ -259,9 +259,10 @@ impl ParsedDerivation {
     /// outputs.
     ///
     /// Streams build log lines to the server via `updater` while the daemon is
-    /// running.  Returns one [`BuildOutput`] per output name; `nar_size` and
-    /// `nar_hash` are `None` at this stage and are filled in by the compress
-    /// step.
+    /// running.  Returns one [`BuildOutput`] per output name (`nar_size` and
+    /// `nar_hash` are `None` at this stage, filled in by the compress step)
+    /// plus a `substituted` flag - true when the daemon reported the outputs as
+    /// already valid (empty `built_outputs`), i.e. no work was performed.
     #[allow(clippy::too_many_arguments)]
     pub(super) async fn realize(
         self,
@@ -273,7 +274,7 @@ impl ParsedDerivation {
         abort: &mut watch::Receiver<bool>,
         log_limits: crate::executor::log_limit::LogRateLimits,
         log_fetch_from_store: bool,
-    ) -> Result<Vec<BuildOutput>, BuildError> {
+    ) -> Result<(Vec<BuildOutput>, bool), BuildError> {
         let mut guard = store.scoped().await.map_err(BuildError::transient)?;
 
         debug!(
@@ -361,7 +362,8 @@ impl ParsedDerivation {
                         drv_path
                     )));
                 }
-                if s.built_outputs.is_empty() {
+                let substituted = s.built_outputs.is_empty();
+                if substituted {
                     debug!(
                         drv = %drv_path,
                         recovered = pairs.len(),
@@ -387,7 +389,7 @@ impl ParsedDerivation {
                         products,
                     });
                 }
-                Ok(outputs)
+                Ok((outputs, substituted))
             }
 
             BuildResultInner::Failure(f) => {
@@ -509,7 +511,7 @@ pub async fn build_derivation(
     );
 
     let started = std::time::Instant::now();
-    let realize_result: Result<Vec<BuildOutput>, BuildError> =
+    let realize_result: Result<(Vec<BuildOutput>, bool), BuildError> =
         match task.timeout_secs.map(std::time::Duration::from_secs) {
             Some(d) => match tokio::time::timeout(d, realize).await {
                 Ok(r) => r,
@@ -527,9 +529,9 @@ pub async fn build_derivation(
     let build_time_ms = started.elapsed().as_millis() as u64;
     let metrics = capture_build_metrics(build_metrics, cgroup_root, &task.drv_path, build_time_ms);
 
-    let outputs = realize_result?;
+    let (outputs, substituted) = realize_result?;
     updater
-        .report_build_output(task.build_id.clone(), outputs.clone(), Some(metrics))
+        .report_build_output(task.build_id.clone(), outputs.clone(), Some(metrics), substituted)
         .map_err(BuildError::transient)?;
     Ok(outputs)
 }

--- a/backend/worker/src/executor/mod.rs
+++ b/backend/worker/src/executor/mod.rs
@@ -342,7 +342,7 @@ impl JobExecutor {
                                 products,
                             });
                         }
-                        updater.report_build_output(build_task.build_id.clone(), reported, None)?;
+                        updater.report_build_output(build_task.build_id.clone(), reported, None, false)?;
                         for (_, p) in &outputs {
                             gc_handles.push(self.gcroots.add(p).await);
                         }

--- a/backend/worker/src/proto/job.rs
+++ b/backend/worker/src/proto/job.rs
@@ -168,11 +168,13 @@ impl JobUpdater {
         build_id: String,
         outputs: Vec<BuildOutput>,
         metrics: Option<BuildMetrics>,
+        substituted: bool,
     ) -> Result<()> {
         self.send_update(JobUpdateKind::BuildOutput {
             build_id,
             outputs,
             metrics,
+            substituted,
         })
     }
 
@@ -344,11 +346,13 @@ impl JobReporter for JobUpdater {
         build_id: String,
         outputs: Vec<BuildOutput>,
         metrics: Option<BuildMetrics>,
+        substituted: bool,
     ) -> Result<()> {
         self.send_update(JobUpdateKind::BuildOutput {
             build_id,
             outputs,
             metrics,
+            substituted,
         })
     }
 

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -7167,7 +7167,7 @@ components:
           description: Full derivation store path
         status:
           type: string
-          description: Build status string (e.g. `"Queued"`, `"Building"`, `"Succeeded"`)
+          description: Build status string (e.g. `"Queued"`, `"Building"`, `"Completed"`, `"Substituted"`)
         updated_at:
           type: string
           format: date-time
@@ -7355,7 +7355,7 @@ components:
 
     BuildStatus:
       type: string
-      enum: [Queued, Building, Succeeded, FailedPermanent, FailedTransient, FailedTimeout, Cancelled]
+      enum: [Queued, Building, Completed, Substituted, FailedPermanent, FailedTransient, FailedTimeout, Aborted, DependencyFailed]
       description: |-
         Current state of a single build.
 
@@ -7363,16 +7363,18 @@ components:
         |---|---|---|
         | `Queued` | No | Waiting to be dispatched to a worker |
         | `Building` | No | Actively executing on a worker |
-        | `Succeeded` | Yes | Build completed successfully |
+        | `Completed` | Yes | Build executed successfully |
+        | `Substituted` | Yes | Outputs were already present (in the local store or pre-evaluated); no build ran |
         | `FailedPermanent` | Yes | Builder exited non-zero; no retry will be attempted |
         | `FailedTransient` | No | Transient failure (OOM, disk full, network error); an automatic retry is pending |
         | `FailedTimeout` | Yes | Exceeded the wall-clock or silent-output timeout |
-        | `Cancelled` | Yes | Cancelled by user or dependency failure |
+        | `Aborted` | Yes | Cancelled by user |
+        | `DependencyFailed` | Yes | A dependency build failed, so this build was not attempted |
 
         `FailedTransient` is non-terminal: the scheduler will re-queue the build
         automatically. Treat it as in-progress when deciding whether an evaluation
         has finished. The frontend renders `FailedPermanent`, `FailedTransient`, and
-        `FailedTimeout` all as "Failed".
+        `FailedTimeout` all as "Failed", and `Completed`/`Substituted` both as success.
 
     Architecture:
       type: string

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -1886,6 +1886,25 @@ Tests (`cargo test -p scheduler --tests substitut`):
   eval completes without dispatching a build. Confirms the hash-based
   fallback in `compute_truly_substituted`.
 
+## Substituted at build time - outputs already valid on the worker (#303)
+
+When the daemon reports a build's outputs as already valid (empty
+`built_outputs`), no build actually ran. The worker now sets the
+`substituted` flag on its `BuildOutput` job update; `handle_build_output`
+moves the build to `Substituted`, and `handle_build_job_completed`
+preserves that terminal status instead of overwriting it with `Completed`.
+This is distinct from eval-time `compute_truly_substituted` (above), which
+covers outputs already cached before evaluation.
+
+Tests:
+
+- `build_sm_building_to_substituted` (`core`) - the `Building → Substituted`
+  transition is permitted by the state machine.
+- `build_completed_preserves_substituted_status` (`scheduler`) - a build
+  already moved to `Substituted` keeps that status on `JobCompleted`; the
+  `from == to` transition skips the build UPDATE and the evaluation still
+  finalises as `Completed`.
+
 ## Scheduler policy - anti-starvation cap (#112)
 
 `WaitTimeRule::max_wait_secs` caps how much wait time can contribute to a
@@ -3182,6 +3201,9 @@ Run with: `cargo test -p core --lib state_machine::build`
   and `FailedTimeout` are terminal; no outgoing transitions are accepted.
 - `build_sm_terminal_failure_rejects_requeue` — attempting to transition
   either terminal failure status back to `Queued` is rejected.
+- `build_sm_building_to_substituted` — `Building → Substituted` is valid, so
+  a worker that finds the outputs already valid can finalize the build as
+  `Substituted` rather than `Completed` (issue #303).
 
 ### Retry decision and backoff — `scheduler/src/build.rs`
 

--- a/frontend/src/app/core/services/evaluations.service.ts
+++ b/frontend/src/app/core/services/evaluations.service.ts
@@ -60,6 +60,19 @@ export interface BuildItem {
   build_time_ms: number | null;
 }
 
+export interface BuildWithOutputs {
+  id: string;
+  evaluation: string;
+  status: string;
+  derivation_path: string;
+  architecture: string;
+  worker: string | null;
+  via: string | null;
+  output: Record<string, string>;
+  created_at: string;
+  updated_at: string;
+}
+
 export interface PaginatedBuilds {
   builds: BuildItem[];
   total: number;
@@ -104,6 +117,10 @@ export class EvaluationsService {
     if (offset !== undefined) params.push(`offset=${offset}`);
     const query = params.length > 0 ? `?${params.join('&')}` : '';
     return this.api.get<PaginatedBuilds>(`evals/${evaluationId}/builds${query}`);
+  }
+
+  getBuild(buildId: string): Observable<BuildWithOutputs> {
+    return this.api.get<BuildWithOutputs>(`builds/${buildId}`);
   }
 
   getBuildLog(buildId: string): Observable<string> {

--- a/frontend/src/app/features/auth/login/login.component.html
+++ b/frontend/src/app/features/auth/login/login.component.html
@@ -64,16 +64,13 @@
         </div>
 
         <button
+          pButton
           type="submit"
-          class="btn-primary"
+          class="w-full"
+          [label]="loading() ? 'Signing in...' : 'Sign In'"
+          [loading]="loading()"
           [disabled]="!loginForm.valid || loading()"
-        >
-          @if (loading()) {
-            <span>Signing in...</span>
-          } @else {
-            <span>Sign In</span>
-          }
-        </button>
+        ></button>
       </form>
     }
 
@@ -83,10 +80,15 @@
           <span>OR</span>
         </div>
       }
-      <button type="button" class="btn-secondary" (click)="loginWithOIDC()">
-        <span class="material-symbols-outlined">login</span>
-        Sign in with SSO
-      </button>
+      <button
+        pButton
+        type="button"
+        class="w-full"
+        severity="secondary"
+        icon="pi pi-sign-in"
+        label="Sign in with SSO"
+        (click)="loginWithOIDC()"
+      ></button>
     }
 
     @if (!registrationDisabled) {

--- a/frontend/src/app/features/auth/login/login.component.scss
+++ b/frontend/src/app/features/auth/login/login.component.scss
@@ -147,49 +147,9 @@
   }
 }
 
-.btn-primary,
-.btn-secondary {
+.w-full {
   width: 100%;
-  padding: $spacing-md;
-  border-radius: $border-radius-sm;
-  font-size: $font-size-md;
-  font-weight: 500;
-  cursor: pointer;
-  transition: $transition-fast;
-  display: flex;
-  align-items: center;
   justify-content: center;
-  gap: $spacing-sm;
-
-  &:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-}
-
-.btn-primary {
-  background-color: $text-primary;
-  color: $color-primary;
-  border: none;
-
-  &:hover:not(:disabled) {
-    background-color: $text-secondary;
-  }
-}
-
-.btn-secondary {
-  background-color: $color-quaternary;
-  border: 1px solid $color-border;
-  color: $text-primary;
-
-  &:hover {
-    background-color: $color-hover;
-    border-color: $text-secondary;
-  }
-
-  .material-symbols-outlined {
-    font-size: 20px;
-  }
 }
 
 .auth-divider {

--- a/frontend/src/app/features/auth/login/login.component.ts
+++ b/frontend/src/app/features/auth/login/login.component.ts
@@ -8,6 +8,7 @@ import { Component, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { ButtonModule } from 'primeng/button';
 import { AuthService } from '@core/services/auth.service';
 import { ConfigService } from '@core/services/config.service';
 import { take } from 'rxjs';
@@ -16,7 +17,7 @@ import { environment } from '@environments/environment';
 @Component({
   selector: 'app-login',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, RouterModule],
+  imports: [CommonModule, ReactiveFormsModule, RouterModule, ButtonModule],
   templateUrl: './login.component.html',
   styleUrl: './login.component.scss',
 })

--- a/frontend/src/app/features/auth/register/register.component.html
+++ b/frontend/src/app/features/auth/register/register.component.html
@@ -17,10 +17,14 @@
         <span class="material-symbols-outlined">lock</span>
         <p>This server requires SSO sign-in. Use the button below to create or access your account.</p>
       </div>
-      <button type="button" class="btn-primary" (click)="loginWithOIDC()">
-        <span class="material-symbols-outlined">login</span>
-        Continue with SSO
-      </button>
+      <button
+        pButton
+        type="button"
+        class="w-full"
+        icon="pi pi-sign-in"
+        label="Continue with SSO"
+        (click)="loginWithOIDC()"
+      ></button>
       <div class="auth-footer">
         Already have an account?
         <a routerLink="/account/login">Sign in</a>
@@ -184,16 +188,13 @@
           </div>
 
           <button
+            pButton
             type="submit"
-            class="btn-primary"
+            class="w-full"
+            [label]="loading() ? 'Creating account...' : 'Create Account'"
+            [loading]="loading()"
             [disabled]="!registerForm.valid || loading()"
-          >
-            @if (loading()) {
-              <span>Creating account...</span>
-            } @else {
-              <span>Create Account</span>
-            }
-          </button>
+          ></button>
         </form>
 
         <div class="auth-footer">

--- a/frontend/src/app/features/auth/register/register.component.scss
+++ b/frontend/src/app/features/auth/register/register.component.scss
@@ -177,30 +177,9 @@
   }
 }
 
-.btn-primary {
+.w-full {
   width: 100%;
-  padding: $spacing-md;
-  border-radius: $border-radius-sm;
-  font-size: $font-size-md;
-  font-weight: 500;
-  cursor: pointer;
-  transition: $transition-fast;
-  display: flex;
-  align-items: center;
   justify-content: center;
-  gap: $spacing-sm;
-  background-color: $text-primary;
-  color: $color-primary;
-  border: none;
-
-  &:hover:not(:disabled) {
-    background-color: $text-secondary;
-  }
-
-  &:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
 }
 
 .auth-blocked {

--- a/frontend/src/app/features/auth/register/register.component.ts
+++ b/frontend/src/app/features/auth/register/register.component.ts
@@ -15,6 +15,7 @@ import {
   ValidationErrors,
 } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
+import { ButtonModule } from 'primeng/button';
 import { AuthService } from '@core/services/auth.service';
 import { ConfigService } from '@core/services/config.service';
 import { environment } from '@environments/environment';
@@ -24,7 +25,7 @@ import { of, timer } from 'rxjs';
 @Component({
   selector: 'app-register',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, RouterModule],
+  imports: [CommonModule, ReactiveFormsModule, RouterModule, ButtonModule],
   templateUrl: './register.component.html',
   styleUrl: './register.component.scss',
 })

--- a/frontend/src/app/features/caches/cache-nars/cache-nars.component.html
+++ b/frontend/src/app/features/caches/cache-nars/cache-nars.component.html
@@ -35,11 +35,11 @@
       </div>
       <div class="stat-card">
         <span class="stat-label">Last uploaded</span>
-        <span class="stat-value small">{{ s.last_uploaded_at ?? '-' }}</span>
+        <span class="stat-value small">{{ formatDate(s.last_uploaded_at) }}</span>
       </div>
       <div class="stat-card">
         <span class="stat-label">Oldest fetched</span>
-        <span class="stat-value small">{{ s.oldest_fetched_at ?? '-' }}</span>
+        <span class="stat-value small">{{ formatDate(s.oldest_fetched_at) }}</span>
       </div>
     </div>
   }
@@ -53,16 +53,7 @@
       <label for="filter-package">Package</label>
       <input pInputText id="filter-package" [ngModel]="package()" (ngModelChange)="package.set($event)" placeholder="package name" class="w-full" (keydown.enter)="applyFilters()" />
     </div>
-    <div class="filter-group">
-      <label for="filter-sort">Sort by</label>
-      <select id="filter-sort" [ngModel]="sort()" (ngModelChange)="setSort($event)" class="role-select w-full">
-        @for (o of sortOptions; track o.value) {
-          <option [value]="o.value">{{ o.label }}</option>
-        }
-      </select>
-    </div>
     <div class="filter-actions">
-      <button pButton type="button" [icon]="order() === 'asc' ? 'pi pi-sort-amount-up' : 'pi pi-sort-amount-down'" severity="secondary" (click)="toggleOrder()" [title]="order() === 'asc' ? 'Ascending' : 'Descending'"></button>
       <button pButton type="button" label="Apply" icon="pi pi-filter" (click)="applyFilters()"></button>
       <button pButton type="button" label="Reset" severity="secondary" (click)="reset()"></button>
     </div>
@@ -88,9 +79,25 @@
       <div class="nar-row nar-head">
         <span class="col col-hash">Hash</span>
         <span class="col col-package">Package</span>
-        <span class="col col-size">NAR size</span>
+        <span class="col col-size sortable" (click)="sortBy('nar_size')">
+          NAR size
+          @if (sort() === 'nar_size') {
+            <i class="pi" [class.pi-sort-amount-up]="order() === 'asc'" [class.pi-sort-amount-down]="order() === 'desc'"></i>
+          }
+        </span>
         <span class="col col-size">File size</span>
-        <span class="col col-time">Last fetched</span>
+        <span class="col col-time sortable" (click)="sortBy('created_at')">
+          Created
+          @if (sort() === 'created_at') {
+            <i class="pi" [class.pi-sort-amount-up]="order() === 'asc'" [class.pi-sort-amount-down]="order() === 'desc'"></i>
+          }
+        </span>
+        <span class="col col-time sortable" (click)="sortBy('last_fetched_at')">
+          Last fetched
+          @if (sort() === 'last_fetched_at') {
+            <i class="pi" [class.pi-sort-amount-up]="order() === 'asc'" [class.pi-sort-amount-down]="order() === 'desc'"></i>
+          }
+        </span>
         <span class="col col-actions"></span>
       </div>
       @for (row of rows(); track row.hash) {
@@ -99,7 +106,8 @@
           <span class="col col-package">{{ row.package }}</span>
           <span class="col col-size">{{ formatBytes(row.nar_size) }}</span>
           <span class="col col-size">{{ formatBytes(row.file_size) }}</span>
-          <span class="col col-time text-secondary">{{ row.last_fetched_at ?? 'never' }}</span>
+          <span class="col col-time text-secondary">{{ formatDate(row.created_at) }}</span>
+          <span class="col col-time text-secondary">{{ formatDate(row.last_fetched_at, 'never') }}</span>
           <span class="col col-actions" (click)="$event.stopPropagation()">
             <button pButton icon="pi pi-eye" severity="secondary" [text]="true" (click)="show(row)" title="Show details"></button>
             <button

--- a/frontend/src/app/features/caches/cache-nars/cache-nars.component.scss
+++ b/frontend/src/app/features/caches/cache-nars/cache-nars.component.scss
@@ -110,7 +110,7 @@
 
 .nar-row {
   display: grid;
-  grid-template-columns: 220px 1fr 110px 110px 180px 100px;
+  grid-template-columns: 220px 1fr 110px 110px 160px 160px 100px;
   gap: $spacing-md;
   align-items: center;
   padding: $spacing-md $spacing-lg;
@@ -130,6 +130,18 @@
     letter-spacing: 0.04em;
     color: $text-secondary;
     font-weight: 600;
+
+    .sortable {
+      cursor: pointer;
+      user-select: none;
+      display: inline-flex;
+      align-items: center;
+      gap: $spacing-xs;
+
+      &:hover { color: $text-primary; }
+
+      .pi { font-size: $font-size-xs; }
+    }
   }
 }
 

--- a/frontend/src/app/features/caches/cache-nars/cache-nars.component.ts
+++ b/frontend/src/app/features/caches/cache-nars/cache-nars.component.ts
@@ -72,12 +72,6 @@ export class CacheNarsComponent implements OnInit {
   pendingDelete = signal<NarSummary | null>(null);
   deletingHash = signal<string | null>(null);
 
-  readonly sortOptions: { value: SortKey; label: string }[] = [
-    { value: 'created_at', label: 'Created' },
-    { value: 'nar_size', label: 'Size' },
-    { value: 'last_fetched_at', label: 'Last fetched' },
-  ];
-
   totalPages = computed(() => {
     const pp = this.perPage();
     return pp > 0 ? Math.max(1, Math.ceil(this.total() / pp)) : 1;
@@ -164,13 +158,13 @@ export class CacheNarsComponent implements OnInit {
     });
   }
 
-  toggleOrder(): void {
-    this.order.set(this.order() === 'asc' ? 'desc' : 'asc');
-    this.applyFilters();
-  }
-
-  setSort(value: SortKey): void {
-    this.sort.set(value);
+  sortBy(key: SortKey): void {
+    if (this.sort() === key) {
+      this.order.set(this.order() === 'asc' ? 'desc' : 'asc');
+    } else {
+      this.sort.set(key);
+      this.order.set('desc');
+    }
     this.applyFilters();
   }
 
@@ -210,6 +204,12 @@ export class CacheNarsComponent implements OnInit {
         this.deletingHash.set(null);
       },
     });
+  }
+
+  formatDate(iso: string | null | undefined, fallback = '-'): string {
+    if (!iso) return fallback;
+    const d = new Date(iso.includes('T') ? iso : iso.replace(' ', 'T') + 'Z');
+    return isNaN(d.getTime()) ? iso : d.toLocaleString();
   }
 
   formatBytes(bytes: number | null | undefined): string {

--- a/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.html
+++ b/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.html
@@ -78,7 +78,7 @@
         >
           <div
             *cdkVirtualFor="let build of visibleBuilds(); trackBy: trackBuildById; let i = index"
-            class="build-item status-{{ build.status.toLowerCase() }}"
+            class="build-item status-{{ statusClass(build.status) }}"
             [class.selected]="selectedBuildId() === build.id"
             [attr.data-build-id]="build.id"
             (click)="selectBuild(build, true)"
@@ -91,7 +91,7 @@
             role="option"
             [attr.aria-selected]="selectedBuildId() === build.id"
           >
-            <span class="build-dot status-{{ build.status.toLowerCase() }}"></span>
+            <span class="build-dot status-{{ statusClass(build.status) }}"></span>
             <span class="build-name">{{ buildDisplayName(build.name) }}</span>
             @if (getBuildElapsed(build)) {
               <span class="build-elapsed" [class.build-elapsed--running]="build.status === 'Building'">{{ getBuildElapsed(build) }}</span>
@@ -265,7 +265,7 @@
           <div class="log-container-wrapper">
             <div class="log-build-header">
               <code class="log-build-path">{{ selectedBuild()?.name }}</code>
-              <span class="status-badge status-{{ selectedBuild()?.status?.toLowerCase() }}">{{ selectedBuild()?.status }}</span>
+              <span class="status-badge status-{{ statusClass(selectedBuild()?.status) }}">{{ selectedBuild()?.status }}</span>
             </div>
             @if (chunkedMode() && searchOpen()) {
               <div class="log-search-bar">
@@ -279,7 +279,11 @@
                   (keydown.shift.enter)="prevHit()"
                 />
                 <span class="log-search-count">
-                  {{ searchHits().length === 0 ? 0 : currentHit() + 1 }} / {{ searchTotal() }}
+                  @if (searchLoading()) {
+                    <i class="pi pi-spin pi-spinner"></i>
+                  } @else {
+                    {{ searchHits().length === 0 ? 0 : currentHit() + 1 }} / {{ searchTotal() }}
+                  }
                 </span>
                 <button class="log-search-btn" (click)="prevHit()" title="Previous match">↑</button>
                 <button class="log-search-btn" (click)="nextHit()" title="Next match">↓</button>

--- a/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.ts
+++ b/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.ts
@@ -28,7 +28,7 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { interval, Subscription } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { CdkVirtualScrollViewport, ScrollingModule } from '@angular/cdk/scrolling';
-import { EvaluationsService, BuildItem } from '@core/services/evaluations.service';
+import { EvaluationsService, BuildItem, BuildWithOutputs } from '@core/services/evaluations.service';
 import { OrganizationsService } from '@core/services/organizations.service';
 import { Evaluation, EvaluationMessage, EvaluationStatus, WaitingReason, TriggerType } from '@core/models';
 import { AuthService } from '@core/services/auth.service';
@@ -77,6 +77,7 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
   evaluationId = '';
   private initialBuildId: string | null = null;
   private initialShowEval = false;
+  private fetchingInitialBuild = false;
 
   // Derived from backend totals - accurate regardless of how many builds are loaded.
   completedBuildsCount = computed(() => this.totalBuildsCount() - this.activeBuildsCount());
@@ -125,6 +126,11 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
   searchHits = signal<LogSearchHit[]>([]);
   searchTotal = signal(0);
   currentHit = signal(-1);
+  searchLoading = signal(false);
+  private searchDebounceTimer?: ReturnType<typeof setTimeout>;
+  private searchSeq = 0;
+  private readonly MIN_SEARCH_LEN = 3;
+  private readonly SEARCH_DEBOUNCE_MS = 300;
   private chunkIndex: LogChunkIndex | null = null;
   private windowStart = 1;
   private windowText: string[] = [];
@@ -160,6 +166,7 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
     this.stopDurationTimer();
     this.stopActiveStream();
     this.stopBuildRevealTimer();
+    if (this.searchDebounceTimer !== undefined) clearTimeout(this.searchDebounceTimer);
   }
 
   loadEvaluation(): void {
@@ -189,19 +196,40 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
   }
 
   private readonly buildStatusOrder: Record<string, number> = {
-    Building: 0,
-    Queued: 1,
-    Failed: 2,
-    Aborted: 3,
-    DependencyFailed: 3,
-    Completed: 4,
-    Substituted: 4,
+    building: 0,
+    queued: 1,
+    failed: 2,
+    aborted: 3,
+    dependencyfailed: 3,
+    completed: 4,
+    substituted: 4,
   };
 
+  /// Maps every BuildStatus variant onto the canonical token used by the SCSS
+  /// status classes (status-failed, status-completed, …). The three failed
+  /// reasons collapse onto `failed` so the red dot/badge renders for all of them.
+  statusClass(status: string | null | undefined): string {
+    switch (status) {
+      case 'Completed': return 'completed';
+      case 'Substituted': return 'substituted';
+      case 'Building': return 'building';
+      case 'Queued':
+      case 'Created': return 'queued';
+      case 'FailedPermanent':
+      case 'FailedTransient':
+      case 'FailedTimeout': return 'failed';
+      case 'DependencyFailed': return 'dependencyfailed';
+      case 'Aborted': return 'aborted';
+      default: return (status ?? '').toLowerCase();
+    }
+  }
+
   private sortBuilds(builds: BuildItem[]): BuildItem[] {
-    return [...builds].sort((a, b) => {
-      const oa = this.buildStatusOrder[a.status] ?? 99;
-      const ob = this.buildStatusOrder[b.status] ?? 99;
+    const seen = new Set<string>();
+    const unique = builds.filter(b => (seen.has(b.id) ? false : (seen.add(b.id), true)));
+    return unique.sort((a, b) => {
+      const oa = this.buildStatusOrder[this.statusClass(a.status)] ?? 99;
+      const ob = this.buildStatusOrder[this.statusClass(b.status)] ?? 99;
       if (oa !== ob) return oa - ob;
       return this.buildDisplayName(a.name).localeCompare(this.buildDisplayName(b.name));
     });
@@ -311,13 +339,7 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
           }
         }
 
-        if (this.initialBuildId) {
-          const target = this.builds().find(b => b.id === this.initialBuildId);
-          if (target) {
-            this.initialBuildId = null;
-            this.selectBuild(target, true);
-          }
-        }
+        this.resolveInitialBuild();
 
         // Auto-fetch more pages until all active builds are in memory.
         // This ensures status transitions and log streaming work for every build.
@@ -354,19 +376,11 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
         }
         this.loadingMore = false;
 
-        // Resolve pending initialBuildId that may have been beyond the first page
-        if (this.initialBuildId) {
-          const target = this.builds().find(b => b.id === this.initialBuildId);
-          if (target) {
-            this.initialBuildId = null;
-            this.selectBuild(target, true);
-          }
-        }
+        // A build paged in here may be the one we deep-linked to.
+        this.resolveInitialBuild();
 
         // Continue fetching if there are still active builds not yet in memory
-        const stillNeedsMore = this.builds().length < result.active_count
-          || (this.initialBuildId !== null && this.builds().length < this.totalBuilds);
-        if (stillNeedsMore) {
+        if (this.builds().length < result.active_count) {
           this.doLoadMore();
         }
       },
@@ -415,6 +429,42 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
       queryParams: { build: null, eval: 1 },
       queryParamsHandling: 'merge',
       replaceUrl: true,
+    });
+  }
+
+  /// Resolves a deep-linked `?build=<id>`. If the build is already loaded we
+  /// select it; otherwise we fetch that single build directly and inject it into
+  /// the sidebar so its log shows immediately, rather than paging through the
+  /// whole evaluation. `sortBuilds` dedups it once pagination catches up.
+  private resolveInitialBuild(): void {
+    const id = this.initialBuildId;
+    if (!id) return;
+    const target = this.builds().find(b => b.id === id);
+    if (target) {
+      this.initialBuildId = null;
+      this.selectBuild(target, true);
+      return;
+    }
+    if (this.fetchingInitialBuild) return;
+    this.fetchingInitialBuild = true;
+    this.evalService.getBuild(id).subscribe({
+      next: (b: BuildWithOutputs) => {
+        this.fetchingInitialBuild = false;
+        if (this.initialBuildId !== id) return;
+        const item: BuildItem = {
+          id: b.id,
+          name: b.derivation_path,
+          status: b.status,
+          has_artefacts: false,
+          updated_at: b.updated_at,
+          build_time_ms: null,
+        };
+        this.initialBuildId = null;
+        this.builds.update(cur => this.sortBuilds([item, ...cur]));
+        this.visibleBuilds.update(cur => this.sortBuilds([item, ...cur]));
+        this.selectBuild(item, true);
+      },
+      error: () => { this.fetchingInitialBuild = false; },
     });
   }
 
@@ -673,20 +723,49 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
 
   onSearchInput(event: Event): void {
     this.searchQuery.set((event.target as HTMLInputElement).value);
+    this.scheduleSearch();
+  }
+
+  /// Debounced auto-search: only fires once typing pauses and at least
+  /// MIN_SEARCH_LEN characters are present. Shorter queries reset results.
+  private scheduleSearch(): void {
+    if (this.searchDebounceTimer !== undefined) clearTimeout(this.searchDebounceTimer);
+    const q = this.searchQuery().trim();
+    if (q.length < this.MIN_SEARCH_LEN) {
+      this.searchSeq++;
+      this.searchLoading.set(false);
+      this.searchHits.set([]);
+      this.searchTotal.set(0);
+      this.currentHit.set(-1);
+      return;
+    }
+    this.searchLoading.set(true);
+    this.searchDebounceTimer = setTimeout(() => {
+      this.searchDebounceTimer = undefined;
+      this.runSearch();
+    }, this.SEARCH_DEBOUNCE_MS);
   }
 
   closeSearch(): void {
     this.searchOpen.set(false);
     this.highlightLine.set(null);
+    if (this.searchDebounceTimer !== undefined) clearTimeout(this.searchDebounceTimer);
+    this.searchSeq++;
+    this.searchLoading.set(false);
   }
 
   async runSearch(): Promise<void> {
     const buildId = this.selectedBuildId();
     const q = this.searchQuery().trim();
-    if (!buildId || q === '') return;
+    if (!buildId || q.length < this.MIN_SEARCH_LEN) {
+      this.searchLoading.set(false);
+      return;
+    }
+    const seq = ++this.searchSeq;
     this.searchHits.set([]);
     this.searchTotal.set(0);
     this.currentHit.set(-1);
+    this.searchLoading.set(true);
     try {
       const res = await fetch(
         `${environment.apiUrl}/builds/${buildId}/log/search?q=${encodeURIComponent(q)}`,
@@ -700,6 +779,11 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
+        // A newer search superseded this one - abandon the stale stream.
+        if (seq !== this.searchSeq) {
+          await reader.cancel().catch(() => { /* ignore */ });
+          return;
+        }
         buffered += decoder.decode(value, { stream: true });
         const parts = buffered.split('\n');
         buffered = parts.pop() ?? '';
@@ -717,6 +801,8 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
       if (hits.length > 0) this.gotoHit(0);
     } catch {
       // ignore
+    } finally {
+      if (seq === this.searchSeq) this.searchLoading.set(false);
     }
   }
 
@@ -742,7 +828,7 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
         return;
       }
       const next = this.pendingBuilds.shift()!;
-      this.visibleBuilds.update(vbs => [next, ...vbs]);
+      this.visibleBuilds.update(vbs => vbs.some(b => b.id === next.id) ? vbs : [next, ...vbs]);
     }, 10);
   }
 
@@ -914,6 +1000,23 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
     if (!buildId) return;
     const total = this.chunkIndex.total_lines;
     const windowEnd = this.windowStart + this.windowText.length - 1;
+
+    // Fast scrollbar drag: the viewport jumped into a spacer region with no
+    // rendered lines. Burst-load a fresh window centred on the new position
+    // instead of crawling one page at a time from an edge.
+    if (this.windowText.length > 0) {
+      const loadedTopPx = this.topSpacerPx();
+      const loadedBottomPx = loadedTopPx + this.windowText.length * this.LINE_PX;
+      if (el.scrollTop + el.clientHeight < loadedTopPx || el.scrollTop > loadedBottomPx) {
+        const centerLine = Math.min(
+          total,
+          Math.max(1, Math.round((el.scrollTop + el.clientHeight / 2) / this.LINE_PX)),
+        );
+        const { start, end } = windowAround(total, centerLine, this.WINDOW_PAGE);
+        this.loadWindow(buildId, start, end, 'replace');
+        return;
+      }
+    }
 
     if (el.scrollTop < 200 && this.windowStart > 1) {
       const start = Math.max(1, this.windowStart - this.WINDOW_PAGE);

--- a/frontend/src/app/features/projects/project-actions/project-actions.component.html
+++ b/frontend/src/app/features/projects/project-actions/project-actions.component.html
@@ -90,14 +90,14 @@
               </div>
               <div class="action-actions">
                 <button
-                  *appWritable="access()"
+                  *appWritable="triggerAccess()"
                   pButton
                   label="Test"
                   icon="pi pi-play"
                   severity="secondary"
                   size="small"
                   [loading]="testingId() === action.id"
-                  [disabled]="rowDisabled()"
+                  [disabled]="triggerRowDisabled()"
                   (click)="testAction(action.id)"
                 ></button>
                 <button

--- a/frontend/src/app/features/projects/project-actions/project-actions.component.ts
+++ b/frontend/src/app/features/projects/project-actions/project-actions.component.ts
@@ -65,6 +65,15 @@ export class ProjectActionsComponent implements OnInit {
       this.accessSvc.shouldDisableInput(this.access()),
   );
 
+  triggerAccess = computed(() => this.accessSvc.triggerAccess(this.access()));
+
+  triggerRowDisabled = computed(
+    () =>
+      this.testingId() !== null ||
+      this.deletingId() !== null ||
+      this.accessSvc.shouldDisableInput(this.triggerAccess()),
+  );
+
   loading = signal(true);
   saving = signal(false);
   deletingId = signal<string | null>(null);

--- a/frontend/src/app/features/projects/project-triggers/project-triggers.component.html
+++ b/frontend/src/app/features/projects/project-triggers/project-triggers.component.html
@@ -69,14 +69,14 @@
               </div>
               <div class="trigger-actions">
                 <button
-                  *appWritable="access()"
+                  *appWritable="triggerAccess()"
                   pButton
                   label="Fire Now"
                   icon="pi pi-play"
                   severity="secondary"
                   size="small"
                   [loading]="firingId() === trigger.id"
-                  [disabled]="rowDisabled()"
+                  [disabled]="triggerRowDisabled()"
                   (click)="fireNow(trigger.id)"
                 ></button>
                 <button

--- a/frontend/src/app/features/projects/project-triggers/project-triggers.component.ts
+++ b/frontend/src/app/features/projects/project-triggers/project-triggers.component.ts
@@ -97,6 +97,15 @@ export class ProjectTriggersComponent implements OnInit {
       this.accessSvc.shouldDisableInput(this.access()),
   );
 
+  triggerAccess = computed(() => this.accessSvc.triggerAccess(this.access()));
+
+  triggerRowDisabled = computed(
+    () =>
+      this.firingId() !== null ||
+      this.deletingId() !== null ||
+      this.accessSvc.shouldDisableInput(this.triggerAccess()),
+  );
+
   loading = signal(true);
   saving = signal(false);
   deletingId = signal<string | null>(null);


### PR DESCRIPTION
Addresses the list in #303: login/register buttons follow the pButton styleguide; cache NAR timestamps are formatted and the table headers are click-to-sort; Test/Fire buttons are gated on permission only (not managed state); evaluation-log fixes (consistent failed-status styling, sidebar build dedup, deep-link single-build fetch, burst-load on fast scroll, debounced ≥3-char search with loading indicator); follower builds are deduped in the build list; and already-valid builds now finalize as `Substituted` instead of `Completed`.

The "login polls too fast / 409" item was already resolved in the current CLI device-poll loop (respects the server interval, handles Pending/Expired/Denied) — no 409 path remains.

Closes #303