### PR TITLE
Group build sidebar by status with sticky headers (#32, #341)

### DIFF
--- a/frontend/src/app/features/board/live-jobs/live-jobs.component.ts
+++ b/frontend/src/app/features/board/live-jobs/live-jobs.component.ts
@@ -155,21 +155,11 @@ export class BoardLiveJobsComponent implements OnInit, OnDestroy {
   }
 
   canInspect(j: DispatchedJobSummary): boolean {
-    if (!this.isLive(j)) return true;
-
-    return !!(j.organization && (j.build_id || j.evaluation_id));
+    return !this.isLive(j);
   }
 
   inspect(j: DispatchedJobSummary): void {
-    if (!this.isLive(j)) {
-      this.router.navigate(['/board/jobs', j.id]);
-      return;
-    }
-
-    if (j.organization && j.build_id) {
-      this.router.navigate(['/organization', j.organization, 'artefacts', j.build_id]);
-    } else if (j.organization && j.evaluation_id) {
-      this.router.navigate(['/organization', j.organization, 'log', j.evaluation_id]);
-    }
+    if (this.isLive(j)) return;
+    this.router.navigate(['/board/jobs', j.id]);
   }
 }

--- a/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.html
+++ b/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.html
@@ -68,56 +68,59 @@
       @if (visibleBuilds().length === 0) {
         <div class="no-builds">No builds yet</div>
       } @else {
-        <cdk-virtual-scroll-viewport
-          #buildsViewport
-          itemSize="36"
-          minBufferPx="360"
-          maxBufferPx="720"
-          class="builds-list"
-          (scrolledIndexChange)="onBuildsViewportScroll()"
-        >
-          <div
-            *cdkVirtualFor="let build of visibleBuilds(); trackBy: trackBuildById; let i = index"
-            class="build-item status-{{ statusClass(build.status) }}"
-            [class.selected]="selectedBuildId() === build.id"
-            [attr.data-build-id]="build.id"
-            (click)="selectBuild(build, true)"
-            (keydown.enter)="selectBuild(build, true)"
-            (keydown.space)="$event.preventDefault(); selectBuild(build, true)"
-            (keydown.arrowdown)="$event.preventDefault(); selectAdjacentBuild(i + 1)"
-            (keydown.arrowup)="$event.preventDefault(); selectAdjacentBuild(i - 1)"
-            [title]="build.name"
-            tabindex="0"
-            role="option"
-            [attr.aria-selected]="selectedBuildId() === build.id"
-          >
-            <span class="build-status-icon material-symbols-outlined status-{{ statusClass(build.status) }}" [attr.aria-label]="build.status" [title]="build.status">{{ statusIcon(build.status) }}</span>
-            <span class="build-name">{{ buildDisplayName(build.name) }}</span>
-            @if (getBuildElapsed(build)) {
-              <span class="build-elapsed" [class.build-elapsed--running]="build.status === 'Building'">{{ getBuildElapsed(build) }}</span>
-            }
-            @if ((build.status === 'Completed' || build.status === 'Substituted') && build.has_artefacts) {
-              <a
-                class="build-dl-link"
-                [routerLink]="['/organization', orgName, 'artefacts', build.id]"
-                [queryParams]="{ evalId: evaluationId }"
-                (click)="$event.stopPropagation()"
-                title="View build artefacts"
-              >
-                <span class="material-symbols-outlined">download</span>
-              </a>
-            }
-            <a
-              class="graph-link"
-              [routerLink]="['/organization', orgName, 'graph', build.id]"
-              [queryParams]="{ evalId: evaluationId }"
-              (click)="$event.stopPropagation()"
-              title="View dependency graph"
-            >
-              <span class="material-symbols-outlined">account_tree</span>
-            </a>
-          </div>
-        </cdk-virtual-scroll-viewport>
+        <div class="builds-list" (scroll)="onBuildsViewportScroll($event)">
+          @for (group of groupedBuilds(); track group.key) {
+            <div class="build-group">
+              <div class="build-group-header">
+                <span class="build-dot status-{{ group.key }}"></span>
+                {{ group.label }}
+                <span class="build-group-count">{{ group.builds.length }}</span>
+              </div>
+              @for (item of group.builds; track item.build.id) {
+                <div
+                  class="build-item status-{{ statusClass(item.build.status) }}"
+                  [class.selected]="selectedBuildId() === item.build.id"
+                  [attr.data-build-id]="item.build.id"
+                  (click)="selectBuild(item.build, true)"
+                  (keydown.enter)="selectBuild(item.build, true)"
+                  (keydown.space)="$event.preventDefault(); selectBuild(item.build, true)"
+                  (keydown.arrowdown)="$event.preventDefault(); selectAdjacentBuild(item.index + 1)"
+                  (keydown.arrowup)="$event.preventDefault(); selectAdjacentBuild(item.index - 1)"
+                  [title]="item.build.name"
+                  tabindex="0"
+                  role="option"
+                  [attr.aria-selected]="selectedBuildId() === item.build.id"
+                >
+                  <span class="build-dot status-{{ statusClass(item.build.status) }}"></span>
+                  <span class="build-name">{{ buildDisplayName(item.build.name) }}</span>
+                  @if (getBuildElapsed(item.build)) {
+                    <span class="build-elapsed" [class.build-elapsed--running]="item.build.status === 'Building'">{{ getBuildElapsed(item.build) }}</span>
+                  }
+                  @if ((item.build.status === 'Completed' || item.build.status === 'Substituted') && item.build.has_artefacts) {
+                    <a
+                      class="build-dl-link"
+                      [routerLink]="['/organization', orgName, 'artefacts', item.build.id]"
+                      [queryParams]="{ evalId: evaluationId }"
+                      (click)="$event.stopPropagation()"
+                      title="View build artefacts"
+                    >
+                      <span class="material-symbols-outlined">download</span>
+                    </a>
+                  }
+                  <a
+                    class="graph-link"
+                    [routerLink]="['/organization', orgName, 'graph', item.build.id]"
+                    [queryParams]="{ evalId: evaluationId }"
+                    (click)="$event.stopPropagation()"
+                    title="View dependency graph"
+                  >
+                    <span class="material-symbols-outlined">account_tree</span>
+                  </a>
+                </div>
+              }
+            </div>
+          }
+        </div>
       }
     </aside>
 
@@ -269,7 +272,6 @@
                 <span class="log-line-count">{{ logLineCount() }} {{ logLineCount() === 1 ? 'line' : 'lines' }}</span>
               }
               <span class="status-badge status-{{ statusClass(selectedBuild()?.status) }}">
-                <span class="status-icon material-symbols-outlined">{{ statusIcon(selectedBuild()?.status) }}</span>
                 {{ selectedBuild()?.status }}
               </span>
             </div>

--- a/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.scss
+++ b/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.scss
@@ -123,20 +123,6 @@
   min-height: 0;
 }
 
-cdk-virtual-scroll-viewport.builds-list {
-  // CdkVirtualScrollViewport positions its content absolutely; it needs an
-  // explicit height (flex: 1 inside a flex column gives it one).
-  contain: strict;
-}
-
-// CDK injects `.cdk-virtual-scroll-content-wrapper` as `position: absolute`
-// with `width: auto`, so flex rows inside it would size to their natural
-// content width and overflow the 260 px sidebar. Pinning the wrapper to the
-// viewport width re-activates `text-overflow: ellipsis` on `.build-name`.
-:host ::ng-deep .builds-list .cdk-virtual-scroll-content-wrapper {
-  width: 100%;
-}
-
 .no-builds {
   padding: $spacing-md;
   font-size: $font-size-sm;
@@ -147,7 +133,7 @@ cdk-virtual-scroll-viewport.builds-list {
   display: flex;
   align-items: center;
   gap: $spacing-sm;
-  height: 36px; // must match cdk-virtual-scroll-viewport itemSize
+  height: 36px;
   box-sizing: border-box;
   padding: 0 $spacing-md 0 calc($spacing-md - 3px);
   cursor: pointer;
@@ -186,18 +172,30 @@ cdk-virtual-scroll-viewport.builds-list {
   &.status-aborted, &.status-dependencyfailed { background: $color-secondary; }
 }
 
-// Glyph status indicator (issue #32) - shape distinguishes status without color.
-.build-status-icon {
-  font-size: 14px;
-  flex-shrink: 0;
+// Status sections (issue #32): the labelled, sticky header names the status so
+// it no longer relies on the dot colour alone.
+.build-group-header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: $spacing-xs;
+  padding: $spacing-xs $spacing-md;
+  background: $color-primary;
+  border-bottom: 1px solid $color-border;
+  font-size: $font-size-xs;
+  font-weight: 600;
+  color: $text-secondary;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
   user-select: none;
 
-  &.status-queued                 { color: $color-warning; }
-  &.status-building               { color: $color-info; }
-  &.status-completed,
-  &.status-substituted            { color: $color-success; }
-  &.status-failed  { color: $color-danger; }
-  &.status-aborted, &.status-dependencyfailed { color: $color-secondary; }
+  .build-group-count {
+    margin-left: auto;
+    color: $text-light;
+    font-weight: 500;
+  }
 }
 
 .build-name {
@@ -533,10 +531,6 @@ cdk-virtual-scroll-viewport.builds-list {
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
   flex-shrink: 0;
-}
-
-.status-badge .status-icon {
-  font-size: 0.95rem;
 }
 
 .log-container-wrapper {

--- a/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.ts
+++ b/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.ts
@@ -27,7 +27,6 @@ import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { Subscription } from 'rxjs';
 import { auditTime, switchMap } from 'rxjs/operators';
-import { CdkVirtualScrollViewport, ScrollingModule } from '@angular/cdk/scrolling';
 import { EvaluationsService, BuildItem, BuildWithOutputs } from '@core/services/evaluations.service';
 import { LiveService } from '@core/services/live.service';
 import { OrganizationsService } from '@core/services/organizations.service';
@@ -41,7 +40,7 @@ import { environment } from '@environments/environment';
 @Component({
   selector: 'app-evaluation-log',
   standalone: true,
-  imports: [CommonModule, RouterModule, LoadingSpinnerComponent, ButtonModule, ScrollingModule],
+  imports: [CommonModule, RouterModule, LoadingSpinnerComponent, ButtonModule],
   templateUrl: './evaluation-log.component.html',
   styleUrl: './evaluation-log.component.scss',
 })
@@ -56,7 +55,6 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
   private cdr = inject(ChangeDetectorRef);
 
   @ViewChild('logContainer') logContainerRef?: ElementRef<HTMLDivElement>;
-  @ViewChild('buildsViewport') buildsViewport?: CdkVirtualScrollViewport;
 
   loading = signal(true);
   evaluation = signal<Evaluation | null>(null);
@@ -201,12 +199,38 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
   private readonly buildStatusOrder: Record<string, number> = {
     building: 0,
     queued: 1,
-    failed: 2,
-    aborted: 3,
+    aborted: 2,
+    failed: 3,
     dependencyfailed: 3,
     completed: 4,
     substituted: 4,
   };
+
+  /// Sidebar sections, in display order. `Completed` absorbs `Substituted`,
+  /// `Failed` absorbs `DependencyFailed` - matching the dot colours.
+  private readonly buildGroups: { key: string; label: string; members: string[] }[] = [
+    { key: 'building', label: 'Building', members: ['building'] },
+    { key: 'queued', label: 'Queued', members: ['queued'] },
+    { key: 'aborted', label: 'Aborted', members: ['aborted'] },
+    { key: 'failed', label: 'Failed', members: ['failed', 'dependencyfailed'] },
+    { key: 'completed', label: 'Completed', members: ['completed', 'substituted'] },
+  ];
+
+  /// `visibleBuilds` bucketed into the status sections above (only non-empty
+  /// ones). Each entry keeps its index in `visibleBuilds` so keyboard
+  /// navigation still walks the flat, status-sorted order across sections.
+  groupedBuilds = computed(() => {
+    const indexByGroup = new Map<string, number>();
+    this.buildGroups.forEach((g, i) => g.members.forEach((m) => indexByGroup.set(m, i)));
+    const buckets: { build: BuildItem; index: number }[][] = this.buildGroups.map(() => []);
+    this.visibleBuilds().forEach((build, index) => {
+      const gi = indexByGroup.get(this.statusClass(build.status));
+      if (gi !== undefined) buckets[gi].push({ build, index });
+    });
+    return this.buildGroups
+      .map((g, i) => ({ key: g.key, label: g.label, builds: buckets[i] }))
+      .filter((g) => g.builds.length > 0);
+  });
 
   /// Maps every BuildStatus variant onto the canonical token used by the SCSS
   /// status classes (status-failed, status-completed, …). The three failed
@@ -224,21 +248,6 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
       case 'DependencyFailed': return 'dependencyfailed';
       case 'Aborted': return 'aborted';
       default: return (status ?? '').toLowerCase();
-    }
-  }
-
-  /// Non-color status indicator (issue #32): a Material Symbols glyph so the
-  /// status is distinguishable without relying on the colored dot/badge alone.
-  statusIcon(status: string | null | undefined): string {
-    switch (this.statusClass(status)) {
-      case 'completed':
-      case 'substituted': return 'check_circle';
-      case 'building': return 'sync';
-      case 'queued': return 'schedule';
-      case 'failed': return 'cancel';
-      case 'dependencyfailed': return 'link_off';
-      case 'aborted': return 'block';
-      default: return 'help';
     }
   }
 
@@ -1018,13 +1027,10 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
 
   // ── Scroll management ───────────────────────────────────────────────────────
 
-  onBuildsViewportScroll(): void {
-    const vp = this.buildsViewport;
-    if (!vp) return;
-    const total = vp.getDataLength();
-    const end = vp.getRenderedRange().end;
-    // Pre-fetch next page when rendered range reaches within ~20 rows of the end
-    if (total > 0 && end >= total - 20) {
+  onBuildsViewportScroll(event: Event): void {
+    const el = event.target as HTMLElement;
+    // Pre-fetch the next page as the list nears the bottom.
+    if (el.scrollHeight - el.scrollTop - el.clientHeight < 240) {
       this.loadMoreBuilds();
     }
   }
@@ -1146,16 +1152,13 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
     const list = this.visibleBuilds();
     if (index < 0 || index >= list.length) return;
     this.selectBuild(list[index], true);
-    // Ensure the target row is rendered (virtual scroll may have recycled it)
-    this.buildsViewport?.scrollToIndex(index);
     const targetId = list[index].id;
     setTimeout(() => {
       const el = document.querySelector<HTMLElement>(`.build-item[data-build-id="${targetId}"]`);
+      el?.scrollIntoView({ block: 'nearest' });
       el?.focus();
     }, 0);
   }
-
-  trackBuildById = (_: number, build: BuildItem): string => build.id;
 
   buildDisplayName(path: string): string {
     // /nix/store/hash-name-version.drv → name-version (strip hash prefix only)


### PR DESCRIPTION
Follow-up to #353 (now merged): reworks how the evaluation-log build sidebar conveys status.

- **Dots restored** — reverted the per-build status glyphs (sidebar + log header) back to the colored `.build-dot`.
- **Sticky status groups** — the status-sorted list is bucketed into **Building → Queued → Aborted → Failed → Completed** (Completed absorbs Substituted, Failed absorbs DependencyFailed). Each section has a small sticky header (label + count) that stays pinned while scrolling and is pushed up by the next section. The header naming the status is what addresses #32 now, not the dot colour alone.
- Replaces the CDK virtual scroll (which breaks `position: sticky`) with a native scroll list; infinite-scroll, keyboard nav, and scroll-to-selected reimplemented for native scroll.

`tsc` clean; dev `ng build` passes (template valid under strictTemplates).

**Trade-off:** dropping the virtual viewport means very large build lists render all loaded rows; progressive reveal + paginated loading still bound how much is loaded. Can re-add sticky-aware windowing if needed.

---

### Also in this PR
`fix(frontend): make live (undispatched) Job Board jobs non-clickable again` — reverts the click-through added for live/undispatched Live Jobs entries; only persisted dispatched jobs link to their detail. Filtering is unchanged.
