### PR TITLE
fix: job & worker context corrections (#366)

### DIFF
--- a/backend/scheduler/src/views.rs
+++ b/backend/scheduler/src/views.rs
@@ -17,7 +17,6 @@ use crate::jobs::PendingJob;
 pub struct WorkerContextView {
     pub architectures: Vec<String>,
     pub system_features: Vec<String>,
-    pub fetch: bool,
     pub capabilities: GradientCapabilities,
     pub cpu_count: u32,
     pub cpu_core_score: u32,
@@ -34,7 +33,6 @@ impl WorkerContextView {
         Self {
             architectures: w.architectures.to_vec(),
             system_features: w.system_features.to_vec(),
-            fetch: w.fetch,
             capabilities,
             cpu_count: m.cpu_count,
             cpu_core_score: m.cpu_core_score,

--- a/backend/web/src/endpoints/board.rs
+++ b/backend/web/src/endpoints/board.rs
@@ -131,6 +131,7 @@ pub struct DispatchedJobDetail {
     pub id: Uuid,
     pub kind: i16,
     pub organization: Uuid,
+    pub organization_name: String,
     pub worker_id: String,
     pub score: f64,
     pub queued_at: String,
@@ -161,10 +162,17 @@ pub async fn get_dispatched_job(
         return Err(WebError::not_found("Job"));
     }
 
+    let organization_name = entity::organization::Entity::find_by_id(j.organization)
+        .one(&state.web_db)
+        .await?
+        .map(|o| o.name)
+        .unwrap_or_default();
+
     Ok(ok_json(DispatchedJobDetail {
         id: j.id.into(),
         kind: j.kind,
         organization: j.organization.into(),
+        organization_name,
         worker_id: j.worker_id,
         score: j.score,
         queued_at: j.queued_at.and_utc().to_rfc3339(),

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -9127,7 +9127,6 @@ components:
       properties:
         architectures: { type: array, items: { type: string } }
         system_features: { type: array, items: { type: string } }
-        fetch: { type: boolean }
         capabilities:
           type: object
           properties:
@@ -9220,6 +9219,7 @@ components:
         id: { type: string, format: uuid }
         kind: { type: integer }
         organization: { type: string, format: uuid }
+        organization_name: { type: string }
         worker_id: { type: string }
         score: { type: number }
         queued_at: { type: string, format: date-time }

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -3697,3 +3697,26 @@ Frontend (`frontend/.../board/job-detail/job-detail.component.spec.ts`) -
 structured context panels: renders worker `cpu_count`, a derivations row
 (`pname`/`drv_path`), the job-context kind + history `peak_ram_mb`, and the
 instance-context windowed table with scalar counts.
+
+## Job & worker context fixes (#366)
+
+The dispatched-job detail now hides the server-only `core`/`cache` capability
+flags and the redundant standalone `fetch` row, shows the job-context
+architecture only for build jobs, links the worker id to its org-scoped metrics
+page (`organization_name` is now part of `DispatchedJobDetail`), makes the
+derivation rows the build entry-point, and falls back to a limited view (or a
+"Job not found" message) when a queued job has no dispatch record yet. The live
+board persists its tab/filter selection in `sessionStorage` and reconciles the
+optimistic live rows with the persisted, selectable rows shortly after a
+dispatch event.
+
+Frontend (`board/job-detail/job-detail.component.spec.ts`) - capability list
+excludes `core`/`cache` and has no separate `Fetch` row; architecture renders
+for build jobs and is hidden for eval jobs; the worker id links to
+`/organization/{org}/workers/{id}/metrics`; an undispatched job renders the
+pending view without a scoring breakdown, and an unknown id renders "Job not
+found".
+
+Frontend (`board/live-jobs/live-jobs.component.spec.ts`) - the view/filter
+selection round-trips through `sessionStorage`: a persisted `pending` view is
+restored on load and switching the tab writes it back.

--- a/frontend/src/app/core/services/board.service.ts
+++ b/frontend/src/app/core/services/board.service.ts
@@ -47,7 +47,6 @@ export interface Windowed { w5m: number; w1h: number; w24h: number; }
 export interface WorkerContextView {
   architectures: string[];
   system_features: string[];
-  fetch: boolean;
   capabilities: GradientCapabilities;
   cpu_count: number;
   cpu_core_score: number;
@@ -105,6 +104,7 @@ export interface InstanceContextView {
 }
 
 export interface DispatchedJobDetail extends DispatchedJobSummary {
+  organization_name: string;
   queued_at: string;
   finished_at: string | null;
   score_breakdown: { rules: Record<string, number>; total: number };

--- a/frontend/src/app/features/board/job-detail/job-detail.component.spec.ts
+++ b/frontend/src/app/features/board/job-detail/job-detail.component.spec.ts
@@ -5,16 +5,17 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ActivatedRoute } from '@angular/router';
-import { EMPTY, of } from 'rxjs';
+import { ActivatedRoute, provideRouter } from '@angular/router';
+import { EMPTY, of, throwError } from 'rxjs';
 import { BoardJobDetailComponent } from './job-detail.component';
-import { BoardService, DispatchedJobDetail } from '@core/services/board.service';
+import { BoardService, DispatchedJobDetail, PendingJobSummary } from '@core/services/board.service';
 import { EvaluationsService } from '@core/services/evaluations.service';
 
 const DETAIL: DispatchedJobDetail = {
   id: 'job-1',
   kind: 1,
   organization: 'o1',
+  organization_name: 'org-one',
   worker_id: 'w1',
   score: 12.5,
   dispatched_at: '2026-06-08T00:01:00Z',
@@ -26,7 +27,6 @@ const DETAIL: DispatchedJobDetail = {
   worker_context: {
     architectures: ['x86_64-linux'],
     system_features: ['kvm'],
-    fetch: true,
     capabilities: { core: true, federate: false, fetch: true, eval: false, build: true, cache: true },
     cpu_count: 8,
     cpu_core_score: 1.5,
@@ -82,12 +82,45 @@ const DETAIL: DispatchedJobDetail = {
   candidates: null,
 };
 
-function setup(): ComponentFixture<BoardJobDetailComponent> {
+const EVAL_DETAIL: DispatchedJobDetail = {
+  ...DETAIL,
+  kind: 0,
+  job_context: {
+    kind: 'Eval',
+    architecture: '',
+    missing_count: null,
+    missing_nar_size: null,
+    org_work_share: null,
+    rescore_count: 0,
+    queued_at: '2026-06-08T00:00:00Z',
+    ready_at: '2026-06-08T00:00:30Z',
+    fetch_flake: true,
+  },
+};
+
+const PENDING: PendingJobSummary = {
+  kind: 1,
+  organization: 'o1',
+  evaluation_id: 'e1',
+  build_id: 'b9',
+  queued_at: '2026-06-08T00:00:00Z',
+  dependency_count: 3,
+};
+
+function setup(board: Partial<BoardService> = {}, id = 'job-1'): ComponentFixture<BoardJobDetailComponent> {
   TestBed.configureTestingModule({
     imports: [BoardJobDetailComponent],
     providers: [
-      { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => 'job-1' } } } },
-      { provide: BoardService, useValue: { getJob: () => of(DETAIL) } },
+      provideRouter([]),
+      { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => id } } } },
+      {
+        provide: BoardService,
+        useValue: {
+          getJob: () => of(DETAIL),
+          getPendingJobs: () => of({ jobs: [], other_pending: 0 }),
+          ...board,
+        },
+      },
       { provide: EvaluationsService, useValue: { getBuild: () => EMPTY } },
     ],
   });
@@ -110,6 +143,23 @@ describe('BoardJobDetailComponent - structured context panels', () => {
     expect(worker.textContent).toContain('8');
   });
 
+  it('lists only worker capabilities, never the server-only core/cache flags', () => {
+    const el = setup().nativeElement as HTMLElement;
+    const caps = Array.from(el.querySelectorAll('.ctx.worker tr')).find((r) =>
+      r.textContent?.includes('Capabilities'),
+    ) as HTMLElement;
+    expect(caps.textContent).toContain('fetch');
+    expect(caps.textContent).toContain('build');
+    expect(caps.textContent).not.toContain('core');
+    expect(caps.textContent).not.toContain('cache');
+  });
+
+  it('has no redundant standalone Fetch row in the worker context', () => {
+    const el = setup().nativeElement as HTMLElement;
+    const labels = Array.from(el.querySelectorAll('.ctx.worker td.label')).map((c) => c.textContent?.trim());
+    expect(labels).not.toContain('Fetch');
+  });
+
   it('renders a derivations row with the pname / drv_path', () => {
     const el = setup().nativeElement as HTMLElement;
     const drv = el.querySelector('.ctx.job .drv-row') as HTMLElement;
@@ -118,19 +168,48 @@ describe('BoardJobDetailComponent - structured context panels', () => {
     expect(drv.textContent).toContain('/nix/store/xxx-foo');
   });
 
-  it('shows the job-context kind and history peak_ram_mb', () => {
+  it('links the worker id to the org-scoped worker metrics page', () => {
     const el = setup().nativeElement as HTMLElement;
-    const job = el.querySelector('section.ctx.job') as HTMLElement;
-    expect(job).toBeTruthy();
-    expect(job.textContent).toContain('Build');
-    expect(job.textContent).toContain('777');
+    const link = el.querySelector('.ids .worker-link') as HTMLAnchorElement;
+    expect(link).toBeTruthy();
+    expect(link.getAttribute('href')).toBe('/organization/org-one/workers/w1/metrics');
   });
 
-  it('renders the instance-context windowed table with scalar counts', () => {
+  it('shows the architecture for build jobs', () => {
     const el = setup().nativeElement as HTMLElement;
-    const inst = el.querySelector('section.ctx.instance') as HTMLElement;
-    expect(inst).toBeTruthy();
-    expect(inst.textContent).toContain('Instance context');
-    expect(inst.textContent).toContain('7');
+    const job = el.querySelector('section.ctx.job') as HTMLElement;
+    expect(job.textContent).toContain('Architecture');
+  });
+
+  it('hides the architecture for eval jobs', () => {
+    const el = setup({ getJob: () => of(EVAL_DETAIL) }).nativeElement as HTMLElement;
+    const job = el.querySelector('section.ctx.job') as HTMLElement;
+    expect(job.textContent).toContain('Eval');
+    expect(job.textContent).not.toContain('Architecture');
+  });
+});
+
+describe('BoardJobDetailComponent - pending fallback', () => {
+  it('renders a limited pending view when the job is not yet dispatched', () => {
+    const el = setup(
+      {
+        getJob: () => throwError(() => new Error('not found')),
+        getPendingJobs: () => of({ jobs: [PENDING], other_pending: 0 }),
+      },
+      'e1',
+    ).nativeElement as HTMLElement;
+    expect(el.textContent).toContain('Pending job');
+    expect(el.textContent).not.toContain('Score breakdown');
+  });
+
+  it('shows "Job not found" when neither dispatched nor pending', () => {
+    const el = setup(
+      {
+        getJob: () => throwError(() => new Error('not found')),
+        getPendingJobs: () => of({ jobs: [], other_pending: 0 }),
+      },
+      'missing',
+    ).nativeElement as HTMLElement;
+    expect(el.textContent).toContain('Job not found');
   });
 });

--- a/frontend/src/app/features/board/job-detail/job-detail.component.ts
+++ b/frontend/src/app/features/board/job-detail/job-detail.component.ts
@@ -14,6 +14,7 @@ import {
   DispatchedJobDetail,
   GradientCapabilities,
   InstanceContextView,
+  PendingJobSummary,
   Windowed,
 } from '@core/services/board.service';
 import { EvaluationsService, BuildWithOutputs } from '@core/services/evaluations.service';
@@ -45,11 +46,11 @@ interface RuleRow {
       </header>
 
       <section class="ids">
-        <div><span class="label">Worker</span><span class="mono">{{ j.worker_id }}</span></div>
+        <div>
+          <span class="label">Worker</span>
+          <a class="mono worker-link" [routerLink]="['/organization', j.organization_name, 'workers', j.worker_id, 'metrics']">{{ j.worker_id }}</a>
+        </div>
         <div><span class="label">Evaluation</span><span class="mono">{{ j.evaluation_id }}</span></div>
-        @if (j.build_id) {
-          <div><span class="label">Build</span><button type="button" class="mono link" (click)="openBuild(j.build_id)">{{ j.build_id }}</button></div>
-        }
       </section>
 
       <section class="timeline">
@@ -89,7 +90,6 @@ interface RuleRow {
             <tr><td class="label">Architectures</td><td class="mono">{{ j.worker_context.architectures.join(', ') || '—' }}</td></tr>
             <tr><td class="label">System features</td><td class="mono">{{ j.worker_context.system_features.join(', ') || '—' }}</td></tr>
             <tr><td class="label">Capabilities</td><td class="mono">{{ capabilityList(j.worker_context.capabilities) || '—' }}</td></tr>
-            <tr><td class="label">Fetch</td><td class="mono">{{ j.worker_context.fetch ? 'yes' : 'no' }}</td></tr>
             <tr><td class="label">CPU count</td><td class="mono">{{ j.worker_context.cpu_count }}</td></tr>
             <tr><td class="label">CPU core score</td><td class="mono">{{ j.worker_context.cpu_core_score | number: '1.0-2' }}</td></tr>
             <tr><td class="label">CPU usage</td><td class="mono">{{ j.worker_context.cpu_usage_pct | number: '1.0-1' }} %</td></tr>
@@ -106,7 +106,9 @@ interface RuleRow {
         <table class="kv">
           <tbody>
             <tr><td class="label">Kind</td><td class="mono">{{ j.job_context.kind }}</td></tr>
-            <tr><td class="label">Architecture</td><td class="mono">{{ j.job_context.architecture }}</td></tr>
+            @if (j.job_context.kind === 'Build') {
+              <tr><td class="label">Architecture</td><td class="mono">{{ j.job_context.architecture }}</td></tr>
+            }
             <tr><td class="label">Missing count</td><td class="mono">{{ j.job_context.missing_count ?? '—' }}</td></tr>
             <tr><td class="label">Missing NAR size</td><td class="mono">{{ j.job_context.missing_nar_size != null ? (j.job_context.missing_nar_size | number) : '—' }}</td></tr>
             <tr><td class="label">Org work share</td><td class="mono">{{ j.job_context.org_work_share != null ? (j.job_context.org_work_share | number: '1.0-3') : '—' }}</td></tr>
@@ -143,7 +145,7 @@ interface RuleRow {
           <h3>Derivations</h3>
           <div class="drv-list">
             @for (d of j.job_context.derivations; track d.drv_path) {
-              <div class="drv-row">
+              <div class="drv-row clickable" (click)="openBuild(d.build_id)">
                 <span class="mono pname">{{ d.pname ?? '—' }}</span>
                 <span class="mono path">{{ d.drv_path }}</span>
               </div>
@@ -178,6 +180,26 @@ interface RuleRow {
           </table>
         </section>
       }
+    } @else if (pending(); as p) {
+      <header class="head">
+        <div>
+          <span class="kind" [class.build]="p.kind === 1">{{ p.kind === 1 ? 'build' : 'eval' }}</span>
+          <h1>Pending job</h1>
+        </div>
+      </header>
+      <p class="muted">Still queued — limited details are available until it is dispatched.</p>
+      <section class="ids">
+        <div><span class="label">Evaluation</span><span class="mono">{{ p.evaluation_id }}</span></div>
+        @if (p.build_id) {
+          <div><span class="label">Build</span><span class="mono">{{ p.build_id }}</span></div>
+        }
+      </section>
+      <section class="timeline">
+        <div class="step"><span class="label">Queued</span><span>{{ p.queued_at | date: 'medium' }}</span></div>
+        <div class="step"><span class="label">Dependencies</span><span class="hl">{{ p.dependency_count }}</span></div>
+      </section>
+    } @else if (notFound()) {
+      <p class="muted">Job not found.</p>
     } @else {
       <p class="muted">Loading job…</p>
     }
@@ -239,8 +261,8 @@ interface RuleRow {
       .step { background: #21262d; border: 1px solid #2d333b; border-radius: 8px; padding: 0.75rem; color: #abb0b4; font-size: 0.85rem; }
       .step .hl { color: #17a2b8; font-weight: 600; }
       .mono { font-family: monospace; color: #d6dade; font-size: 0.85rem; }
-      .link { background: none; border: none; padding: 0; cursor: pointer; text-align: left; color: #17a2b8; text-decoration: underline; }
-      .link:hover { color: #4cc2d4; }
+      .worker-link { text-decoration: none; cursor: pointer; }
+      .worker-link:hover { color: #17a2b8; }
       .build-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
       .build-grid .span2 { grid-column: 1 / -1; }
       .build-grid .out { word-break: break-all; margin-top: 0.25rem; }
@@ -261,6 +283,8 @@ interface RuleRow {
       table.kv.counts { margin-top: 1rem; }
       .drv-list { display: flex; flex-direction: column; gap: 0.5rem; }
       .drv-row { display: flex; flex-direction: column; gap: 0.15rem; background: #21262d; border: 1px solid #2d333b; border-radius: 6px; padding: 0.5rem 0.75rem; }
+      .drv-row.clickable { cursor: pointer; transition: background 0.1s, border-color 0.1s; }
+      .drv-row.clickable:hover { background: #2d333b; border-color: #444c56; }
       .drv-row .pname { color: #d6dade; }
       .drv-row .path { color: #818181; font-size: 0.8rem; word-break: break-all; }
     `,
@@ -272,10 +296,14 @@ export class BoardJobDetailComponent implements OnInit {
   private evaluations = inject(EvaluationsService);
 
   job = signal<DispatchedJobDetail | null>(null);
+  pending = signal<PendingJobSummary | null>(null);
+  notFound = signal(false);
   build = signal<BuildWithOutputs | null>(null);
   buildDialog = signal(false);
   buildLoading = signal(false);
   buildError = signal<string | null>(null);
+
+  private static readonly WORKER_CAPS: (keyof GradientCapabilities)[] = ['federate', 'fetch', 'eval', 'build'];
 
   currentState = computed(() => {
     const j = this.job();
@@ -310,14 +338,26 @@ export class BoardJobDetailComponent implements OnInit {
 
   ngOnInit(): void {
     const id = this.route.snapshot.paramMap.get('id');
-    if (id) {
-      this.board.getJob(id).subscribe((d) => {
+    if (!id) return;
+    this.board.getJob(id).subscribe({
+      next: (d) => {
         this.job.set(d);
         if (d.build_id) {
           this.loadBuild(d.build_id);
         }
-      });
-    }
+      },
+      error: () => this.loadPending(id),
+    });
+  }
+
+  private loadPending(id: string): void {
+    this.board.getPendingJobs().subscribe({
+      next: (r) => {
+        const match = r.jobs.find((p) => p.evaluation_id === id || p.build_id === id);
+        match ? this.pending.set(match) : this.notFound.set(true);
+      },
+      error: () => this.notFound.set(true),
+    });
   }
 
   openBuild(buildId: string): void {
@@ -332,10 +372,7 @@ export class BoardJobDetailComponent implements OnInit {
   }
 
   capabilityList(c: GradientCapabilities): string {
-    return Object.entries(c)
-      .filter(([, on]) => on)
-      .map(([name]) => name)
-      .join(', ');
+    return BoardJobDetailComponent.WORKER_CAPS.filter((k) => c[k]).join(', ');
   }
 
   instanceWindows(inst: InstanceContextView): { name: string; w: Windowed }[] {

--- a/frontend/src/app/features/board/live-jobs/live-jobs.component.spec.ts
+++ b/frontend/src/app/features/board/live-jobs/live-jobs.component.spec.ts
@@ -45,9 +45,30 @@ function setup(): ComponentFixture<BoardLiveJobsComponent> {
 }
 
 describe('BoardLiveJobsComponent - pending view toggle', () => {
+  beforeEach(() => sessionStorage.clear());
+
   it('defaults to dispatched view', () => {
     const fixture = setup();
     expect(fixture.componentInstance.view()).toBe('dispatched');
+  });
+
+  it('restores the persisted view and filters from sessionStorage', () => {
+    sessionStorage.setItem(
+      'board.live-jobs.filters',
+      JSON.stringify({ view: 'pending', kindFilter: 'build', statusFilter: 'all', scoreMin: null, scoreMax: null }),
+    );
+    const cmp = setup().componentInstance;
+    expect(cmp.view()).toBe('pending');
+    expect(cmp.kindFilter()).toBe('build');
+    expect(cmp.pendingJobs().length).toBe(1);
+  });
+
+  it('persists the view to sessionStorage when switched', () => {
+    const fixture = setup();
+    fixture.componentInstance.setView('pending');
+    fixture.detectChanges();
+    const stored = JSON.parse(sessionStorage.getItem('board.live-jobs.filters') ?? '{}');
+    expect(stored.view).toBe('pending');
   });
 
   it('loads pending jobs when switching to pending view', () => {

--- a/frontend/src/app/features/board/live-jobs/live-jobs.component.ts
+++ b/frontend/src/app/features/board/live-jobs/live-jobs.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnDestroy, OnInit, inject, signal, computed } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject, signal, computed, effect } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
@@ -119,10 +119,13 @@ type StatusFilter = 'all' | 'pending' | 'dispatched';
   ],
 })
 export class BoardLiveJobsComponent implements OnInit, OnDestroy {
+  private static readonly STATE_KEY = 'board.live-jobs.filters';
+
   private board = inject(BoardService);
   private live = inject(BoardLiveService);
   private router = inject(Router);
   private sub?: Subscription;
+  private refreshTimer?: ReturnType<typeof setTimeout>;
 
   jobs = signal<DispatchedJobSummary[]>([]);
   otherRunning = signal(0);
@@ -135,6 +138,24 @@ export class BoardLiveJobsComponent implements OnInit, OnDestroy {
   statusFilter = signal<StatusFilter>('all');
   scoreMin = signal<number | null>(null);
   scoreMax = signal<number | null>(null);
+
+  constructor() {
+    this.restoreState();
+    effect(() => {
+      const state = {
+        view: this.view(),
+        kindFilter: this.kindFilter(),
+        statusFilter: this.statusFilter(),
+        scoreMin: this.scoreMin(),
+        scoreMax: this.scoreMax(),
+      };
+      try {
+        sessionStorage.setItem(BoardLiveJobsComponent.STATE_KEY, JSON.stringify(state));
+      } catch {
+        /* storage unavailable */
+      }
+    });
+  }
 
   filteredJobs = computed(() => {
     const kind = this.kindFilter();
@@ -154,10 +175,8 @@ export class BoardLiveJobsComponent implements OnInit, OnDestroy {
   });
 
   ngOnInit(): void {
-    this.board.getDispatchedJobs().subscribe((r) => {
-      this.jobs.set(r.jobs);
-      this.otherRunning.set(r.other_running);
-    });
+    this.loadDispatched();
+    if (this.view() === 'pending') this.loadPending();
     this.sub = this.live.connect().subscribe({
       next: (ev) => {
         if (ev.type === 'job_dispatched' && ev.organization) {
@@ -176,6 +195,7 @@ export class BoardLiveJobsComponent implements OnInit, OnDestroy {
               ...list,
             ].slice(0, 200)
           );
+          this.scheduleRefresh();
         }
       },
       error: () => {},
@@ -184,11 +204,45 @@ export class BoardLiveJobsComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.sub?.unsubscribe();
+    clearTimeout(this.refreshTimer);
   }
 
   setView(v: 'dispatched' | 'pending'): void {
     this.view.set(v);
     if (v === 'pending') this.loadPending();
+  }
+
+  private loadDispatched(): void {
+    this.board.getDispatchedJobs().subscribe((r) => {
+      this.jobs.set(r.jobs);
+      this.otherRunning.set(r.other_running);
+    });
+  }
+
+  /// Reconcile the optimistic live rows with the persisted, selectable rows.
+  /// Throttled so a busy board refreshes at most once per window instead of
+  /// deferring forever under a steady event stream.
+  private scheduleRefresh(): void {
+    if (this.refreshTimer) return;
+    this.refreshTimer = setTimeout(() => {
+      this.refreshTimer = undefined;
+      this.loadDispatched();
+    }, 1500);
+  }
+
+  private restoreState(): void {
+    try {
+      const raw = sessionStorage.getItem(BoardLiveJobsComponent.STATE_KEY);
+      if (!raw) return;
+      const s = JSON.parse(raw);
+      if (s.view) this.view.set(s.view);
+      if (s.kindFilter) this.kindFilter.set(s.kindFilter);
+      if (s.statusFilter) this.statusFilter.set(s.statusFilter);
+      this.scoreMin.set(s.scoreMin ?? null);
+      this.scoreMax.set(s.scoreMax ?? null);
+    } catch {
+      /* ignore malformed state */
+    }
   }
 
   private loadPending(): void {


### PR DESCRIPTION
Fixes #366.

Worker capabilities now hide the server-only `core`/`cache` flags and the redundant standalone `fetch` row; job-context architecture shows for build jobs only; the worker id links to its metrics page and derivation rows are the clickable build entry-point (no blue link). The live board remembers its tab/filters across navigation and reconciles optimistically-added jobs into selectable rows; an undispatched job now renders a limited pending view instead of "job not found".