### PR TITLE
Make live (undispatched) Job Board jobs non-clickable again

### DIFF
--- a/frontend/src/app/features/board/live-jobs/live-jobs.component.ts
+++ b/frontend/src/app/features/board/live-jobs/live-jobs.component.ts
@@ -155,21 +155,11 @@ export class BoardLiveJobsComponent implements OnInit, OnDestroy {
   }
 
   canInspect(j: DispatchedJobSummary): boolean {
-    if (!this.isLive(j)) return true;
-
-    return !!(j.organization && (j.build_id || j.evaluation_id));
+    return !this.isLive(j);
   }
 
   inspect(j: DispatchedJobSummary): void {
-    if (!this.isLive(j)) {
-      this.router.navigate(['/board/jobs', j.id]);
-      return;
-    }
-
-    if (j.organization && j.build_id) {
-      this.router.navigate(['/organization', j.organization, 'artefacts', j.build_id]);
-    } else if (j.organization && j.evaluation_id) {
-      this.router.navigate(['/organization', j.organization, 'log', j.evaluation_id]);
-    }
+    if (this.isLive(j)) return;
+    this.router.navigate(['/board/jobs', j.id]);
   }
 }


### PR DESCRIPTION
Reverts the click-through behavior added for live/undispatched Live Jobs entries (#341). `canInspect`/`inspect` now only act on persisted dispatched jobs, so live rows show no `›` and aren't clickable; the Live Jobs filtering is untouched. tsc + dev ng build pass.