### PR TITLE
Allow setting Cargo features on nix gradient-cli package

### DIFF
--- a/nix/packages/gradient-cli.nix
+++ b/nix/packages/gradient-cli.nix
@@ -12,14 +12,22 @@
 , openssl
 , pkg-config
 , stdenv
+, cargoFeatures ? [ ]
 }:
 let
   nixVersion = nixVersions.nix_2_34;
 
   src = craneLib.cleanCargoSource ../../cli;
 
+  # Crane has no easy way to set Cargo features, this sets them manually via cargoExtraArgs.
+  # It has `--locked` hard coded since that is the default of Crane.
+  cargoExtraArgs = lib.concatStringsSep " " (
+    [ "--locked" ]
+    ++ lib.optional (cargoFeatures != [ ]) "--features ${lib.concatStringsSep "," cargoFeatures}"
+  );
+
   commonArgs = {
-    inherit src;
+    inherit src cargoExtraArgs;
     strictDeps = true;
 
     nativeBuildInputs = [
@@ -34,7 +42,7 @@ let
     ];
   };
 
-  # Cached dependency layer - only rebuilt when Cargo.lock changes
+  # Cached dependency layer - only rebuilt when Cargo.lock or features change
   cargoArtifacts = craneLib.buildDepsOnly commonArgs;
 in
 craneLib.buildPackage (commonArgs // {


### PR DESCRIPTION
First off, I want to thank you for all the work on this project. I have been trying it out on my personal servers for a few days now and it is pretty cool.

This is just a tiny PR that allows setting the cargo features for the `gradient-cli` package when consuming it via the `flake.nix`. I had it installed on my system, but wanted to build it with the `nix` Cargo feature and it wasn't easily doable.

With this change you can just do a `.override` however you are installing the package, e.g.

```nix
gradient-cli.override {
  cargoFeatures = [ "nix" ];
}
```

If you don't specify anything the build should stay exactly the same.