### PR TITLE
fix(web): org members get read-only cache stats and key creation (#334)

### DIFF
--- a/backend/web/src/access.rs
+++ b/backend/web/src/access.rs
@@ -481,6 +481,25 @@ async fn is_cache_org_subscriber(
     Ok(member.is_some())
 }
 
+/// The caller's effective cache permission mask for minting cache-scoped API
+/// keys: a direct cache member's role mask, or read-only [`cache_view_mask`]
+/// for a member of a subscribed organization (mirroring `load_cache(Readable)`).
+/// `None` means the caller cannot see the cache.
+pub async fn effective_cache_mask(
+    state: &Arc<ServerState>,
+    user_id: UserId,
+    cache_id: CacheId,
+    api_key: Option<&ApiKeyContext>,
+) -> WebResult<Option<i64>> {
+    if let Some(mask) = cache_role_mask(state, user_id, cache_id).await? {
+        return Ok(Some(mask));
+    }
+    if is_cache_org_subscriber(state, user_id, cache_id, api_key).await? {
+        return Ok(Some(crate::permissions::cache_view_mask()));
+    }
+    Ok(None)
+}
+
 async fn cache_role_mask(
     state: &Arc<ServerState>,
     user_id: UserId,
@@ -1382,6 +1401,70 @@ mod tests {
             .await
             .expect_err("View role must lack WriteStore");
             assert!(matches!(err, WebError::Forbidden(..)));
+        });
+    }
+
+    fn org_cache_fixture() -> entity::organization_cache::Model {
+        entity::organization_cache::Model {
+            id: gradient_core::types::ids::OrganizationCacheId::new(uuid!(
+                "a0000000-0000-0000-0000-000000000040"
+            )),
+            organization: OrganizationId::new(uuid!("a0000000-0000-0000-0000-000000000001")),
+            cache: gradient_core::types::ids::CacheId::new(uuid!(
+                "a0000000-0000-0000-0000-000000000020"
+            )),
+            mode: entity::organization_cache::CacheSubscriptionMode::ReadOnly,
+        }
+    }
+
+    #[test]
+    fn effective_cache_mask_returns_role_for_member() {
+        run(async {
+            let user = user_fixture();
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([vec![cache_member_fixture()]])
+                .append_query_results([vec![cache_role_fixture()]])
+                .into_connection();
+            let state = make_state(db);
+            let mask = effective_cache_mask(&state, user.id, cache_fixture(false).id, None)
+                .await
+                .expect("query ok")
+                .expect("member has a mask");
+            assert_eq!(mask, crate::permissions::cache_admin_mask());
+        });
+    }
+
+    #[test]
+    fn effective_cache_mask_returns_view_for_org_subscriber() {
+        run(async {
+            let user = user_fixture();
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([Vec::<entity::cache_user::Model>::new()])
+                .append_query_results([vec![org_cache_fixture()]])
+                .append_query_results([vec![membership_fixture(BASE_ROLE_VIEW_ID)]])
+                .into_connection();
+            let state = make_state(db);
+            let mask = effective_cache_mask(&state, user.id, cache_fixture(false).id, None)
+                .await
+                .expect("query ok")
+                .expect("subscriber gets view-only mask");
+            assert_eq!(mask, crate::permissions::cache_view_mask());
+        });
+    }
+
+    #[test]
+    fn effective_cache_mask_none_for_outsider() {
+        run(async {
+            let user = user_fixture();
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([Vec::<entity::cache_user::Model>::new()])
+                .append_query_results([Vec::<entity::organization_cache::Model>::new()])
+                .into_connection();
+            let state = make_state(db);
+            let mask = effective_cache_mask(&state, user.id, cache_fixture(false).id, None)
+                .await
+                .expect("query ok");
+            assert!(mask.is_none(), "outsider must not get a cache mask");
         });
     }
 

--- a/backend/web/src/endpoints/stats.rs
+++ b/backend/web/src/endpoints/stats.rs
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-use crate::authorization::MaybeUser;
+use crate::access::{CacheAccess, Caller, load_cache};
+use crate::authorization::{MaybeApiKey, MaybeUser};
 use crate::error::{WebError, WebResult};
-use crate::helpers::{OptionExt, ok_json};
+use crate::helpers::ok_json;
 use axum::extract::{Path, State};
 use axum::{Extension, Json};
 use chrono::{NaiveDateTime, Timelike};
-use gradient_core::db::get_any_cache_by_name;
 use gradient_core::types::*;
 use sea_orm::{ConnectionTrait, DatabaseBackend, Statement};
 use serde::Serialize;
@@ -205,18 +205,17 @@ async fn aggregate_storage<C: sea_orm::ConnectionTrait>(
 pub async fn get_cache_stats(
     state: State<Arc<ServerState>>,
     Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
     Path(cache): Path<String>,
 ) -> WebResult<Json<BaseResponse<CacheStatsResponse>>> {
-    let cache = get_any_cache_by_name(state.0.clone(), cache)
-        .await?
-        .or_not_found("Cache")?;
-
-    if !cache.public {
-        match &maybe_user {
-            Some(user) if cache.created_by == user.id => {}
-            _ => return Err(WebError::not_found("Cache")),
-        }
-    }
+    let cache = load_cache(
+        &state,
+        Caller::from_option(&maybe_user),
+        api_key.as_ref(),
+        cache,
+        CacheAccess::Readable,
+    )
+    .await?;
 
     // Total compressed bytes and package count for this cache.
     let total_row = state

--- a/backend/web/src/endpoints/user.rs
+++ b/backend/web/src/endpoints/user.rs
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-use crate::access::{CacheAccess, Caller, load_cache};
+use crate::access::{CacheAccess, Caller, effective_cache_mask, load_cache};
 use crate::audit::{RequestInfo, events, record as audit_record};
 use crate::authorization::{MaybeApiKey, generate_api_key, hash_api_key};
 use crate::error::{WebError, WebResult};
 use crate::helpers::{OptionExt, ok_json};
 use crate::permissions::{
-    CachePermission, PermissionEntry, available_cache_permissions, available_permissions,
-    mask_to_vec, parse_cache_permission_list, parse_permission_list,
+    PermissionEntry, available_cache_permissions, available_permissions, mask_to_vec,
+    parse_cache_permission_list, parse_permission_list,
 };
 use axum::extract::{Path, Query, State};
 use axum::http::HeaderMap;
@@ -421,16 +421,21 @@ pub async fn post_keys(
             Caller::User(&user),
             None,
             cache_name,
-            CacheAccess::Require {
-                permission: CachePermission::ManageCacheMembers,
-                reject_managed: false,
-            },
+            CacheAccess::Readable,
         )
         .await?;
         let m = parse_cache_permission_list(&body.permissions, "GET /user/keys/permissions")?;
         if m == 0 {
             return Err(WebError::bad_request(
                 "At least one permission is required for an API key.",
+            ));
+        }
+        let granted = effective_cache_mask(&state, user.id, cache.id, None)
+            .await?
+            .ok_or_else(|| WebError::not_found("Cache"))?;
+        if m & !granted != 0 {
+            return Err(WebError::forbidden(
+                "API key cannot grant cache permissions you do not hold.",
             ));
         }
         (m, None, Some(cache.id))

--- a/backend/web/tests/cache_api_key_pinning.rs
+++ b/backend/web/tests/cache_api_key_pinning.rs
@@ -204,7 +204,7 @@ fn create_key_rejects_both_org_and_cache_pin() {
             .add_header("authorization", format!("Bearer {}", token))
             .json(&serde_json::json!({
                 "name": "bad-key",
-                "permissions": ["view-cache"],
+                "permissions": ["viewCache"],
                 "organization": "test-org",
                 "cache": "test-cache",
             }))
@@ -217,24 +217,26 @@ fn create_key_rejects_both_org_and_cache_pin() {
 }
 
 #[test]
-fn create_cache_pinned_key_requires_manage_cache_members() {
+fn create_cache_pinned_key_cannot_exceed_member_mask() {
     run(async {
         let session_id = gradient_core::types::SessionId::now_v7();
         let token = test_support::web::make_token(session_id);
         let session = test_support::web::live_session(session_id);
 
-        // User has View role on the cache (lacks ManageCacheMembers) → 403.
+        // A View-role member (or org member, same View mask) may mint a
+        // read-only key, but not one granting `writeStore` beyond their mask → 403 (#334).
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results([vec![session.clone()]])
             .append_query_results([vec![session]])
             .append_query_results([vec![user()]])
             // Name-clash check returns empty (no existing key with that name)
             .append_query_results([Vec::<api::Model>::new()])
-            // load_cache(ManageCacheMembers): cache lookup
+            // load_cache(Readable): cache lookup
             .append_query_results([vec![private_cache_row()]])
-            // load_cache: member lookup
+            // load_cache(Readable): membership visibility check
             .append_query_results([vec![view_cache_member()]])
-            // load_cache: role lookup
+            // effective_cache_mask: member + role lookup → View mask
+            .append_query_results([vec![view_cache_member()]])
             .append_query_results([vec![view_cache_role()]]);
 
         let server = make_test_server(db.into_connection());
@@ -243,7 +245,7 @@ fn create_cache_pinned_key_requires_manage_cache_members() {
             .add_header("authorization", format!("Bearer {}", token))
             .json(&serde_json::json!({
                 "name": "my-cache-key",
-                "permissions": ["view-cache"],
+                "permissions": ["writeStore"],
                 "cache": "test-cache",
             }))
             .await;

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -739,6 +739,9 @@ paths:
         Creates a new API key. The full key (prefixed with `GRAD`) is returned once -
         it cannot be retrieved again. Use it as `Authorization: Bearer GRAD<key>`.
         Pass `expires_in_days` to make the key auto-expire; omit for no expiry.
+        A cache-pinned key may only grant cache permissions the caller already
+        holds; members of an organization subscribed to the cache are treated as
+        read-only, so they can mint read-only cache keys.
       operationId: createUserKey
       requestBody:
         required: true
@@ -4530,7 +4533,11 @@ paths:
     get:
       tags: [caches]
       summary: Get cache statistics
-      description: Returns bandwidth and hit statistics for the cache.
+      description: >-
+        Returns bandwidth and hit statistics for the cache. Visible to anyone
+        for public caches, and to cache members or members of any organization
+        subscribed to a private cache (matching `GET /caches/{cache}`); other
+        callers receive `404`.
       operationId: getCacheStats
       responses:
         '200':

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -663,6 +663,30 @@ NixOS VM (`nix/tests/gradient/state`):
   subscribing org, neither lists nor can show the private caches, pinning the
   broadened read access so it does not leak caches to unrelated users.
 
+## Org members get read-only cache access (#334)
+
+Backend (`cargo test -p web --lib access::tests`):
+- `effective_cache_mask_returns_role_for_member` - a direct cache member's API
+  key is capped by their cache role mask.
+- `effective_cache_mask_returns_view_for_org_subscriber` - a member of a
+  subscribed organization with no `cache_user` row is treated as read-only
+  (`cache_view_mask`), so they can mint a read-only cache key and view stats.
+- `effective_cache_mask_none_for_outsider` - a user with neither a cache role
+  nor a subscribing org gets no mask, so cache-pinned key creation 404s.
+
+These pin the fix for the remaining "cache not found" responses: creating a
+read-only cache API key (`POST /user/keys`) and reading cache traffic/storage
+metrics (`GET /caches/{cache}/stats`) now route through the same
+member-or-subscriber visibility as `GET /caches/{cache}`, instead of requiring
+`ManageCacheMembers` / cache ownership.
+
+NixOS VM (`nix/tests/gradient/state`):
+- `org member reads cache stats and mints a read-only key` - `bob` (a `corp`
+  member with no cache role) reads `GET /caches/main/stats` and creates a
+  read-only cache key, but is denied a `writeStore` key he could not use.
+- `non-members cannot see private caches` also asserts `charlie` gets a 404 on
+  `GET /caches/main/stats`.
+
 ## Hashed API keys at rest
 
 Backend (`cargo test -p core --lib state::provisioning::api_key_hash_tests`):

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -680,12 +680,9 @@ metrics (`GET /caches/{cache}/stats`) now route through the same
 member-or-subscriber visibility as `GET /caches/{cache}`, instead of requiring
 `ManageCacheMembers` / cache ownership.
 
-NixOS VM (`nix/tests/gradient/state`):
-- `org member reads cache stats and mints a read-only key` - `bob` (a `corp`
-  member with no cache role) reads `GET /caches/main/stats` and creates a
-  read-only cache key, but is denied a `writeStore` key he could not use.
-- `non-members cannot see private caches` also asserts `charlie` gets a 404 on
-  `GET /caches/main/stats`.
+Integration (`cargo test -p web --test cache_api_key_pinning`):
+- `create_cache_pinned_key_cannot_exceed_member_mask` - a View-mask member is
+  denied a `writeStore` cache-pinned key (perms beyond their mask) → 403.
 
 ## Hashed API keys at rest
 


### PR DESCRIPTION
Fixes #334.

Follow-up to #327/#329: two more cache endpoints rejected non-owner org members with `404`.

- `GET /caches/{cache}/stats` used a creator-only inline check; now routes through `load_cache(Readable)` so cache members and subscribed-org members can read traffic/storage metrics.
- `POST /user/keys` (cache-pinned) required `ManageCacheMembers`; now any caller who can see the cache may mint a key whose permissions are a subset of their own. Subscribed-org members are treated as read-only (`cache_view_mask`), so they can create read-only cache keys but not write keys.

Covered by `access::tests::effective_cache_mask_*` and the `state` NixOS VM test.