### PR TITLE
fix(scheduler): keep cross-arch substitutable builds dispatchable + #375

### DIFF
--- a/backend/gradient-db/src/build.rs
+++ b/backend/gradient-db/src/build.rs
@@ -1,0 +1,113 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use gradient_entity::build::Entity;
+use gradient_entity::ids::BuildId;
+use sea_orm::{ConnectionTrait, DbBackend, DbErr, EntityTrait, Statement};
+
+/// Returns the subset of `build_ids` whose every dependency has a `Completed`(3)
+/// or `Substituted`(7) build in the same evaluation. Mirrors the dispatcher's
+/// readiness antijoin in `gradient-scheduler`.
+pub async fn builds_with_satisfied_deps<C: ConnectionTrait>(
+    db: &C,
+    build_ids: &[BuildId],
+) -> Result<std::collections::HashSet<BuildId>, DbErr> {
+    use std::collections::HashSet;
+    if build_ids.is_empty() {
+        return Ok(HashSet::new());
+    }
+    let rows = crate::fetch_in_chunks(build_ids, |chunk| async move {
+        let placeholders = chunk
+            .iter()
+            .map(|id| format!("'{id}'"))
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            r#"
+            SELECT b.*
+            FROM public.build b
+            WHERE b.id IN ({placeholders})
+              AND NOT EXISTS (
+                  SELECT 1 FROM public.derivation_dependency dep_edge
+                  WHERE dep_edge.derivation = b.derivation
+                    AND NOT EXISTS (
+                        SELECT 1 FROM public.build dep_build
+                        WHERE dep_build.evaluation = b.evaluation
+                          AND dep_build.derivation = dep_edge.dependency
+                          AND dep_build.status IN (3, 7)
+                    )
+              )
+            "#
+        );
+        let stmt = Statement::from_string(DbBackend::Postgres, sql);
+        Entity::find().from_raw_sql(stmt).all(db).await
+    })
+    .await?;
+    Ok(rows.into_iter().map(|b| b.id).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gradient_entity::build::{BuildStatus, Model as MBuild};
+    use gradient_entity::ids::{DerivationId, EvaluationId};
+    use sea_orm::{DatabaseBackend, MockDatabase};
+
+    fn build_row(id: BuildId, status: BuildStatus) -> MBuild {
+        MBuild {
+            id,
+            evaluation: EvaluationId::now_v7(),
+            derivation: DerivationId::now_v7(),
+            status,
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_input_returns_empty_set() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
+        let result = builds_with_satisfied_deps(&db, &[]).await.unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn unsatisfied_dep_excluded() {
+        let parent_id = BuildId::now_v7();
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([Vec::<MBuild>::new()])
+            .into_connection();
+
+        let result = builds_with_satisfied_deps(&db, &[parent_id]).await.unwrap();
+        assert!(!result.contains(&parent_id));
+    }
+
+    #[tokio::test]
+    async fn satisfied_dep_included() {
+        let parent_id = BuildId::now_v7();
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![build_row(parent_id, BuildStatus::Queued)]])
+            .into_connection();
+
+        let result = builds_with_satisfied_deps(&db, &[parent_id]).await.unwrap();
+        assert!(result.contains(&parent_id));
+    }
+
+    #[tokio::test]
+    async fn dep_substituted_then_included() {
+        let parent_id = BuildId::now_v7();
+        let dep_id = BuildId::now_v7();
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([Vec::<MBuild>::new()])
+            .append_query_results([vec![build_row(parent_id, BuildStatus::Queued)]])
+            .into_connection();
+
+        let result_before = builds_with_satisfied_deps(&db, &[parent_id]).await.unwrap();
+        assert!(!result_before.contains(&parent_id), "dep not yet ready");
+
+        let result_after = builds_with_satisfied_deps(&db, &[dep_id, parent_id]).await.unwrap();
+        assert!(result_after.contains(&parent_id), "dep now Substituted → parent ready");
+    }
+}

--- a/backend/gradient-db/src/build.rs
+++ b/backend/gradient-db/src/build.rs
@@ -9,8 +9,8 @@ use gradient_entity::ids::BuildId;
 use sea_orm::{ConnectionTrait, DbBackend, DbErr, EntityTrait, Statement};
 
 /// Returns the subset of `build_ids` whose every dependency has a `Completed`(3)
-/// or `Substituted`(7) build in the same evaluation. Mirrors the dispatcher's
-/// readiness antijoin in `gradient-scheduler`.
+/// or `Substituted`(7) build in the same evaluation. Antijoin mirrors
+/// `gradient-scheduler/src/dispatch.rs:680`; behavioral correctness is covered by end-to-end CI.
 pub async fn builds_with_satisfied_deps<C: ConnectionTrait>(
     db: &C,
     build_ids: &[BuildId],
@@ -73,41 +73,21 @@ mod tests {
         assert!(result.is_empty());
     }
 
+    // MockDatabase replays preconfigured rows without executing SQL, so this only
+    // verifies that returned rows are mapped to the correct BuildId set.
     #[tokio::test]
-    async fn unsatisfied_dep_excluded() {
-        let parent_id = BuildId::now_v7();
+    async fn maps_returned_rows_to_id_set() {
+        let id_a = BuildId::now_v7();
+        let id_b = BuildId::now_v7();
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_query_results([Vec::<MBuild>::new()])
+            .append_query_results([vec![
+                build_row(id_a, BuildStatus::Queued),
+                build_row(id_b, BuildStatus::Queued),
+            ]])
             .into_connection();
 
-        let result = builds_with_satisfied_deps(&db, &[parent_id]).await.unwrap();
-        assert!(!result.contains(&parent_id));
-    }
-
-    #[tokio::test]
-    async fn satisfied_dep_included() {
-        let parent_id = BuildId::now_v7();
-        let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_query_results([vec![build_row(parent_id, BuildStatus::Queued)]])
-            .into_connection();
-
-        let result = builds_with_satisfied_deps(&db, &[parent_id]).await.unwrap();
-        assert!(result.contains(&parent_id));
-    }
-
-    #[tokio::test]
-    async fn dep_substituted_then_included() {
-        let parent_id = BuildId::now_v7();
-        let dep_id = BuildId::now_v7();
-        let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_query_results([Vec::<MBuild>::new()])
-            .append_query_results([vec![build_row(parent_id, BuildStatus::Queued)]])
-            .into_connection();
-
-        let result_before = builds_with_satisfied_deps(&db, &[parent_id]).await.unwrap();
-        assert!(!result_before.contains(&parent_id), "dep not yet ready");
-
-        let result_after = builds_with_satisfied_deps(&db, &[dep_id, parent_id]).await.unwrap();
-        assert!(result_after.contains(&parent_id), "dep now Substituted → parent ready");
+        let result = builds_with_satisfied_deps(&db, &[id_a, id_b]).await.unwrap();
+        assert!(result.contains(&id_a));
+        assert!(result.contains(&id_b));
     }
 }

--- a/backend/gradient-db/src/lib.rs
+++ b/backend/gradient-db/src/lib.rs
@@ -5,6 +5,7 @@
  */
 
 pub mod admin_tasks;
+pub mod build;
 pub mod build_attempt;
 pub mod cache_reach;
 pub mod cache_storage;
@@ -29,6 +30,7 @@ pub mod state_machine;
 pub mod status;
 pub mod status_reactor;
 
+pub use self::build::builds_with_satisfied_deps;
 pub use self::build_attempt::*;
 pub use self::cache_reach::*;
 pub use self::cache_storage::{

--- a/backend/gradient-scheduler/src/build.rs
+++ b/backend/gradient-scheduler/src/build.rs
@@ -26,7 +26,7 @@ use sea_orm::{
 use tracing::{error, info, warn};
 
 use super::jobs::PendingBuildJob;
-use crate::dispatch_mode::{decide_dispatch_mode, BuildDispatchMode};
+use crate::dispatch_mode::{arch_available, decide_dispatch_mode, BuildDispatchMode};
 use gradient_types::BuildOutputMetadata;
 use gradient_types::proto::BuildFailureKind;
 use gradient_types::proto::BuildMetrics;
@@ -948,7 +948,7 @@ impl BuildabilityChecker {
                 return false;
             };
             let miss = self.substitute_misses.get(&b.id).copied().unwrap_or(0);
-            let arch_has_worker = self.connected_architectures.contains(&drv.architecture);
+            let arch_has_worker = arch_available(&self.connected_architectures, &drv.architecture);
             match decide_dispatch_mode(
                 b.substitutable,
                 miss,
@@ -1000,7 +1000,7 @@ impl BuildabilityChecker {
             let arch_has_worker = self
                 .drv_by_id
                 .get(&b.derivation)
-                .map(|d| self.connected_architectures.contains(&d.architecture))
+                .map(|d| arch_available(&self.connected_architectures, &d.architecture))
                 .unwrap_or(false);
             if matches!(
                 decide_dispatch_mode(b.substitutable, miss, self.substitute_miss_escalation_threshold, arch_has_worker),

--- a/backend/gradient-scheduler/src/build.rs
+++ b/backend/gradient-scheduler/src/build.rs
@@ -26,6 +26,7 @@ use sea_orm::{
 use tracing::{error, info, warn};
 
 use super::jobs::PendingBuildJob;
+use crate::dispatch_mode::{decide_dispatch_mode, BuildDispatchMode};
 use gradient_types::BuildOutputMetadata;
 use gradient_types::proto::BuildFailureKind;
 use gradient_types::proto::BuildMetrics;
@@ -665,7 +666,9 @@ impl<'a> BuildStateHandler<'a> {
                 ) {
                     continue;
                 }
-                let checker = BuildabilityChecker::load(self.state, &pending_builds).await?;
+                let arches: std::collections::HashSet<String> =
+                    worker_caps.iter().flat_map(|(a, _)| a.iter().cloned()).collect();
+                let checker = BuildabilityChecker::load(self.state, &pending_builds, arches).await?;
                 let target = if checker.any_buildable(&pending_builds, worker_caps) {
                     EvaluationStatus::Building
                 } else {
@@ -860,6 +863,8 @@ struct BuildabilityChecker {
     /// Maps derivation ID → list of required feature IDs.
     features_by_drv: HashMap<DerivationId, Vec<FeatureId>>,
     feature_name: HashMap<FeatureId, String>,
+    connected_architectures: std::collections::HashSet<String>,
+    deps_satisfied: std::collections::HashSet<BuildId>,
 }
 
 impl BuildabilityChecker {
@@ -868,10 +873,17 @@ impl BuildabilityChecker {
     /// [`any_buildable`].
     ///
     /// [`any_buildable`]: BuildabilityChecker::any_buildable
-    async fn load(state: &Arc<ServerState>, builds: &[MBuild]) -> Result<Self> {
+    async fn load(
+        state: &Arc<ServerState>,
+        builds: &[MBuild],
+        connected_architectures: std::collections::HashSet<String>,
+    ) -> Result<Self> {
         let db = &state.worker_db;
         let drv_ids: Vec<DerivationId> = builds.iter().map(|b| b.derivation).collect();
         let build_ids: Vec<BuildId> = builds.iter().map(|b| b.id).collect();
+        let deps_satisfied = gradient_db::builds_with_satisfied_deps(db, &build_ids)
+            .await
+            .unwrap_or_default();
         // A count-query failure → 0 misses → substitute-mode, same as the dispatch side.
         let substitute_misses = gradient_db::substitute_miss_counts(db, &build_ids)
             .await
@@ -919,37 +931,42 @@ impl BuildabilityChecker {
                 .substitute_miss_escalation_threshold as i64,
             features_by_drv,
             feature_name,
+            connected_architectures,
+            deps_satisfied,
         })
     }
 
-    /// True while `build` should still be dispatched as a substitute
-    /// (builtin / any-worker): it is substitutable and below the escalation
-    /// threshold. Once it crosses the threshold it is checked against its real
-    /// arch/features instead.
-    fn in_substitute_mode(&self, build: &MBuild) -> bool {
-        build.substitutable
-            && self.substitute_misses.get(&build.id).copied().unwrap_or(0)
-                < self.substitute_miss_escalation_threshold
-    }
-
-    /// Returns `true` if at least one build in `builds` can be satisfied by
-    /// some worker in `worker_caps`:
-    /// `(build.arch ∈ worker.architectures) ∧ (∀ required feature ∈ worker.system_features)`.
     fn any_buildable(&self, builds: &[MBuild], worker_caps: &[(Vec<String>, Vec<String>)]) -> bool {
         builds.iter().any(|b| {
-            if self.in_substitute_mode(b) {
+            if b.status == BuildStatus::Building {
                 return true;
+            }
+            if !self.deps_satisfied.contains(&b.id) {
+                return false;
             }
             let Some(drv) = self.drv_by_id.get(&b.derivation) else {
                 return false;
             };
-            let required: Vec<&str> = self.required_features_for(&b.derivation);
-            worker_caps.iter().any(|(arch, feats)| {
-                let arch_ok =
-                    drv.architecture == "builtin" || arch.iter().any(|a| a == &drv.architecture);
-                let feats_ok = required.iter().all(|f| feats.iter().any(|sf| sf == f));
-                arch_ok && feats_ok
-            })
+            let miss = self.substitute_misses.get(&b.id).copied().unwrap_or(0);
+            let arch_has_worker = self.connected_architectures.contains(&drv.architecture);
+            match decide_dispatch_mode(
+                b.substitutable,
+                miss,
+                self.substitute_miss_escalation_threshold,
+                arch_has_worker,
+            ) {
+                BuildDispatchMode::SubstituteBuiltin => true,
+                BuildDispatchMode::SubstituteStalled => false,
+                BuildDispatchMode::RealArch => {
+                    let required: Vec<&str> = self.required_features_for(&b.derivation);
+                    worker_caps.iter().any(|(arch, feats)| {
+                        let arch_ok = drv.architecture == "builtin"
+                            || arch.iter().any(|a| a == &drv.architecture);
+                        let feats_ok = required.iter().all(|f| feats.iter().any(|sf| sf == f));
+                        arch_ok && feats_ok
+                    })
+                }
+            }
         })
     }
 
@@ -979,7 +996,16 @@ impl BuildabilityChecker {
     ) -> WaitingReason {
         let mut grouped: BTreeMap<(String, Vec<String>), u32> = BTreeMap::new();
         for b in builds {
-            if self.in_substitute_mode(b) {
+            let miss = self.substitute_misses.get(&b.id).copied().unwrap_or(0);
+            let arch_has_worker = self
+                .drv_by_id
+                .get(&b.derivation)
+                .map(|d| self.connected_architectures.contains(&d.architecture))
+                .unwrap_or(false);
+            if matches!(
+                decide_dispatch_mode(b.substitutable, miss, self.substitute_miss_escalation_threshold, arch_has_worker),
+                BuildDispatchMode::SubstituteBuiltin
+            ) {
                 continue;
             }
             let Some(drv) = self.drv_by_id.get(&b.derivation) else {
@@ -1147,6 +1173,8 @@ mod waiting_reason_tests {
             substitute_miss_escalation_threshold: 2,
             features_by_drv,
             feature_name,
+            connected_architectures: std::collections::HashSet::new(),
+            deps_satisfied: std::collections::HashSet::new(),
         }
     }
 
@@ -1348,6 +1376,7 @@ mod waiting_reason_tests {
         let build = substitutable_build(d.id, eval_id);
         let mut checker = checker_with(vec![d], vec![]);
         checker.substitute_misses.insert(build.id, 1);
+        checker.deps_satisfied.insert(build.id);
 
         let caps: Vec<(Vec<String>, Vec<String>)> = vec![(vec!["x86_64-linux".into()], vec![])];
         let builds = [build];
@@ -1364,6 +1393,7 @@ mod waiting_reason_tests {
         let build = substitutable_build(d.id, eval_id);
         let mut checker = checker_with(vec![d], vec![]);
         checker.substitute_misses.insert(build.id, 2);
+        checker.deps_satisfied.insert(build.id);
 
         // No aarch64 worker: the escalated build is no longer buildable-anywhere
         // and surfaces as an unmet aarch64 requirement so the parker can park it.
@@ -1374,5 +1404,46 @@ mod waiting_reason_tests {
         let (unmet, _, _) = workers_view(&reason);
         assert_eq!(unmet.len(), 1);
         assert_eq!(unmet[0].architecture, "aarch64-linux");
+    }
+
+    #[test]
+    fn stalled_substitute_is_not_buildable_and_appears_in_unmet() {
+        let eval_id = EvaluationId::now_v7();
+        let d = drv(DerivationId::now_v7(), "i686-linux");
+        let mut b = build_for(d.id, eval_id);
+        b.substitutable = true;
+        let mut checker = checker_with(vec![d.clone()], vec![]);
+        checker.substitute_misses.insert(b.id, 2);
+        checker.deps_satisfied.insert(b.id);
+        checker.connected_architectures.insert("x86_64-linux".into());
+        let caps = vec![(vec!["x86_64-linux".to_string()], vec![])];
+        assert!(!checker.any_buildable(&[b.clone()], &caps));
+        let reason = checker.compute_waiting_reason(&[b], &caps);
+        let (unmet, _, available) = workers_view(&reason);
+        assert!(unmet.iter().any(|u| u.architecture == "i686-linux"));
+        assert_eq!(available, ["x86_64-linux"]);
+    }
+
+    #[test]
+    fn dependency_blocked_build_is_not_buildable() {
+        let eval_id = EvaluationId::now_v7();
+        let d = drv(DerivationId::now_v7(), "x86_64-linux");
+        let b = build_for(d.id, eval_id);
+        let mut checker = checker_with(vec![d], vec![]);
+        checker.connected_architectures.insert("x86_64-linux".into());
+        let caps = vec![(vec!["x86_64-linux".to_string()], vec![])];
+        assert!(!checker.any_buildable(&[b], &caps));
+    }
+
+    #[test]
+    fn substitutable_within_budget_is_buildable_anywhere() {
+        let eval_id = EvaluationId::now_v7();
+        let d = drv(DerivationId::now_v7(), "i686-linux");
+        let mut b = build_for(d.id, eval_id);
+        b.substitutable = true;
+        let mut checker = checker_with(vec![d], vec![]);
+        checker.deps_satisfied.insert(b.id);
+        let caps = vec![(vec!["x86_64-linux".to_string()], vec![])];
+        assert!(checker.any_buildable(&[b], &caps));
     }
 }

--- a/backend/gradient-scheduler/src/dispatch.rs
+++ b/backend/gradient-scheduler/src/dispatch.rs
@@ -18,7 +18,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::dispatch_mode::{decide_dispatch_mode, BuildDispatchMode};
+use crate::dispatch_mode::{arch_available, decide_dispatch_mode, BuildDispatchMode};
 use gradient_entity::build::BuildStatus;
 use gradient_entity::evaluation::EvaluationStatus;
 use gradient_sources::get_path_from_derivation_output;
@@ -620,7 +620,7 @@ impl BuildDispatchMaps {
 
         let job_id = format!("build:{}", build.id);
         let miss_count = self.substitute_misses.get(&build.id).copied().unwrap_or(0);
-        let arch_has_worker = self.connected_architectures.contains(&derivation.architecture);
+        let arch_has_worker = arch_available(&self.connected_architectures, &derivation.architecture);
         let mode = decide_dispatch_mode(
             build.substitutable,
             miss_count,

--- a/backend/gradient-scheduler/src/dispatch.rs
+++ b/backend/gradient-scheduler/src/dispatch.rs
@@ -18,6 +18,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::dispatch_mode::{decide_dispatch_mode, BuildDispatchMode};
 use gradient_entity::build::BuildStatus;
 use gradient_entity::evaluation::EvaluationStatus;
 use gradient_sources::get_path_from_derivation_output;
@@ -313,6 +314,8 @@ struct BuildDispatchMaps {
     /// build_id → consecutive `SubstituteUnavailable` miss count. Absent ⇒ 0.
     substitute_misses: HashMap<BuildId, i64>,
     substitute_miss_escalation_threshold: i64,
+    connected_architectures: HashSet<String>,
+    build_retry_backoff_secs: u64,
     default_timeout_secs: Option<u64>,
     default_max_silent_secs: Option<u64>,
 }
@@ -323,6 +326,7 @@ impl BuildDispatchMaps {
         state: &Arc<ServerState>,
         builds: &[MBuild],
         uses_history: bool,
+        connected_architectures: HashSet<String>,
     ) -> anyhow::Result<Self> {
         let default_timeout_secs = nonzero(state.config.eval.build_default_timeout_secs);
         let default_max_silent_secs = nonzero(state.config.eval.build_default_max_silent_secs);
@@ -572,6 +576,8 @@ impl BuildDispatchMaps {
                 .config
                 .eval
                 .substitute_miss_escalation_threshold as i64,
+            connected_architectures,
+            build_retry_backoff_secs: state.config.eval.build_retry_backoff_secs,
             default_timeout_secs,
             default_max_silent_secs,
         })
@@ -613,11 +619,31 @@ impl BuildDispatchMaps {
         })?;
 
         let job_id = format!("build:{}", build.id);
-        // Substitute-mode only while the build hasn't exhausted its substitute
-        // attempts. After repeated misses it escalates to a real arch-bound
-        // build so an arch worker takes it (or the parker parks the eval).
         let miss_count = self.substitute_misses.get(&build.id).copied().unwrap_or(0);
-        let substitute = build.substitutable && miss_count < self.substitute_miss_escalation_threshold;
+        let arch_has_worker = self.connected_architectures.contains(&derivation.architecture);
+        let mode = decide_dispatch_mode(
+            build.substitutable,
+            miss_count,
+            self.substitute_miss_escalation_threshold,
+            arch_has_worker,
+        );
+
+        if mode == BuildDispatchMode::SubstituteStalled
+            && !crate::build::retry_backoff_elapsed(
+                miss_count as i32,
+                build.updated_at,
+                now(),
+                self.build_retry_backoff_secs,
+            )
+        {
+            debug!(build_id = %build.id, "substitute stalled (no arch worker); backing off re-probe");
+            return None;
+        }
+
+        let substitute = matches!(
+            mode,
+            BuildDispatchMode::SubstituteBuiltin | BuildDispatchMode::SubstituteStalled
+        );
         // Placeholder; the real value is set per-assignment in
         // `job_handlers::apply_sign_flag` based on the receiving worker's
         // `sign` capability.
@@ -747,8 +773,22 @@ pub(crate) async fn dispatch_ready_builds(scheduler: &Scheduler) -> anyhow::Resu
         error!(error = %e, "failed to stamp build ready_at");
     }
 
-    let maps =
-        BuildDispatchMaps::load(state, &new_builds, scheduler.policy.uses_history()).await?;
+    let connected_architectures: HashSet<String> = scheduler
+        .worker_pool
+        .read()
+        .await
+        .all_workers()
+        .into_iter()
+        .flat_map(|w| w.architectures)
+        .collect();
+
+    let maps = BuildDispatchMaps::load(
+        state,
+        &new_builds,
+        scheduler.policy.uses_history(),
+        connected_architectures,
+    )
+    .await?;
 
     let mut enqueued = 0usize;
     for build in new_builds {
@@ -797,6 +837,17 @@ async fn organization_id_for_eval(
             error!(error = %e, %project_id, "failed to load project for eval");
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod dispatch_mode_tests {
+    use crate::dispatch_mode::{decide_dispatch_mode, BuildDispatchMode};
+
+    #[test]
+    fn stalled_substitute_stays_builtin() {
+        assert_eq!(decide_dispatch_mode(true, 2, 2, false), BuildDispatchMode::SubstituteStalled);
+        assert_eq!(decide_dispatch_mode(true, 2, 2, true), BuildDispatchMode::RealArch);
     }
 }
 

--- a/backend/gradient-scheduler/src/dispatch_mode.rs
+++ b/backend/gradient-scheduler/src/dispatch_mode.rs
@@ -17,6 +17,10 @@ pub(crate) enum BuildDispatchMode {
 /// - substitutable, under the miss budget → `SubstituteBuiltin` (builtin, any worker)
 /// - substitutable, budget spent, a worker for its arch IS connected → `RealArch` (escalate)
 /// - substitutable, budget spent, NO worker for its arch → `SubstituteStalled`
+pub(crate) fn arch_available(connected: &std::collections::HashSet<String>, arch: &str) -> bool {
+    arch == "builtin" || connected.contains(arch)
+}
+
 pub(crate) fn decide_dispatch_mode(
     substitutable: bool,
     miss_count: i64,
@@ -59,5 +63,16 @@ mod tests {
     fn stalls_when_budget_spent_and_no_arch_worker() {
         assert_eq!(decide_dispatch_mode(true, 2, 2, false), BuildDispatchMode::SubstituteStalled);
         assert_eq!(decide_dispatch_mode(true, 9, 2, false), BuildDispatchMode::SubstituteStalled);
+    }
+
+    #[test]
+    fn arch_available_builtin_always_true() {
+        let empty = std::collections::HashSet::new();
+        assert!(arch_available(&empty, "builtin"));
+        let mut connected = std::collections::HashSet::new();
+        connected.insert("x86_64-linux".to_string());
+        assert!(arch_available(&connected, "builtin"));
+        assert!(arch_available(&connected, "x86_64-linux"));
+        assert!(!arch_available(&connected, "aarch64-linux"));
     }
 }

--- a/backend/gradient-scheduler/src/dispatch_mode.rs
+++ b/backend/gradient-scheduler/src/dispatch_mode.rs
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum BuildDispatchMode {
+    RealArch,
+    SubstituteBuiltin,
+    SubstituteStalled,
+}
+
+/// Decide how a ready build should be dispatched.
+///
+/// - non-substitutable        → `RealArch`
+/// - substitutable, under the miss budget → `SubstituteBuiltin` (builtin, any worker)
+/// - substitutable, budget spent, a worker for its arch IS connected → `RealArch` (escalate)
+/// - substitutable, budget spent, NO worker for its arch → `SubstituteStalled`
+pub(crate) fn decide_dispatch_mode(
+    substitutable: bool,
+    miss_count: i64,
+    threshold: i64,
+    arch_has_worker: bool,
+) -> BuildDispatchMode {
+    if !substitutable {
+        BuildDispatchMode::RealArch
+    } else if miss_count < threshold {
+        BuildDispatchMode::SubstituteBuiltin
+    } else if arch_has_worker {
+        BuildDispatchMode::RealArch
+    } else {
+        BuildDispatchMode::SubstituteStalled
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_substitutable_is_real_arch() {
+        assert_eq!(decide_dispatch_mode(false, 0, 2, false), BuildDispatchMode::RealArch);
+        assert_eq!(decide_dispatch_mode(false, 5, 2, true), BuildDispatchMode::RealArch);
+    }
+
+    #[test]
+    fn substitutable_under_threshold_is_builtin() {
+        assert_eq!(decide_dispatch_mode(true, 0, 2, false), BuildDispatchMode::SubstituteBuiltin);
+        assert_eq!(decide_dispatch_mode(true, 1, 2, false), BuildDispatchMode::SubstituteBuiltin);
+    }
+
+    #[test]
+    fn escalates_only_when_arch_worker_present() {
+        assert_eq!(decide_dispatch_mode(true, 2, 2, true), BuildDispatchMode::RealArch);
+    }
+
+    #[test]
+    fn stalls_when_budget_spent_and_no_arch_worker() {
+        assert_eq!(decide_dispatch_mode(true, 2, 2, false), BuildDispatchMode::SubstituteStalled);
+        assert_eq!(decide_dispatch_mode(true, 9, 2, false), BuildDispatchMode::SubstituteStalled);
+    }
+}

--- a/backend/gradient-scheduler/src/jobs.rs
+++ b/backend/gradient-scheduler/src/jobs.rs
@@ -273,6 +273,7 @@ pub struct PendingJobInfo {
     pub organization: OrganizationId,
     pub queued_at: chrono::NaiveDateTime,
     pub dependency_count: u32,
+    pub pname: Option<String>,
 }
 
 #[derive(Debug, Default)]
@@ -648,9 +649,9 @@ impl JobTracker {
         self.pending
             .values()
             .map(|job| {
-                let (kind, build_id) = match job {
-                    PendingJob::Build(b) => (1i16, Some(b.build_id)),
-                    PendingJob::Eval(_) => (0i16, None),
+                let (kind, build_id, pname) = match job {
+                    PendingJob::Build(b) => (1i16, Some(b.build_id), b.pname.clone()),
+                    PendingJob::Eval(_) => (0i16, None, None),
                 };
                 PendingJobInfo {
                     kind,
@@ -659,6 +660,7 @@ impl JobTracker {
                     organization: job.peer_id(),
                     queued_at: job.queued_at(),
                     dependency_count: job.dependency_count(),
+                    pname,
                 }
             })
             .collect()

--- a/backend/gradient-scheduler/src/lib.rs
+++ b/backend/gradient-scheduler/src/lib.rs
@@ -24,6 +24,7 @@ pub mod views;
 pub mod worker_pool;
 pub mod worker_state;
 
+mod dispatch_mode;
 mod job_handlers;
 pub(crate) mod trigger_dispatch;
 mod worker_lifecycle;

--- a/backend/gradient-web/src/endpoints/board.rs
+++ b/backend/gradient-web/src/endpoints/board.rs
@@ -40,6 +40,7 @@ pub struct DispatchedJobSummary {
     pub dispatched_at: String,
     pub build_id: Option<Uuid>,
     pub evaluation_id: Uuid,
+    pub pname: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -57,6 +58,7 @@ pub struct PendingJobSummary {
     pub build_id: Option<Uuid>,
     pub queued_at: String,
     pub dependency_count: u32,
+    pub pname: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -85,6 +87,7 @@ pub async fn get_pending_jobs(
                 build_id: j.build_id.map(Into::into),
                 queued_at: j.queued_at.and_utc().to_rfc3339(),
                 dependency_count: j.dependency_count,
+                pname: j.pname.clone(),
             });
         } else {
             other_pending += 1;
@@ -110,13 +113,34 @@ pub async fn get_dispatched_jobs(
     let mut other_running = 0u64;
     for j in open {
         if scope.allows(&Uuid::from(j.organization)) {
-            let build_id = build_attempt::Entity::find()
+            let attempt = build_attempt::Entity::find()
                 .filter(build_attempt::Column::DispatchedJob.eq(j.id))
                 .one(&state.web_db)
                 .await
                 .ok()
-                .flatten()
-                .map(|a| a.build.into());
+                .flatten();
+
+            let build_id = attempt.as_ref().map(|a| a.build.into());
+
+            let pname = match attempt.as_ref() {
+                Some(a) => {
+                    let b = gradient_entity::build::Entity::find_by_id(a.build)
+                        .one(&state.web_db)
+                        .await
+                        .ok()
+                        .flatten();
+                    match b {
+                        Some(b) => gradient_entity::derivation::Entity::find_by_id(b.derivation)
+                            .one(&state.web_db)
+                            .await
+                            .ok()
+                            .flatten()
+                            .and_then(|d| d.pname),
+                        None => None,
+                    }
+                }
+                None => None,
+            };
 
             jobs.push(DispatchedJobSummary {
                 id: j.id.into(),
@@ -127,6 +151,7 @@ pub async fn get_dispatched_jobs(
                 dispatched_at: j.dispatched_at.and_utc().to_rfc3339(),
                 build_id,
                 evaluation_id: j.evaluation_id.into(),
+                pname,
             });
         } else {
             other_running += 1;

--- a/backend/gradient-web/src/endpoints/board.rs
+++ b/backend/gradient-web/src/endpoints/board.rs
@@ -183,6 +183,7 @@ pub struct DispatchedJobDetail {
     pub finished_at: Option<String>,
     pub build_id: Option<Uuid>,
     pub evaluation_id: Uuid,
+    pub pname: Option<String>,
     pub score_breakdown: serde_json::Value,
     pub worker_context: serde_json::Value,
     pub job_context: serde_json::Value,
@@ -221,6 +222,19 @@ pub async fn get_dispatched_job(
 
     let build_id: Option<Uuid> = this_attempt.as_ref().map(|a| a.build.into());
 
+    let pname = match build_id {
+        Some(bid) => {
+            let b = gradient_entity::build::Entity::find_by_id(gradient_types::ids::BuildId::from(bid))
+                .one(&state.web_db).await.ok().flatten();
+            match b {
+                Some(b) => gradient_entity::derivation::Entity::find_by_id(b.derivation)
+                    .one(&state.web_db).await.ok().flatten().and_then(|d| d.pname),
+                None => None,
+            }
+        }
+        None => None,
+    };
+
     let previous_attempts = match build_id {
         Some(bid) => build_attempt::Entity::find()
             .filter(build_attempt::Column::Build.eq(gradient_types::ids::BuildId::from(bid)))
@@ -252,6 +266,7 @@ pub async fn get_dispatched_job(
         finished_at: j.finished_at.map(|t| t.and_utc().to_rfc3339()),
         build_id,
         evaluation_id: j.evaluation_id.into(),
+        pname,
         score_breakdown: j.score_breakdown,
         worker_context: j.worker_context,
         job_context: j.job_context,

--- a/backend/gradient-web/src/endpoints/board.rs
+++ b/backend/gradient-web/src/endpoints/board.rs
@@ -162,6 +162,15 @@ pub async fn get_dispatched_jobs(
 }
 
 #[derive(Serialize)]
+pub struct AttemptSummary {
+    pub dispatched_job_id: Uuid,
+    pub substitute: bool,
+    pub outcome: i32,
+    pub reason: Option<i32>,
+    pub created_at: String,
+}
+
+#[derive(Serialize)]
 pub struct DispatchedJobDetail {
     pub id: Uuid,
     pub kind: i16,
@@ -178,8 +187,8 @@ pub struct DispatchedJobDetail {
     pub worker_context: serde_json::Value,
     pub job_context: serde_json::Value,
     pub instance_context: serde_json::Value,
-    /// Runner-up candidates, superuser-only.
     pub candidates: Option<serde_json::Value>,
+    pub previous_attempts: Vec<AttemptSummary>,
 }
 
 pub async fn get_dispatched_job(
@@ -203,13 +212,33 @@ pub async fn get_dispatched_job(
         .map(|o| o.name)
         .unwrap_or_default();
 
-    let build_id = build_attempt::Entity::find()
+    let this_attempt = build_attempt::Entity::find()
         .filter(build_attempt::Column::DispatchedJob.eq(j.id))
         .one(&state.web_db)
         .await
         .ok()
-        .flatten()
-        .map(|a| a.build.into());
+        .flatten();
+
+    let build_id: Option<Uuid> = this_attempt.as_ref().map(|a| a.build.into());
+
+    let previous_attempts = match build_id {
+        Some(bid) => build_attempt::Entity::find()
+            .filter(build_attempt::Column::Build.eq(gradient_types::ids::BuildId::from(bid)))
+            .order_by_asc(build_attempt::Column::CreatedAt)
+            .all(&state.web_db)
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .map(|a| AttemptSummary {
+                dispatched_job_id: a.dispatched_job.into(),
+                substitute: a.substitute,
+                outcome: i32::from(a.outcome),
+                reason: a.reason.map(i32::from),
+                created_at: a.created_at.and_utc().to_rfc3339(),
+            })
+            .collect(),
+        None => Vec::new(),
+    };
 
     Ok(ok_json(DispatchedJobDetail {
         id: j.id.into(),
@@ -228,6 +257,7 @@ pub async fn get_dispatched_job(
         job_context: j.job_context,
         instance_context: j.instance_context.unwrap_or(serde_json::Value::Null),
         candidates: if scope.is_all() { j.candidates } else { None },
+        previous_attempts,
     }))
 }
 

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -5719,7 +5719,7 @@ paths:
     get:
       tags: [board]
       summary: Live dispatched jobs
-      description: In-flight dispatched jobs visible to the caller; out-of-scope jobs collapse to an aggregate `other_running` count.
+      description: In-flight dispatched jobs visible to the caller; out-of-scope jobs collapse to an aggregate `other_running` count. Each summary includes `pname` (nullable string) from the build's derivation.
       operationId: getBoardDispatchedJobs
       responses:
         '200':
@@ -5729,7 +5729,7 @@ paths:
     get:
       tags: [board]
       summary: Pending (undispatched) jobs
-      description: Queued jobs not yet dispatched to a worker, visible to the caller; out-of-scope jobs collapse to an aggregate `other_pending` count.
+      description: Queued jobs not yet dispatched to a worker, visible to the caller; out-of-scope jobs collapse to an aggregate `other_pending` count. Each build-kind summary includes `pname` (nullable string); eval-kind summaries have `pname` null.
       operationId: getBoardPendingJobs
       responses:
         '200':

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -5719,21 +5719,43 @@ paths:
     get:
       tags: [board]
       summary: Live dispatched jobs
-      description: In-flight dispatched jobs visible to the caller; out-of-scope jobs collapse to an aggregate `other_running` count. Each summary includes `pname` (nullable string) from the build's derivation.
+      description: In-flight dispatched jobs visible to the caller; out-of-scope jobs collapse to an aggregate `other_running` count.
       operationId: getBoardDispatchedJobs
       responses:
         '200':
           description: Dispatched jobs plus other_running count
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobs:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/DispatchedJobSummary'
+                  other_running:
+                    type: integer
 
   /board/jobs/pending:
     get:
       tags: [board]
       summary: Pending (undispatched) jobs
-      description: Queued jobs not yet dispatched to a worker, visible to the caller; out-of-scope jobs collapse to an aggregate `other_pending` count. Each build-kind summary includes `pname` (nullable string); eval-kind summaries have `pname` null.
+      description: Queued jobs not yet dispatched to a worker, visible to the caller; out-of-scope jobs collapse to an aggregate `other_pending` count.
       operationId: getBoardPendingJobs
       responses:
         '200':
           description: Pending jobs plus other_pending count
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobs:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PendingJobSummary'
+                  other_pending:
+                    type: integer
 
   /board/jobs/expensive:
     get:
@@ -9243,3 +9265,29 @@ components:
           nullable: true
           description: Runner-up candidates, superuser-only.
           items: { type: object, additionalProperties: true }
+
+    DispatchedJobSummary:
+      type: object
+      description: Summary of a single in-flight dispatched job.
+      properties:
+        id: { type: string, format: uuid }
+        kind: { type: integer }
+        organization: { type: string, format: uuid }
+        worker_id: { type: string }
+        score: { type: number }
+        dispatched_at: { type: string, format: date-time }
+        build_id: { type: string, format: uuid, nullable: true }
+        evaluation_id: { type: string, format: uuid }
+        pname: { type: string, nullable: true }
+
+    PendingJobSummary:
+      type: object
+      description: Summary of a single queued but not-yet-dispatched job.
+      properties:
+        kind: { type: integer }
+        organization: { type: string, format: uuid }
+        evaluation_id: { type: string, format: uuid }
+        build_id: { type: string, format: uuid, nullable: true }
+        queued_at: { type: string, format: date-time }
+        dependency_count: { type: integer }
+        pname: { type: string, nullable: true }

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -9265,6 +9265,20 @@ components:
           nullable: true
           description: Runner-up candidates, superuser-only.
           items: { type: object, additionalProperties: true }
+        previous_attempts:
+          type: array
+          description: All build attempts for the same build, ordered by creation time ascending.
+          items: { $ref: '#/components/schemas/AttemptSummary' }
+
+    AttemptSummary:
+      type: object
+      description: Summary of a single build attempt.
+      properties:
+        dispatched_job_id: { type: string, format: uuid }
+        substitute: { type: boolean }
+        outcome: { type: integer }
+        reason: { type: integer, nullable: true }
+        created_at: { type: string, format: date-time }
 
     DispatchedJobSummary:
       type: object

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -9253,6 +9253,7 @@ components:
         finished_at: { type: string, format: date-time, nullable: true }
         build_id: { type: string, format: uuid, nullable: true }
         evaluation_id: { type: string, format: uuid }
+        pname: { type: string, nullable: true }
         score_breakdown:
           type: object
           additionalProperties: true

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -3813,3 +3813,11 @@ found".
 Frontend (`board/live-jobs/live-jobs.component.spec.ts`) - the view/filter
 selection round-trips through `sessionStorage`: a persisted `pending` view is
 restored on load and switching the tab writes it back.
+
+## Minor frontend & job board fixes (#375)
+
+Frontend tests documenting UI improvements to the action form, live jobs list, and job detail page:
+
+- `action-form.component.spec.ts` - `forge_status_report` actions submit an empty `events` array; submit errors render inside the action dialog.
+- `live-jobs.component.spec.ts` - dispatched/pending job rows show the derivation `pname`.
+- `job-detail.component.spec.ts` - the "Previous Build Attempts" section renders only when a build has more than one attempt, one linked row per attempt.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -711,7 +711,7 @@ Backend (`cargo test -p scheduler --lib jobs::tests::add_pending_does_not_requeu
 ## Cross-architecture substitutable-build scheduling
 
 Backend (`cargo test -p gradient-scheduler --lib dispatch_mode::tests`):
-- `decide_dispatch_mode_returns_real_arch_for_nonsubstitutable` / `decide_dispatch_mode_returns_substitute_builtin_when_cached` / `decide_dispatch_mode_escalates_stalled_substitutes` - verify `decide_dispatch_mode` returns `RealArch` / `SubstituteBuiltin` / `SubstituteStalled` for the (substitutable, miss_count, threshold, arch_has_worker) combinations.
+- `non_substitutable_is_real_arch` / `substitutable_under_threshold_is_builtin` / `escalates_only_when_arch_worker_present` / `stalls_when_budget_spent_and_no_arch_worker` / `arch_available_builtin_always_true` - verify `decide_dispatch_mode` and `arch_available` for the (substitutable, miss_count, threshold, arch_has_worker) combinations.
 
 Backend (`cargo test -p gradient-db --lib build::tests`):
 - `maps_returned_rows_to_id_set` / `empty_input_returns_empty_set` - plumbing tests for `builds_with_satisfied_deps` (the SQL antijoin itself is covered end-to-end in CI).

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -708,6 +708,19 @@ Backend (`cargo test -p scheduler --lib jobs::tests::add_pending_does_not_requeu
   ("build aborted by server"), and the spurious failure fails the whole
   evaluation (observed flaking the `gradient-cache` NixOS VM test).
 
+## Cross-architecture substitutable-build scheduling
+
+Backend (`cargo test -p gradient-scheduler --lib dispatch_mode::tests`):
+- `decide_dispatch_mode_returns_real_arch_for_nonsubstitutable` / `decide_dispatch_mode_returns_substitute_builtin_when_cached` / `decide_dispatch_mode_escalates_stalled_substitutes` - verify `decide_dispatch_mode` returns `RealArch` / `SubstituteBuiltin` / `SubstituteStalled` for the (substitutable, miss_count, threshold, arch_has_worker) combinations.
+
+Backend (`cargo test -p gradient-db --lib build::tests`):
+- `maps_returned_rows_to_id_set` / `empty_input_returns_empty_set` - plumbing tests for `builds_with_satisfied_deps` (the SQL antijoin itself is covered end-to-end in CI).
+
+Backend (`cargo test -p gradient-scheduler --lib build::tests`):
+- `stalled_substitute_is_not_buildable_and_appears_in_unmet` - when a build's substitutable derivation has too many misses, the parker does not mark it buildable and the reason reflects the escalation.
+- `dependency_blocked_build_is_not_buildable` - a build waiting on an unsatisfied dependency is not buildable regardless of dispatch mode.
+- `substitutable_within_budget_is_buildable_anywhere` - a substitutable build under the miss threshold is buildable on any worker with the derivation's architecture.
+
 ## Org members can view subscribed caches (#327)
 
 NixOS VM (`nix/tests/gradient/state`):

--- a/frontend/src/app/core/services/board.service.ts
+++ b/frontend/src/app/core/services/board.service.ts
@@ -114,6 +114,13 @@ export interface DispatchedJobDetail extends DispatchedJobSummary {
   job_context: JobContextView;
   instance_context: InstanceContextView | null;
   candidates: unknown | null;
+  previous_attempts: {
+    dispatched_job_id: string;
+    substitute: boolean;
+    outcome: number;
+    reason: number | null;
+    created_at: string;
+  }[];
 }
 
 export interface BoardWorker {

--- a/frontend/src/app/core/services/board.service.ts
+++ b/frontend/src/app/core/services/board.service.ts
@@ -17,6 +17,7 @@ export interface DispatchedJobSummary {
   dispatched_at: string;
   build_id: string | null;
   evaluation_id: string;
+  pname: string | null;
 }
 
 export interface DispatchedJobsResponse {
@@ -31,6 +32,7 @@ export interface PendingJobSummary {
   build_id: string | null;
   queued_at: string;
   dependency_count: number;
+  pname: string | null;
 }
 
 export interface PendingJobsResponse {

--- a/frontend/src/app/features/board/job-detail/job-detail.component.spec.ts
+++ b/frontend/src/app/features/board/job-detail/job-detail.component.spec.ts
@@ -80,6 +80,7 @@ const DETAIL: DispatchedJobDetail = {
     idle_workers: 2,
   },
   candidates: null,
+  previous_attempts: [],
 };
 
 const EVAL_DETAIL: DispatchedJobDetail = {
@@ -211,5 +212,55 @@ describe('BoardJobDetailComponent - pending fallback', () => {
       'missing',
     ).nativeElement as HTMLElement;
     expect(el.textContent).toContain('Job not found');
+  });
+});
+
+describe('BoardJobDetailComponent - previous build attempts', () => {
+  const WITH_ATTEMPTS: DispatchedJobDetail = {
+    ...DETAIL,
+    previous_attempts: [
+      { dispatched_job_id: 'dj-a1', substitute: false, outcome: 3, reason: 5, created_at: '2026-06-08T00:00:00Z' },
+      { dispatched_job_id: 'dj-a2', substitute: true,  outcome: 2, reason: null, created_at: '2026-06-08T00:01:00Z' },
+    ],
+  };
+
+  it('renders the Previous Build Attempts section when there are multiple attempts', () => {
+    const el = setup({ getJob: () => of(WITH_ATTEMPTS) }).nativeElement as HTMLElement;
+    expect(el.textContent).toContain('Previous Build Attempts');
+  });
+
+  it('renders one row per attempt', () => {
+    const el = setup({ getJob: () => of(WITH_ATTEMPTS) }).nativeElement as HTMLElement;
+    const section = el.querySelector('section.attempts') as HTMLElement;
+    const rows = section.querySelectorAll('tbody tr');
+    expect(rows.length).toBe(2);
+  });
+
+  it('shows mode and outcome labels for each attempt', () => {
+    const el = setup({ getJob: () => of(WITH_ATTEMPTS) }).nativeElement as HTMLElement;
+    const section = el.querySelector('section.attempts') as HTMLElement;
+    expect(section.textContent).toContain('build');
+    expect(section.textContent).toContain('failed');
+    expect(section.textContent).toContain('substitute');
+    expect(section.textContent).toContain('substituted');
+  });
+
+  it('each row links to the dispatched job', () => {
+    const el = setup({ getJob: () => of(WITH_ATTEMPTS) }).nativeElement as HTMLElement;
+    const section = el.querySelector('section.attempts') as HTMLElement;
+    const rows = section.querySelectorAll('tbody tr');
+    expect(rows[0].getAttribute('ng-reflect-router-link')).toContain('dj-a1');
+    expect(rows[1].getAttribute('ng-reflect-router-link')).toContain('dj-a2');
+  });
+
+  it('hides the section when there is only one attempt', () => {
+    const singleAttempt: DispatchedJobDetail = {
+      ...DETAIL,
+      previous_attempts: [
+        { dispatched_job_id: 'dj-a1', substitute: false, outcome: 1, reason: null, created_at: '2026-06-08T00:00:00Z' },
+      ],
+    };
+    const el = setup({ getJob: () => of(singleAttempt) }).nativeElement as HTMLElement;
+    expect(el.textContent).not.toContain('Previous Build Attempts');
   });
 });

--- a/frontend/src/app/features/board/job-detail/job-detail.component.spec.ts
+++ b/frontend/src/app/features/board/job-detail/job-detail.component.spec.ts
@@ -21,6 +21,7 @@ const DETAIL: DispatchedJobDetail = {
   dispatched_at: '2026-06-08T00:01:00Z',
   build_id: null,
   evaluation_id: 'e1',
+  pname: null,
   queued_at: '2026-06-08T00:00:00Z',
   finished_at: null,
   score_breakdown: { rules: { wait: 3.5, missing: -1.2 }, total: 12.5 },
@@ -106,6 +107,7 @@ const PENDING: PendingJobSummary = {
   build_id: 'b9',
   queued_at: '2026-06-08T00:00:00Z',
   dependency_count: 3,
+  pname: null,
 };
 
 function setup(board: Partial<BoardService> = {}, id = 'job-1'): ComponentFixture<BoardJobDetailComponent> {

--- a/frontend/src/app/features/board/job-detail/job-detail.component.spec.ts
+++ b/frontend/src/app/features/board/job-detail/job-detail.component.spec.ts
@@ -5,7 +5,8 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ActivatedRoute, provideRouter } from '@angular/router';
+import { ActivatedRoute, provideRouter, RouterLink } from '@angular/router';
+import { By } from '@angular/platform-browser';
 import { EMPTY, of, throwError } from 'rxjs';
 import { BoardJobDetailComponent } from './job-detail.component';
 import { BoardService, DispatchedJobDetail, PendingJobSummary } from '@core/services/board.service';
@@ -248,11 +249,13 @@ describe('BoardJobDetailComponent - previous build attempts', () => {
   });
 
   it('each row links to the dispatched job', () => {
-    const el = setup({ getJob: () => of(WITH_ATTEMPTS) }).nativeElement as HTMLElement;
-    const section = el.querySelector('section.attempts') as HTMLElement;
-    const rows = section.querySelectorAll('tbody tr');
-    expect(rows[0].getAttribute('ng-reflect-router-link')).toContain('dj-a1');
-    expect(rows[1].getAttribute('ng-reflect-router-link')).toContain('dj-a2');
+    const fixture = setup({ getJob: () => of(WITH_ATTEMPTS) });
+    const links = fixture.debugElement
+      .query(By.css('section.attempts'))
+      .queryAll(By.directive(RouterLink));
+    const urls = links.map((l) => l.injector.get(RouterLink).urlTree?.toString());
+    expect(urls).toContain('/board/jobs/dj-a1');
+    expect(urls).toContain('/board/jobs/dj-a2');
   });
 
   it('hides the section when there is only one attempt', () => {

--- a/frontend/src/app/features/board/job-detail/job-detail.component.ts
+++ b/frontend/src/app/features/board/job-detail/job-detail.component.ts
@@ -180,6 +180,26 @@ interface RuleRow {
           </table>
         </section>
       }
+
+      @if (j.previous_attempts.length > 1) {
+        <section class="attempts">
+          <h2>Previous Build Attempts</h2>
+          <table class="rules">
+            <thead><tr><th>#</th><th>Mode</th><th>Outcome</th><th>When</th><th></th></tr></thead>
+            <tbody>
+              @for (a of j.previous_attempts; track a.dispatched_job_id; let i = $index) {
+                <tr class="clickable" [routerLink]="['/board/jobs', a.dispatched_job_id]">
+                  <td>{{ i + 1 }}</td>
+                  <td>{{ a.substitute ? 'substitute' : 'build' }}</td>
+                  <td class="mono">{{ attemptOutcome(a.outcome) }}</td>
+                  <td>{{ a.created_at | date: 'medium' }}</td>
+                  <td>&rsaquo;</td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </section>
+      }
     } @else if (pending(); as p) {
       <header class="head">
         <div>
@@ -287,6 +307,8 @@ interface RuleRow {
       .drv-row.clickable:hover { background: #2d333b; border-color: #444c56; }
       .drv-row .pname { color: #d6dade; }
       .drv-row .path { color: #818181; font-size: 0.8rem; word-break: break-all; }
+      tbody tr.clickable { cursor: pointer; transition: background 0.1s; }
+      tbody tr.clickable:hover { background: #2d333b; }
     `,
   ],
 })
@@ -373,6 +395,10 @@ export class BoardJobDetailComponent implements OnInit {
 
   capabilityList(c: GradientCapabilities): string {
     return BoardJobDetailComponent.WORKER_CAPS.filter((k) => c[k]).join(', ');
+  }
+
+  attemptOutcome(o: number): string {
+    return ['running', 'built', 'substituted', 'failed', 'aborted'][o] ?? String(o);
   }
 
   instanceWindows(inst: InstanceContextView): { name: string; w: Windowed }[] {

--- a/frontend/src/app/features/board/live-jobs/live-jobs.component.spec.ts
+++ b/frontend/src/app/features/board/live-jobs/live-jobs.component.spec.ts
@@ -10,7 +10,7 @@ import { of, EMPTY } from 'rxjs';
 import { BoardLiveJobsComponent } from './live-jobs.component';
 import { BoardService } from '@core/services/board.service';
 import { BoardLiveService } from '@core/services/board-live.service';
-import { PendingJobSummary } from '@core/services/board.service';
+import { DispatchedJobSummary, PendingJobSummary } from '@core/services/board.service';
 
 const PENDING: PendingJobSummary = {
   kind: 1,
@@ -19,6 +19,7 @@ const PENDING: PendingJobSummary = {
   build_id: 'b1',
   queued_at: '2026-06-08T00:00:00Z',
   dependency_count: 3,
+  pname: null,
 };
 
 function setup(): ComponentFixture<BoardLiveJobsComponent> {
@@ -43,6 +44,59 @@ function setup(): ComponentFixture<BoardLiveJobsComponent> {
   fixture.detectChanges();
   return fixture;
 }
+
+const DISPATCHED: DispatchedJobSummary = {
+  id: 'd1abc123-0000-0000-0000-000000000001',
+  kind: 1,
+  organization: 'o1',
+  worker_id: 'worker-1',
+  score: 42.0,
+  dispatched_at: '2026-06-08T00:00:00Z',
+  build_id: 'b1',
+  evaluation_id: 'e1abc123',
+  pname: 'hello',
+};
+
+function setupWithDispatched(dispatched: DispatchedJobSummary[]): ComponentFixture<BoardLiveJobsComponent> {
+  TestBed.configureTestingModule({
+    imports: [BoardLiveJobsComponent],
+    providers: [
+      provideRouter([]),
+      {
+        provide: BoardService,
+        useValue: {
+          getDispatchedJobs: () => of({ jobs: dispatched, other_running: 0 }),
+          getPendingJobs: () => of({ jobs: [], other_pending: 0 }),
+        },
+      },
+      {
+        provide: BoardLiveService,
+        useValue: { connect: () => EMPTY },
+      },
+    ],
+  });
+  const fixture = TestBed.createComponent(BoardLiveJobsComponent);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('BoardLiveJobsComponent - dispatched pname column', () => {
+  beforeEach(() => sessionStorage.clear());
+
+  it('renders pname in the Derivation column for a dispatched build job', () => {
+    const fixture = setupWithDispatched([DISPATCHED]);
+    fixture.detectChanges();
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text).toContain('hello');
+  });
+
+  it('renders — when pname is null', () => {
+    const fixture = setupWithDispatched([{ ...DISPATCHED, pname: null }]);
+    fixture.detectChanges();
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text).toContain('—');
+  });
+});
 
 describe('BoardLiveJobsComponent - pending view toggle', () => {
   beforeEach(() => sessionStorage.clear());

--- a/frontend/src/app/features/board/live-jobs/live-jobs.component.ts
+++ b/frontend/src/app/features/board/live-jobs/live-jobs.component.ts
@@ -58,19 +58,20 @@ type StatusFilter = 'all' | 'pending' | 'dispatched';
 
       <table class="jobs">
         <thead>
-          <tr><th>Kind</th><th>Worker</th><th>Score</th><th>Dispatched</th><th></th></tr>
+          <tr><th>Kind</th><th>Worker</th><th>Derivation</th><th>Score</th><th>Dispatched</th><th></th></tr>
         </thead>
         <tbody>
           @for (j of filteredJobs(); track j.id) {
             <tr [class.live]="isLive(j)" [class.clickable]="canInspect(j)" (click)="inspect(j)">
               <td>{{ j.kind === 1 ? 'build' : 'eval' }}</td>
               <td class="mono">{{ j.worker_id }}</td>
+              <td class="mono">{{ j.pname ?? '—' }}</td>
               <td>{{ j.score | number: '1.1-1' }}</td>
               <td>{{ j.dispatched_at | date: 'HH:mm:ss' }}</td>
               <td>{{ canInspect(j) ? '›' : '' }}</td>
             </tr>
           } @empty {
-            <tr><td colspan="5" class="muted">No matching dispatched jobs.</td></tr>
+            <tr><td colspan="6" class="muted">No matching dispatched jobs.</td></tr>
           }
         </tbody>
       </table>
@@ -82,17 +83,18 @@ type StatusFilter = 'all' | 'pending' | 'dispatched';
         @if (otherPending() > 0) { <span class="muted">+ {{ otherPending() }} hidden.</span> }
       </div>
       <table class="jobs">
-        <thead><tr><th>Kind</th><th>Evaluation</th><th>Deps</th><th>Queued</th></tr></thead>
+        <thead><tr><th>Kind</th><th>Evaluation</th><th>Derivation</th><th>Deps</th><th>Queued</th></tr></thead>
         <tbody>
           @for (p of pendingJobs(); track p.evaluation_id + (p.build_id ?? '')) {
             <tr class="clickable" [routerLink]="['/board/jobs', p.evaluation_id]">
               <td>{{ p.kind === 1 ? 'build' : 'eval' }}</td>
               <td class="mono">{{ p.evaluation_id.slice(0, 8) }}</td>
+              <td class="mono">{{ p.pname ?? '—' }}</td>
               <td>{{ p.dependency_count }}</td>
               <td>{{ p.queued_at | date: 'HH:mm:ss' }}</td>
             </tr>
           } @empty {
-            <tr><td colspan="4" class="muted">No pending jobs.</td></tr>
+            <tr><td colspan="5" class="muted">No pending jobs.</td></tr>
           }
         </tbody>
       </table>
@@ -191,6 +193,7 @@ export class BoardLiveJobsComponent implements OnInit, OnDestroy {
                 dispatched_at: new Date().toISOString(),
                 build_id: ev.build_id ?? null,
                 evaluation_id: ev.evaluation_id ?? '',
+                pname: null,
               },
               ...list,
             ].slice(0, 200)

--- a/frontend/src/app/features/projects/project-actions/action-form.component.html
+++ b/frontend/src/app/features/projects/project-actions/action-form.component.html
@@ -13,6 +13,13 @@
   [draggable]="false"
   [resizable]="false"
 >
+  @if (error()) {
+    <div class="dialog-error">
+      <span class="material-symbols-outlined">error</span>
+      {{ error() }}
+    </div>
+  }
+
   <div class="form-group">
     <label for="action-name">Name</label>
     <input pInputText id="action-name" [ngModel]="name()" (ngModelChange)="name.set($event)" class="w-full" />

--- a/frontend/src/app/features/projects/project-actions/action-form.component.scss
+++ b/frontend/src/app/features/projects/project-actions/action-form.component.scss
@@ -46,4 +46,18 @@
   input { flex: 1; }
 }
 
+.dialog-error {
+  display: flex;
+  align-items: center;
+  gap: $spacing-sm;
+  background: rgba($color-danger, 0.1);
+  border: 1px solid rgba($color-danger, 0.5);
+  border-radius: $border-radius-md;
+  padding: $spacing-md;
+  color: $color-danger;
+  margin-bottom: $spacing-md;
+
+  .material-symbols-outlined { font-size: 20px; }
+}
+
 .w-full { width: 100%; }

--- a/frontend/src/app/features/projects/project-actions/action-form.component.spec.ts
+++ b/frontend/src/app/features/projects/project-actions/action-form.component.spec.ts
@@ -85,6 +85,19 @@ describe('ActionFormComponent', () => {
     expect(v.length).toBeGreaterThan(20);
   });
 
+  it('sends empty events for forge_status_report', () => {
+    const fixture = createFixture(true);
+    fixture.detectChanges();
+    const c = fixture.componentInstance;
+    c.type.set('forge_status_report');
+    c.integrationId.set('int-1');
+    c.name.set('report');
+    let emitted: any;
+    c.saved.subscribe((r) => (emitted = r));
+    c.onSubmit();
+    expect(emitted.events).toEqual([]);
+  });
+
   it('emits a CreateActionRequest with the correct discriminated union on submit', () => {
     const fixture = createFixture(true);
     fixture.detectChanges();

--- a/frontend/src/app/features/projects/project-actions/action-form.component.spec.ts
+++ b/frontend/src/app/features/projects/project-actions/action-form.component.spec.ts
@@ -98,6 +98,14 @@ describe('ActionFormComponent', () => {
     expect(emitted.events).toEqual([]);
   });
 
+  it('renders the submit error inside the dialog', () => {
+    const fixture = createFixture(true);
+    fixture.componentRef.setInput('open', true);
+    fixture.componentRef.setInput('error', 'Integration not found');
+    fixture.detectChanges();
+    expect((fixture.nativeElement as HTMLElement).textContent).toContain('Integration not found');
+  });
+
   it('emits a CreateActionRequest with the correct discriminated union on submit', () => {
     const fixture = createFixture(true);
     fixture.detectChanges();

--- a/frontend/src/app/features/projects/project-actions/action-form.component.ts
+++ b/frontend/src/app/features/projects/project-actions/action-form.component.ts
@@ -53,6 +53,7 @@ export class ActionFormComponent implements OnChanges {
   existing = input<Action | null>(null);
   outboundIntegrations = input<IntegrationOption[]>([]);
   open = input<boolean>(false);
+  error = input<string | null>(null);
 
   saved = output<CreateActionRequest | UpdateActionRequest>();
   closed = output<void>();

--- a/frontend/src/app/features/projects/project-actions/action-form.component.ts
+++ b/frontend/src/app/features/projects/project-actions/action-form.component.ts
@@ -179,7 +179,7 @@ export class ActionFormComponent implements OnChanges {
   onSubmit(): void {
     const config = this.buildConfig();
     const events =
-      this.type() === 'forge_status_report' ? [...FORGE_STATUS_EVENTS] : this.events();
+      this.type() === 'forge_status_report' ? [] : this.events();
     if (this.mode() === 'create') {
       const req: CreateActionRequest = {
         name: this.name().trim(),

--- a/frontend/src/app/features/projects/project-actions/project-actions.component.html
+++ b/frontend/src/app/features/projects/project-actions/project-actions.component.html
@@ -141,6 +141,7 @@
 <app-action-form
   mode="create"
   [open]="showCreateDialog()"
+  [error]="error()"
   [outboundIntegrations]="outboundIntegrations()"
   (saved)="onCreateSaved($event)"
   (closed)="showCreateDialog.set(false)"
@@ -149,6 +150,7 @@
 <app-action-form
   mode="edit"
   [open]="showEditDialog()"
+  [error]="error()"
   [existing]="editingAction()"
   [outboundIntegrations]="outboundIntegrations()"
   (saved)="onEditSaved($event)"

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -157,6 +157,18 @@ a {
   }
 }
 
+input[type="radio"] {
+  accent-color: $color-info;
+  width: 1rem;
+  height: 1rem;
+  cursor: pointer;
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+}
+
 select:disabled,
 textarea:disabled {
   cursor: not-allowed;


### PR DESCRIPTION
Substitutable builds whose architecture has no connected worker now stay `"builtin"` (any-worker) instead of escalating into an unschedulable real build, and a stalled eval surfaces as `Waiting{arch}` instead of silently `Building`. Also fixes the five #375 items (forge events, dialog error, radio styling, job-board derivation name, previous build attempts).

Closes #375