### PR TITLE
Add docstring for cache ingest module

### DIFF
--- a/backend/core/src/cache/mod.rs
+++ b/backend/core/src/cache/mod.rs
@@ -3,4 +3,5 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+/// Module for cache ingestion functionalities.
 pub mod ingest;


### PR DESCRIPTION
### 问题背景
公共模块 `ingest` 在代码中缺乏文档字符串，这降低了代码的可读性和可维护性。作为开源项目，良好的文档有助于新贡献者快速理解模块功能，并遵循 Rust 社区的文档最佳实践。

### 修改内容
在 `backend/core/src/cache/mod.rs` 文件中，为 `pub mod ingest;` 添加了文档字符串 `/// Module for cache ingestion functionalities.`。这是一个最小化的改动，不改变代码功能或 API，仅提升文档覆盖。

### 验证方式
1. 直接查看修改后的文件，确认文档字符串已正确添加在模块声明前。
2. 运行 `cargo doc` 命令生成项目文档，检查 `ingest` 模块的文档是否正常显示，确保无语法错误。