### PR TITLE
Runtime closure size (#338)

### DIFF
--- a/backend/core/src/db/mod.rs
+++ b/backend/core/src/db/mod.rs
@@ -15,6 +15,7 @@ pub mod drv_output_spec;
 pub mod gc;
 pub mod org_cache;
 pub mod org_workers;
+pub mod runtime_closure;
 pub mod status;
 
 pub use self::cache_reach::*;
@@ -27,4 +28,5 @@ pub use self::drv_output_spec::DrvOutputSpec;
 pub use self::gc::*;
 pub use self::org_cache::org_has_writable_cache;
 pub use self::org_workers::org_has_eval_capable_worker_registration;
+pub use self::runtime_closure::*;
 pub use self::status::*;

--- a/backend/core/src/db/runtime_closure.rs
+++ b/backend/core/src/db/runtime_closure.rs
@@ -1,0 +1,149 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Runtime-closure walks over store-path references.
+//!
+//! Unlike the build closure (a walk of `derivation_dependency`), the runtime
+//! closure follows `cached_path.references` - the narinfo `References:` field -
+//! starting from a build's output store paths. It captures exactly what a built
+//! artefact needs at runtime, and is only populated once outputs are cached.
+
+use sea_orm::{ColumnTrait, ConnectionTrait, DbErr, EntityTrait, QueryFilter};
+use std::collections::{HashMap, HashSet};
+
+use crate::types::*;
+
+/// Extract the 32-char store hash from a `hash-name` reference token. Store
+/// hashes are dash-free, so the hash is everything before the first `-`.
+pub fn parse_reference_hash(reference: &str) -> Option<String> {
+    let hash = reference.split('-').next().unwrap_or_default();
+    (!hash.is_empty()).then(|| hash.to_string())
+}
+
+/// Output store-path hashes of `drv_ids`, the seeds of their runtime closures.
+pub async fn output_hashes_for_drvs<C: ConnectionTrait>(
+    db: &C,
+    drv_ids: &[DerivationId],
+) -> Result<Vec<String>, DbErr> {
+    if drv_ids.is_empty() {
+        return Ok(vec![]);
+    }
+    Ok(EDerivationOutput::find()
+        .filter(CDerivationOutput::Derivation.is_in(drv_ids.to_vec()))
+        .all(db)
+        .await?
+        .into_iter()
+        .map(|o| o.hash)
+        .collect())
+}
+
+/// BFS over `cached_path.references` from `seed_hashes`; returns every reached
+/// `cached_path` row keyed by hash. Seeds and references without a `cached_path`
+/// row (NAR not yet uploaded) are simply absent from the result.
+pub async fn runtime_closure_reachable<C: ConnectionTrait>(
+    db: &C,
+    seed_hashes: &[String],
+) -> Result<HashMap<String, entity::cached_path::Model>, DbErr> {
+    let mut reached: HashMap<String, entity::cached_path::Model> = HashMap::new();
+    let mut visited: HashSet<String> = seed_hashes.iter().cloned().collect();
+    let mut frontier: Vec<String> = seed_hashes.to_vec();
+
+    while !frontier.is_empty() {
+        let rows = ECachedPath::find()
+            .filter(CCachedPath::Hash.is_in(frontier.clone()))
+            .all(db)
+            .await?;
+        frontier.clear();
+        for row in rows {
+            for token in row.references.clone().unwrap_or_default().split_whitespace() {
+                if let Some(hash) = parse_reference_hash(token)
+                    && visited.insert(hash.clone())
+                {
+                    frontier.push(hash);
+                }
+            }
+            reached.insert(row.hash.clone(), row);
+        }
+    }
+
+    Ok(reached)
+}
+
+/// Total NAR size of the runtime closure seeded at `seed_hashes`.
+pub async fn runtime_closure_size<C: ConnectionTrait>(
+    db: &C,
+    seed_hashes: &[String],
+) -> Result<i64, DbErr> {
+    let reached = runtime_closure_reachable(db, seed_hashes).await?;
+    Ok(reached.values().filter_map(|r| r.nar_size).sum())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use entity::cached_path;
+    use sea_orm::{DatabaseBackend, MockDatabase};
+
+    fn now() -> chrono::NaiveDateTime {
+        chrono::Utc::now().naive_utc()
+    }
+
+    fn cp(hash: &str, nar_size: i64, references: &str) -> cached_path::Model {
+        cached_path::Model {
+            id: CachedPathId::now_v7(),
+            store_path: format!("/nix/store/{hash}-foo"),
+            hash: hash.into(),
+            package: "foo".into(),
+            file_hash: Some("sha256:dummy".into()),
+            file_size: Some(nar_size / 2),
+            nar_size: Some(nar_size),
+            nar_hash: None,
+            references: (!references.is_empty()).then(|| references.to_string()),
+            ca: None,
+            deriver: None,
+            created_at: now(),
+        }
+    }
+
+    #[test]
+    fn reference_hash_strips_name() {
+        assert_eq!(parse_reference_hash("abc123-hello-2.10").as_deref(), Some("abc123"));
+        assert_eq!(parse_reference_hash("abc123").as_deref(), Some("abc123"));
+        assert_eq!(parse_reference_hash(""), None);
+    }
+
+    // root -refs-> child (size 100 + 40) => total 140 over two reached rows.
+    #[tokio::test]
+    async fn walks_references_and_sums() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![cp("root", 100, "child-foo")]])
+            .append_query_results([vec![cp("child", 40, "")]])
+            .into_connection();
+
+        let reached = runtime_closure_reachable(&db, &["root".into()]).await.unwrap();
+        assert_eq!(reached.len(), 2);
+        assert_eq!(reached.values().filter_map(|r| r.nar_size).sum::<i64>(), 140);
+    }
+
+    // root -> a, root -> b, a -> c, b -> c: c counted once.
+    #[tokio::test]
+    async fn dedups_diamond() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![cp("root", 10, "a-foo b-foo")]])
+            .append_query_results([vec![cp("a", 20, "c-foo"), cp("b", 30, "c-foo")]])
+            .append_query_results([vec![cp("c", 40, "")]])
+            .into_connection();
+
+        let total = runtime_closure_size(&db, &["root".into()]).await.unwrap();
+        assert_eq!(total, 100);
+    }
+
+    #[tokio::test]
+    async fn empty_seeds_is_zero() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
+        assert_eq!(runtime_closure_size(&db, &[]).await.unwrap(), 0);
+    }
+}

--- a/backend/web/src/endpoints/builds/closure.rs
+++ b/backend/web/src/endpoints/builds/closure.rs
@@ -24,7 +24,7 @@ const CLOSURE_NODE_CAP: usize = 1000;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct ClosureNode {
-    pub id: DerivationId,
+    pub id: String,
     pub name: String,
     pub path: String,
     pub nar_size: Option<i64>,
@@ -32,13 +32,13 @@ pub struct ClosureNode {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct ClosureEdge {
-    pub source: DerivationId,
-    pub target: DerivationId,
+    pub source: String,
+    pub target: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct ClosureGraph {
-    pub roots: Vec<DerivationId>,
+    pub roots: Vec<String>,
     pub total_size_bytes: Option<i64>,
     pub node_count: usize,
     pub edge_count: usize,
@@ -88,7 +88,7 @@ pub async fn build_closure_graph<C: sea_orm::ConnectionTrait>(
         .into_iter()
         .map(|d| ClosureNode {
             nar_size: size_by_drv.get(&d.id).copied(),
-            id: d.id,
+            id: d.id.to_string(),
             name: d.name.clone(),
             path: d.store_path(),
         })
@@ -100,7 +100,7 @@ pub async fn build_closure_graph<C: sea_orm::ConnectionTrait>(
     if truncated {
         nodes.truncate(CLOSURE_NODE_CAP);
     }
-    let kept: HashSet<DerivationId> = nodes.iter().map(|n| n.id).collect();
+    let kept: HashSet<String> = nodes.iter().map(|n| n.id.clone()).collect();
 
     let dep_rows = EDerivationDependency::find()
         .filter(CDerivationDependency::Derivation.is_in(all_ids))
@@ -108,15 +108,15 @@ pub async fn build_closure_graph<C: sea_orm::ConnectionTrait>(
         .await?;
     let edges: Vec<ClosureEdge> = dep_rows
         .into_iter()
-        .filter(|e| kept.contains(&e.derivation) && kept.contains(&e.dependency))
         .map(|e| ClosureEdge {
-            source: e.dependency,
-            target: e.derivation,
+            source: e.dependency.to_string(),
+            target: e.derivation.to_string(),
         })
+        .filter(|e| kept.contains(&e.source) && kept.contains(&e.target))
         .collect();
 
     Ok(ClosureGraph {
-        roots,
+        roots: roots.iter().map(|r| r.to_string()).collect(),
         total_size_bytes,
         node_count: nodes.len(),
         edge_count: edges.len(),
@@ -169,6 +169,115 @@ pub async fn get_eval_closure(
     };
 
     let graph = build_closure_graph(&state.web_db, roots).await?;
+    Ok(ok_json(graph))
+}
+
+/// Build a runtime closure graph seeded at the output store-path hashes
+/// `seed_hashes`: the transitive `cached_path.references` set with per-node and
+/// exact total NAR sizes. Reachability is only as complete as the cached outputs.
+pub async fn build_runtime_closure_graph<C: sea_orm::ConnectionTrait>(
+    db: &C,
+    seed_hashes: Vec<String>,
+) -> WebResult<ClosureGraph> {
+    let reached = gradient_core::db::runtime_closure_reachable(db, &seed_hashes).await?;
+
+    let total: i64 = reached.values().filter_map(|r| r.nar_size).sum();
+    let total_size_bytes = (total > 0).then_some(total);
+
+    let mut nodes: Vec<ClosureNode> = reached
+        .values()
+        .map(|r| ClosureNode {
+            id: r.hash.clone(),
+            name: r.package.clone(),
+            path: r.store_path.clone(),
+            nar_size: r.nar_size,
+        })
+        .collect();
+    nodes.sort_by_key(|n| std::cmp::Reverse(n.nar_size.unwrap_or(0)));
+
+    let truncated = nodes.len() > CLOSURE_NODE_CAP;
+    if truncated {
+        nodes.truncate(CLOSURE_NODE_CAP);
+    }
+    let kept: HashSet<String> = nodes.iter().map(|n| n.id.clone()).collect();
+
+    let mut edges: Vec<ClosureEdge> = Vec::new();
+    for row in reached.values().filter(|r| kept.contains(&r.hash)) {
+        for token in row.references.clone().unwrap_or_default().split_whitespace() {
+            if let Some(dep) = gradient_core::db::parse_reference_hash(token)
+                && dep != row.hash
+                && kept.contains(&dep)
+            {
+                edges.push(ClosureEdge {
+                    source: dep,
+                    target: row.hash.clone(),
+                });
+            }
+        }
+    }
+
+    let roots: Vec<String> = seed_hashes
+        .into_iter()
+        .filter(|h| reached.contains_key(h))
+        .collect();
+
+    Ok(ClosureGraph {
+        roots,
+        total_size_bytes,
+        node_count: nodes.len(),
+        edge_count: edges.len(),
+        truncated,
+        nodes,
+        edges,
+    })
+}
+
+/// GET /builds/{build}/runtime-closure - runtime reference closure of a build.
+pub async fn get_build_runtime_closure(
+    state: State<Arc<ServerState>>,
+    Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
+    Path(build_id): Path<BuildId>,
+) -> WebResult<Json<BaseResponse<ClosureGraph>>> {
+    let ctx = BuildAccessContext::load(&state, build_id, &maybe_user, api_key.as_ref()).await?;
+    let seeds =
+        gradient_core::db::output_hashes_for_drvs(&state.web_db, &[ctx.build.derivation]).await?;
+    let graph = build_runtime_closure_graph(&state.web_db, seeds).await?;
+    Ok(ok_json(graph))
+}
+
+/// GET /evals/{evaluation}/runtime-closure - union runtime closure of entry points.
+pub async fn get_eval_runtime_closure(
+    state: State<Arc<ServerState>>,
+    Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
+    Path(evaluation_id): Path<EvaluationId>,
+) -> WebResult<Json<BaseResponse<ClosureGraph>>> {
+    let _ctx =
+        EvalAccessContext::load(&state, evaluation_id, &maybe_user, api_key.as_ref()).await?;
+
+    let ep_build_ids: Vec<BuildId> = EEntryPoint::find()
+        .filter(CEntryPoint::Evaluation.eq(evaluation_id))
+        .all(&state.web_db)
+        .await?
+        .into_iter()
+        .map(|ep| ep.build)
+        .collect();
+
+    let roots: Vec<DerivationId> = if ep_build_ids.is_empty() {
+        vec![]
+    } else {
+        EBuild::find()
+            .filter(CBuild::Id.is_in(ep_build_ids))
+            .all(&state.web_db)
+            .await?
+            .into_iter()
+            .map(|b| b.derivation)
+            .collect()
+    };
+
+    let seeds = gradient_core::db::output_hashes_for_drvs(&state.web_db, &roots).await?;
+    let graph = build_runtime_closure_graph(&state.web_db, seeds).await?;
     Ok(ok_json(graph))
 }
 
@@ -241,13 +350,55 @@ mod tests {
         assert_eq!(g.edge_count, 1);
         assert!(!g.truncated);
         // Largest first.
-        assert_eq!(g.nodes[0].id, root);
+        assert_eq!(g.nodes[0].id, root.to_string());
         assert_eq!(g.nodes[0].nar_size, Some(100));
         assert_eq!(
             g.edges[0],
             ClosureEdge {
-                source: child,
-                target: root
+                source: child.to_string(),
+                target: root.to_string(),
+            }
+        );
+    }
+
+    fn cached(hash: &str, nar_size: i64, references: &str) -> entity::cached_path::Model {
+        entity::cached_path::Model {
+            id: CachedPathId::now_v7(),
+            store_path: format!("/nix/store/{hash}-foo"),
+            hash: hash.into(),
+            package: "foo".into(),
+            file_hash: Some("sha256:dummy".into()),
+            file_size: Some(nar_size / 2),
+            nar_size: Some(nar_size),
+            nar_hash: None,
+            references: (!references.is_empty()).then(|| references.to_string()),
+            ca: None,
+            deriver: None,
+            created_at: now(),
+        }
+    }
+
+    // root -refs-> child; sizes 100 + 40 => total 140, two nodes, one edge.
+    #[tokio::test]
+    async fn runtime_closure_graph_sums_and_links() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![cached("root", 100, "child-foo")]])
+            .append_query_results([vec![cached("child", 40, "")]])
+            .into_connection();
+
+        let g = build_runtime_closure_graph(&db, vec!["root".into()])
+            .await
+            .unwrap();
+        assert_eq!(g.total_size_bytes, Some(140));
+        assert_eq!(g.node_count, 2);
+        assert_eq!(g.edge_count, 1);
+        assert_eq!(g.roots, vec!["root".to_string()]);
+        assert_eq!(g.nodes[0].id, "root");
+        assert_eq!(
+            g.edges[0],
+            ClosureEdge {
+                source: "child".into(),
+                target: "root".into(),
             }
         );
     }

--- a/backend/web/src/endpoints/builds/mod.rs
+++ b/backend/web/src/endpoints/builds/mod.rs
@@ -12,8 +12,9 @@ pub mod log_chunks;
 pub mod query;
 
 pub use self::closure::{
-    ClosureEdge, ClosureGraph, ClosureNode, build_closure_graph, derivation_closure_reachable,
-    get_build_closure, get_eval_closure, sum_output_sizes,
+    ClosureEdge, ClosureGraph, ClosureNode, build_closure_graph, build_runtime_closure_graph,
+    derivation_closure_reachable, get_build_closure, get_build_runtime_closure, get_eval_closure,
+    get_eval_runtime_closure, sum_output_sizes,
 };
 pub use self::downloads::{
     BuildProduct, DownloadQuery, get_build_download, get_build_download_token, get_build_downloads,

--- a/backend/web/src/endpoints/projects/metrics.rs
+++ b/backend/web/src/endpoints/projects/metrics.rs
@@ -7,6 +7,7 @@
 use crate::access::{Caller, OrgAccess, load_org};
 use crate::authorization::{MaybeApiKey, MaybeUser};
 use crate::endpoints::builds::closure::{derivation_closure_reachable, sum_output_sizes};
+use gradient_core::db::{output_hashes_for_drvs, runtime_closure_size};
 use crate::error::WebResult;
 use crate::helpers::{OptionExt, ok_json};
 use axum::extract::{Path, Query, State};
@@ -24,6 +25,7 @@ pub struct ProjectMetricPoint {
     pub eval_time_ms: i64,
     pub output_size_bytes: Option<i64>,
     pub closure_size_bytes: Option<i64>,
+    pub runtime_closure_size_bytes: Option<i64>,
     pub dependencies_count: i64,
 }
 
@@ -102,9 +104,13 @@ pub async fn get_project_metrics(
         let closure = derivation_closure_reachable(&state.web_db, ep_drv_ids.clone()).await?;
         let dependencies_count = (closure.len() as i64) - entry_point_count;
 
-        let output_size_bytes = sum_output_sizes(&state.web_db, ep_drv_ids).await?;
+        let output_size_bytes = sum_output_sizes(&state.web_db, ep_drv_ids.clone()).await?;
         let closure_size_bytes =
             sum_output_sizes(&state.web_db, closure.into_iter().collect()).await?;
+
+        let seeds = output_hashes_for_drvs(&state.web_db, &ep_drv_ids).await?;
+        let runtime = runtime_closure_size(&state.web_db, &seeds).await?;
+        let runtime_closure_size_bytes = (runtime > 0).then_some(runtime);
 
         points.push(ProjectMetricPoint {
             evaluation_id: evaluation.id,
@@ -113,6 +119,7 @@ pub async fn get_project_metrics(
             eval_time_ms,
             output_size_bytes,
             closure_size_bytes,
+            runtime_closure_size_bytes,
             dependencies_count,
         });
     }
@@ -142,6 +149,7 @@ pub struct EntryPointMetricPoint {
     pub build_time_ms: Option<i64>,
     pub output_size_bytes: Option<i64>,
     pub closure_size_bytes: Option<i64>,
+    pub runtime_closure_size_bytes: Option<i64>,
     pub dependencies_count: i64,
 }
 
@@ -210,6 +218,10 @@ pub async fn get_entry_point_metrics(
         let closure_size_bytes =
             sum_output_sizes(&state.web_db, closure.into_iter().collect()).await?;
 
+        let seeds = output_hashes_for_drvs(&state.web_db, &[build.derivation]).await?;
+        let runtime = runtime_closure_size(&state.web_db, &seeds).await?;
+        let runtime_closure_size_bytes = (runtime > 0).then_some(runtime);
+
         points.push(EntryPointMetricPoint {
             evaluation_id: evaluation.id,
             build_id: build.id,
@@ -218,6 +230,7 @@ pub async fn get_entry_point_metrics(
             build_time_ms,
             output_size_bytes,
             closure_size_bytes,
+            runtime_closure_size_bytes,
             dependencies_count,
         });
     }

--- a/backend/web/src/lib.rs
+++ b/backend/web/src/lib.rs
@@ -448,6 +448,10 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
         )
         .route("/evals/{evaluation}/artefacts", get(evals::get_artefacts))
         .route("/evals/{evaluation}/closure", get(builds::get_eval_closure))
+        .route(
+            "/evals/{evaluation}/runtime-closure",
+            get(builds::get_eval_runtime_closure),
+        )
         .route("/builds/{build}", get(builds::get_build))
         .route("/builds/{build}/log", get(builds::get_build_log))
         .route(
@@ -469,6 +473,10 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
         )
         .route("/builds/{build}/graph", get(builds::get_build_graph))
         .route("/builds/{build}/closure", get(builds::get_build_closure))
+        .route(
+            "/builds/{build}/runtime-closure",
+            get(builds::get_build_runtime_closure),
+        )
         .route(
             "/builds/{build}/downloads",
             get(builds::get_build_downloads),

--- a/backend/web/tests/entry_point_metrics.rs
+++ b/backend/web/tests/entry_point_metrics.rs
@@ -205,6 +205,7 @@ fn returns_point_when_eval_is_in_progress_but_build_is_completed() {
             .append_query_results([Vec::<entity::derivation_dependency::Model>::new()])
             .append_query_results([Vec::<entity::derivation_output::Model>::new()])
             .append_query_results([Vec::<entity::derivation_output::Model>::new()])
+            .append_query_results([Vec::<entity::derivation_output::Model>::new()])
             .into_connection();
 
         let server = TestServer::new(create_router(make_state(db)));
@@ -243,6 +244,7 @@ fn returns_point_when_eval_is_in_progress_but_build_is_substituted() {
             .append_query_results([vec![building_eval_row()]])
             .append_query_results([vec![substituted_build_row()]])
             .append_query_results([Vec::<entity::derivation_dependency::Model>::new()])
+            .append_query_results([Vec::<entity::derivation_output::Model>::new()])
             .append_query_results([Vec::<entity::derivation_output::Model>::new()])
             .append_query_results([Vec::<entity::derivation_output::Model>::new()])
             .into_connection();

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -3044,6 +3044,33 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /evals/{evaluation}/runtime-closure:
+    parameters:
+      - $ref: '#/components/parameters/EvaluationId'
+    get:
+      tags: [evals]
+      summary: Get runtime closure size graph for an evaluation
+      description: |-
+        Union runtime reference closure of all the evaluation's entry-point build
+        outputs. Runtime counterpart of `/evals/{evaluation}/closure`.
+      operationId: getEvalRuntimeClosure
+      responses:
+        '200':
+          description: Runtime closure size graph
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BaseResponse'
+                  - type: object
+                    properties:
+                      message:
+                        $ref: '#/components/schemas/ClosureGraph'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   # ── Build Requests ───────────────────────────────────────────────────────────
 
   /build-requests/manifest:
@@ -3464,6 +3491,35 @@ paths:
       responses:
         '200':
           description: Closure size graph
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BaseResponse'
+                  - type: object
+                    properties:
+                      message:
+                        $ref: '#/components/schemas/ClosureGraph'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /builds/{build}/runtime-closure:
+    parameters:
+      - $ref: '#/components/parameters/BuildId'
+    get:
+      tags: [builds]
+      summary: Get runtime closure size graph
+      description: |-
+        Like `/builds/{build}/closure` but walks runtime store-path references
+        (narinfo `References:`) from the build's outputs instead of build-time
+        dependencies. Only as complete as the cached outputs; node ids are
+        store-path hashes. Same `ClosureGraph` shape.
+      operationId: getBuildRuntimeClosure
+      responses:
+        '200':
+          description: Runtime closure size graph
           content:
             application/json:
               schema:
@@ -6886,6 +6942,10 @@ components:
           type: integer
           nullable: true
           description: Total closure size including all transitive dependencies
+        runtime_closure_size_bytes:
+          type: integer
+          nullable: true
+          description: Total runtime reference closure size of the entry-point outputs
         dependencies_count:
           type: integer
           description: Number of dependency builds (excluding entry points)
@@ -6937,6 +6997,11 @@ components:
           format: int64
           nullable: true
           description: Total closure size including all transitive dependency outputs
+        runtime_closure_size_bytes:
+          type: integer
+          format: int64
+          nullable: true
+          description: Total runtime reference closure size of the entry-point build's outputs
         dependencies_count:
           type: integer
           format: int64
@@ -7573,14 +7638,13 @@ components:
       properties:
         id:
           type: string
-          format: uuid
-          description: Derivation UUID
+          description: Node id - derivation UUID (build closure) or store-path hash (runtime closure)
         name:
           type: string
           example: hello-2.12.1
         path:
           type: string
-          description: Full Nix store path of the `.drv`
+          description: Full Nix store path
         nar_size:
           type: integer
           format: int64
@@ -7593,12 +7657,10 @@ components:
       properties:
         source:
           type: string
-          format: uuid
-          description: Dependency derivation
+          description: Dependency node id
         target:
           type: string
-          format: uuid
-          description: Derivation that depends on `source`
+          description: Node id that depends on `source`
 
     ClosureGraph:
       type: object
@@ -7608,8 +7670,7 @@ components:
           type: array
           items:
             type: string
-            format: uuid
-          description: Seed derivations (one for a build, all entry points for an evaluation)
+          description: Seed node ids (one for a build, all entry points for an evaluation)
         total_size_bytes:
           type: integer
           format: int64

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -3410,3 +3410,18 @@ bounds and handles empty logs. Run a single spec with
 **CLI** — `gradient builds log <id>` keeps streaming parity (the server's
 `GET /log` reassembles chunks); `--lines L120-L130` fetches a line range and
 `--search <term>` streams matches.
+
+## Runtime closure (#338)
+
+**`core::db::runtime_closure`** — `parse_reference_hash` strips the `-name`
+suffix from a `hash-name` reference token; `runtime_closure_reachable` walks
+`cached_path.references` and sums NAR sizes, deduping diamonds and returning zero
+for empty seeds.
+
+**`web::endpoints::builds::closure::runtime_closure_graph_sums_and_links`** —
+`build_runtime_closure_graph` sums sizes, keys nodes by store-path hash, and
+emits `source` → `target` edges (referrer depends on reference).
+
+**Frontend `closure-graph`** — the view requests the runtime closure by default
+and the build-time closure only under `?type=build` (eval scope uses the eval
+runtime endpoint).

--- a/docs/src/usage/closure-view.md
+++ b/docs/src/usage/closure-view.md
@@ -7,6 +7,15 @@ taking up space?" when trimming netboot images, ISOs, or container layers.
 Open it from an entry point's metrics page via the **View Closure** button, which
 links to the closure of that entry point's most recent build.
 
+## Runtime vs build closure
+
+The view shows the **runtime** closure by default — the transitive store-path
+references (narinfo `References:`) of the build's outputs, i.e. what the artefact
+actually needs to run. It is only as complete as the cached outputs. Append
+`?type=build` to the URL to see the **build-time** closure instead (the full
+`derivation` dependency graph); there is no button for this, it is reached by URL
+only. The header badge shows which closure is displayed.
+
 The dependency graph is a DAG, which has no conserved flow; rendering it as a
 Sankey directly produces meaningless bar heights and backward links. The view
 therefore reduces it to a rooted tree (each package keeps a single parent, via
@@ -29,10 +38,14 @@ Both endpoints return per-node sizes plus an exact `total_size_bytes`, so they
 are also useful for custom tooling and scripts:
 
 ```sh
-GET /api/v1/builds/{build}/closure
+GET /api/v1/builds/{build}/closure          # build-time closure
 GET /api/v1/evals/{evaluation}/closure
+GET /api/v1/builds/{build}/runtime-closure  # runtime reference closure
+GET /api/v1/evals/{evaluation}/runtime-closure
 ```
 
 Response (`ClosureGraph`): `roots`, `total_size_bytes`, `node_count`,
 `edge_count`, `truncated`, `nodes` (`id`, `name`, `path`, `nar_size`), and
-`edges` (`source` → `target`, where `target` depends on `source`).
+`edges` (`source` → `target`, where `target` depends on `source`). Node ids are
+derivation UUIDs for the build closure and store-path hashes for the runtime
+closure.

--- a/frontend/src/app/core/services/evaluations.service.ts
+++ b/frontend/src/app/core/services/evaluations.service.ts
@@ -143,6 +143,14 @@ export class EvaluationsService {
     return this.api.get<ClosureGraph>(`evals/${evalId}/closure`);
   }
 
+  getBuildRuntimeClosure(buildId: string): Observable<ClosureGraph> {
+    return this.api.get<ClosureGraph>(`builds/${buildId}/runtime-closure`);
+  }
+
+  getEvalRuntimeClosure(evalId: string): Observable<ClosureGraph> {
+    return this.api.get<ClosureGraph>(`evals/${evalId}/runtime-closure`);
+  }
+
   getBuildDownloads(buildId: string): Observable<BuildProduct[]> {
     return this.api.get<BuildProduct[]>(`builds/${buildId}/downloads`);
   }

--- a/frontend/src/app/core/services/projects.service.ts
+++ b/frontend/src/app/core/services/projects.service.ts
@@ -103,6 +103,7 @@ export interface ProjectMetricPoint {
   eval_time_ms: number;
   output_size_bytes: number | null;
   closure_size_bytes: number | null;
+  runtime_closure_size_bytes: number | null;
   dependencies_count: number;
 }
 
@@ -119,6 +120,7 @@ export interface EntryPointMetricPoint {
   build_time_ms: number | null;
   output_size_bytes: number | null;
   closure_size_bytes: number | null;
+  runtime_closure_size_bytes: number | null;
   dependencies_count: number;
 }
 

--- a/frontend/src/app/features/evaluations/closure-graph/closure-graph.component.html
+++ b/frontend/src/app/features/evaluations/closure-graph/closure-graph.component.html
@@ -24,6 +24,7 @@
         <div class="header-info">
           <div class="header-title">
             <span class="header-name">{{ rootName() }}</span>
+            <span class="type-badge">{{ typeLabel() }}</span>
             <span class="total-badge">{{ totalLabel() }}</span>
           </div>
           <div class="header-meta">

--- a/frontend/src/app/features/evaluations/closure-graph/closure-graph.component.scss
+++ b/frontend/src/app/features/evaluations/closure-graph/closure-graph.component.scss
@@ -84,6 +84,14 @@
   font-size: $font-size-sm;
 }
 
+.type-badge {
+  color: $text-secondary;
+  font-size: $font-size-sm;
+  border: 1px solid $color-border;
+  border-radius: $border-radius-sm;
+  padding: 1px 8px;
+}
+
 .icon-btn {
   background: none;
   border: none;

--- a/frontend/src/app/features/evaluations/closure-graph/closure-graph.component.spec.ts
+++ b/frontend/src/app/features/evaluations/closure-graph/closure-graph.component.spec.ts
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
+import { of } from 'rxjs';
+import { ClosureGraphComponent } from './closure-graph.component';
+import { EvaluationsService } from '@core/services/evaluations.service';
+
+const emptyGraph = {
+  roots: [], total_size_bytes: 0, node_count: 0, edge_count: 0,
+  truncated: false, nodes: [], edges: [],
+};
+
+function service() {
+  return {
+    getBuildClosure: vi.fn(() => of(emptyGraph)),
+    getEvalClosure: vi.fn(() => of(emptyGraph)),
+    getBuildRuntimeClosure: vi.fn(() => of(emptyGraph)),
+    getEvalRuntimeClosure: vi.fn(() => of(emptyGraph)),
+  };
+}
+
+function setup(kind: string, type?: string) {
+  const svc = service();
+  const route = {
+    snapshot: {
+      paramMap: convertToParamMap({ org: 'acme', kind, id: 'x1' }),
+      queryParamMap: convertToParamMap(type ? { type } : {}),
+    },
+  } as unknown as ActivatedRoute;
+
+  TestBed.configureTestingModule({
+    imports: [ClosureGraphComponent],
+    providers: [
+      provideRouter([]),
+      { provide: ActivatedRoute, useValue: route },
+      { provide: EvaluationsService, useValue: svc },
+    ],
+  });
+  const fixture = TestBed.createComponent(ClosureGraphComponent);
+  fixture.detectChanges();
+  return svc;
+}
+
+describe('ClosureGraphComponent - view selection', () => {
+  it('defaults to the runtime closure when no type query param is present', () => {
+    const svc = setup('build');
+    expect(svc.getBuildRuntimeClosure).toHaveBeenCalledWith('x1');
+    expect(svc.getBuildClosure).not.toHaveBeenCalled();
+  });
+
+  it('shows the build closure when type=build', () => {
+    const svc = setup('build', 'build');
+    expect(svc.getBuildClosure).toHaveBeenCalledWith('x1');
+    expect(svc.getBuildRuntimeClosure).not.toHaveBeenCalled();
+  });
+
+  it('uses the eval runtime closure for the eval scope by default', () => {
+    const svc = setup('eval');
+    expect(svc.getEvalRuntimeClosure).toHaveBeenCalledWith('x1');
+  });
+});

--- a/frontend/src/app/features/evaluations/closure-graph/closure-graph.component.ts
+++ b/frontend/src/app/features/evaluations/closure-graph/closure-graph.component.ts
@@ -57,6 +57,8 @@ export class ClosureGraphComponent implements OnInit, OnDestroy {
   orgName = '';
   kind = '';
   id = '';
+  closureType = 'runtime';
+  typeLabel = signal('');
 
   private bounds = { minX: 0, minY: 0, maxX: 0, maxY: 0 };
   private isPanning = false;
@@ -68,6 +70,8 @@ export class ClosureGraphComponent implements OnInit, OnDestroy {
     this.orgName = this.route.snapshot.paramMap.get('org') || '';
     this.kind = this.route.snapshot.paramMap.get('kind') || 'build';
     this.id = this.route.snapshot.paramMap.get('id') || '';
+    this.closureType = this.route.snapshot.queryParamMap.get('type') === 'build' ? 'build' : 'runtime';
+    this.typeLabel.set(this.closureType === 'build' ? 'Build closure' : 'Runtime closure');
     this.load();
   }
 
@@ -77,9 +81,10 @@ export class ClosureGraphComponent implements OnInit, OnDestroy {
   }
 
   private load(): void {
-    const req = this.kind === 'eval'
-      ? this.evalService.getEvalClosure(this.id)
-      : this.evalService.getBuildClosure(this.id);
+    const isEval = this.kind === 'eval';
+    const req = this.closureType === 'build'
+      ? (isEval ? this.evalService.getEvalClosure(this.id) : this.evalService.getBuildClosure(this.id))
+      : (isEval ? this.evalService.getEvalRuntimeClosure(this.id) : this.evalService.getBuildRuntimeClosure(this.id));
     req.subscribe({
       next: (g) => {
         this.nodeCount.set(g.node_count);

--- a/frontend/src/app/features/projects/entry-point-metrics/entry-point-metrics.component.ts
+++ b/frontend/src/app/features/projects/entry-point-metrics/entry-point-metrics.component.ts
@@ -28,6 +28,7 @@ const CHART_COLORS = {
   buildTime: '#17a2b8',
   outputSize: '#28a745',
   closureSize: '#fd7e14',
+  runtimeClosure: '#20c997',
   deps: '#e83e8c',
   background: '#21262d',
   border: '#2d333b',
@@ -152,7 +153,11 @@ export class EntryPointMetricsComponent implements OnInit {
   closureSizeChart = computed<ChartOptions>(() => {
     const pts = this.points();
     const opts = this.baseChart(CHART_COLORS.closureSize);
-    opts.series = [{ name: 'Closure size', data: pts.map((p) => p.closure_size_bytes) }];
+    opts.colors = [CHART_COLORS.closureSize, CHART_COLORS.runtimeClosure];
+    opts.series = [
+      { name: 'Build closure', data: pts.map((p) => p.closure_size_bytes) },
+      { name: 'Runtime closure', data: pts.map((p) => p.runtime_closure_size_bytes) },
+    ];
     opts.yaxis = { ...opts.yaxis, labels: { style: { colors: CHART_COLORS.text }, formatter: (v: number) => this.formatBytes(v) } };
     opts.tooltip = { theme: 'dark', y: { formatter: (v: number) => this.formatBytes(v) } };
     return opts;

--- a/frontend/src/app/features/projects/project-metrics/project-metrics.component.ts
+++ b/frontend/src/app/features/projects/project-metrics/project-metrics.component.ts
@@ -28,6 +28,7 @@ const CHART_COLORS = {
   evalTime: '#6f42c1',
   outputSize: '#28a745',
   closureSize: '#fd7e14',
+  runtimeClosure: '#20c997',
   deps: '#e83e8c',
   background: '#21262d',
   border: '#2d333b',
@@ -159,7 +160,11 @@ export class ProjectMetricsComponent implements OnInit {
   closureSizeChart = computed<ChartOptions>(() => {
     const pts = this.metrics();
     const opts = this.baseChart(CHART_COLORS.closureSize);
-    opts.series = [{ name: 'Closure size', data: pts.map((p) => p.closure_size_bytes) }];
+    opts.colors = [CHART_COLORS.closureSize, CHART_COLORS.runtimeClosure];
+    opts.series = [
+      { name: 'Build closure', data: pts.map((p) => p.closure_size_bytes) },
+      { name: 'Runtime closure', data: pts.map((p) => p.runtime_closure_size_bytes) },
+    ];
     opts.yaxis = { ...opts.yaxis, labels: { style: { colors: CHART_COLORS.text }, formatter: (v: number) => this.formatBytes(v) } };
     opts.tooltip = { theme: 'dark', y: { formatter: (v: number) => this.formatBytes(v) } };
     return opts;


### PR DESCRIPTION
Closes #338.

Adds a runtime reference closure (walk of `cached_path.references`) alongside the existing build-time closure. The closure view now defaults to runtime; `?type=build` shows the build closure (URL-only, no button). Stats pages gain a second runtime-closure line.

- new `/builds/{build}/runtime-closure` and `/evals/{evaluation}/runtime-closure` endpoints
- `runtime_closure_size_bytes` added to project & entry-point metrics