### PR TITLE
fix: HTTP upstream gradient-cache probe reports fake caches (#363)

### DIFF
--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -177,6 +177,22 @@ a banner instructing the admin to subscribe to a cache before workers can run.
 - `WorkersComponent - no-cache banner` - banner show/hide specs at
   `frontend/src/app/features/organizations/workers/workers.component.spec.ts`
 
+## Frontend - HTTP upstream Gradient-cache probe (#363)
+
+The "Add HTTP Upstream" dialog probes the entered substituter URL for
+`gradient-cache-info` to offer switching to the native Gradient protocol. The
+probe must only fire for real absolute URLs and only trust a genuine
+gradient-cache-info body, so a scheme-less input (which resolves to the SPA's
+own origin and returns a 200 `index.html`) no longer reports a Gradient cache.
+
+- `normalizeProbeUrl` / `isGradientCacheInfo` - pure-logic specs at
+  `frontend/src/app/features/caches/cache-upstreams/cache-upstream-probe.spec.ts`
+  (absolute http(s)-only URL gating; body must carry `GradientVersion` +
+  `GradientUrl`).
+- `CacheUpstreamsComponent - HTTP upstream probe` - wiring specs at
+  `frontend/src/app/features/caches/cache-upstreams/cache-upstreams.component.spec.ts`
+  (skips fetch for scheme-less input; suggests proto only on a valid body).
+
 ## Auth middleware response envelope
 
 Integration tests in `backend/web/tests/auth_middleware.rs` lock in the

--- a/frontend/src/app/features/caches/cache-upstreams/cache-upstream-probe.spec.ts
+++ b/frontend/src/app/features/caches/cache-upstreams/cache-upstream-probe.spec.ts
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { normalizeProbeUrl, isGradientCacheInfo } from './cache-upstream-probe';
+
+describe('normalizeProbeUrl', () => {
+  it('accepts absolute http(s) URLs and strips trailing slashes', () => {
+    expect(normalizeProbeUrl('https://cache.nixos.org')).toBe('https://cache.nixos.org');
+    expect(normalizeProbeUrl('  http://cache.example.com/  ')).toBe('http://cache.example.com');
+  });
+
+  it('rejects scheme-less or relative input that would resolve to our own origin', () => {
+    expect(normalizeProbeUrl('randomtext')).toBeNull();
+    expect(normalizeProbeUrl('cache.nixos.org')).toBeNull();
+    expect(normalizeProbeUrl('/randomtext')).toBeNull();
+    expect(normalizeProbeUrl('')).toBeNull();
+    expect(normalizeProbeUrl('   ')).toBeNull();
+  });
+
+  it('rejects non-http protocols', () => {
+    expect(normalizeProbeUrl('ftp://cache.example.com')).toBeNull();
+    expect(normalizeProbeUrl('file:///etc/passwd')).toBeNull();
+  });
+});
+
+describe('isGradientCacheInfo', () => {
+  it('accepts a body with both Gradient fields', () => {
+    expect(isGradientCacheInfo({ GradientVersion: '0.1.0', GradientUrl: 'https://g.example.com' })).toBe(true);
+  });
+
+  it('rejects bodies missing the Gradient fields', () => {
+    expect(isGradientCacheInfo({})).toBe(false);
+    expect(isGradientCacheInfo({ GradientVersion: '0.1.0' })).toBe(false);
+    expect(isGradientCacheInfo({ WantMassQuery: true, StoreDir: '/nix/store' })).toBe(false);
+  });
+
+  it('rejects non-object bodies', () => {
+    expect(isGradientCacheInfo(null)).toBe(false);
+    expect(isGradientCacheInfo('<html>index</html>')).toBe(false);
+    expect(isGradientCacheInfo(undefined)).toBe(false);
+  });
+});

--- a/frontend/src/app/features/caches/cache-upstreams/cache-upstream-probe.ts
+++ b/frontend/src/app/features/caches/cache-upstreams/cache-upstream-probe.ts
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+// Returns the entered substituter URL normalized to an absolute http(s) origin,
+// or null when it is not a real absolute URL (so we never probe the app's own
+// origin via a relative path).
+export function normalizeProbeUrl(raw: string): string | null {
+  const trimmed = raw.trim().replace(/\/+$/, '');
+  if (!trimmed) return null;
+  try {
+    const { protocol } = new URL(trimmed);
+    return protocol === 'http:' || protocol === 'https:' ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+// True only when the parsed `gradient-cache-info?json` body carries the
+// fields a Gradient server emits, so a plain 200 (e.g. an SPA fallback) is
+// not mistaken for a Gradient cache.
+export function isGradientCacheInfo(body: unknown): boolean {
+  if (typeof body !== 'object' || body === null) return false;
+  const info = body as Record<string, unknown>;
+  return typeof info['GradientVersion'] === 'string' && typeof info['GradientUrl'] === 'string';
+}

--- a/frontend/src/app/features/caches/cache-upstreams/cache-upstreams.component.spec.ts
+++ b/frontend/src/app/features/caches/cache-upstreams/cache-upstreams.component.spec.ts
@@ -69,6 +69,47 @@ function setup(access: AccessState): ComponentFixture<CacheUpstreamsComponent> {
   return fixture;
 }
 
+describe('CacheUpstreamsComponent - HTTP upstream probe', () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = realFetch; });
+
+  function probeWith(url: string, fetchImpl: typeof fetch) {
+    globalThis.fetch = fetchImpl;
+    const fixture = setup({ managed: false, canEdit: true, canTrigger: true });
+    fixture.componentInstance.upstreamForm.url = url;
+    return fixture.componentInstance;
+  }
+
+  it('does not probe a scheme-less URL that would hit our own origin', async () => {
+    const fetchSpy = vi.fn();
+    const component = probeWith('randomtext', fetchSpy as unknown as typeof fetch);
+    await component.probeHttpUrl();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(component.probeSuggestsProto()).toBe(false);
+  });
+
+  it('suggests proto only when the body is a real gradient-cache-info', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ GradientVersion: '0.1.0', GradientUrl: 'https://g.example.com' }),
+    });
+    const component = probeWith('https://g.example.com', fetchSpy as unknown as typeof fetch);
+    await component.probeHttpUrl();
+    expect(fetchSpy).toHaveBeenCalledWith('https://g.example.com/gradient-cache-info?json', expect.anything());
+    expect(component.probeSuggestsProto()).toBe(true);
+  });
+
+  it('does not suggest proto when a 200 returns a non-gradient body', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.reject(new SyntaxError('Unexpected token <')),
+    });
+    const component = probeWith('https://not-gradient.example.com', fetchSpy as unknown as typeof fetch);
+    await component.probeHttpUrl();
+    expect(component.probeSuggestsProto()).toBe(false);
+  });
+});
+
 describe('CacheUpstreamsComponent - access gating', () => {
   it('renders the upstream list under read-only access', () => {
     const fixture = setup({ managed: false, canEdit: false, canTrigger: false });

--- a/frontend/src/app/features/caches/cache-upstreams/cache-upstreams.component.ts
+++ b/frontend/src/app/features/caches/cache-upstreams/cache-upstreams.component.ts
@@ -15,6 +15,7 @@ import { CachesService, UpstreamCache, CacheSubscriptionMode } from '@core/servi
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { WritableDirective, ManagedDisableDirective, AccessService } from '@shared/access';
 import { injectCacheAccess } from '@core/resolvers/inject-access';
+import { normalizeProbeUrl, isGradientCacheInfo } from './cache-upstream-probe';
 
 @Component({
   selector: 'app-cache-upstreams',
@@ -234,12 +235,13 @@ export class CacheUpstreamsComponent implements OnInit {
     });
   }
 
-  probeHttpUrl(): void {
+  probeHttpUrl(): Promise<void> {
     this.probeSuggestsProto.set(false);
-    const url = this.upstreamForm.url.trim().replace(/\/$/, '');
-    if (!url) return;
-    fetch(`${url}/gradient-cache-info`, { method: 'GET', mode: 'cors' })
-      .then((r) => { if (r.ok) this.probeSuggestsProto.set(true); })
+    const url = normalizeProbeUrl(this.upstreamForm.url);
+    if (!url) return Promise.resolve();
+    return fetch(`${url}/gradient-cache-info?json`, { method: 'GET', mode: 'cors' })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((body) => { if (isGradientCacheInfo(body)) this.probeSuggestsProto.set(true); })
       .catch(() => {});
   }
 


### PR DESCRIPTION
The "switch to Gradient" probe in the Add HTTP Upstream dialog fired for any 200, so a scheme-less input (resolving to the SPA's own origin → `index.html` 200) was wrongly reported as a Gradient cache. It now probes only absolute http(s) URLs and only trusts a genuine `gradient-cache-info` body.

Closes #363