### PR TITLE
fix: #341 frontend issue batch + Job Board admin/pending views

### DIFF
--- a/backend/scheduler/src/jobs.rs
+++ b/backend/scheduler/src/jobs.rs
@@ -224,6 +224,16 @@ pub struct WorkerJobScore {
     pub missing_nar_size: u64,
 }
 
+#[derive(Debug, Clone)]
+pub struct PendingJobInfo {
+    pub kind: i16,
+    pub evaluation_id: EvaluationId,
+    pub build_id: Option<BuildId>,
+    pub organization: OrganizationId,
+    pub queued_at: chrono::NaiveDateTime,
+    pub dependency_count: u32,
+}
+
 #[derive(Debug, Default)]
 pub struct JobTracker {
     pending: HashMap<String, PendingJob>,
@@ -574,6 +584,26 @@ impl JobTracker {
 
     pub fn pending_count(&self) -> usize {
         self.pending.len()
+    }
+
+    pub fn pending_snapshot(&self) -> Vec<PendingJobInfo> {
+        self.pending
+            .values()
+            .map(|job| {
+                let (kind, build_id) = match job {
+                    PendingJob::Build(b) => (1i16, Some(b.build_id)),
+                    PendingJob::Eval(_) => (0i16, None),
+                };
+                PendingJobInfo {
+                    kind,
+                    evaluation_id: job.evaluation_id(),
+                    build_id,
+                    organization: job.peer_id(),
+                    queued_at: job.queued_at(),
+                    dependency_count: job.dependency_count(),
+                }
+            })
+            .collect()
     }
 
     pub fn active_count(&self) -> usize {
@@ -1178,6 +1208,18 @@ mod tests {
     fn remove_job_unknown_id_is_noop() {
         let mut tracker = JobTracker::new();
         tracker.remove_job("does-not-exist");
+    }
+
+    #[test]
+    fn pending_snapshot_reports_kind_and_org() {
+        let mut tracker = JobTracker::new();
+        let org = OrganizationId::now_v7();
+        tracker.add_pending("eval:1".into(), eval_job(org));
+        let snap = tracker.pending_snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].kind, 0);
+        assert_eq!(snap[0].organization, org);
+        assert!(snap[0].build_id.is_none());
     }
 
     #[test]

--- a/backend/scheduler/src/lib.rs
+++ b/backend/scheduler/src/lib.rs
@@ -40,6 +40,7 @@ use worker_pool::WorkerPool;
 type DeferredDeps = Arc<RwLock<HashMap<EvaluationId, Vec<(String, Vec<String>)>>>>;
 
 pub use gradient_core::types::BoardEvent;
+pub use jobs::PendingJobInfo;
 pub use worker_pool::WorkerInfo;
 
 #[cfg(test)]
@@ -118,5 +119,9 @@ impl Scheduler {
         let workers = self.worker_pool.read().await.worker_count();
         let tracker = self.job_tracker.read().await;
         (workers, tracker.pending_count(), tracker.active_count())
+    }
+
+    pub async fn pending_jobs_snapshot(&self) -> Vec<jobs::PendingJobInfo> {
+        self.job_tracker.read().await.pending_snapshot()
     }
 }

--- a/backend/web/src/endpoints/board.rs
+++ b/backend/web/src/endpoints/board.rs
@@ -47,6 +47,51 @@ pub struct DispatchedJobsResponse {
     pub other_running: u64,
 }
 
+#[derive(Serialize)]
+pub struct PendingJobSummary {
+    pub kind: i16,
+    pub organization: Uuid,
+    pub evaluation_id: Uuid,
+    pub build_id: Option<Uuid>,
+    pub queued_at: String,
+    pub dependency_count: u32,
+}
+
+#[derive(Serialize)]
+pub struct PendingJobsResponse {
+    pub jobs: Vec<PendingJobSummary>,
+    /// Pending jobs owned by orgs the caller can't see, shown only as a count.
+    pub other_pending: u64,
+}
+
+pub async fn get_pending_jobs(
+    State(state): State<Arc<ServerState>>,
+    Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
+    Extension(scheduler): Extension<Arc<Scheduler>>,
+) -> WebResult<Json<BaseResponse<PendingJobsResponse>>> {
+    let scope = MetricsScope::resolve(&state.web_db, &maybe_user).await?;
+    let snapshot = scheduler.pending_jobs_snapshot().await;
+
+    let mut jobs = Vec::new();
+    let mut other_pending = 0u64;
+    for j in snapshot {
+        if scope.allows(&Uuid::from(j.organization)) {
+            jobs.push(PendingJobSummary {
+                kind: j.kind,
+                organization: j.organization.into(),
+                evaluation_id: j.evaluation_id.into(),
+                build_id: j.build_id.map(Into::into),
+                queued_at: j.queued_at.and_utc().to_rfc3339(),
+                dependency_count: j.dependency_count,
+            });
+        } else {
+            other_pending += 1;
+        }
+    }
+
+    Ok(ok_json(PendingJobsResponse { jobs, other_pending }))
+}
+
 pub async fn get_dispatched_jobs(
     State(state): State<Arc<ServerState>>,
     Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,

--- a/backend/web/src/lib.rs
+++ b/backend/web/src/lib.rs
@@ -529,6 +529,7 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
             get(projects::get_entry_point_metrics),
         )
         .route("/board/jobs/dispatched", get(board::get_dispatched_jobs))
+        .route("/board/jobs/pending", get(board::get_pending_jobs))
         .route("/board/jobs/expensive", get(board::get_expensive_jobs))
         .route(
             "/board/jobs/expensive-by-resource",

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -5623,35 +5623,35 @@ paths:
   # These endpoints live outside /api/v1. The server URL for these is the root,
   # e.g. https://gradient.example.com (no /api/v1 prefix).
 
-x-nix-cache-paths:
-  description: |-
-    The following Nix binary cache endpoints are served at the root of the server
-    (not under `/api/v1`). They implement the Nix binary cache protocol and are
-    used by `nix-store --realise`, `nixos-rebuild`, and other Nix clients.
-    Private caches require HTTP Basic Auth (any username, JWT or API key as password).
+  x-nix-cache-paths:
+    description: |-
+      The following Nix binary cache endpoints are served at the root of the server
+      (not under `/api/v1`). They implement the Nix binary cache protocol and are
+      used by `nix-store --realise`, `nixos-rebuild`, and other Nix clients.
+      Private caches require HTTP Basic Auth (any username, JWT or API key as password).
 
-    ### Substituter surface
+      ### Substituter surface
 
-    | Endpoint | Description |
-    |---|---|
-    | `GET /cache/{cache}/nix-cache-info` | Cache metadata for Nix. Add `?json` for JSON response (`NixCacheInfo`). |
-    | `GET /cache/{cache}/gradient-cache-info` | Gradient-specific cache metadata. Add `?json` for JSON response (`GradientCacheInfo`). Responds with `Access-Control-Allow-Origin: *` for browser probes. |
-    | `GET /cache/{cache}/{hash}.narinfo` | Path info for a store path. Add `?json` for JSON response (`NixPathInfo`). |
-    | `GET /cache/{cache}/nar/{hash}.nar.zst` | Compressed NAR archive |
+      | Endpoint | Description |
+      |---|---|
+      | `GET /cache/{cache}/nix-cache-info` | Cache metadata for Nix. Add `?json` for JSON response (`NixCacheInfo`). |
+      | `GET /cache/{cache}/gradient-cache-info` | Gradient-specific cache metadata. Add `?json` for JSON response (`GradientCacheInfo`). Responds with `Access-Control-Allow-Origin: *` for browser probes. |
+      | `GET /cache/{cache}/{hash}.narinfo` | Path info for a store path. Add `?json` for JSON response (`NixPathInfo`). |
+      | `GET /cache/{cache}/nar/{hash}.nar.zst` | Compressed NAR archive |
 
-    ### Gradient Proto surface
+      ### Gradient Proto surface
 
-    | Endpoint | Description |
-    |---|---|
-    | `GET /cache/{cache}/proto` | WebSocket upgrade carrying rkyv-encoded binary frames (same wire format as `/proto`). Read-only, cache-scoped. PUBLIC caches allow anonymous connections (governed by `GRADIENT_PROTO_ALLOW_ANONYMOUS_CACHE`, default `true`); PRIVATE caches require `Authorization: GRAD<key>`. Anonymous sessions are subject to per-IP connection and rate caps (`GRADIENT_PROTO_ANON_MAX_CONNECTIONS_PER_IP`, `GRADIENT_PROTO_ANON_RATE_PER_SECOND`, `GRADIENT_PROTO_ANON_RATE_BURST`). Only `CacheQuery` (Normal/Pull modes) and `NarRequest` messages are accepted; Push, job RPCs, and worker registration are rejected. |
+      | Endpoint | Description |
+      |---|---|
+      | `GET /cache/{cache}/proto` | WebSocket upgrade carrying rkyv-encoded binary frames (same wire format as `/proto`). Read-only, cache-scoped. PUBLIC caches allow anonymous connections (governed by `GRADIENT_PROTO_ALLOW_ANONYMOUS_CACHE`, default `true`); PRIVATE caches require `Authorization: GRAD<key>`. Anonymous sessions are subject to per-IP connection and rate caps (`GRADIENT_PROTO_ANON_MAX_CONNECTIONS_PER_IP`, `GRADIENT_PROTO_ANON_RATE_PER_SECOND`, `GRADIENT_PROTO_ANON_RATE_BURST`). Only `CacheQuery` (Normal/Pull modes) and `NarRequest` messages are accepted; Push, job RPCs, and worker registration are rejected. |
 
-    ### Inspection surface
+      ### Inspection surface
 
-    | Endpoint | Description |
-    |---|---|
-    | `GET /cache/{cache}/ls/{hash}` | JSON tree listing of the NAR (nix-serve `.ls` v1 schema). Rate-limited at 60 req/min. |
-    | `GET /cache/{cache}/serve/{hash}/{path}` | Extract a single file (bytes, Content-Type sniffed) or directory (tar.zst) from a NAR. Rate-limited at 60 req/min. |
-    | `GET /cache/{cache}/log/{drv}` | Build log for `<drv>.drv`, from either locally-built or upstream-substituted builds (substituter compat - `nix log`). Rate-limited at ~300 req/min. |
+      | Endpoint | Description |
+      |---|---|
+      | `GET /cache/{cache}/ls/{hash}` | JSON tree listing of the NAR (nix-serve `.ls` v1 schema). Rate-limited at 60 req/min. |
+      | `GET /cache/{cache}/serve/{hash}/{path}` | Extract a single file (bytes, Content-Type sniffed) or directory (tar.zst) from a NAR. Rate-limited at 60 req/min. |
+      | `GET /cache/{cache}/log/{drv}` | Build log for `<drv>.drv`, from either locally-built or upstream-substituted builds (substituter compat - `nix log`). Rate-limited at ~300 req/min. |
 
   /metrics/catalog:
     get:
@@ -5720,6 +5720,16 @@ x-nix-cache-paths:
       responses:
         '200':
           description: Dispatched jobs plus other_running count
+
+  /board/jobs/pending:
+    get:
+      tags: [board]
+      summary: Pending (undispatched) jobs
+      description: Queued jobs not yet dispatched to a worker, visible to the caller; out-of-scope jobs collapse to an aggregate `other_pending` count.
+      operationId: getBoardPendingJobs
+      responses:
+        '200':
+          description: Pending jobs plus other_pending count
 
   /board/jobs/expensive:
     get:
@@ -5931,16 +5941,6 @@ x-nix-cache-paths:
           description: System health
         '403':
           description: Superuser required
-
-  /board/live:
-    get:
-      tags: [board]
-      summary: Live board events (WebSocket)
-      description: WebSocket stream of dispatch / worker / queue-depth events, filtered to the caller's scope.
-      operationId: getBoardLive
-      responses:
-        '101':
-          description: Switching Protocols (WebSocket upgrade)
 
   /board/acknowledged-derivations:
     get:

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -3552,3 +3552,24 @@ serializes to the `{"type":"cache_changed"}` ping.
 `LiveService.connect(path)` builds the correct `ws(s)://…${apiUrl}${path}` URL,
 emits parsed JSON frames, ignores malformed frames, and closes the socket on
 unsubscribe.
+
+## Frontend issues batch (#341)
+
+Frontend (`pnpm --dir frontend exec ng test --include='<glob>' --watch=false`):
+- `evaluation-log/build-search.spec.ts` - `matchesBuildSearch` is a case-insensitive
+  substring match; empty/whitespace query matches all.
+- `evaluation-log/evaluation-log.component.spec.ts` - `renderLog` updates
+  `logLineCount` (live count on building builds); the sidebar search filters
+  `groupedBuilds` by name while preserving the `visibleBuilds` index used for
+  keyboard navigation.
+- `core/services/admin.service.spec.ts` - `startDeepGc`/`listTasks` hit the
+  `admin/maintenance/deep-gc` and `admin/tasks` endpoints; `githubAppConfigured`
+  resolves true/false from the credentials probe.
+- `board/health/health.component.spec.ts` - the HTTP-routes table is gone, the
+  admin tasks table renders, and the GitHub link reflects the configured state.
+- `board/live-jobs/live-jobs.component.spec.ts` - the view toggle loads and
+  renders the pending-jobs list.
+
+Backend (`cargo test -p scheduler --tests jobs`):
+- `pending_snapshot_reports_kind_and_org` - `JobTracker::pending_snapshot` reports
+  each pending job's kind, org, and build-id, backing `GET /board/jobs/pending`.

--- a/frontend/src/app/core/services/admin.service.spec.ts
+++ b/frontend/src/app/core/services/admin.service.spec.ts
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { AdminService, AdminTask, StartDeepGcResponse } from './admin.service';
+import { environment } from '@environments/environment';
+
+const apiUrl = environment.apiUrl;
+
+const sampleTask: AdminTask = {
+  id: 'task-1',
+  kind: 'deep-gc',
+  status: 'pending',
+  created_at: '2026-01-01T00:00:00Z',
+  started_at: null,
+  finished_at: null,
+  progress: null,
+  error: null,
+  created_by: 'user-1',
+};
+
+describe('AdminService', () => {
+  let service: AdminService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [AdminService, provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(AdminService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('startDeepGc() POSTs to admin/maintenance/deep-gc and unwraps the response', () => {
+    let result: StartDeepGcResponse | undefined;
+    service.startDeepGc().subscribe((v) => (result = v));
+
+    const req = httpMock.expectOne(`${apiUrl}/admin/maintenance/deep-gc`);
+    expect(req.request.method).toBe('POST');
+    req.flush({ error: false, message: { task_id: 't1', status: 'pending' } });
+
+    expect(result).toEqual({ task_id: 't1', status: 'pending' });
+  });
+
+  it('listTasks() GETs admin/tasks and returns the task array', () => {
+    let result: AdminTask[] | undefined;
+    service.listTasks().subscribe((v) => (result = v));
+
+    const req = httpMock.expectOne(`${apiUrl}/admin/tasks`);
+    expect(req.request.method).toBe('GET');
+    req.flush({ error: false, message: [sampleTask] });
+
+    expect(result?.length).toBe(1);
+  });
+
+  it('githubAppConfigured() emits true when credentials endpoint succeeds', () => {
+    let result: boolean | undefined;
+    service.githubAppConfigured().subscribe((v) => (result = v));
+
+    const req = httpMock.expectOne(`${apiUrl}/admin/github-app/credentials`);
+    req.flush({ error: false, message: { id: 1, slug: 'app', html_url: '', pem: '', webhook_secret: '', client_id: '', client_secret: '' } });
+
+    expect(result).toBe(true);
+  });
+
+  it('githubAppConfigured() emits false when credentials endpoint returns 404', () => {
+    let result: boolean | undefined;
+    service.githubAppConfigured().subscribe((v) => (result = v));
+
+    const req = httpMock.expectOne(`${apiUrl}/admin/github-app/credentials`);
+    req.flush('nope', { status: 404, statusText: 'Not Found' });
+
+    expect(result).toBe(false);
+  });
+});

--- a/frontend/src/app/core/services/admin.service.ts
+++ b/frontend/src/app/core/services/admin.service.ts
@@ -5,7 +5,8 @@
  */
 
 import { Injectable, inject } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
 import { ApiService } from '@core/services/api.service';
 
 export interface GithubAppManifestResponse {
@@ -24,6 +25,23 @@ export interface GithubAppCredentials {
   client_secret: string;
 }
 
+export interface AdminTask {
+  id: string;
+  kind: string;
+  status: string;
+  created_at: string;
+  started_at: string | null;
+  finished_at: string | null;
+  progress: unknown | null;
+  error: string | null;
+  created_by: string | null;
+}
+
+export interface StartDeepGcResponse {
+  task_id: string;
+  status: string;
+}
+
 @Injectable({ providedIn: 'root' })
 export class AdminService {
   private api = inject(ApiService);
@@ -34,5 +52,17 @@ export class AdminService {
 
   fetchGithubAppCredentials(): Observable<GithubAppCredentials> {
     return this.api.get<GithubAppCredentials>('admin/github-app/credentials');
+  }
+
+  startDeepGc(): Observable<StartDeepGcResponse> {
+    return this.api.post<StartDeepGcResponse>('admin/maintenance/deep-gc', {});
+  }
+
+  listTasks(): Observable<AdminTask[]> {
+    return this.api.get<AdminTask[]>('admin/tasks');
+  }
+
+  githubAppConfigured(): Observable<boolean> {
+    return this.fetchGithubAppCredentials().pipe(map(() => true), catchError(() => of(false)));
   }
 }

--- a/frontend/src/app/core/services/board.service.ts
+++ b/frontend/src/app/core/services/board.service.ts
@@ -24,6 +24,20 @@ export interface DispatchedJobsResponse {
   other_running: number;
 }
 
+export interface PendingJobSummary {
+  kind: number;
+  organization: string;
+  evaluation_id: string;
+  build_id: string | null;
+  queued_at: string;
+  dependency_count: number;
+}
+
+export interface PendingJobsResponse {
+  jobs: PendingJobSummary[];
+  other_pending: number;
+}
+
 export interface DispatchedJobDetail extends DispatchedJobSummary {
   queued_at: string;
   finished_at: string | null;
@@ -190,6 +204,10 @@ export class BoardService {
 
   getDispatchedJobs(): Observable<DispatchedJobsResponse> {
     return this.api.get<DispatchedJobsResponse>('board/jobs/dispatched');
+  }
+
+  getPendingJobs(): Observable<PendingJobsResponse> {
+    return this.api.get<PendingJobsResponse>('board/jobs/pending');
   }
 
   getJob(id: string): Observable<DispatchedJobDetail> {

--- a/frontend/src/app/features/board/board-layout.component.ts
+++ b/frontend/src/app/features/board/board-layout.component.ts
@@ -44,15 +44,21 @@ import { RouterModule } from '@angular/router';
       }
       .board-nav {
         display: flex;
-        gap: 1.25rem;
+        gap: 0.25rem;
         margin-bottom: 1.5rem;
         border-bottom: 1px solid #2d333b;
       }
       .board-nav a {
         color: #abb0b4;
-        padding: 0.5rem 0;
+        padding: 0.5rem 0.75rem;
         text-decoration: none;
         border-bottom: 2px solid transparent;
+        border-radius: 6px 6px 0 0;
+        transition: color 0.15s, background 0.15s;
+      }
+      .board-nav a:hover {
+        color: #fff;
+        background: #21262d;
       }
       .board-nav a.active {
         color: #fff;

--- a/frontend/src/app/features/board/health/health.component.spec.ts
+++ b/frontend/src/app/features/board/health/health.component.spec.ts
@@ -1,0 +1,104 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { BoardHealthComponent } from './health.component';
+import { BoardService, BoardHealth } from '@core/services/board.service';
+import { AdminService, AdminTask } from '@core/services/admin.service';
+
+const HEALTH: BoardHealth = {
+  version: '1.0.0',
+  uptime_seconds: 3600,
+  workers_connected: 2,
+  jobs_pending: 1,
+  jobs_active: 3,
+  cache_bytes: 1024 * 1024 * 1024,
+  cache_packages: 42,
+  process: {
+    resident_memory_bytes: 64 * 1024 * 1024,
+    virtual_memory_bytes: 128 * 1024 * 1024,
+    open_fds: 10,
+    max_fds: 1024,
+    threads: 4,
+    cpu_seconds_total: 300,
+  },
+  http: [],
+  rollup_lag_seconds: 0,
+  latest_rollup_bucket: null,
+};
+
+const TASK: AdminTask = {
+  id: 't1',
+  kind: 'deep_gc',
+  status: 'completed',
+  created_at: '2026-06-01T10:00:00',
+  started_at: '2026-06-01T10:00:01',
+  finished_at: '2026-06-01T10:05:00',
+  progress: null,
+  error: null,
+  created_by: null,
+};
+
+function setup(githubAppConfigured: () => Observable<boolean>): ComponentFixture<BoardHealthComponent> {
+  TestBed.configureTestingModule({
+    imports: [BoardHealthComponent],
+    providers: [
+      provideRouter([]),
+      { provide: BoardService, useValue: { getHealth: () => of(HEALTH) } },
+      {
+        provide: AdminService,
+        useValue: {
+          listTasks: () => of([TASK]),
+          githubAppConfigured,
+          startDeepGc: () => of({ task_id: 't2', status: 'pending' }),
+        },
+      },
+    ],
+  });
+  const fixture = TestBed.createComponent(BoardHealthComponent);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('BoardHealthComponent', () => {
+  describe('when GitHub App is configured', () => {
+    let fixture: ComponentFixture<BoardHealthComponent>;
+
+    beforeEach(() => { fixture = setup(() => of(true)); });
+    afterEach(() => TestBed.resetTestingModule());
+
+    it('does not render "HTTP routes" heading', () => {
+      expect(fixture.nativeElement.textContent).not.toContain('HTTP routes');
+    });
+
+    it('renders the deep_gc task row', () => {
+      expect(fixture.nativeElement.textContent).toContain('deep_gc');
+    });
+
+    it('shows "GitHub App configured" text with disabled class on the link', () => {
+      const link: HTMLAnchorElement = fixture.nativeElement.querySelector('a.btn');
+      expect(link).toBeTruthy();
+      expect(link.textContent?.trim()).toBe('GitHub App configured');
+      expect(link.classList.contains('disabled')).toBe(true);
+    });
+  });
+
+  describe('when GitHub App is NOT configured', () => {
+    let fixture: ComponentFixture<BoardHealthComponent>;
+
+    beforeEach(() => { fixture = setup(() => of(false)); });
+    afterEach(() => TestBed.resetTestingModule());
+
+    it('shows "Set up GitHub App" text without disabled class', () => {
+      const link: HTMLAnchorElement = fixture.nativeElement.querySelector('a.btn');
+      expect(link).toBeTruthy();
+      expect(link.textContent?.trim()).toBe('Set up GitHub App');
+      expect(link.classList.contains('disabled')).toBe(false);
+    });
+  });
+});

--- a/frontend/src/app/features/board/health/health.component.ts
+++ b/frontend/src/app/features/board/health/health.component.ts
@@ -6,14 +6,16 @@
 
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
 import { BoardService, BoardHealth } from '@core/services/board.service';
+import { AdminService, AdminTask } from '@core/services/admin.service';
 
 const MIB = 1024 ** 2;
 
 @Component({
   selector: 'app-board-health',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, RouterModule],
   template: `
     @if (health(); as h) {
       <div class="kpis">
@@ -40,20 +42,29 @@ const MIB = 1024 ** 2;
         <div class="cell"><span class="label">Packages</span><span>{{ h.cache_packages }}</span></div>
       </div>
 
-      <h2>HTTP routes</h2>
+      <h2>Admin</h2>
+      <div class="admin-actions">
+        <a class="btn" [class.disabled]="githubConfigured()" routerLink="/admin/github-app"
+           [attr.aria-disabled]="githubConfigured()">
+          {{ githubConfigured() ? 'GitHub App configured' : 'Set up GitHub App' }}
+        </a>
+        <button class="btn" (click)="runDeepGc()" [disabled]="gcBusy()">Run Deep GC</button>
+        @if (gcNotice(); as n) { <span class="notice">{{ n }}</span> }
+      </div>
+
       <table class="http">
-        <thead><tr><th>Method</th><th>Route</th><th class="num">Requests</th><th class="num">Avg ms</th><th class="num">Errors</th></tr></thead>
+        <thead><tr><th>Task</th><th>Status</th><th>Created</th><th>Finished</th><th>Error</th></tr></thead>
         <tbody>
-          @for (r of h.http; track r.method + r.route) {
+          @for (t of tasks(); track t.id) {
             <tr>
-              <td>{{ r.method }}</td>
-              <td class="mono">{{ r.route }}</td>
-              <td class="num">{{ r.count }}</td>
-              <td class="num">{{ r.avg_ms | number: '1.1-1' }}</td>
-              <td class="num" [class.bad]="r.errors > 0">{{ r.errors }}</td>
+              <td>{{ t.kind }}</td>
+              <td>{{ t.status }}</td>
+              <td>{{ t.created_at | date: 'short' }}</td>
+              <td>{{ t.finished_at ? (t.finished_at | date: 'short') : '—' }}</td>
+              <td [class.bad]="!!t.error">{{ t.error ?? '' }}</td>
             </tr>
           } @empty {
-            <tr><td colspan="5" class="muted">No HTTP route data yet.</td></tr>
+            <tr><td colspan="5" class="muted">No admin tasks yet.</td></tr>
           }
         </tbody>
       </table>
@@ -78,12 +89,22 @@ const MIB = 1024 ** 2;
       .mono { font-family: monospace; }
       .num { text-align: right; font-variant-numeric: tabular-nums; }
       .muted { color: #818181; }
+      .admin-actions { display: flex; align-items: center; gap: 0.75rem; margin: 0 0 1rem; }
+      .btn { background: #2d333b; color: #fff; border: 1px solid #444c56; border-radius: 6px; padding: 0.4rem 0.8rem; cursor: pointer; text-decoration: none; font-size: 0.85rem; }
+      .btn[disabled], .btn.disabled { opacity: 0.5; pointer-events: none; }
+      .notice { color: #e3b341; font-size: 0.8rem; }
     `,
   ],
 })
 export class BoardHealthComponent implements OnInit {
   private board = inject(BoardService);
+  private admin = inject(AdminService);
+
   health = signal<BoardHealth | null>(null);
+  tasks = signal<AdminTask[]>([]);
+  githubConfigured = signal(false);
+  gcBusy = signal(false);
+  gcNotice = signal<string | null>(null);
 
   mib(bytes: number): string {
     return (bytes / MIB).toFixed(0);
@@ -95,7 +116,22 @@ export class BoardHealthComponent implements OnInit {
     return h > 0 ? `${h}h ${m}m` : `${m}m`;
   }
 
+  private loadTasks(): void {
+    this.admin.listTasks().subscribe((t) => this.tasks.set(t));
+  }
+
+  runDeepGc(): void {
+    this.gcBusy.set(true);
+    this.gcNotice.set(null);
+    this.admin.startDeepGc().subscribe({
+      next: () => { this.gcBusy.set(false); this.loadTasks(); },
+      error: (e) => { this.gcBusy.set(false); this.gcNotice.set(e?.message ?? 'Deep GC failed to start'); },
+    });
+  }
+
   ngOnInit(): void {
     this.board.getHealth().subscribe((h) => this.health.set(h));
+    this.loadTasks();
+    this.admin.githubAppConfigured().subscribe((v) => this.githubConfigured.set(v));
   }
 }

--- a/frontend/src/app/features/board/live-jobs/live-jobs.component.spec.ts
+++ b/frontend/src/app/features/board/live-jobs/live-jobs.component.spec.ts
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { of, EMPTY } from 'rxjs';
+import { BoardLiveJobsComponent } from './live-jobs.component';
+import { BoardService } from '@core/services/board.service';
+import { BoardLiveService } from '@core/services/board-live.service';
+import { PendingJobSummary } from '@core/services/board.service';
+
+const PENDING: PendingJobSummary = {
+  kind: 1,
+  organization: 'o1',
+  evaluation_id: 'e1abc123',
+  build_id: 'b1',
+  queued_at: '2026-06-08T00:00:00Z',
+  dependency_count: 3,
+};
+
+function setup(): ComponentFixture<BoardLiveJobsComponent> {
+  TestBed.configureTestingModule({
+    imports: [BoardLiveJobsComponent],
+    providers: [
+      provideRouter([]),
+      {
+        provide: BoardService,
+        useValue: {
+          getDispatchedJobs: () => of({ jobs: [], other_running: 0 }),
+          getPendingJobs: () => of({ jobs: [PENDING], other_pending: 2 }),
+        },
+      },
+      {
+        provide: BoardLiveService,
+        useValue: { connect: () => EMPTY },
+      },
+    ],
+  });
+  const fixture = TestBed.createComponent(BoardLiveJobsComponent);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('BoardLiveJobsComponent - pending view toggle', () => {
+  it('defaults to dispatched view', () => {
+    const fixture = setup();
+    expect(fixture.componentInstance.view()).toBe('dispatched');
+  });
+
+  it('loads pending jobs when switching to pending view', () => {
+    const fixture = setup();
+    const cmp = fixture.componentInstance;
+    cmp.setView('pending');
+    expect(cmp.pendingJobs().map((j) => j.evaluation_id)).toEqual(['e1abc123']);
+    expect(cmp.otherPending()).toBe(2);
+  });
+
+  it('renders pending job count in the banner after switching view', () => {
+    const fixture = setup();
+    const cmp = fixture.componentInstance;
+    cmp.setView('pending');
+    fixture.detectChanges();
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text).toContain('pending job(s)');
+  });
+});

--- a/frontend/src/app/features/board/live-jobs/live-jobs.component.ts
+++ b/frontend/src/app/features/board/live-jobs/live-jobs.component.ts
@@ -9,7 +9,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
 import { Subscription } from 'rxjs';
-import { BoardService, DispatchedJobSummary } from '@core/services/board.service';
+import { BoardService, DispatchedJobSummary, PendingJobSummary } from '@core/services/board.service';
 import { BoardLiveService } from '@core/services/board-live.service';
 
 type KindFilter = 'all' | 'eval' | 'build';
@@ -20,54 +20,83 @@ type StatusFilter = 'all' | 'pending' | 'dispatched';
   standalone: true,
   imports: [CommonModule, FormsModule, RouterModule],
   template: `
-    <div class="banner">
-      Showing {{ filteredJobs().length }} of {{ jobs().length }} dispatched job(s) you can see.
-      @if (otherRunning() > 0) {
-        <span class="muted">+ {{ otherRunning() }} other running (hidden).</span>
-      }
+    <div class="view-toggle">
+      <button [class.active]="view() === 'dispatched'" (click)="setView('dispatched')">Dispatched</button>
+      <button [class.active]="view() === 'pending'" (click)="setView('pending')">Pending</button>
     </div>
 
-    <div class="filters">
-      <label>Type
-        <select [ngModel]="kindFilter()" (ngModelChange)="kindFilter.set($event)">
-          <option value="all">all</option>
-          <option value="eval">eval</option>
-          <option value="build">build</option>
-        </select>
-      </label>
-      <label>Status
-        <select [ngModel]="statusFilter()" (ngModelChange)="statusFilter.set($event)">
-          <option value="all">all</option>
-          <option value="pending">pending (live)</option>
-          <option value="dispatched">dispatched</option>
-        </select>
-      </label>
-      <label>Score min
-        <input type="number" step="0.1" [ngModel]="scoreMin()" (ngModelChange)="scoreMin.set($event)" placeholder="—" />
-      </label>
-      <label>Score max
-        <input type="number" step="0.1" [ngModel]="scoreMax()" (ngModelChange)="scoreMax.set($event)" placeholder="—" />
-      </label>
-    </div>
-
-    <table class="jobs">
-      <thead>
-        <tr><th>Kind</th><th>Worker</th><th>Score</th><th>Dispatched</th><th></th></tr>
-      </thead>
-      <tbody>
-        @for (j of filteredJobs(); track j.id) {
-          <tr [class.live]="isLive(j)" [class.clickable]="canInspect(j)" (click)="inspect(j)">
-            <td>{{ j.kind === 1 ? 'build' : 'eval' }}</td>
-            <td class="mono">{{ j.worker_id }}</td>
-            <td>{{ j.score | number: '1.1-1' }}</td>
-            <td>{{ j.dispatched_at | date: 'HH:mm:ss' }}</td>
-            <td>{{ canInspect(j) ? '›' : '' }}</td>
-          </tr>
-        } @empty {
-          <tr><td colspan="5" class="muted">No matching dispatched jobs.</td></tr>
+    @if (view() === 'dispatched') {
+      <div class="banner">
+        Showing {{ filteredJobs().length }} of {{ jobs().length }} dispatched job(s) you can see.
+        @if (otherRunning() > 0) {
+          <span class="muted">+ {{ otherRunning() }} other running (hidden).</span>
         }
-      </tbody>
-    </table>
+      </div>
+
+      <div class="filters">
+        <label>Type
+          <select [ngModel]="kindFilter()" (ngModelChange)="kindFilter.set($event)">
+            <option value="all">all</option>
+            <option value="eval">eval</option>
+            <option value="build">build</option>
+          </select>
+        </label>
+        <label>Status
+          <select [ngModel]="statusFilter()" (ngModelChange)="statusFilter.set($event)">
+            <option value="all">all</option>
+            <option value="pending">pending (live)</option>
+            <option value="dispatched">dispatched</option>
+          </select>
+        </label>
+        <label>Score min
+          <input type="number" step="0.1" [ngModel]="scoreMin()" (ngModelChange)="scoreMin.set($event)" placeholder="—" />
+        </label>
+        <label>Score max
+          <input type="number" step="0.1" [ngModel]="scoreMax()" (ngModelChange)="scoreMax.set($event)" placeholder="—" />
+        </label>
+      </div>
+
+      <table class="jobs">
+        <thead>
+          <tr><th>Kind</th><th>Worker</th><th>Score</th><th>Dispatched</th><th></th></tr>
+        </thead>
+        <tbody>
+          @for (j of filteredJobs(); track j.id) {
+            <tr [class.live]="isLive(j)" [class.clickable]="canInspect(j)" (click)="inspect(j)">
+              <td>{{ j.kind === 1 ? 'build' : 'eval' }}</td>
+              <td class="mono">{{ j.worker_id }}</td>
+              <td>{{ j.score | number: '1.1-1' }}</td>
+              <td>{{ j.dispatched_at | date: 'HH:mm:ss' }}</td>
+              <td>{{ canInspect(j) ? '›' : '' }}</td>
+            </tr>
+          } @empty {
+            <tr><td colspan="5" class="muted">No matching dispatched jobs.</td></tr>
+          }
+        </tbody>
+      </table>
+    }
+
+    @if (view() === 'pending') {
+      <div class="banner">
+        {{ pendingJobs().length }} pending job(s) you can see.
+        @if (otherPending() > 0) { <span class="muted">+ {{ otherPending() }} hidden.</span> }
+      </div>
+      <table class="jobs">
+        <thead><tr><th>Kind</th><th>Evaluation</th><th>Deps</th><th>Queued</th></tr></thead>
+        <tbody>
+          @for (p of pendingJobs(); track p.evaluation_id + (p.build_id ?? '')) {
+            <tr class="clickable" [routerLink]="['/board/jobs', p.evaluation_id]">
+              <td>{{ p.kind === 1 ? 'build' : 'eval' }}</td>
+              <td class="mono">{{ p.evaluation_id.slice(0, 8) }}</td>
+              <td>{{ p.dependency_count }}</td>
+              <td>{{ p.queued_at | date: 'HH:mm:ss' }}</td>
+            </tr>
+          } @empty {
+            <tr><td colspan="4" class="muted">No pending jobs.</td></tr>
+          }
+        </tbody>
+      </table>
+    }
   `,
   styles: [
     `
@@ -83,6 +112,9 @@ type StatusFilter = 'all' | 'pending' | 'dispatched';
       tbody tr.clickable:hover { background: #2d333b; }
       tbody tr.live { opacity: 0.7; font-style: italic; }
       .mono { font-family: monospace; }
+      .view-toggle { display: flex; gap: 0.5rem; margin-bottom: 1rem; }
+      .view-toggle button { background: #21262d; color: #abb0b4; border: 1px solid #2d333b; border-radius: 6px; padding: 0.3rem 0.8rem; cursor: pointer; }
+      .view-toggle button.active { background: #2d333b; color: #fff; }
     `,
   ],
 })
@@ -94,6 +126,10 @@ export class BoardLiveJobsComponent implements OnInit, OnDestroy {
 
   jobs = signal<DispatchedJobSummary[]>([]);
   otherRunning = signal(0);
+
+  view = signal<'dispatched' | 'pending'>('dispatched');
+  pendingJobs = signal<PendingJobSummary[]>([]);
+  otherPending = signal(0);
 
   kindFilter = signal<KindFilter>('all');
   statusFilter = signal<StatusFilter>('all');
@@ -148,6 +184,18 @@ export class BoardLiveJobsComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.sub?.unsubscribe();
+  }
+
+  setView(v: 'dispatched' | 'pending'): void {
+    this.view.set(v);
+    if (v === 'pending') this.loadPending();
+  }
+
+  private loadPending(): void {
+    this.board.getPendingJobs().subscribe((r) => {
+      this.pendingJobs.set(r.jobs);
+      this.otherPending.set(r.other_pending);
+    });
   }
 
   isLive(j: DispatchedJobSummary): boolean {

--- a/frontend/src/app/features/evaluations/evaluation-log/build-search.spec.ts
+++ b/frontend/src/app/features/evaluations/evaluation-log/build-search.spec.ts
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { matchesBuildSearch } from './build-search';
+
+describe('matchesBuildSearch', () => {
+  it('empty query matches all', () => {
+    expect(matchesBuildSearch('gcc-13.2.0', '')).toBe(true);
+  });
+
+  it('whitespace-only query matches all', () => {
+    expect(matchesBuildSearch('gcc-13.2.0', '   ')).toBe(true);
+  });
+
+  it('case-insensitive substring match', () => {
+    expect(matchesBuildSearch('gcc-13.2.0', 'GCC')).toBe(true);
+    expect(matchesBuildSearch('nixos-system', 'system')).toBe(true);
+  });
+
+  it('non-matching query returns false', () => {
+    expect(matchesBuildSearch('gcc-13.2.0', 'clang')).toBe(false);
+  });
+});

--- a/frontend/src/app/features/evaluations/evaluation-log/build-search.ts
+++ b/frontend/src/app/features/evaluations/evaluation-log/build-search.ts
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+/** Case-insensitive substring match; an empty/whitespace query matches all. */
+export function matchesBuildSearch(name: string, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  return q === '' || name.toLowerCase().includes(q);
+}

--- a/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.html
+++ b/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.html
@@ -17,7 +17,7 @@
   <div class="eval-layout">
 
     <!-- ── Sidebar ──────────────────────────────────────────────── -->
-    <aside class="builds-sidebar">
+    <aside class="builds-sidebar" (focusin)="setSidebarFocus(true)" (focusout)="setSidebarFocus(false)">
 
       <div class="sidebar-breadcrumb">
         <a [routerLink]="['/organization', orgName]" class="breadcrumb-link">{{ orgDisplayName() || orgName }}</a>
@@ -64,6 +64,16 @@
       </div>
 
       <div class="builds-list-header">Builds</div>
+
+      <div class="sidebar-search">
+        <input
+          type="text"
+          placeholder="Search builds… (Ctrl+F)"
+          [value]="sidebarSearchQuery()"
+          (input)="sidebarSearchQuery.set($any($event.target).value)"
+          (keydown.escape)="sidebarSearchQuery.set('')"
+        />
+      </div>
 
       @if (visibleBuilds().length === 0) {
         <div class="no-builds">No builds yet</div>
@@ -119,6 +129,9 @@
                 </div>
               }
             </div>
+          }
+          @empty {
+            <div class="no-builds">No matching builds</div>
           }
         </div>
       }
@@ -309,7 +322,7 @@
                       [attr.data-line]="ln.n"
                     >
                       <span class="log-gutter" (click)="selectLine(ln.n)" title="Link to line">{{ ln.n }}</span>
-                      <pre class="log-line-content" [innerHTML]="ln.html"></pre>
+                      <span class="log-line-content" [innerHTML]="ln.html"></span>
                     </div>
                   }
                 </div>

--- a/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.scss
+++ b/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.scss
@@ -105,6 +105,25 @@
   font-variant-numeric: tabular-nums;
 }
 
+.sidebar-search {
+  padding: 0 $spacing-md $spacing-sm;
+
+  input {
+    width: 100%;
+    box-sizing: border-box;
+    background: $color-primary;
+    border: 1px solid $color-border;
+    border-radius: $border-radius-sm;
+    color: $text-primary;
+    font-size: $font-size-xs;
+    padding: 6px 8px;
+    outline: none;
+
+    &:focus { border-color: $color-info; }
+    &::placeholder { color: $text-light; }
+  }
+}
+
 // Builds list
 .builds-list-header {
   padding: $spacing-xs $spacing-md;
@@ -775,14 +794,13 @@
 }
 
 .log-line {
-  display: flex;
-  align-items: flex-start;
+  position: relative;
+  padding-left: 68px;
   font-family: $font-family-mono;
   font-size: $font-size-xs;
   line-height: 1.6;
-  // Exclude the row itself from selection so the line-number gutter and the
-  // flex/block layout don't inject blank lines into copied text; only the
-  // content span below opts back in.
+  // Row is a plain block (not flex) so the content stays genuinely inline —
+  // a flex item would be blockified and re-introduce blank lines on copy.
   user-select: none;
   -webkit-user-select: none;
 
@@ -792,7 +810,8 @@
 }
 
 .log-gutter {
-  flex: 0 0 auto;
+  position: absolute;
+  left: 0;
   width: 56px;
   padding-right: 12px;
   text-align: right;
@@ -806,8 +825,7 @@
 }
 
 .log-line-content {
-  margin: 0;
-  flex: 1 1 auto;
+  display: inline;
   color: $text-primary;
   white-space: pre-wrap;
   word-break: break-word;

--- a/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.spec.ts
+++ b/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.spec.ts
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { EvaluationLogComponent } from './evaluation-log.component';
+import { BuildItem } from '@core/services/evaluations.service';
+
+function build(id: string, name: string, status = 'Completed'): BuildItem {
+  return { id, name, status, has_artefacts: false, updated_at: '', build_time_ms: null };
+}
+
+function setup(): { fixture: ComponentFixture<EvaluationLogComponent>; cmp: EvaluationLogComponent } {
+  TestBed.configureTestingModule({
+    imports: [EvaluationLogComponent],
+    providers: [provideRouter([]), provideHttpClient(), provideHttpClientTesting()],
+  });
+  const fixture = TestBed.createComponent(EvaluationLogComponent);
+  return { fixture, cmp: fixture.componentInstance };
+}
+
+describe('EvaluationLogComponent', () => {
+  // #341: the live line-count must update on the streaming (Building) render
+  // path, identical to chunked (Completed) builds.
+  describe('line count', () => {
+    it('renderLog sets logLineCount from logLines', () => {
+      const { cmp } = setup();
+      (cmp as unknown as { logLines: string[] }).logLines = ['a', 'b', 'c'];
+      (cmp as unknown as { renderLog: () => void }).renderLog();
+      expect(cmp.logLineCount()).toBe(3);
+    });
+  });
+
+  // #341: sidebar search filters the build list by name without disturbing the
+  // status-sorted indices used for keyboard navigation.
+  describe('sidebar search', () => {
+    it('filters grouped builds by name, case-insensitively', () => {
+      const { cmp } = setup();
+      cmp.visibleBuilds.set([build('a', '/nix/store/aaa-hello'), build('b', '/nix/store/bbb-world')]);
+      cmp.sidebarSearchQuery.set('HELLO');
+      const names = cmp.groupedBuilds().flatMap((g) => g.builds.map((x) => x.build.name));
+      expect(names).toEqual(['/nix/store/aaa-hello']);
+    });
+
+    it('keeps every build when the query is empty', () => {
+      const { cmp } = setup();
+      cmp.visibleBuilds.set([build('a', 'aaa'), build('b', 'bbb')]);
+      cmp.sidebarSearchQuery.set('');
+      const names = cmp.groupedBuilds().flatMap((g) => g.builds.map((x) => x.build.name));
+      expect(names).toEqual(['aaa', 'bbb']);
+    });
+
+    it('preserves visibleBuilds index for matched builds (arrow-nav stays correct)', () => {
+      const { cmp } = setup();
+      cmp.visibleBuilds.set([build('a', 'aaa'), build('b', 'bbb'), build('c', 'ccc')]);
+      cmp.sidebarSearchQuery.set('ccc');
+      const indices = cmp.groupedBuilds().flatMap((g) => g.builds.map((x) => x.index));
+      expect(indices).toEqual([2]);
+    });
+  });
+});

--- a/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.ts
+++ b/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.ts
@@ -22,6 +22,7 @@ import {
   parseLineFragment,
   windowAround,
 } from './log-window';
+import { matchesBuildSearch } from './build-search';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
@@ -124,6 +125,8 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
   highlightLine = signal<number | null>(null);
   searchOpen = signal(false);
   searchQuery = signal('');
+  sidebarSearchQuery = signal('');
+  private sidebarFocused = false;
   searchHits = signal<LogSearchHit[]>([]);
   searchTotal = signal(0);
   currentHit = signal(-1);
@@ -224,6 +227,7 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
     this.buildGroups.forEach((g, i) => g.members.forEach((m) => indexByGroup.set(m, i)));
     const buckets: { build: BuildItem; index: number }[][] = this.buildGroups.map(() => []);
     this.visibleBuilds().forEach((build, index) => {
+      if (!matchesBuildSearch(build.name, this.sidebarSearchQuery())) return;
       const gi = indexByGroup.get(this.statusClass(build.status));
       if (gi !== undefined) buckets[gi].push({ build, index });
     });
@@ -457,6 +461,8 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
     this.liveSub?.unsubscribe();
     this.liveSub = undefined;
   }
+
+  setSidebarFocus(v: boolean): void { this.sidebarFocused = v; }
 
   // ── Build selection & log loading ──────────────────────────────────────────
 
@@ -760,13 +766,23 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
 
   @HostListener('document:keydown', ['$event'])
   onKeydown(event: KeyboardEvent): void {
+    const isFind = (event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'f';
+    if (isFind && this.sidebarFocused) {
+      event.preventDefault();
+      setTimeout(() => { (document.querySelector('.sidebar-search input') as HTMLInputElement | null)?.focus(); }, 0);
+      return;
+    }
+
+    if (event.key === 'Escape' && this.sidebarSearchQuery()) {
+      this.sidebarSearchQuery.set('');
+      return;
+    }
+
     if (!this.chunkedMode() || !this.selectedBuildId()) return;
-    if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'f') {
+    if (isFind) {
       event.preventDefault();
       this.searchOpen.set(true);
-      setTimeout(() => {
-        (document.querySelector('.log-search-input') as HTMLInputElement | null)?.focus();
-      }, 0);
+      setTimeout(() => { (document.querySelector('.log-search-input') as HTMLInputElement | null)?.focus(); }, 0);
     } else if (event.key === 'Escape' && this.searchOpen()) {
       this.closeSearch();
     }

--- a/frontend/src/app/features/projects/project-actions/project-actions.component.spec.ts
+++ b/frontend/src/app/features/projects/project-actions/project-actions.component.spec.ts
@@ -98,7 +98,8 @@ describe('ProjectActionsComponent', () => {
     expect(deleteBtn).not.toBeNull();
     expect(deleteBtn!.disabled).toBe(true);
     expect(testBtn).not.toBeNull();
-    expect(testBtn!.disabled).toBe(true);
+    // Test is a trigger action, not a config edit - exempt from the managed flag (AccessService.triggerAccess).
+    expect(testBtn!.disabled).toBe(false);
   });
 
   it('renders action name and event chips', () => {

--- a/frontend/src/app/features/projects/project-triggers/project-triggers.component.spec.ts
+++ b/frontend/src/app/features/projects/project-triggers/project-triggers.component.spec.ts
@@ -125,6 +125,7 @@ describe('ProjectTriggersComponent - access gating', () => {
     expect(deleteBtn).not.toBeNull();
     expect(deleteBtn!.disabled).toBe(true);
     expect(fireBtn).not.toBeNull();
-    expect(fireBtn!.disabled).toBe(true);
+    // Fire Now is a trigger action, not a config edit - exempt from the managed flag (AccessService.triggerAccess).
+    expect(fireBtn!.disabled).toBe(false);
   });
 });


### PR DESCRIPTION
Addresses the open items in #341.

- [x] Eval-log copy no longer leaves blank lines between rows (block row + inline content)
- [x] Build sidebar Ctrl+F search (filters by name; keyboard-nav indices preserved)
- [x] System Health: removed the HTTP-routes table; added a superuser admin panel (GitHub App setup link, Run Deep GC, executed-tasks table) wired to existing `/admin/*` endpoints
- [x] Live Jobs: new "Pending" view backed by org-scoped `GET /board/jobs/pending` (new scheduler snapshot)
- [x] Job Board nav tabs: hover highlight now has padding
- [x] Live line-count on building builds — already worked; added a regression guard
- [x] OpenAPI repair: duplicate `/board/live` key + `x-nix-cache-paths` had orphaned 26 `/board`+`/metrics` paths out of `paths:`; the spec now parses and those endpoints are under `paths:`

Note: the 2 pre-existing `project-triggers`/`project-actions` access-gating spec failures are unrelated to this PR.

Closes #341