### PR TITLE
fix: declarative organization ids and integration-backed triggers in state (#333, #332)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build docs
         run: |
           nix-shell \
-          -p "python3.withPackages (ps: [ ps.mkdocs ps.mkdocs-mermaid2-plugin ])" \
+          -p "python3.withPackages (ps: [ ps.mkdocs ps.mkdocs-mermaid2-plugin ps.pymdown-extensions ])" \
           --run "mkdocs build --strict --site-dir _site"
 
       - name: Upload artifact

--- a/backend/core/src/lib.rs
+++ b/backend/core/src/lib.rs
@@ -37,6 +37,13 @@ use storage::{FileLogStorage, S3LogStorage};
 use types::*;
 
 pub async fn init_state(cli: Cli) -> Arc<ServerState> {
+    if cli.secrets.crypt_secret_file.is_empty() || cli.secrets.jwt_secret_file.is_empty() {
+        tracing::error!(
+            "--crypt-secret-file and --jwt-secret-file are required to run the server"
+        );
+        std::process::exit(1);
+    }
+
     tracing::info!(
         ip = %cli.server.ip,
         port = cli.server.port,

--- a/backend/core/src/state/export.rs
+++ b/backend/core/src/state/export.rs
@@ -114,6 +114,7 @@ pub async fn export_state<C: ConnectionTrait>(db: &C) -> Result<StateConfigurati
             StateOrganization {
                 name: o.name.clone(),
                 display_name: o.display_name.clone(),
+                id: Some(o.id.to_string()),
                 description: opt(&o.description),
                 private_key_file: String::new(),
                 public: o.public,

--- a/backend/core/src/state/mod.rs
+++ b/backend/core/src/state/mod.rs
@@ -72,6 +72,13 @@ pub struct StateUser {
 pub struct StateOrganization {
     pub name: String,
     pub display_name: String,
+    /// Explicit organization UUID. When set, a freshly created org is given
+    /// this id instead of a server-generated one, so a declarative deployment
+    /// can pin the value a worker references in its `peerFile`
+    /// (`<org_id>:<token>`). Applied on create only; the primary key is
+    /// immutable, so a value that conflicts with an existing org is rejected.
+    #[serde(default)]
+    pub id: Option<String>,
     #[serde(default)]
     pub description: Option<String>,
     pub private_key_file: String,
@@ -392,12 +399,30 @@ impl StateConfiguration {
             }
         }
 
+        let mut org_ids_seen: std::collections::HashSet<String> = std::collections::HashSet::new();
         for org in self.organizations.values() {
             if !self.users.contains_key(&org.created_by) {
                 errors.push(ValidationError {
                     field: format!("organizations.{}.created_by", org.name),
                     message: format!("User '{}' does not exist", org.created_by),
                 });
+            }
+
+            if let Some(id) = &org.id {
+                match id.trim().parse::<uuid::Uuid>() {
+                    Ok(parsed) => {
+                        if !org_ids_seen.insert(parsed.to_string()) {
+                            errors.push(ValidationError {
+                                field: format!("organizations.{}.id", org.name),
+                                message: format!("Duplicate organization id '{}'", id),
+                            });
+                        }
+                    }
+                    Err(_) => errors.push(ValidationError {
+                        field: format!("organizations.{}.id", org.name),
+                        message: format!("Invalid UUID '{}'", id),
+                    }),
+                }
             }
 
             let declared_org_role_names: std::collections::HashSet<&str> = self
@@ -1229,6 +1254,94 @@ mod tests {
                 == "workers.550e8400-e29b-41d4-a716-446655440001.organizations"
                 && e.message.contains("at least one")),
             "expected at-least-one-org error, got: {:?}",
+            v.errors
+        );
+    }
+
+    #[test]
+    fn state_org_accepts_explicit_id() {
+        let json = r#"{
+            "organizations": {
+                "acme": {
+                    "name": "acme",
+                    "display_name": "ACME",
+                    "id": "018f6f3a-0000-7000-8000-000000000001",
+                    "private_key_file": "/dev/null",
+                    "public": false,
+                    "created_by": "alice"
+                }
+            }
+        }"#;
+        let cfg: StateConfiguration = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            cfg.organizations["acme"].id.as_deref(),
+            Some("018f6f3a-0000-7000-8000-000000000001")
+        );
+    }
+
+    #[test]
+    fn state_org_id_defaults_none() {
+        let json = r#"{
+            "organizations": {
+                "acme": {
+                    "name": "acme",
+                    "display_name": "ACME",
+                    "private_key_file": "/dev/null",
+                    "public": false,
+                    "created_by": "alice"
+                }
+            }
+        }"#;
+        let cfg: StateConfiguration = serde_json::from_str(json).unwrap();
+        assert!(cfg.organizations["acme"].id.is_none());
+    }
+
+    #[test]
+    fn state_org_validator_rejects_malformed_id() {
+        let json = r#"{
+            "users": {
+                "alice": { "username": "alice", "name": "Alice", "email": "a@x.io", "password_file": "/dev/null" }
+            },
+            "organizations": {
+                "acme": {
+                    "name": "acme", "display_name": "ACME", "id": "not-a-uuid",
+                    "private_key_file": "/dev/null", "public": false, "created_by": "alice"
+                }
+            }
+        }"#;
+        let cfg: StateConfiguration = serde_json::from_str(json).unwrap();
+        let v = cfg.validate();
+        assert!(!v.is_valid);
+        assert!(
+            v.errors.iter().any(|e| e.field == "organizations.acme.id"),
+            "expected invalid-id error, got: {:?}",
+            v.errors
+        );
+    }
+
+    #[test]
+    fn state_org_validator_rejects_duplicate_ids() {
+        let json = r#"{
+            "users": {
+                "alice": { "username": "alice", "name": "Alice", "email": "a@x.io", "password_file": "/dev/null" }
+            },
+            "organizations": {
+                "acme": {
+                    "name": "acme", "display_name": "ACME", "id": "018f6f3a-0000-7000-8000-000000000001",
+                    "private_key_file": "/dev/null", "public": false, "created_by": "alice"
+                },
+                "globex": {
+                    "name": "globex", "display_name": "Globex", "id": "018f6f3a-0000-7000-8000-000000000001",
+                    "private_key_file": "/dev/null", "public": false, "created_by": "alice"
+                }
+            }
+        }"#;
+        let cfg: StateConfiguration = serde_json::from_str(json).unwrap();
+        let v = cfg.validate();
+        assert!(!v.is_valid);
+        assert!(
+            v.errors.iter().any(|e| e.message.contains("Duplicate organization id")),
+            "expected duplicate-id error, got: {:?}",
             v.errors
         );
     }

--- a/backend/core/src/state/mod.rs
+++ b/backend/core/src/state/mod.rs
@@ -45,6 +45,7 @@ pub fn resolve_oidc_group_roles(
     map
 }
 
+use crate::ci::GITHUB_APP_INTEGRATION_NAME;
 use crate::types::triggers::{ConcurrencyPolicy, TriggerType};
 use entity::organization_cache::CacheSubscriptionMode;
 use sea_orm::DatabaseConnection;
@@ -517,6 +518,42 @@ impl StateConfiguration {
                     });
                 }
             }
+
+            // Reporter triggers resolve their `integration` against the org's
+            // inbound integrations at apply time; catch a missing/outbound/typo
+            // reference here so it fails validation instead of mid-apply (#332).
+            for trigger in project.triggers.iter().flatten() {
+                if !matches!(
+                    trigger.trigger_type,
+                    TriggerType::ReporterPush | TriggerType::ReporterPullRequest
+                ) {
+                    continue;
+                }
+                let Some(name) = &trigger.integration else {
+                    errors.push(ValidationError {
+                        field: format!("projects.{}.triggers", project.name),
+                        message: "reporter_push/reporter_pull_request triggers require an `integration`".into(),
+                    });
+                    continue;
+                };
+                if name == GITHUB_APP_INTEGRATION_NAME {
+                    continue;
+                }
+                let declared_inbound = self.integrations.values().any(|i| {
+                    i.name == *name
+                        && i.organization == project.organization
+                        && i.kind == "inbound"
+                });
+                if !declared_inbound {
+                    errors.push(ValidationError {
+                        field: format!("projects.{}.triggers", project.name),
+                        message: format!(
+                            "Reporter trigger references integration '{}' which is not a declared inbound integration in organization '{}'",
+                            name, project.organization
+                        ),
+                    });
+                }
+            }
         }
 
         for integration in self.integrations.values() {
@@ -734,6 +771,20 @@ impl StateConfiguration {
             errors,
         }
     }
+}
+
+/// Load and validate a state file without touching the database. Returns the
+/// human-readable validation errors (empty `Vec` = valid). Backs the
+/// `--validate-state` CLI flag so config mistakes surface at build/CI time
+/// instead of on server start.
+pub fn validate_state_file(path: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let config = StateConfiguration::from_file(path)?;
+    Ok(config
+        .validate()
+        .errors
+        .into_iter()
+        .map(|e| format!("{}: {}", e.field, e.message))
+        .collect())
 }
 
 pub async fn load_and_apply_state(
@@ -1011,6 +1062,75 @@ mod tests {
         assert_eq!(cfg.projects["web"].actions.len(), 3);
         assert_eq!(cfg.projects["web"].actions[0].action_type, "send_mail");
         assert!(cfg.projects["web"].actions[2].events.is_empty());
+    }
+
+    fn reporter_cfg(integration_name: &str, integrations_json: &str) -> StateConfiguration {
+        let json = format!(
+            r#"{{
+                "users": {{
+                    "alice": {{ "username": "alice", "name": "Alice", "email": "a@x.io", "password_file": "/dev/null" }}
+                }},
+                "organizations": {{
+                    "acme": {{ "name": "acme", "display_name": "ACME", "private_key_file": "/dev/null", "public": false, "created_by": "alice" }}
+                }},
+                "integrations": {integrations_json},
+                "projects": {{
+                    "web": {{
+                        "name": "web", "organization": "acme", "display_name": "Web",
+                        "repository": "https://example.com/acme/web.git", "created_by": "alice",
+                        "triggers": [
+                            {{ "type": "reporter_push", "integration": "{integration_name}", "config": {{ "branches": ["main"] }} }}
+                        ]
+                    }}
+                }}
+            }}"#
+        );
+        serde_json::from_str(&json).unwrap()
+    }
+
+    #[test]
+    fn state_reporter_trigger_accepts_declared_inbound_integration() {
+        let integrations = r#"{
+            "forge": { "name": "forge", "organization": "acme", "kind": "inbound", "forge_type": "forgejo", "created_by": "alice" }
+        }"#;
+        let cfg = reporter_cfg("forge", integrations);
+        let v = cfg.validate();
+        assert!(v.is_valid, "errors: {:?}", v.errors);
+    }
+
+    #[test]
+    fn state_reporter_trigger_rejects_unknown_integration() {
+        let cfg = reporter_cfg("ghost", "{}");
+        let v = cfg.validate();
+        assert!(!v.is_valid);
+        assert!(
+            v.errors.iter().any(|e| e.field == "projects.web.triggers"
+                && e.message.contains("ghost")),
+            "expected unknown-integration trigger error, got: {:?}",
+            v.errors
+        );
+    }
+
+    #[test]
+    fn state_reporter_trigger_rejects_outbound_integration() {
+        let integrations = r#"{
+            "forge": { "name": "forge", "organization": "acme", "kind": "outbound", "forge_type": "forgejo", "created_by": "alice" }
+        }"#;
+        let cfg = reporter_cfg("forge", integrations);
+        let v = cfg.validate();
+        assert!(!v.is_valid);
+        assert!(
+            v.errors.iter().any(|e| e.field == "projects.web.triggers"),
+            "expected outbound-integration trigger error, got: {:?}",
+            v.errors
+        );
+    }
+
+    #[test]
+    fn state_reporter_trigger_accepts_github_app_name() {
+        let cfg = reporter_cfg("github", "{}");
+        let v = cfg.validate();
+        assert!(v.is_valid, "errors: {:?}", v.errors);
     }
 
     #[test]

--- a/backend/core/src/state/provisioning.rs
+++ b/backend/core/src/state/provisioning.rs
@@ -343,8 +343,24 @@ impl<'a> StateApplicator<'a> {
 
             let now = now();
 
+            let declared_id = match &state_org.id {
+                Some(s) => Some(s.trim().parse::<OrganizationId>().map_err(|e| {
+                    format!("Organization '{}' has an invalid id '{}': {}", state_org.name, s, e)
+                })?),
+                None => None,
+            };
+
             let org_id = if let Some(existing) = existing_org {
                 let org_id = existing.id;
+                if let Some(declared) = declared_id
+                    && declared != org_id
+                {
+                    return Err(format!(
+                        "Organization '{}' already exists with id {} but state declares id {}; the id is immutable",
+                        state_org.name, org_id, declared
+                    )
+                    .into());
+                }
                 let mut org: organization::ActiveModel = existing.into();
                 org.display_name = Set(state_org.display_name.clone());
                 org.description = Set(state_org.description.clone().unwrap_or_default());
@@ -364,7 +380,7 @@ impl<'a> StateApplicator<'a> {
                 tracing::info!(name = %state_org.name, "Updated managed organization");
                 org_id
             } else {
-                let org_id = OrganizationId::now_v7();
+                let org_id = declared_id.unwrap_or_else(OrganizationId::now_v7);
                 let org = organization::ActiveModel {
                     id: Set(org_id),
                     name: Set(state_org.name.clone()),

--- a/backend/core/src/state/provisioning.rs
+++ b/backend/core/src/state/provisioning.rs
@@ -76,8 +76,11 @@ pub(super) async fn apply_state_to_database(
     let role_ids = app.apply_roles(&config.roles).await?;
     app.apply_organization_members(&config.organizations, &mut pending)
         .await?;
-    app.apply_projects(&config.projects).await?;
+    // Integrations must land before projects: project triggers
+    // (reporter_push/reporter_pull_request) and `forge_status_report` actions
+    // resolve integrations by name from the DB at apply time (#332).
     app.apply_integrations(&config.integrations).await?;
+    app.apply_projects(&config.projects).await?;
     app.apply_caches(&config.caches).await?;
     app.apply_api_keys(&config.api_keys).await?;
     app.apply_workers(&config.workers).await?;

--- a/backend/core/src/types/cli/secrets.rs
+++ b/backend/core/src/types/cli/secrets.rs
@@ -6,10 +6,35 @@
 
 use clap::Args;
 
+/// Both files are required to run the server but deliberately default to empty
+/// so `--validate-state` (a DB-free, secret-free build/CI check) can parse
+/// without them; `init_state` rejects an empty value on the live server path.
 #[derive(Args, Debug, Clone, Default)]
 pub struct SecretsArgs {
-    #[arg(long, env = "GRADIENT_CRYPT_SECRET_FILE")]
+    #[arg(long, env = "GRADIENT_CRYPT_SECRET_FILE", default_value = "")]
     pub crypt_secret_file: String,
-    #[arg(long, env = "GRADIENT_JWT_SECRET_FILE")]
+    #[arg(long, env = "GRADIENT_JWT_SECRET_FILE", default_value = "")]
     pub jwt_secret_file: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::types::Cli;
+    use clap::Parser;
+
+    #[test]
+    fn validate_state_parses_without_secret_files() {
+        let cli = Cli::try_parse_from(["gradient-server", "--state-file", "s.json", "--validate-state"])
+            .expect("--validate-state must parse without secret files");
+        assert!(cli.storage.validate_state);
+    }
+
+    #[test]
+    fn secret_files_parse_from_flags() {
+        let cli =
+            Cli::try_parse_from(["gradient-server", "--crypt-secret-file", "/c", "--jwt-secret-file", "/j"])
+                .expect("explicit secret files must parse");
+        assert_eq!(cli.secrets.crypt_secret_file, "/c");
+        assert_eq!(cli.secrets.jwt_secret_file, "/j");
+    }
 }

--- a/backend/core/src/types/cli/storage.rs
+++ b/backend/core/src/types/cli/storage.rs
@@ -14,6 +14,12 @@ pub struct StorageArgs {
     pub base_path: String,
     #[arg(long, env = "GRADIENT_STATE_FILE")]
     pub state_file: Option<String>,
+    /// Validate `--state-file` (schema + cross-references, no database access)
+    /// and exit: zero when valid, non-zero on the first batch of errors.
+    /// Intended for build-time / CI checks; see the NixOS `validateState`
+    /// option. Deliberately has no env var so it never trips a live server.
+    #[arg(long)]
+    pub validate_state: bool,
     #[arg(long, env = "GRADIENT_DELETE_STATE", default_value = "true")]
     pub delete_state: bool,
     #[arg(long, env = "GRADIENT_KEEP_EVALUATIONS", default_value = "30")]
@@ -46,6 +52,7 @@ impl Default for StorageArgs {
             store_path: None,
             base_path: ".".into(),
             state_file: None,
+            validate_state: false,
             delete_state: true,
             keep_evaluations: 30,
             nar_ttl_hours: 336,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -68,6 +68,11 @@ pub fn main() -> std::io::Result<()> {
 async fn run() -> std::io::Result<()> {
     let cli = Cli::parse();
     init_logging(&cli.logging);
+
+    if cli.storage.validate_state {
+        return validate_state_and_exit(cli.storage.state_file.as_deref());
+    }
+
     let state = init_state(cli).await;
 
     info!(
@@ -98,4 +103,30 @@ async fn run() -> std::io::Result<()> {
     web::serve_web(Arc::clone(&state)).await?;
 
     Ok(())
+}
+
+/// One-shot `--validate-state` action: validate the state file with no DB
+/// access and exit non-zero on error so a NixOS build (or CI) fails fast.
+fn validate_state_and_exit(state_file: Option<&str>) -> std::io::Result<()> {
+    let Some(path) = state_file else {
+        eprintln!("--validate-state requires --state-file");
+        std::process::exit(2);
+    };
+    match gradient_core::state::validate_state_file(path) {
+        Ok(errors) if errors.is_empty() => {
+            println!("State configuration '{path}' is valid");
+            Ok(())
+        }
+        Ok(errors) => {
+            eprintln!("State configuration '{path}' is invalid:");
+            for e in &errors {
+                eprintln!("  - {e}");
+            }
+            std::process::exit(1);
+        }
+        Err(e) => {
+            eprintln!("Failed to load state file '{path}': {e}");
+            std::process::exit(1);
+        }
+    }
 }

--- a/backend/web/src/endpoints/orgs/workers.rs
+++ b/backend/web/src/endpoints/orgs/workers.rs
@@ -193,6 +193,16 @@ pub async fn post_org_worker(
     }))
 }
 
+/// A connected worker counts as live for `org` only when it authenticated for
+/// it: open-mode workers (`authorized_peers == None`) match any org, restricted
+/// workers only the orgs whose token they presented in the handshake. This
+/// keeps a worker authorized for one org from showing as connected on another.
+fn worker_live_for_org(info: &WorkerInfo, org: OrganizationId) -> bool {
+    info.authorized_peers
+        .as_ref()
+        .is_none_or(|peers| peers.contains(&org))
+}
+
 pub async fn get_org_workers(
     state: State<Arc<ServerState>>,
     Path(organization): Path<String>,
@@ -232,11 +242,7 @@ pub async fn get_org_workers(
             // some other org) without having a valid token for this org.
             let live = live_workers
                 .get(&reg.worker_id)
-                .filter(|w| {
-                    w.authorized_peers
-                        .as_ref()
-                        .is_none_or(|peers| peers.contains(&org.id))
-                })
+                .filter(|w| worker_live_for_org(w, org.id))
                 .map(|w| WorkerLiveInfo {
                     capabilities: w.capabilities.clone(),
                     // architectures/system_features are only non-empty for build-capable workers
@@ -383,4 +389,38 @@ pub async fn delete_org_worker(
     scheduler.request_reauth(&worker_id).await;
 
     Ok(ok_json(format!("worker '{}' unregistered", worker_id)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    fn worker(authorized: Option<Vec<OrganizationId>>) -> WorkerInfo {
+        WorkerInfo {
+            id: "w1".into(),
+            capabilities: GradientCapabilities::default(),
+            architectures: vec![],
+            system_features: vec![],
+            max_concurrent_builds: 1,
+            assigned_job_count: 0,
+            draining: false,
+            authorized_peers: authorized.map(|v| v.into_iter().collect::<HashSet<_>>()),
+        }
+    }
+
+    #[test]
+    fn restricted_worker_is_live_only_on_authorized_orgs() {
+        let org_a = OrganizationId::now_v7();
+        let org_b = OrganizationId::now_v7();
+        let w = worker(Some(vec![org_a]));
+        assert!(worker_live_for_org(&w, org_a));
+        assert!(!worker_live_for_org(&w, org_b));
+    }
+
+    #[test]
+    fn open_worker_is_live_on_any_org() {
+        let w = worker(None);
+        assert!(worker_live_for_org(&w, OrganizationId::now_v7()));
+    }
 }

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -3935,6 +3935,7 @@ paths:
                   organizations = {
                     myorg = {
                       name = "myorg";
+                      id = "018f6f3a-0000-7000-8000-000000000001";
                       private_key_file = null;
                       created_by = "operator";
                     };

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -296,7 +296,7 @@ echo "<peer_id>:<token>" > /run/secrets/gradient-worker-peers
 
 The special peer ID `*` can be used instead of a specific UUID to respond with that token for any peer the server challenges:
 
-```
+```text
 # /run/secrets/gradient-worker-peers
 *:<token>
 ```

--- a/docs/src/development/architecture.md
+++ b/docs/src/development/architecture.md
@@ -8,7 +8,7 @@ Gradient is a multi-crate Rust workspace with two separate binaries: **`gradient
 
 The server binary starts three concurrent async tasks:
 
-```
+```text
 ┌────────────────────────────────────────┐
 │           gradient binary              │
 │                                        │
@@ -39,7 +39,7 @@ The server does not require access to a Nix daemon. All store interaction (eval,
 
 ## Crates
 
-```
+```text
 backend/
 ├── core/         Shared state, config, DB pool, utility functions
 ├── entity/       SeaORM entity definitions (one module per table)
@@ -73,7 +73,7 @@ One module per database table using SeaORM derive macros. The naming convention 
 
 Key entities and their relationships:
 
-```
+```text
 organization
   ├── worker_registration[]    registered worker auth tokens
   ├── cache[]                  binary caches (via subscription)
@@ -127,7 +127,7 @@ Axum HTTP server. All API routes live under `/api/v1` via `Router::nest`. Auth r
 
 Endpoints are split by resource in `web/src/endpoints/`:
 
-```
+```text
 auth.rs          Login, register, OIDC/OAuth2
 builds/          Build detail, log streaming, graph, downloads, direct build
 caches.rs        Cache CRUD + Nix cache protocol handlers

--- a/docs/src/development/internals.md
+++ b/docs/src/development/internals.md
@@ -59,7 +59,7 @@ Derivations, outputs, dependency edges, and builds are bulk-inserted in chunks o
 
 **4. Status transitions**
 
-```
+```text
 build:       Created → Queued → Building → Completed | Failed
                                          ↘ Substituted (already in store)
                                          ↘ Aborted | DependencyFailed
@@ -124,7 +124,7 @@ This makes "is the full closure of build B available in cache C" a single DB loo
 
 `GET /builds/{build}/graph` - BFS from the requested build, capped at 500 nodes. The graph is stored on derivations, so the BFS walks `derivation_dependency` and resolves each visited derivation back to a `build` row in the same evaluation for UI display:
 
-```
+```text
 root_drv = build.derivation
 visited_drvs = {root_drv}
 queue = [[root_drv]]

--- a/docs/src/development/proto.md
+++ b/docs/src/development/proto.md
@@ -537,7 +537,7 @@ FetchResult {
 
 The worker assembles the archive command as:
 
-```
+```text
 nix flake archive [--override-input <name> <ref>]... --json <flake-ref>
 ```
 

--- a/docs/src/development/tests.md
+++ b/docs/src/development/tests.md
@@ -18,7 +18,7 @@ that replace production dependencies (nix-daemon, filesystem, WebSocket) with
 in-memory implementations. The diagram below shows how production and test code
 relate:
 
-```
+```text
                      ┌─────────────────────────────────────────┐
                      │              proto crate                │
                      │                                         │
@@ -88,7 +88,7 @@ a production trait and substitutes the real dependency with an in-memory version
 It performs a BFS from the entry-point derivation through `inputDrvs` to build
 the full closure and populates fakes.
 
-```
+```text
   test/
   ├── output          # single line: /nix/store/<hash>-hello-2.12.3.drv
   └── store/          # 951 real ATerm .drv files
@@ -97,7 +97,7 @@ the full closure and populates fakes.
       └── ...
 ```
 
-```
+```text
          load_store("test/")
                │
                v
@@ -239,7 +239,7 @@ lifecycle. Tests exercise the state machine directly without any async runtime.
 
 ### Job lifecycle state machine
 
-```
+```text
                      add_pending()
                           │
                           v
@@ -263,7 +263,7 @@ lifecycle. Tests exercise the state machine directly without any async runtime.
 
 ### Peer-based filtering
 
-```
+```text
   ┌─────────────────────────────────────────────────┐
   │               JobTracker                        │
   │                                                 │
@@ -305,7 +305,7 @@ authorized peers, and assigned-job tracking.
 
 ### Worker lifecycle
 
-```
+```text
   register()                           unregister()
       │                                     │
       v                                     v
@@ -400,7 +400,7 @@ Tests for the `StoreFixture` itself, validating that real `.drv` files from
 
 ### Build-wave convergence
 
-```
+```text
   Wave 0 (nothing built):
     ready_to_build() → leaf nodes only (no dependencies)
        mark_built(leaves)
@@ -469,7 +469,7 @@ nix-daemon, filesystem, or WebSocket connection.
 
 ### Evaluation data flow (test configuration)
 
-```
+```text
   FakeDerivationResolver         FakeDrvReader
   ┌───────────────────────┐      ┌───────────────────────┐
   │ list_flake_derivations│      │ from_raw_drvs(        │
@@ -627,7 +627,7 @@ Tests for `RepositoryUrl` (stored in the database, used for display and git oper
 
 Tests for `parse_drv`, which parses the textual `Derive(…)` format produced by `nix derivation show`. The fixture derivation used by these tests is:
 
-```
+```text
 Derive(
   [("out","/nix/store/abc-hello","","")],
   [("/nix/store/xyz.drv",["out"])],
@@ -786,7 +786,7 @@ the two functions responsible for reading peer-to-token pairs from `--peers` /
 
 ### Token source precedence
 
-```
+```text
   peers_file set? ──yes──► read file contents  ──► parse lines
                   │
                   no
@@ -800,7 +800,7 @@ the two functions responsible for reading peer-to-token pairs from `--peers` /
 
 ### Line format
 
-```
+```text
   peer_id:token64    →  ("peer_id", "token64")  ✓
   *:token64          →  ("*", "token64")         ✓  (wildcard)
   # comment          →  skipped
@@ -844,7 +844,7 @@ credential kinds the server sends during a job: a UTF-8 signing key and raw SSH
 private key bytes. Both are wrapped in `SecureString`/`SecureBytes` to avoid
 accidental logging.
 
-```
+```text
   CredentialStore (Arc<Mutex<Inner>>)
   ┌───────────────────────────────────┐
   │ signing_key: Option<SecureString> │  ← UTF-8 Ed25519 secret key
@@ -878,7 +878,7 @@ Tests for `score_candidates()`, which annotates each `JobCandidate` with the
 number of its `required_paths` that are absent from the worker's local store.
 The scheduler uses this score to prefer jobs whose inputs are already cached.
 
-```
+```text
   score_candidates(candidates, store)
        │
        ├─ for each candidate:
@@ -1021,7 +1021,7 @@ methods for reporting job progress. Each test uses `MockProtoServer` and a
 client opens its connection (required to avoid deadlock on the single-thread
 tokio runtime).
 
-```
+```text
   JobUpdater::report_fetching()
        │
        └─► ProtoConnection::send(ClientMessage::JobUpdate {
@@ -1053,7 +1053,7 @@ Tests for `push_direct()` (chunk-streaming to server) and `upload_presigned()`
 
 ### `push_direct` flow
 
-```
+```text
   push_direct(job_id, store_path, conn)
        │
        ├─ NarByteStream::new(store_path) → async byte stream
@@ -1066,7 +1066,7 @@ Tests for `push_direct()` (chunk-streaming to server) and `upload_presigned()`
 
 ### `upload_presigned` flow
 
-```
+```text
   upload_presigned(job_id, store_path, url, conn)
        │
        ├─ stream NAR → HTTP PUT to presigned URL
@@ -1093,7 +1093,7 @@ required by `fingerprint_path`. No nix-daemon, filesystem, or network access.
 
 ### Hash conversion pipeline
 
-```
+```text
   sign_one_path()
        │
        ├─ query_path_info() → path_info.nar_hash  (SRI format: "sha256-<base64>")
@@ -1376,7 +1376,7 @@ call the pending job count is asserted directly on the scheduler.
 
 ### `dispatch_queued_evals` - DB call sequence
 
-```
+```text
   dispatch_queued_evals(scheduler)
        │
        ├─ 1. EEvaluation::find().filter(status=Queued).all()       Q
@@ -1394,7 +1394,7 @@ call the pending job count is asserted directly on the scheduler.
 
 ### `dispatch_ready_builds` - DB call sequence
 
-```
+```text
   dispatch_ready_builds(scheduler)
        │
        ├─ 1. EBuild::find().from_raw_sql(ready_builds_query).all() Q
@@ -1442,7 +1442,7 @@ staged query/exec results - no real Postgres required.
 
 SeaORM 1.x on Postgres has a subtle split between two result queues:
 
-```
+```text
   append_query_results  →  consumed by SELECT, UPDATE…RETURNING, find_by_id,
                            and insert_many().exec() (Postgres uses RETURNING)
 
@@ -1458,7 +1458,7 @@ with a valid `id: Uuid`.
 
 ### Data flow through `handle_eval_result`
 
-```
+```text
   Worker sends EvalResult
        │
        v
@@ -1485,7 +1485,7 @@ with a valid `id: Uuid`.
 
 ### Cascade flow through `handle_build_job_failed`
 
-```
+```text
   handle_build_job_failed(state, build_id, error)
        │
        ├─ EBuild::find_by_id()                              Q
@@ -1558,7 +1558,7 @@ Tests for `gradient_core::db::abort_evaluation`, which cascades `Aborted` to
 all active builds before aborting the evaluation itself.
 
 **DB call sequence:**
-```
+```text
   abort_evaluation(state, evaluation)
        │
        ├─ guard: if eval.status == Completed → return (no DB calls)
@@ -1604,7 +1604,7 @@ the spawned webhook tasks run on the `current_thread` runtime. Deliveries are
 captured by `RecordingWebhookClient` (returned alongside the state by
 `test_state_recorded`).
 
-```
+```text
   handle_build_job_completed()
          │
          ├─ update_build_status(Completed)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -32,7 +32,7 @@
 
 A public binary cache with pre-built Gradient packages is available:
 
-```
+```text
 URL:        https://public.gradient.ci/cache/main
 Public Key: public.gradient.ci-main:qmxRE+saUvhNa3jqaCMWje+feVU77TjABchZrPGf7A8=
 ```

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -543,6 +543,14 @@ Backend (`cargo test -p core --lib state::tests`):
   `force_evaluation`; serde's default unknown-field handling drops it
   silently so existing deployments parse cleanly after the field's
   removal from the schema.
+- `state_org_accepts_explicit_id` / `state_org_id_defaults_none` -
+  `StateOrganization.id` deserialises from a UUID string and defaults to
+  `None`, so a declarative deployment can pin the org UUID a worker's
+  `peersFile` references (`<org_id>:<token>`) (issue #333).
+- `state_org_validator_rejects_malformed_id` - a non-UUID `id` yields a
+  validation error pinpointing `organizations.<org>.id`.
+- `state_org_validator_rejects_duplicate_ids` - two organizations
+  declaring the same `id` is an error.
 - `state_org_members_serde_round_trip` - `StateOrganization.members`
   round-trips through JSON as `[{ user, role }]` entries, covering both
   built-in (`Write`) and custom (`releaser`) role names.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -609,6 +609,26 @@ Backend (`cargo test -p core --lib state::provisioning::trigger_helper_tests`):
   otherwise persist an id no webhook ever resolves to and the trigger would
   silently never fire.
 
+## Integrations apply before projects, validated at build time (#332)
+
+Backend (`cargo test -p core --lib state::tests`):
+- `state_reporter_trigger_accepts_declared_inbound_integration` - a
+  `reporter_push` trigger naming a declared inbound integration in the same
+  org passes validation.
+- `state_reporter_trigger_rejects_unknown_integration` - a reporter trigger
+  naming an integration that is not declared yields a
+  `projects.<project>.triggers` validation error, surfacing the mistake at
+  build/`--validate-state` time instead of mid state-apply.
+- `state_reporter_trigger_rejects_outbound_integration` - a reporter trigger
+  pointing at an `outbound`-kind integration is rejected (reporters resolve
+  against inbound integrations only).
+- `state_reporter_trigger_accepts_github_app_name` - the reserved `github`
+  integration name needs no explicit declaration (auto-managed GitHub App row).
+
+The apply order in `apply_state_to_database` now runs `apply_integrations`
+before `apply_projects` so trigger/action integration lookups resolve against
+rows already in the DB.
+
 ## Scheduler does not double-dispatch a build
 
 Backend (`cargo test -p scheduler --lib jobs::tests::add_pending_does_not_requeue_active_job`):

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -629,6 +629,15 @@ The apply order in `apply_state_to_database` now runs `apply_integrations`
 before `apply_projects` so trigger/action integration lookups resolve against
 rows already in the DB.
 
+## `--validate-state` parses without secret files
+
+Backend (`cargo test -p core --lib types::cli::secrets::tests`):
+- `validate_state_parses_without_secret_files` - `--state-file ... --validate-state`
+  parses with no `--crypt-secret-file`/`--jwt-secret-file`, so the secret-free Nix
+  build/CI check (`services.gradient.validateState`) runs without provisioning secrets.
+- `secret_files_parse_from_flags` - the live-server path still accepts both secret
+  flags; `init_state` rejects an empty value before startup.
+
 ## Scheduler does not double-dispatch a build
 
 Backend (`cargo test -p scheduler --lib jobs::tests::add_pending_does_not_requeue_active_job`):

--- a/docs/src/usage/actions.md
+++ b/docs/src/usage/actions.md
@@ -60,7 +60,7 @@ POSTs a JSON payload to a URL. Optional `Authorization: Bearer <token>` header.
 
 **Request headers:**
 
-```
+```http
 Content-Type: application/json
 X-Gradient-Event: build.completed
 Authorization: Bearer <token>   # only if token is set

--- a/docs/src/usage/api.md
+++ b/docs/src/usage/api.md
@@ -12,7 +12,7 @@ The full OpenAPI 3.1 specification is in the repository at `docs/gradient-api.ya
 
 Endpoints under `/api/v1` (except `/auth/*`, `/health`, and `/config`) require a bearer token:
 
-```
+```http
 Authorization: Bearer <token>
 ```
 

--- a/docs/src/usage/cli.md
+++ b/docs/src/usage/cli.md
@@ -249,7 +249,7 @@ Project and worker name completion uses the currently selected organization
 
 ## Global Options
 
-```
+```text
 gradient --help      Show help for any command
 gradient --version   Print CLI version
 gradient --json      Emit machine-readable JSON output

--- a/docs/src/usage/integration.md
+++ b/docs/src/usage/integration.md
@@ -101,7 +101,7 @@ From the Integrations page:
 
 All inbound webhook URLs have the form:
 
-```
+```text
 {serveUrl}/api/v1/hooks/{forge}/{organization}/{integration_name}
 ```
 

--- a/docs/src/usage/overview.md
+++ b/docs/src/usage/overview.md
@@ -20,7 +20,7 @@ Two wildcard tokens expand attribute names at a given level:
 
 ### `*` vs `#`
 
-```
+```text
 packages.x86_64-linux.*   # finds packages.*.*.*  - recurses past x86_64-linux into each package
 packages.x86_64-linux.#   # finds packages that are derivations directly under x86_64-linux, no deeper
 ```
@@ -31,7 +31,7 @@ In practice `*` is the right choice for almost all flakes. Use `#` when a flake 
 
 Prefix a pattern with `!` to remove matching paths from the set built by the preceding include patterns.
 
-```
+```text
 packages.*,!packages.x86_64-linux.broken
 ```
 

--- a/docs/src/usage/state.md
+++ b/docs/src/usage/state.md
@@ -4,6 +4,16 @@
 
 When `settings.deleteState = true` (default), entities that are removed from `state` are also deleted from the database. Set it to `false` to make them editable by users in the frontend instead.
 
+## Build-time validation
+
+`services.gradient.validateState` (default `true`) checks the generated state at **build time** by running the server binary's `--validate-state` over it. Schema and cross-reference errors — unknown organizations or users, reporter triggers pointing at an undeclared inbound integration, duplicate org ids, and so on — then fail the Nix build instead of the server on first start. No database is touched, so it is safe to run in CI. Set it to `false` to skip the check.
+
+To validate a state file by hand:
+
+```sh
+gradient-server --state-file ./gradient-state.json --validate-state
+```
+
 ## State-Managed Resources
 
 Users, organizations, and caches created by the NixOS module configuration carry `managed = true`. The API rejects mutations and deletions of these records with `403 Forbidden`. This allows declarative configuration to be the source of truth without Gradient's UI overwriting it.

--- a/docs/src/usage/state.md
+++ b/docs/src/usage/state.md
@@ -117,12 +117,28 @@ ssh-keygen -t ed25519 -N "" -f /run/secrets/acme-ssh-key
 # Add the public key (.pub) to your Git host as a deploy key
 ```
 
+To pin the organization UUID for a fully declarative deployment (so a worker's `peersFile` can reference it before the server first starts), generate one with `uuidgen` and set it as `id`:
+
+```sh
+uuidgen   # e.g. 018f6f3a-0000-7000-8000-000000000001
+```
+
+```nix
+services.gradient.state.organizations.acme = {
+  id               = "018f6f3a-0000-7000-8000-000000000001";
+  display_name     = "ACME Corp";
+  private_key_file = "/run/secrets/acme-ssh-key";
+  created_by       = "alice";
+};
+```
+
 ### Organization options
 
 | Option | Default | Description |
 |---|---|---|
 | `name` | `<attrset key>` | Unique organization name |
 | `display_name` | `<name>` | Display name |
+| `id` | `null` | Explicit organization UUID, applied on create only. Pin it to reference the org in a worker's `peersFile` (`<id>:<token>`) without first looking up the server-generated id. Immutable — a value conflicting with an existing org is rejected |
 | `description` | `null` | Optional description |
 | `private_key_file` | - | Path to SSH private key (required) |
 | `public` | `false` | Visible to all users |
@@ -459,6 +475,8 @@ services.gradient.worker.workerId = "550e8400-e29b-41d4-a716-446655440001";
 ```
 
 State-managed worker registrations are deleted automatically when removed from `state.workers`, and per-(worker_id, organization) rows are deleted when an organization is dropped from `organizations` (subject to `settings.deleteState`).
+
+On the worker machine, the `peersFile` authenticates with `<org_id>:<token>` lines. The `org_id` is the organization's UUID — to know it ahead of the first server start, pin it with `state.organizations.<name>.id` and reference that same value in the worker's `peersFile`. The `*:<token>` wildcard remains the alternative when a single token may serve any org.
 
 ### Worker options
 

--- a/docs/src/usage/state.md
+++ b/docs/src/usage/state.md
@@ -6,7 +6,7 @@ When `settings.deleteState = true` (default), entities that are removed from `st
 
 ## Build-time validation
 
-`services.gradient.validateState` (default `true`) checks the generated state at **build time** by running the server binary's `--validate-state` over it. Schema and cross-reference errors — unknown organizations or users, reporter triggers pointing at an undeclared inbound integration, duplicate org ids, and so on — then fail the Nix build instead of the server on first start. No database is touched, so it is safe to run in CI. Set it to `false` to skip the check.
+`services.gradient.validateState` (default `true`) checks the generated state at **build time** by running the server binary's `--validate-state` over it. Schema and cross-reference errors — unknown organizations or users, reporter triggers pointing at an undeclared inbound integration, duplicate org ids, and so on — then fail the Nix build instead of the server on first start. No database is touched and no secret files are required, so it is safe to run in CI. Set it to `false` to skip the check.
 
 To validate a state file by hand:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,3 +44,10 @@ markdown_extensions:
   - toc:
       permalink: true
   - fenced_code
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences

--- a/nix/modules/gradient-state.nix
+++ b/nix/modules/gradient-state.nix
@@ -105,10 +105,20 @@
         description = "Display name for the organization";
       };
 
-      description = mkOption {
+      id = mkOption {
         type = types.nullOr types.str;
         default = null;
-        description = "Description of the organization";
+        example = "018f6f3a-0000-7000-8000-000000000001";
+        description = ''
+          Explicit organization UUID. When set, a freshly created
+          organization is given this id instead of a server-generated one,
+          so a worker's `peersFile` can reference it (`<id>:<token>`) in a
+          fully declarative deployment without first looking up the
+          auto-generated id. Applied on create only; the id is immutable, so
+          a value conflicting with an existing organization is rejected.
+
+          Generate one with `uuidgen`.
+        '';
       };
 
       private_key_file = mkOption {

--- a/nix/modules/gradient-worker.nix
+++ b/nix/modules/gradient-worker.nix
@@ -129,6 +129,11 @@ in {
         a 48-byte random secret (e.g. <literal>openssl rand -base64 48</literal>)
         and is registered via <literal>POST /api/v1/orgs/{org}/workers</literal>.
 
+        In a fully declarative deployment, pin the org UUID with
+        <literal>services.gradient.state.organizations.&lt;name&gt;.id</literal>
+        on the server and reference the same value here, so the peer id is
+        known ahead of the first server start.
+
         When null (default), the worker connects in open/discoverable mode -
         the server accepts the connection without token validation. Suitable
         for local co-located workers.

--- a/nix/modules/gradient.nix
+++ b/nix/modules/gradient.nix
@@ -17,6 +17,17 @@
     integrations = augmentedIntegrations;
   });
 
+  # GoBGP-style build-time check: run the server binary's `--validate-state`
+  # over the generated state file so config errors fail the Nix build instead
+  # of surfacing on first server start.
+  validatedStateJsonFile = if cfg.validateState then
+    pkgs.runCommand "gradient-state-validated.json" { } ''
+      ${lib.getExe cfg.packages.server} --state-file ${stateJsonFile} --validate-state
+      cp ${stateJsonFile} $out
+    ''
+  else
+    stateJsonFile;
+
   userPasswordFiles = lib.concatLists (lib.mapAttrsToList (_: user:
     lib.optional (user.password_file != null)
       "gradient_user_${user.username}_password:${user.password_file}"
@@ -55,6 +66,18 @@ in {
   options = {
     services.gradient = {
       enable = lib.mkEnableOption "Gradient";
+
+      validateState = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Validate the generated `state` configuration at build time by running
+          the server binary's `--validate-state` over it. Schema and
+          cross-reference errors (unknown organizations, reporter triggers
+          pointing at undeclared integrations, …) then fail the Nix build
+          instead of the server on first start. No database is touched.
+        '';
+      };
       reverseProxy = {
         nginx.enable = lib.mkEnableOption "Nginx configuration" // {
           default = !cfg.reverseProxy.caddy.enable;
@@ -619,7 +642,7 @@ in {
           "gradient_database_url:${cfg.databaseUrlFile}"
           "gradient_crypt_secret:${cfg.cryptSecretFile}"
           "gradient_jwt_secret:${cfg.jwtSecretFile}"
-          "gradient_state:${stateJsonFile}"
+          "gradient_state:${validatedStateJsonFile}"
         ] ++ lib.optional cfg.oidc.enable [
           "gradient_oidc_client_secret:${cfg.oidc.clientSecretFile}"
         ] ++ lib.optional cfg.email.enable [


### PR DESCRIPTION
Closes #333. Closes #332.

- `state.organizations.<name>.id` pins an org UUID on create so workers can reference it in `peersFile` before the server generates one; workers only show "connected" on orgs they actually authenticated for.
- Apply integrations before projects so reporter triggers / forge-status actions resolve, and reject undeclared integration references at validate time.
- `--validate-state` / `services.gradient.validateState` (default on) validates the state config at build time with no DB access.