### PR TITLE
feat: max storage limits per instance and per cache (#216)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build docs
         run: |
           nix-shell \
-          -p "python3.withPackages (ps: [ ps.mkdocs ps.mkdocs-mermaid2-plugin ps.pymdown-extensions ])" \
+          -p "python3.withPackages (ps: [ ps.mkdocs ps.mkdocs-mermaid2-plugin ps.pymdown-extensions ps.pygments ])" \
           --run "mkdocs build --strict --site-dir _site"
 
       - name: Upload artifact

--- a/backend/cache/src/cacher/mod.rs
+++ b/backend/cache/src/cacher/mod.rs
@@ -78,6 +78,14 @@ pub async fn cache_loop(state: Arc<ServerState>) {
         {
             error!(error = ?e, "NAR TTL GC failed");
         }
+        if let Err(e) = gradient_core::ci::unpark_storage_full_all(
+            &state.worker_db,
+            state.config.storage.max_storage_gb,
+        )
+        .await
+        {
+            error!(error = ?e, "Failed to unpark storage-full evaluations after cleanup");
+        }
         if let Err(e) = cleanup_stale_build_request_blobs(Arc::clone(&state)).await {
             error!(error = ?e, "Build-request blob GC failed");
         }

--- a/backend/core/src/ci/actions.rs
+++ b/backend/core/src/ci/actions.rs
@@ -162,6 +162,10 @@ pub async fn dispatch_evaluation_created(
             "evaluation.queued",
             Some("Waiting for a writable cache subscription before this evaluation can run."),
         ),
+        (EvaluationStatus::Waiting, Some(WaitingReason::CacheStorageFull)) => (
+            "evaluation.queued",
+            Some("Waiting for cache storage to free up before this evaluation can run."),
+        ),
         (
             EvaluationStatus::Waiting,
             Some(WaitingReason::Workers {

--- a/backend/core/src/ci/apply.rs
+++ b/backend/core/src/ci/apply.rs
@@ -10,7 +10,9 @@
 
 use super::abort::{AbortKind, abort_evaluation};
 use super::trigger::{TriggerError, trigger_evaluation};
-use crate::db::{org_has_eval_capable_worker_registration, org_has_writable_cache};
+use crate::db::{
+    org_caches_all_full, org_has_eval_capable_worker_registration, org_has_writable_cache,
+};
 use crate::types::triggers::{ConcurrencyPolicy, TriggerType};
 use crate::types::waiting_reason::WaitingReason;
 use crate::types::*;
@@ -72,6 +74,9 @@ pub struct ApplyInput {
     /// in `evaluation.source_comment` so the terminal-status reporter can
     /// react with thumbs-up / thumbs-down once the build resolves.
     pub source_comment: Option<serde_json::Value>,
+    /// Instance-wide `max_storage_gb` limit (`GRADIENT_MAX_STORAGE_GB`), used by
+    /// the storage-full gate. `0` disables the instance-wide limit.
+    pub instance_max_storage_gb: i32,
 }
 
 /// Identification of the pull request a maintainer must approve before the
@@ -176,6 +181,8 @@ pub async fn apply_trigger<C: ConnectionTrait>(
 
     let eval = park_if_pending_approval(db, eval, input.gate_approval.as_ref()).await?;
     let eval = park_if_no_cache(db, eval, project.organization).await?;
+    let eval =
+        park_if_storage_full(db, eval, project.organization, input.instance_max_storage_gb).await?;
     let eval = park_if_no_workers(db, eval, project.organization).await?;
     Ok(ApplyOutcome::Created {
         evaluation: eval,
@@ -229,6 +236,31 @@ pub async fn park_if_no_cache<C: ConnectionTrait>(
     let mut ae: AEvaluation = eval.into();
     ae.status = Set(EvaluationStatus::Waiting);
     ae.waiting_reason = Set(Some(WaitingReason::NoCache.to_json()));
+    ae.updated_at = Set(crate::types::now());
+    ae.update(db).await
+}
+
+/// Move a freshly-created `Queued` evaluation into `Waiting` with
+/// `WaitingReason::CacheStorageFull` when every writable cache for the org is
+/// within `STORAGE_HEADROOM_BYTES` of its configured `max_storage_gb` (or the
+/// instance-wide limit). Returns the evaluation unchanged when at least one
+/// writable cache still has headroom, or when the org has no writable cache at
+/// all (that case is owned by [`park_if_no_cache`]).
+pub async fn park_if_storage_full<C: ConnectionTrait>(
+    db: &C,
+    eval: MEvaluation,
+    organization: OrganizationId,
+    instance_max_storage_gb: i32,
+) -> Result<MEvaluation, sea_orm::DbErr> {
+    if eval.status != EvaluationStatus::Queued {
+        return Ok(eval);
+    }
+    if !org_caches_all_full(db, organization, instance_max_storage_gb).await? {
+        return Ok(eval);
+    }
+    let mut ae: AEvaluation = eval.into();
+    ae.status = Set(EvaluationStatus::Waiting);
+    ae.waiting_reason = Set(Some(WaitingReason::CacheStorageFull.to_json()));
     ae.updated_at = Set(crate::types::now());
     ae.update(db).await
 }
@@ -324,6 +356,25 @@ mod tests {
         }
     }
 
+    /// The storage gate only acts on `Queued` evaluations; a row already
+    /// parked (e.g. by the approval gate) is returned untouched without
+    /// issuing any cache queries.
+    #[tokio::test]
+    async fn storage_gate_ignores_non_queued_eval() {
+        let already_waiting = make_eval(
+            EvaluationId::now_v7(),
+            ProjectId::nil(),
+            CommitId::now_v7(),
+            EvaluationStatus::Waiting,
+        );
+        let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
+        let out = park_if_storage_full(&db, already_waiting.clone(), OrganizationId::nil(), 0)
+            .await
+            .unwrap();
+        assert_eq!(out.status, EvaluationStatus::Waiting);
+        assert_eq!(out.id, already_waiting.id);
+    }
+
     fn make_commit(id: CommitId, hash: Vec<u8>) -> entity::commit::Model {
         entity::commit::Model {
             id,
@@ -351,6 +402,7 @@ mod tests {
             repository_override: None,
             wildcard_override: None,
             source_comment: None,
+            instance_max_storage_gb: 0,
         }
     }
 
@@ -369,6 +421,7 @@ mod tests {
             created_by: UserId::nil(),
             created_at: NaiveDateTime::default(),
             managed: false,
+            max_storage_gb: 0,
         }
     }
 
@@ -387,6 +440,13 @@ mod tests {
         let cache = cache_row(true);
         db.append_query_results([vec![org_cache_row(cache.id)]])
             .append_query_results([vec![cache]])
+    }
+
+    /// Append the single query `park_if_storage_full` issues for the "not
+    /// full" path: `org_writable_caches` finds no org_cache rows, so
+    /// `org_caches_all_full` short-circuits to `false`.
+    fn with_storage_not_full(db: MockDatabase) -> MockDatabase {
+        db.append_query_results([Vec::<entity::organization_cache::Model>::new()])
     }
 
     fn worker_registration_row(
@@ -490,7 +550,7 @@ mod tests {
                 last_insert_id: 0,
                 rows_affected: 1,
             }]);
-        let db = with_eval_worker(with_writable_cache(db)).into_connection();
+        let db = with_eval_worker(with_storage_not_full(with_writable_cache(db))).into_connection();
 
         let res = apply_trigger(
             &db,
@@ -609,7 +669,7 @@ mod tests {
                 last_insert_id: 0,
                 rows_affected: 1,
             }]);
-        let db = with_eval_worker(with_writable_cache(db)).into_connection();
+        let db = with_eval_worker(with_storage_not_full(with_writable_cache(db))).into_connection();
 
         let res = apply_trigger(
             &db,
@@ -705,7 +765,7 @@ mod tests {
                 last_insert_id: 0,
                 rows_affected: 1,
             }]);
-        let db = with_eval_worker(with_writable_cache(db)).into_connection();
+        let db = with_eval_worker(with_storage_not_full(with_writable_cache(db))).into_connection();
 
         let res = apply_trigger(
             &db,
@@ -797,7 +857,7 @@ mod tests {
                 last_insert_id: 0,
                 rows_affected: 1,
             }]);
-        let db = with_eval_worker(with_writable_cache(db)).into_connection();
+        let db = with_eval_worker(with_storage_not_full(with_writable_cache(db))).into_connection();
 
         let res = apply_trigger(
             &db,
@@ -888,6 +948,7 @@ mod tests {
             repository_override: None,
             wildcard_override: None,
             source_comment: None,
+            instance_max_storage_gb: 0,
         };
         let res = apply_trigger(&db, &project, applied).await.unwrap();
 
@@ -1047,7 +1108,9 @@ mod tests {
                 rows_affected: 1,
             }]);
         // park_if_no_cache: writable cache exists → returns unchanged.
-        let db = with_writable_cache(db)
+        let db = with_writable_cache(db);
+        // park_if_storage_full: no writable cache rows → not full.
+        let db = with_storage_not_full(db)
             // park_if_no_workers: no eval-capable registration → park.
             .append_query_results([Vec::<entity::worker_registration::Model>::new()])
             // Park: update eval read-back + exec, returns the parked row.

--- a/backend/core/src/ci/mod.rs
+++ b/backend/core/src/ci/mod.rs
@@ -32,4 +32,5 @@ pub use self::trigger::*;
 pub use self::unpark::{
     find_approval_gated_eval, set_evaluation_source_comment, unpark_approval,
     unpark_approval_with_wildcard, unpark_no_cache_for_org, unpark_no_workers_for_org,
+    unpark_storage_full_all, unpark_storage_full_for_org,
 };

--- a/backend/core/src/ci/mod.rs
+++ b/backend/core/src/ci/mod.rs
@@ -21,7 +21,7 @@ pub mod unpark;
 pub use self::abort::{AbortKind, abort_evaluation};
 pub use self::apply::{
     ApplyError, ApplyInput, ApplyOutcome, ApprovalInfo, apply_trigger, park_if_no_cache,
-    park_if_no_workers, park_if_pending_approval,
+    park_if_no_workers, park_if_pending_approval, park_if_storage_full,
 };
 pub use self::github_app::*;
 pub use self::http_validation::validate_webhook_url;

--- a/backend/core/src/ci/unpark.rs
+++ b/backend/core/src/ci/unpark.rs
@@ -38,6 +38,63 @@ pub async fn unpark_no_cache_for_org<C: ConnectionTrait>(
     unpark_for_org(db, organization, |r| matches!(r, WaitingReason::NoCache)).await
 }
 
+/// Flip evaluations parked with `WaitingReason::CacheStorageFull` for projects
+/// in `organization` back to `Queued`, but only when the org actually has
+/// storage headroom again. The guard prevents a churn of re-queue → re-park
+/// when nothing actionable changed (mirrors `unpark_no_workers_for_org`).
+pub async fn unpark_storage_full_for_org<C: ConnectionTrait>(
+    db: &C,
+    organization: OrganizationId,
+    instance_max_storage_gb: i32,
+) -> Result<Vec<MEvaluation>, sea_orm::DbErr> {
+    if crate::db::org_caches_all_full(db, organization, instance_max_storage_gb).await? {
+        return Ok(Vec::new());
+    }
+    unpark_for_org(db, organization, |r| {
+        matches!(r, WaitingReason::CacheStorageFull)
+    })
+    .await
+}
+
+/// Scan every org with a `CacheStorageFull`-parked evaluation and unpark those
+/// that now have headroom. Used by the background cleanup pass after NARs are
+/// freed, where there is no single triggering org.
+pub async fn unpark_storage_full_all<C: ConnectionTrait>(
+    db: &C,
+    instance_max_storage_gb: i32,
+) -> Result<Vec<MEvaluation>, sea_orm::DbErr> {
+    let parked = EEvaluation::find()
+        .filter(CEvaluation::Status.eq(EvaluationStatus::Waiting))
+        .all(db)
+        .await?;
+
+    let mut orgs: Vec<OrganizationId> = Vec::new();
+    for eval in &parked {
+        let is_storage = eval
+            .waiting_reason
+            .as_ref()
+            .and_then(WaitingReason::from_json)
+            .is_some_and(|r| matches!(r, WaitingReason::CacheStorageFull));
+        if !is_storage {
+            continue;
+        }
+        let Some(project_id) = eval.project else {
+            continue;
+        };
+        if let Some(project) = EProject::find_by_id(project_id).one(db).await?
+            && !orgs.contains(&project.organization)
+        {
+            orgs.push(project.organization);
+        }
+    }
+
+    let mut unparked = Vec::new();
+    for org in orgs {
+        unparked.extend(unpark_storage_full_for_org(db, org, instance_max_storage_gb).await?);
+    }
+    Ok(unparked)
+}
+
 /// Flip every evaluation parked with `WaitingReason::Workers { connected_workers: 0 }`
 /// for projects in `organization` back to `Queued`. The zero-workers shape
 /// is what `park_if_no_workers` writes when the org has no active
@@ -414,5 +471,41 @@ mod tests {
             .await
             .unwrap();
         assert!(out.is_empty());
+    }
+
+    #[tokio::test]
+    async fn unpark_storage_full_requeues_when_headroom_returns() {
+        let org = OrganizationId::now_v7();
+        let project = make_project(org);
+
+        let stranded = {
+            let mut e = waiting_eval(WaitingReason::CacheStorageFull);
+            e.project = Some(project.id);
+            e
+        };
+        let mut requeued = stranded.clone();
+        requeued.status = EvaluationStatus::Queued;
+        requeued.waiting_reason = None;
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            // Guard `org_caches_all_full`: no writable caches → not full.
+            .append_query_results([Vec::<entity::organization_cache::Model>::new()])
+            // unpark_for_org: org's projects
+            .append_query_results([vec![project.clone()]])
+            // unpark_for_org: Waiting evals across those projects
+            .append_query_results([vec![stranded.clone()]])
+            // Update the matching row → requeued
+            .append_query_results([vec![requeued.clone()]])
+            .append_exec_results([MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }])
+            .into_connection();
+
+        let out = unpark_storage_full_for_org(&db, org, 0).await.unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].id, stranded.id);
+        assert_eq!(out[0].status, EvaluationStatus::Queued);
+        assert!(out[0].waiting_reason.is_none());
     }
 }

--- a/backend/core/src/db/cache_storage.rs
+++ b/backend/core/src/db/cache_storage.rs
@@ -1,0 +1,175 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Storage-accounting helpers for the per-cache / per-instance max-storage
+//! gate. Usage is the logical sum of `cached_path.file_size` (compressed NAR
+//! bytes): per-cache via the `cached_path_signature` join, instance-wide as a
+//! global sum. Backend-agnostic (works for local FS and S3).
+
+use crate::types::ids::{CacheId, OrganizationId};
+use entity::cache::Model as MCache;
+use entity::organization_cache::CacheSubscriptionMode;
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QuerySelect};
+
+/// Park threshold: a cache with less than this much free headroom is "full".
+pub const STORAGE_HEADROOM_BYTES: i64 = 10 * 1024 * 1024;
+
+const BYTES_PER_GB: i64 = 1024 * 1024 * 1024;
+
+fn limit_to_bytes(max_storage_gb: i32) -> Option<i64> {
+    if max_storage_gb <= 0 {
+        None
+    } else {
+        Some(max_storage_gb as i64 * BYTES_PER_GB)
+    }
+}
+
+/// Sum of compressed NAR bytes attributed to a single cache.
+pub async fn cache_used_bytes<C: ConnectionTrait>(
+    db: &C,
+    cache: CacheId,
+) -> Result<i64, sea_orm::DbErr> {
+    use entity::cached_path::{Column as CCP, Entity as ECP};
+    use entity::cached_path_signature::{Column as CSig, Entity as ESig};
+
+    let path_ids: Vec<entity::ids::CachedPathId> = ESig::find()
+        .filter(CSig::Cache.eq(cache))
+        .all(db)
+        .await?
+        .into_iter()
+        .map(|s| s.cached_path)
+        .collect();
+
+    if path_ids.is_empty() {
+        return Ok(0);
+    }
+
+    let sum: Option<i64> = ECP::find()
+        .filter(CCP::Id.is_in(path_ids))
+        .select_only()
+        .column_as(CCP::FileSize.sum(), "total")
+        .into_tuple()
+        .one(db)
+        .await?
+        .flatten();
+    Ok(sum.unwrap_or(0))
+}
+
+/// Sum of compressed NAR bytes stored across the whole instance.
+pub async fn instance_used_bytes<C: ConnectionTrait>(db: &C) -> Result<i64, sea_orm::DbErr> {
+    use entity::cached_path::{Column as CCP, Entity as ECP};
+    let sum: Option<i64> = ECP::find()
+        .select_only()
+        .column_as(CCP::FileSize.sum(), "total")
+        .into_tuple()
+        .one(db)
+        .await?
+        .flatten();
+    Ok(sum.unwrap_or(0))
+}
+
+/// The active, writable (ReadWrite/WriteOnly) caches an org can push to.
+pub async fn org_writable_caches<C: ConnectionTrait>(
+    db: &C,
+    organization: OrganizationId,
+) -> Result<Vec<MCache>, sea_orm::DbErr> {
+    use entity::cache::{Column as CCache, Entity as ECache};
+    use entity::organization_cache::{Column as COC, Entity as EOC};
+
+    let cache_ids: Vec<CacheId> = EOC::find()
+        .filter(COC::Organization.eq(organization))
+        .filter(COC::Mode.is_in([
+            CacheSubscriptionMode::ReadWrite,
+            CacheSubscriptionMode::WriteOnly,
+        ]))
+        .all(db)
+        .await?
+        .into_iter()
+        .map(|r| r.cache)
+        .collect();
+
+    if cache_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    ECache::find()
+        .filter(CCache::Id.is_in(cache_ids))
+        .filter(CCache::Active.eq(true))
+        .all(db)
+        .await
+}
+
+/// Free headroom (bytes) for one cache, bounded by both its own limit and the
+/// instance-wide limit. A non-positive limit means unlimited on that axis.
+/// Returns `i64::MAX` when both axes are unlimited.
+fn headroom(
+    cache_limit_gb: i32,
+    cache_used: i64,
+    instance_limit_gb: i32,
+    instance_used: i64,
+) -> i64 {
+    let cache_free = limit_to_bytes(cache_limit_gb)
+        .map(|lim| lim - cache_used)
+        .unwrap_or(i64::MAX);
+    let instance_free = limit_to_bytes(instance_limit_gb)
+        .map(|lim| lim - instance_used)
+        .unwrap_or(i64::MAX);
+    cache_free.min(instance_free)
+}
+
+/// `true` when the org has at least one writable cache AND every writable cache
+/// has less than `STORAGE_HEADROOM_BYTES` free. An empty writable-cache set
+/// returns `false` (that case is owned by the NoCache gate).
+pub async fn org_caches_all_full<C: ConnectionTrait>(
+    db: &C,
+    organization: OrganizationId,
+    instance_limit_gb: i32,
+) -> Result<bool, sea_orm::DbErr> {
+    let caches = org_writable_caches(db, organization).await?;
+    if caches.is_empty() {
+        return Ok(false);
+    }
+    let instance_used = instance_used_bytes(db).await?;
+    for cache in &caches {
+        let used = cache_used_bytes(db, cache.id).await?;
+        let free = headroom(cache.max_storage_gb, used, instance_limit_gb, instance_used);
+        if free >= STORAGE_HEADROOM_BYTES {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_limit_is_unlimited() {
+        assert_eq!(limit_to_bytes(0), None);
+        assert_eq!(limit_to_bytes(-5), None);
+        assert_eq!(limit_to_bytes(1), Some(BYTES_PER_GB));
+    }
+
+    #[test]
+    fn headroom_bounded_by_tighter_axis() {
+        let five_mb = 5 * 1024 * 1024;
+        let used = BYTES_PER_GB - five_mb;
+        assert_eq!(headroom(1, used, 0, 0), five_mb);
+    }
+
+    #[test]
+    fn headroom_instance_axis_can_dominate() {
+        let one_mb = 1024 * 1024;
+        let inst_used = BYTES_PER_GB - one_mb;
+        assert_eq!(headroom(0, 0, 1, inst_used), one_mb);
+    }
+
+    #[test]
+    fn both_unlimited_is_max() {
+        assert_eq!(headroom(0, 9_999, 0, 9_999), i64::MAX);
+    }
+}

--- a/backend/core/src/db/mod.rs
+++ b/backend/core/src/db/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod admin_tasks;
 pub mod cache_reach;
+pub mod cache_storage;
 pub mod cache_upstream;
 pub mod closure;
 pub mod connection;
@@ -19,6 +20,10 @@ pub mod runtime_closure;
 pub mod status;
 
 pub use self::cache_reach::*;
+pub use self::cache_storage::{
+    STORAGE_HEADROOM_BYTES, cache_used_bytes, instance_used_bytes, org_caches_all_full,
+    org_writable_caches,
+};
 pub use self::cache_upstream::{GradientProtoUpstream, gradient_proto_upstreams_for_org, upstream_urls_for_org};
 pub use self::closure::*;
 pub use self::connection::*;

--- a/backend/core/src/sources/cache_key.rs
+++ b/backend/core/src/sources/cache_key.rs
@@ -319,6 +319,7 @@ mod tests {
             created_by: crate::types::ids::UserId::nil(),
             created_at: NaiveDateTime::default(),
             managed: false,
+            max_storage_gb: 0,
         }
     }
 

--- a/backend/core/src/state/export.rs
+++ b/backend/core/src/state/export.rs
@@ -216,6 +216,7 @@ pub async fn export_state<C: ConnectionTrait>(db: &C) -> Result<StateConfigurati
                 active: c.active,
                 priority: c.priority,
                 local_priority: c.local_priority,
+                max_storage_gb: c.max_storage_gb,
                 signing_key_file: String::new(),
                 organizations,
                 upstreams: cache_upstreams,

--- a/backend/core/src/state/mod.rs
+++ b/backend/core/src/state/mod.rs
@@ -234,6 +234,8 @@ pub struct StateCache {
     pub priority: i32,
     #[serde(default)]
     pub local_priority: Option<i32>,
+    #[serde(default)]
+    pub max_storage_gb: i32,
     pub signing_key_file: String,
     #[serde(default)]
     pub organizations: Vec<String>,

--- a/backend/core/src/state/provisioning.rs
+++ b/backend/core/src/state/provisioning.rs
@@ -934,6 +934,7 @@ impl<'a> StateApplicator<'a> {
                 cache_model.active = Set(state_cache.active);
                 cache_model.priority = Set(state_cache.priority);
                 cache_model.local_priority = Set(state_cache.local_priority);
+                cache_model.max_storage_gb = Set(state_cache.max_storage_gb);
                 cache_model.public_key = Set(public_key.clone());
                 cache_model.private_key = Set(encrypted_signing_key.clone());
                 cache_model.created_by = Set(created_by_id);
@@ -958,6 +959,7 @@ impl<'a> StateApplicator<'a> {
                     created_by: Set(created_by_id),
                     created_at: Set(now),
                     managed: Set(true),
+                    max_storage_gb: Set(state_cache.max_storage_gb),
                 };
                 cache_model.insert(self.db).await?;
                 tracing::info!(name = %state_cache.name, "Created managed cache");

--- a/backend/core/src/types/cli/eval.rs
+++ b/backend/core/src/types/cli/eval.rs
@@ -32,9 +32,9 @@ pub struct EvalArgs {
     pub build_max_attempts: u32,
     #[arg(long, env = "GRADIENT_BUILD_RETRY_BACKOFF_SECS", default_value = "30")]
     pub build_retry_backoff_secs: u64,
-    #[arg(long, env = "GRADIENT_BUILD_DEFAULT_TIMEOUT_SECS", default_value = "3600")]
+    #[arg(long, env = "GRADIENT_BUILD_DEFAULT_TIMEOUT_SECS", default_value = "14400")]
     pub build_default_timeout_secs: u64,
-    #[arg(long, env = "GRADIENT_BUILD_DEFAULT_MAX_SILENT_SECS", default_value = "1800")]
+    #[arg(long, env = "GRADIENT_BUILD_DEFAULT_MAX_SILENT_SECS", default_value = "3600")]
     pub build_default_max_silent_secs: u64,
     /// Name of the scheduler scoring policy (`simple`, `resource-aware`).
     /// Unknown names fall back to `resource-aware`.
@@ -52,8 +52,8 @@ impl Default for EvalArgs {
             max_evaluations_per_worker: 1,
             build_max_attempts: 3,
             build_retry_backoff_secs: 30,
-            build_default_timeout_secs: 3600,
-            build_default_max_silent_secs: 1800,
+            build_default_timeout_secs: 14400,
+            build_default_max_silent_secs: 3600,
             scheduler_scoring_policy: "resource-aware".into(),
         }
     }

--- a/backend/core/src/types/cli/storage.rs
+++ b/backend/core/src/types/cli/storage.rs
@@ -44,6 +44,12 @@ pub struct StorageArgs {
     /// may exceed this. Defaults to 262144 (256 KiB).
     #[arg(long, env = "GRADIENT_LOG_CHUNK_BYTES", default_value_t = 262144)]
     pub log_chunk_bytes: usize,
+    /// Instance-wide cap on total cached NAR bytes, in gigabytes. When the
+    /// stored compressed-NAR total leaves every writable cache for an org with
+    /// less than 10 MiB of headroom, new evaluations park in `Waiting`. `0`
+    /// (default) disables the instance-wide limit; per-cache limits still apply.
+    #[arg(long, env = "GRADIENT_MAX_STORAGE_GB", default_value_t = 0)]
+    pub max_storage_gb: i32,
 }
 
 impl Default for StorageArgs {
@@ -58,6 +64,7 @@ impl Default for StorageArgs {
             nar_ttl_hours: 336,
             keep_orphan_derivations_hours: 24,
             log_chunk_bytes: 262144,
+            max_storage_gb: 0,
         }
     }
 }
@@ -93,5 +100,16 @@ mod tests {
     fn clap_default_nar_ttl_hours_is_two_weeks() {
         let parsed = StorageOnlyCli::try_parse_from(["test"]).unwrap();
         assert_eq!(parsed.storage.nar_ttl_hours, 336);
+    }
+
+    #[test]
+    fn default_max_storage_gb_is_unlimited() {
+        assert_eq!(StorageArgs::default().max_storage_gb, 0);
+    }
+
+    #[test]
+    fn clap_default_max_storage_gb_is_zero() {
+        let parsed = StorageOnlyCli::try_parse_from(["test"]).unwrap();
+        assert_eq!(parsed.storage.max_storage_gb, 0);
     }
 }

--- a/backend/core/src/types/config.rs
+++ b/backend/core/src/types/config.rs
@@ -253,8 +253,8 @@ mod tests {
                 max_evaluations_per_worker: 0,
                 build_max_attempts: 3,
                 build_retry_backoff_secs: 30,
-                build_default_timeout_secs: 3600,
-                build_default_max_silent_secs: 1800,
+                build_default_timeout_secs: 14400,
+                build_default_max_silent_secs: 3600,
                 scheduler_scoring_policy: "resource-aware".into(),
             },
             storage: StorageArgs {

--- a/backend/core/src/types/waiting_reason.rs
+++ b/backend/core/src/types/waiting_reason.rs
@@ -17,6 +17,8 @@
 //!   forge writer on the repo, gated until a maintainer approves.
 //! - `NoCache` - the project's organisation has no active cache configured,
 //!   so the build outputs would have nowhere to land.
+//! - `CacheStorageFull` - every writable cache for the organisation is within
+//!   the headroom threshold of its (or the instance-wide) max-storage limit.
 
 use serde::{Deserialize, Serialize};
 
@@ -33,6 +35,10 @@ pub enum WaitingReason {
         pr_author: String,
     },
     NoCache,
+    /// Every writable cache for the org is within `STORAGE_HEADROOM_BYTES` of
+    /// its configured `max_storage_gb` (or the instance-wide limit), so build
+    /// outputs would have nowhere to land.
+    CacheStorageFull,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -118,6 +124,14 @@ mod tests {
         let r = WaitingReason::NoCache;
         let v = r.to_json();
         assert_eq!(v["kind"], "no_cache");
+        assert_eq!(WaitingReason::from_json(&v).unwrap(), r);
+    }
+
+    #[test]
+    fn cache_storage_full_round_trip() {
+        let r = WaitingReason::CacheStorageFull;
+        let v = r.to_json();
+        assert_eq!(v["kind"], "cache_storage_full");
         assert_eq!(WaitingReason::from_json(&v).unwrap(), r);
     }
 

--- a/backend/entity/src/cache.rs
+++ b/backend/entity/src/cache.rs
@@ -30,6 +30,8 @@ pub struct Model {
     pub created_by: UserId,
     pub created_at: NaiveDateTime,
     pub managed: bool,
+    #[sea_orm(default_value = "0")]
+    pub max_storage_gb: i32,
 }
 
 impl std::fmt::Debug for Model {
@@ -47,6 +49,8 @@ impl std::fmt::Debug for Model {
             .field("public", &self.public)
             .field("created_by", &self.created_by)
             .field("created_at", &self.created_at)
+            .field("managed", &self.managed)
+            .field("max_storage_gb", &self.max_storage_gb)
             .finish()
     }
 }

--- a/backend/migration/src/lib.rs
+++ b/backend/migration/src/lib.rs
@@ -128,6 +128,7 @@ mod m20260604_000002_create_derivation_metric;
 mod m20260605_000000_index_hot_lookups;
 mod m20260605_000001_create_build_log_chunk;
 mod m20260606_000000_add_derivation_fixed_output;
+mod m20260607_000000_add_max_storage_to_cache;
 
 pub struct Migrator;
 
@@ -257,6 +258,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260605_000000_index_hot_lookups::Migration),
             Box::new(m20260605_000001_create_build_log_chunk::Migration),
             Box::new(m20260606_000000_add_derivation_fixed_output::Migration),
+            Box::new(m20260607_000000_add_max_storage_to_cache::Migration),
         ]
     }
 }

--- a/backend/migration/src/m20260607_000000_add_max_storage_to_cache.rs
+++ b/backend/migration/src/m20260607_000000_add_max_storage_to_cache.rs
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Alias::new("cache"))
+                    .add_column(
+                        ColumnDef::new(Alias::new("max_storage_gb"))
+                            .integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Alias::new("cache"))
+                    .drop_column(Alias::new("max_storage_gb"))
+                    .to_owned(),
+            )
+            .await
+    }
+}

--- a/backend/scheduler/src/trigger_dispatch.rs
+++ b/backend/scheduler/src/trigger_dispatch.rs
@@ -221,6 +221,7 @@ pub(crate) async fn dispatch_once(scheduler: &Scheduler) -> anyhow::Result<()> {
                 repository_override: None,
                 wildcard_override: None,
                 source_comment: None,
+                instance_max_storage_gb: state.config.storage.max_storage_gb,
             },
         )
         .await

--- a/backend/test-support/src/cache_fixture.rs
+++ b/backend/test-support/src/cache_fixture.rs
@@ -79,6 +79,7 @@ pub async fn public_cache_with_narinfo() -> Arc<ServerState> {
         created_by: UserId::new(org_id().into_inner()),
         created_at: test_date(),
         managed: false,
+        max_storage_gb: 0,
     };
 
     let drv_output_row = entity::derivation_output::Model {
@@ -187,6 +188,7 @@ pub async fn public_cache_state() -> Arc<ServerState> {
         created_by: UserId::new(org_id().into_inner()),
         created_at: test_date(),
         managed: false,
+        max_storage_gb: 0,
     };
 
     let db = MockDatabase::new(DatabaseBackend::Postgres)
@@ -237,6 +239,7 @@ pub async fn public_cache_with_nar() -> Arc<ServerState> {
         created_by: UserId::new(org_id().into_inner()),
         created_at: test_date(),
         managed: false,
+        max_storage_gb: 0,
     };
 
     let db = MockDatabase::new(DatabaseBackend::Postgres)
@@ -306,6 +309,7 @@ fn cache_row_with_visibility(public: bool) -> entity::cache::Model {
         created_by: UserId::new(org_id().into_inner()),
         created_at: test_date(),
         managed: false,
+        max_storage_gb: 0,
     }
 }
 

--- a/backend/test-support/src/fixtures.rs
+++ b/backend/test-support/src/fixtures.rs
@@ -106,6 +106,7 @@ pub fn cache_with_id(id: CacheId, slug: &str, owner: UserId) -> cache::Model {
         created_by: owner,
         created_at: test_date(),
         managed: false,
+        max_storage_gb: 0,
     }
 }
 

--- a/backend/web/src/access.rs
+++ b/backend/web/src/access.rs
@@ -1151,6 +1151,7 @@ mod tests {
             created_by: UserId::new(uuid!("a0000000-0000-0000-0000-000000000004")),
             created_at: fixture_date(),
             managed,
+            max_storage_gb: 0,
         }
     }
 

--- a/backend/web/src/endpoints/caches/management.rs
+++ b/backend/web/src/endpoints/caches/management.rs
@@ -37,6 +37,8 @@ pub struct MakeCacheRequest {
     pub public: Option<bool>,
     #[serde(default)]
     pub local_priority: Option<i32>,
+    #[serde(default)]
+    pub max_storage_gb: Option<i32>,
 }
 
 #[derive(Serialize)]
@@ -48,6 +50,7 @@ pub struct CacheResponse {
     pub active: bool,
     pub priority: i32,
     pub local_priority: Option<i32>,
+    pub max_storage_gb: i32,
     pub public_key: String,
     pub public: bool,
     pub created_by: UserId,
@@ -63,6 +66,16 @@ pub struct PatchCacheRequest {
     pub description: Option<String>,
     pub priority: Option<i32>,
     pub local_priority: Option<i32>,
+    pub max_storage_gb: Option<i32>,
+}
+
+fn validate_max_storage_gb(value: i32) -> WebResult<()> {
+    if value < 0 {
+        return Err(WebError::bad_request(
+            "max_storage_gb must be 0 (unlimited) or at least 1",
+        ));
+    }
+    Ok(())
 }
 
 // ── Handlers ──────────────────────────────────────────────────────────────────
@@ -140,6 +153,9 @@ pub async fn put(
         )));
     }
 
+    let max_storage_gb = body.max_storage_gb.unwrap_or(0);
+    validate_max_storage_gb(max_storage_gb)?;
+
     let existing_cache = ECache::find()
         .filter(CCache::Name.eq(body.name.clone()))
         .one(&state.web_db)
@@ -171,6 +187,7 @@ pub async fn put(
         created_by: Set(user.id),
         created_at: Set(gradient_core::types::now()),
         managed: Set(false),
+        max_storage_gb: Set(max_storage_gb),
     }
     .insert(&tx)
     .await
@@ -278,6 +295,7 @@ pub async fn get_cache(
         active: cache.active,
         priority: cache.priority,
         local_priority: cache.local_priority,
+        max_storage_gb: cache.max_storage_gb,
         public_key,
         public: cache.public,
         created_by: cache.created_by,
@@ -305,6 +323,8 @@ pub async fn patch_cache(
         },
     )
     .await?;
+    let cache_id = cache.id;
+    let prev_max_storage_gb = cache.max_storage_gb;
     let mut acache: ACache = cache.into();
 
     if let Some(name) = body.name {
@@ -345,10 +365,38 @@ pub async fn patch_cache(
         acache.local_priority = Set(Some(local_priority));
     }
 
+    let mut raised_limit = false;
+    if let Some(max_storage_gb) = body.max_storage_gb {
+        validate_max_storage_gb(max_storage_gb)?;
+        raised_limit = max_storage_gb == 0 || max_storage_gb > prev_max_storage_gb;
+        acache.max_storage_gb = Set(max_storage_gb);
+    }
+
     acache
         .update(&state.web_db)
         .await
         .map_err(|e| WebError::from_db_err(e, "Cache Name"))?;
+
+    if raised_limit {
+        let org_ids: Vec<OrganizationId> = EOrganizationCache::find()
+            .filter(COrganizationCache::Cache.eq(cache_id))
+            .all(&state.web_db)
+            .await?
+            .into_iter()
+            .map(|oc| oc.organization)
+            .collect();
+        for org in org_ids {
+            if let Err(e) = gradient_core::ci::unpark_storage_full_for_org(
+                &state.web_db,
+                org,
+                state.config.storage.max_storage_gb,
+            )
+            .await
+            {
+                tracing::warn!(error = %e, org_id = %org, "failed to unpark storage-full evals");
+            }
+        }
+    }
 
     Ok(ok_json("Cache updated".to_string()))
 }
@@ -501,4 +549,21 @@ pub async fn delete_cache_public(
     acache.update(&state.web_db).await?;
 
     Ok(ok_json("Cache is now private".to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_max_storage_gb;
+
+    #[test]
+    fn validate_max_storage_gb_accepts_zero_and_positive() {
+        assert!(validate_max_storage_gb(0).is_ok());
+        assert!(validate_max_storage_gb(1).is_ok());
+        assert!(validate_max_storage_gb(500).is_ok());
+    }
+
+    #[test]
+    fn validate_max_storage_gb_rejects_negative() {
+        assert!(validate_max_storage_gb(-1).is_err());
+    }
 }

--- a/backend/web/src/endpoints/forge_hooks/trigger.rs
+++ b/backend/web/src/endpoints/forge_hooks/trigger.rs
@@ -511,6 +511,7 @@ where
                 repository_override: repository_override.clone(),
                 wildcard_override: wildcard_override.clone(),
                 source_comment: source_comment.clone(),
+                instance_max_storage_gb: state.config.storage.max_storage_gb,
             },
         )
         .await;

--- a/backend/web/src/endpoints/projects/evaluations.rs
+++ b/backend/web/src/endpoints/projects/evaluations.rs
@@ -247,6 +247,13 @@ pub async fn post_project_evaluate(
 
     let eval =
         gradient_core::ci::park_if_no_cache(&state.web_db, eval, project.organization).await?;
+    let eval = gradient_core::ci::park_if_storage_full(
+        &state.web_db,
+        eval,
+        project.organization,
+        state.config.storage.max_storage_gb,
+    )
+    .await?;
     let eval =
         gradient_core::ci::park_if_no_workers(&state.web_db, eval, project.organization).await?;
     gradient_core::ci::actions::dispatch_evaluation_created(&state, &eval).await;

--- a/backend/web/src/endpoints/projects/triggers.rs
+++ b/backend/web/src/endpoints/projects/triggers.rs
@@ -401,6 +401,7 @@ pub async fn fire_now(
         repository_override: None,
         wildcard_override: None,
         source_comment: None,
+        instance_max_storage_gb: state.config.storage.max_storage_gb,
     };
 
     let outcome = apply_trigger(&state.web_db, &proj, input)

--- a/backend/web/tests/cache_api_key_pinning.rs
+++ b/backend/web/tests/cache_api_key_pinning.rs
@@ -54,6 +54,7 @@ fn cache_row() -> cache::Model {
         created_by: user_id(),
         created_at: test_date(),
         managed: false,
+        max_storage_gb: 0,
     }
 }
 

--- a/backend/web/tests/cache_local_priority.rs
+++ b/backend/web/tests/cache_local_priority.rs
@@ -50,6 +50,7 @@ fn cache_row(local_priority: Option<i32>) -> entity::cache::Model {
         created_by: user_id(),
         created_at: test_date(),
         managed: false,
+        max_storage_gb: 0,
     }
 }
 

--- a/backend/web/tests/cache_members.rs
+++ b/backend/web/tests/cache_members.rs
@@ -43,6 +43,7 @@ fn cache_row(managed: bool) -> cache::Model {
         created_by: user_id(),
         created_at: test_date(),
         managed,
+        max_storage_gb: 0,
     }
 }
 

--- a/backend/web/tests/cache_roles.rs
+++ b/backend/web/tests/cache_roles.rs
@@ -36,6 +36,7 @@ fn cache_row() -> cache::Model {
         created_by: user_id(),
         created_at: test_date(),
         managed: false,
+        max_storage_gb: 0,
     }
 }
 

--- a/backend/web/tests/cache_subscription_gate.rs
+++ b/backend/web/tests/cache_subscription_gate.rs
@@ -61,6 +61,7 @@ fn cache_row(public: bool) -> cache::Model {
         created_by: user_id(),
         created_at: test_date(),
         managed: false,
+        max_storage_gb: 0,
     }
 }
 

--- a/backend/web/tests/caches_create.rs
+++ b/backend/web/tests/caches_create.rs
@@ -48,6 +48,7 @@ fn cache_row(name: &str) -> cache::Model {
         created_by: user_id(),
         created_at: test_date(),
         managed: false,
+        max_storage_gb: 0,
     }
 }
 

--- a/backend/web/tests/forge_hooks.rs
+++ b/backend/web/tests/forge_hooks.rs
@@ -388,6 +388,7 @@ fn apply_trigger_db_chain(db: MockDatabase) -> MockDatabase {
         }]) // UPDATE project
         .append_query_results([vec![org_cache_row()]]) // org_has_writable_cache: subscription rows
         .append_query_results([vec![cache_row()]]) // org_has_writable_cache: active cache rows
+        .append_query_results([Vec::<entity::organization_cache::Model>::new()]) // park_if_storage_full: org_writable_caches → none → not full
         .append_query_results([vec![worker_registration_row()]]) // org_has_eval_capable_worker_registration
         .append_query_results([vec![trigger_row(reporter_push_trigger(vec![]))]]) // touch_trigger_last_fired: SELECT for UPDATE
         .append_exec_results([MockExecResult {

--- a/backend/web/tests/forge_hooks.rs
+++ b/backend/web/tests/forge_hooks.rs
@@ -295,6 +295,7 @@ fn cache_row() -> entity::cache::Model {
         created_by: UserId::nil(),
         created_at: fixture_date(),
         managed: false,
+        max_storage_gb: 0,
     }
 }
 

--- a/backend/web/tests/narinfo.rs
+++ b/backend/web/tests/narinfo.rs
@@ -88,6 +88,7 @@ async fn narinfo_served_from_db_inner() {
         created_by: UserId::new(org_id().into_inner()),
         created_at: test_date(),
         managed: false,
+        max_storage_gb: 0,
     };
 
     // The derivation output matching FIXTURE_HASH.
@@ -249,6 +250,7 @@ async fn narinfo_unsigned_inner() {
         created_by: UserId::new(org_id().into_inner()),
         created_at: test_date(),
         managed: false,
+        max_storage_gb: 0,
     };
 
     let drv_output_row = entity::derivation_output::Model {

--- a/cli/connector/src/caches.rs
+++ b/cli/connector/src/caches.rs
@@ -10,6 +10,8 @@ pub struct CacheResponse {
     pub description: String,
     pub priority: i32,
     pub local_priority: Option<i32>,
+    #[serde(default)]
+    pub max_storage_gb: i32,
     pub active: bool,
     pub managed: bool,
     pub created_by: String,
@@ -22,6 +24,7 @@ pub struct MakeCacheRequest {
     pub display_name: String,
     pub description: String,
     pub priority: i32,
+    pub max_storage_gb: i32,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
@@ -30,6 +33,7 @@ pub struct PatchCacheRequest {
     pub display_name: Option<String>,
     pub description: Option<String>,
     pub priority: Option<i32>,
+    pub max_storage_gb: Option<i32>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/cli/src/commands/cache.rs
+++ b/cli/src/commands/cache.rs
@@ -25,6 +25,9 @@ pub enum Commands {
         description: Option<String>,
         #[arg(short, long)]
         priority: Option<i32>,
+        /// Max cache storage in GB. 0 = unlimited (default); otherwise at least 1.
+        #[arg(short = 'm', long, default_value_t = 0)]
+        max_storage_gb: i32,
     },
     List,
     Edit {
@@ -36,6 +39,9 @@ pub enum Commands {
         description: Option<String>,
         #[arg(short, long)]
         priority: Option<i32>,
+        /// Max cache storage in GB. 0 = unlimited (default); otherwise at least 1.
+        #[arg(short = 'm', long, default_value_t = 0)]
+        max_storage_gb: i32,
     },
     Delete {
         #[arg(add = ArgValueCompleter::new(completion::complete_caches))]
@@ -79,12 +85,14 @@ pub async fn handle(cmd: Commands, out: Output) {
             display_name,
             description,
             priority,
+            max_storage_gb,
         } => {
             let input_fields = [
                 ("Name", name),
                 ("Display Name", display_name),
                 ("Description", description),
                 ("Priority", priority.map(|p| p.to_string())),
+                ("Max Storage (GB)", Some(max_storage_gb.to_string())),
             ]
             .iter()
             .map(|(k, v)| (k.to_string(), v.clone()))
@@ -97,6 +105,7 @@ pub async fn handle(cmd: Commands, out: Output) {
                 Ok(p) => p,
                 Err(_) => out.err(ExitKind::Usage, "Priority must be an integer."),
             };
+            let max_storage_gb = parse_max_storage_gb(input.get("Max Storage (GB)").unwrap(), out);
 
             let client = client_from_config(out);
             match client
@@ -106,6 +115,7 @@ pub async fn handle(cmd: Commands, out: Output) {
                     display_name: input.get("Display Name").unwrap().clone(),
                     description: input.get("Description").unwrap().clone(),
                     priority,
+                    max_storage_gb,
                 })
                 .await
             {
@@ -139,11 +149,13 @@ pub async fn handle(cmd: Commands, out: Output) {
             display_name,
             description,
             priority,
+            max_storage_gb,
         } => {
             let input_fields = [
                 ("Display Name", display_name),
                 ("Description", description),
                 ("Priority", priority.map(|p| p.to_string())),
+                ("Max Storage (GB)", Some(max_storage_gb.to_string())),
             ]
             .iter()
             .map(|(k, v)| (k.to_string(), v.clone()))
@@ -155,6 +167,7 @@ pub async fn handle(cmd: Commands, out: Output) {
                 Ok(p) => p,
                 Err(_) => out.err(ExitKind::Usage, "Priority must be an integer."),
             };
+            let max_storage_gb = parse_max_storage_gb(input.get("Max Storage (GB)").unwrap(), out);
 
             let client = client_from_config(out);
             match client
@@ -164,6 +177,7 @@ pub async fn handle(cmd: Commands, out: Output) {
                     display_name: input.get("Display Name").unwrap().clone(),
                     description: input.get("Description").unwrap().clone(),
                     priority,
+                    max_storage_gb,
                 })
                 .await
             {
@@ -268,6 +282,17 @@ pub async fn handle(cmd: Commands, out: Output) {
 
         Commands::Nar { cmd } => cache_nar::handle(cmd, out).await,
         Commands::Upload(args) => cache_upload::handle(args, out).await,
+    }
+}
+
+fn parse_max_storage_gb(raw: &str, out: Output) -> i32 {
+    match raw.trim().parse::<i32>() {
+        Ok(v) if v >= 0 => v,
+        Ok(_) => out.err(
+            ExitKind::Usage,
+            "Max storage must be 0 (unlimited) or at least 1.",
+        ),
+        Err(_) => out.err(ExitKind::Usage, "Max storage must be an integer."),
     }
 }
 

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -7756,6 +7756,12 @@ components:
             Alternate Priority returned in nix-cache-info when the client
             IP is in the server's local_ips list. Null or 0 disables the
             override.
+        max_storage_gb:
+          type: integer
+          format: int32
+          default: 0
+          minimum: 0
+          description: Max cache storage in GB. 0 (default) = unlimited; otherwise at least 1.
 
     PatchCacheRequest:
       type: object
@@ -7776,6 +7782,11 @@ components:
             Alternate Priority returned in nix-cache-info when the client
             IP is in the server's local_ips list. Null or 0 disables the
             override.
+        max_storage_gb:
+          type: integer
+          format: int32
+          minimum: 0
+          description: Max cache storage in GB. 0 = unlimited; otherwise at least 1.
 
     Cache:
       type: object
@@ -7800,6 +7811,10 @@ components:
             Alternate Priority returned in nix-cache-info when the client
             IP is in the server's local_ips list. Null or 0 disables the
             override.
+        max_storage_gb:
+          type: integer
+          format: int32
+          description: Max cache storage in GB. 0 = unlimited; otherwise at least 1.
         active:
           type: boolean
           description: Whether the cache is publicly accessible

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -55,6 +55,7 @@ openssl rand -base64 48 > /run/secrets/gradient-crypt
 | `settings.maxProtoConnections` | `256` | Max simultaneous worker WebSocket connections; further upgrades return `503 Service Unavailable` with `Retry-After: 10` until a slot frees |
 | `settings.keepEvaluations` | `30` | Global maximum of evaluations kept per project (caps the per-project setting) |
 | `settings.logChunkBytes` | `262144` (256 KiB) | Target uncompressed size for each zstd build-log chunk written on finalize. Chunks split on line boundaries, so an over-long line may exceed this. (`GRADIENT_LOG_CHUNK_BYTES`) |
+| `settings.maxStorageGb` | `0` | Instance-wide cap on total cached NAR storage, in GB. When all writable caches for an org have less than 10 MiB headroom, new evaluations park in `Waiting`. `0` = unlimited; per-cache `max_storage_gb` limits still apply. (`GRADIENT_MAX_STORAGE_GB`) |
 | `settings.maxRequestSize` | `2097152` (2 MiB) | Max HTTP request body in bytes for most endpoints (caps webhook/JSON payloads to prevent OOM). The build-request blob endpoint uses a fixed 20 MiB cap. |
 | `settings.maxNarUploadSize` | `536870912` (512 MiB) | Max body in bytes for `POST /caches/{cache}/nars`; overrides the general `maxRequestSize` cap for NAR uploads. (`GRADIENT_MAX_NAR_UPLOAD_SIZE`) |
 | `settings.logLevel.default` | `info` | Log level: `trace` `debug` `info` `warn` `error` |

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -76,8 +76,8 @@ openssl rand -base64 48 > /run/secrets/gradient-crypt
 | `settings.localIps` | `10.0.0.0/8` | Comma-separated CIDR allowlist whose resolved client IPs receive each cache's `local_priority` value (`GRADIENT_LOCAL_IPS`). |
 | `settings.buildMaxAttempts` | `3` | Maximum number of build attempts before a transient failure is promoted to `FailedPermanent`. (`GRADIENT_BUILD_MAX_ATTEMPTS`) |
 | `settings.buildRetryBackoffSecs` | `30` | Base back-off in seconds before retrying a transient build failure; doubled after each prior attempt (exponential). (`GRADIENT_BUILD_RETRY_BACKOFF_SECS`) |
-| `settings.buildDefaultTimeoutSecs` | `3600` | Default wall-clock timeout (seconds) for builds whose `.drv` does not set a `timeout` attribute. `0` disables. (`GRADIENT_BUILD_DEFAULT_TIMEOUT_SECS`) |
-| `settings.buildDefaultMaxSilentSecs` | `1800` | Default silent-output timeout (seconds) for builds whose `.drv` does not set a `maxSilent` attribute. `0` disables. (`GRADIENT_BUILD_DEFAULT_MAX_SILENT_SECS`) |
+| `settings.buildDefaultTimeoutSecs` | `14400` | Default wall-clock timeout (seconds) for builds whose `.drv` does not set a `timeout` attribute. `0` disables. (`GRADIENT_BUILD_DEFAULT_TIMEOUT_SECS`) |
+| `settings.buildDefaultMaxSilentSecs` | `3600` | Default silent-output timeout (seconds) for builds whose `.drv` does not set a `maxSilent` attribute. `0` disables. (`GRADIENT_BUILD_DEFAULT_MAX_SILENT_SECS`) |
 | `settings.schedulerScoringPolicy` | `resource-aware` | Scheduler scoring policy ranking queued jobs against a requesting worker (`GRADIENT_SCHEDULER_SCORING_POLICY`). Values: `simple`, `resource-aware`. `simple` is the basic rule set, weighing path availability, NAR size, dependency count, wait-time anti-starvation, builtin de-prioritization and fetch-worker reservation. `resource-aware` adds RAM/OOM-fit, CPU affinity, preferLocalBuild affinity and per-org fair-share on top, and is the default. Unknown values fall back to `resource-aware`. See [scheduler scoring](development/scheduler-scoring.md). |
 
 ### Build failure states and retries

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -3446,3 +3446,29 @@ emits `source` → `target` edges (referrer depends on reference).
 **Frontend `closure-graph`** — the view requests the runtime closure by default
 and the build-time closure only under `?type=build` (eval scope uses the eval
 runtime endpoint).
+
+## Cache storage limits (#216)
+
+Per-instance (`GRADIENT_MAX_STORAGE_GB`) and per-cache (`max_storage_gb`, GB,
+0 = unlimited) storage caps. When every writable cache for an org has less than
+10 MiB headroom, new evaluations park in `Waiting` with `CacheStorageFull`.
+
+- **`core::types::waiting_reason::tests::cache_storage_full_round_trip`** — the
+  `CacheStorageFull` reason serialises to `kind=cache_storage_full` and decodes
+  back.
+- **`core::db::cache_storage::tests`** — `zero_limit_is_unlimited`,
+  `headroom_bounded_by_tighter_axis`, `headroom_instance_axis_can_dominate`,
+  `both_unlimited_is_max` cover the GB→bytes conversion and the per-cache /
+  instance headroom math (the decision input for the gate).
+- **`core::ci::apply::tests::storage_gate_ignores_non_queued_eval`** —
+  `park_if_storage_full` returns an already-`Waiting` eval untouched, issuing no
+  cache queries. The `no_eval_capable_worker_parks_*` flow also exercises the
+  gate's not-full pass-through.
+- **`core::ci::unpark::tests::unpark_storage_full_requeues_when_headroom_returns`**
+  — a `CacheStorageFull`-parked eval is re-queued once the org regains headroom.
+- **`core::types::cli::storage::tests`** — `default_max_storage_gb_is_unlimited`
+  / `clap_default_max_storage_gb_is_zero` pin the `0` default.
+- **`web::endpoints::caches::management::tests`** —
+  `validate_max_storage_gb_accepts_zero_and_positive` /
+  `validate_max_storage_gb_rejects_negative` cover the API validator. Full
+  create/patch/get round-trips of `max_storage_gb` run in CI integration tests.

--- a/docs/src/usage/state.md
+++ b/docs/src/usage/state.md
@@ -276,6 +276,7 @@ services.gradient.state.caches = {
     description      = "Production binary cache";
     priority         = 10;
     local_priority   = 1;    # served to clients in services.gradient.settings.localIps
+    max_storage_gb   = 0;    # 0 = unlimited
     public           = false;
     signing_key_file = "/run/secrets/cache-signing-key";
     organizations    = [ "acme" ];
@@ -328,6 +329,7 @@ Without this, startup fails with
 | `active` | `true` | Set false to disable serving without deleting |
 | `priority` | `10` | Higher wins when multiple caches contain the same path |
 | `local_priority` | `null` | Alternate priority returned in `nix-cache-info` for clients whose IP matches `services.gradient.settings.localIps`. Null or 0 disables the override. |
+| `max_storage_gb` | `0` | Max storage for this cache in GB. When all writable caches for an org have less than 10 MiB headroom, new evaluations park in `Waiting`. 0 = unlimited. |
 | `signing_key_file` | - | Path to the (de-prefixed) base64 Ed25519 signing key (required) |
 | `organizations` | `[]` | Organization names allowed to use this cache |
 | `public` | `false` | Available to every organization |

--- a/frontend/src/app/core/models/cache.model.ts
+++ b/frontend/src/app/core/models/cache.model.ts
@@ -12,6 +12,7 @@ export interface Cache {
   active: boolean;
   priority: number;
   local_priority: number | null;
+  max_storage_gb: number;
   public_key?: string;
   public: boolean;
   created_by?: string;

--- a/frontend/src/app/core/resolvers/cache-access.resolver.spec.ts
+++ b/frontend/src/app/core/resolvers/cache-access.resolver.spec.ts
@@ -35,6 +35,7 @@ describe('cacheAccessResolver', () => {
     active: true,
     priority: 10,
     local_priority: null,
+    max_storage_gb: 0,
     public: false,
     managed: false,
     can_edit: true,

--- a/frontend/src/app/features/caches/cache-settings/cache-settings.component.html
+++ b/frontend/src/app/features/caches/cache-settings/cache-settings.component.html
@@ -95,6 +95,22 @@
         </div>
 
         <div class="form-group">
+          <label for="max-storage">Max Storage (GB)</label>
+          <input
+            type="number"
+            id="max-storage"
+            [(ngModel)]="formData.max_storage_gb"
+            [class.input-invalid]="maxStorageInvalid"
+            class="w-full"
+            min="0"
+            [appManagedDisable]="access()"
+          />
+          <small class="text-secondary">
+            Maximum storage for this cache. Set 0 for unlimited (default); otherwise at least 1 GB.
+          </small>
+        </div>
+
+        <div class="form-group">
           <label for="visibility">Visibility</label>
           <select id="visibility" [(ngModel)]="formData.public" class="role-select w-full" [appManagedDisable]="access()">
             <option [ngValue]="false">Private</option>

--- a/frontend/src/app/features/caches/cache-settings/cache-settings.component.spec.ts
+++ b/frontend/src/app/features/caches/cache-settings/cache-settings.component.spec.ts
@@ -21,6 +21,7 @@ function cacheFor(access: AccessState) {
     description: '',
     active: true,
     priority: 50,
+    max_storage_gb: 0,
     public: false,
     managed: access.managed,
     can_edit: access.canEdit,

--- a/frontend/src/app/features/caches/cache-settings/cache-settings.component.ts
+++ b/frontend/src/app/features/caches/cache-settings/cache-settings.component.ts
@@ -62,6 +62,7 @@ export class CacheSettingsComponent implements OnInit {
     description: '',
     priority: 50,
     local_priority: null as number | null,
+    max_storage_gb: 0,
     public: false,
   };
 
@@ -80,6 +81,7 @@ export class CacheSettingsComponent implements OnInit {
           description: cache.description,
           priority: cache.priority,
           local_priority: cache.local_priority,
+          max_storage_gb: cache.max_storage_gb ?? 0,
           public: cache.public,
         };
         this.loading.set(false);
@@ -96,8 +98,13 @@ export class CacheSettingsComponent implements OnInit {
     return p === null || p === undefined || isNaN(Number(p)) || p < 0 || p > 255;
   }
 
+  get maxStorageInvalid(): boolean {
+    const v = this.formData.max_storage_gb;
+    return v === null || v === undefined || isNaN(Number(v)) || v < 0;
+  }
+
   saveSettings(): void {
-    if (this.priorityInvalid) return;
+    if (this.priorityInvalid || this.maxStorageInvalid) return;
     this.saving.set(true);
     this.saveError.set(null);
     this.saveSuccess.set(false);
@@ -111,6 +118,7 @@ export class CacheSettingsComponent implements OnInit {
       description: this.formData.description,
       priority: this.formData.priority,
       local_priority: this.formData.local_priority,
+      max_storage_gb: this.formData.max_storage_gb,
     }).subscribe({
       next: () => {
         visibilityCall.subscribe({

--- a/nix/modules/gradient-state.nix
+++ b/nix/modules/gradient-state.nix
@@ -678,6 +678,16 @@
         '';
       };
 
+      max_storage_gb = mkOption {
+        type = types.ints.unsigned;
+        default = 0;
+        description = ''
+          Max storage for this cache in GB. When all writable caches for an
+          org have less than 10 MiB headroom, new evaluations park in Waiting.
+          0 = unlimited.
+        '';
+      };
+
       signing_key_file = mkOption {
         type = types.str;
         description = "Path to file containing the Nix cache signing key";

--- a/nix/modules/gradient.nix
+++ b/nix/modules/gradient.nix
@@ -397,6 +397,12 @@ in {
           default = 262144;
         };
 
+        maxStorageGb = lib.mkOption {
+          description = "Instance-wide cap on total cached NAR storage in GB. When all writable caches for an org have less than 10 MiB headroom, new evaluations park in Waiting. 0 = unlimited; per-cache limits still apply.";
+          type = lib.types.ints.unsigned;
+          default = 0;
+        };
+
         buildMaxAttempts = lib.mkOption {
           description = "Maximum number of build attempts before a transient failure becomes permanent (must be ≥ 1).";
           type = lib.types.ints.positive;
@@ -684,6 +690,7 @@ in {
         GRADIENT_REPORT_ERRORS = lib.boolToString cfg.reportErrors;
         GRADIENT_KEEP_EVALUATIONS = toString cfg.settings.keepEvaluations;
         GRADIENT_LOG_CHUNK_BYTES = toString cfg.settings.logChunkBytes;
+        GRADIENT_MAX_STORAGE_GB = toString cfg.settings.maxStorageGb;
         GRADIENT_BUILD_MAX_ATTEMPTS = toString cfg.settings.buildMaxAttempts;
         GRADIENT_BUILD_RETRY_BACKOFF_SECS = toString cfg.settings.buildRetryBackoffSecs;
         GRADIENT_BUILD_DEFAULT_TIMEOUT_SECS = toString cfg.settings.buildDefaultTimeoutSecs;

--- a/nix/modules/gradient.nix
+++ b/nix/modules/gradient.nix
@@ -412,13 +412,13 @@ in {
         buildDefaultTimeoutSecs = lib.mkOption {
           description = "Default wall-clock build timeout in seconds when the derivation sets no `timeout`. `0` disables.";
           type = lib.types.ints.unsigned;
-          default = 3600;
+          default = 14400;
         };
 
         buildDefaultMaxSilentSecs = lib.mkOption {
           description = "Default silent (no-output) build timeout in seconds when the derivation sets no `maxSilent`. `0` disables.";
           type = lib.types.ints.unsigned;
-          default = 1800;
+          default = 3600;
         };
 
         schedulerScoringPolicy = lib.mkOption {


### PR DESCRIPTION
Closes #216.

Per-instance (`GRADIENT_MAX_STORAGE_GB`) and per-cache (`max_storage_gb`, GB, 0 = unlimited) storage caps. When every writable cache for an org has less than 10 MiB headroom, new evaluations park in `Waiting` with `CacheStorageFull` and auto-unpark once space frees or a limit is raised. Wired through the cache API, CLI, frontend settings form, and state-file/NixOS module.