### PR TITLE
refactor(backend): construct entities via Model + into_active_model

### DIFF
--- a/backend/gradient-cache/src/cacher/sign_sweep.rs
+++ b/backend/gradient-cache/src/cacher/sign_sweep.rs
@@ -255,13 +255,15 @@ async fn try_record_cache_derivation(
         return Ok(());
     }
 
-    let row = ACacheDerivation {
-        id: Set(CacheDerivationId::now_v7()),
-        cache: Set(cache_id),
-        derivation: Set(derivation_id),
-        cached_at: Set(now),
-        last_fetched_at: Set(None),
-    };
+    let row = MCacheDerivation {
+        id: CacheDerivationId::now_v7(),
+        cache: cache_id,
+        derivation: derivation_id,
+        cached_at: now,
+        ..Default::default()
+    }
+    .into_active_model();
+
     row.insert(&state.worker_db).await?;
     Ok(())
 }

--- a/backend/gradient-ci/src/actions/executor.rs
+++ b/backend/gradient-ci/src/actions/executor.rs
@@ -8,11 +8,11 @@ use super::send::{execute_forge_status_report, execute_send_mail, execute_send_w
 use super::{MAX_BODY_BYTES, truncate};
 use crate::context::CiContext;
 use gradient_types::{
-    AProjectActionDelivery, ActionConfig, MProjectAction, ProjectActionDeliveryId,
+    ActionConfig, MProjectAction, MProjectActionDelivery, ProjectActionDeliveryId,
 };
 use anyhow::{Context, Result};
 use sea_orm::ActiveValue::Set;
-use sea_orm::ActiveModelTrait;
+use sea_orm::{ActiveModelTrait, IntoActiveModel};
 use serde_json::Value as JsonValue;
 use std::time::Instant;
 use tracing::warn;
@@ -67,18 +67,20 @@ pub async fn execute_action(
     };
 
     let action_id = action.id;
-    let delivery = AProjectActionDelivery {
-        id: Set(ProjectActionDeliveryId::now_v7()),
-        action_id: Set(action_id),
-        event: Set(event.to_string()),
-        request_body: Set(request_body),
-        response_status: Set(response_status),
-        response_body: Set(response_body.map(|s| truncate(s, MAX_BODY_BYTES))),
-        error_message: Set(error_message),
-        success: Set(success),
-        duration_ms: Set(duration_ms),
-        delivered_at: Set(gradient_types::now()),
-    };
+    let delivery = MProjectActionDelivery {
+        id: ProjectActionDeliveryId::now_v7(),
+        action_id,
+        event: event.to_string(),
+        request_body,
+        response_status,
+        response_body: response_body.map(|s| truncate(s, MAX_BODY_BYTES)),
+        error_message,
+        success,
+        duration_ms,
+        delivered_at: gradient_types::now(),
+    }
+    .into_active_model();
+
     if let Err(e) = delivery.insert(&ctx.db.worker_db).await {
         warn!(error = %e, %action_id, "Failed to record action delivery");
     }

--- a/backend/gradient-ci/src/integration_lookup.rs
+++ b/backend/gradient-ci/src/integration_lookup.rs
@@ -13,8 +13,9 @@
 
 use gradient_types::*;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
-use sea_orm::ActiveValue::Set;
-use sea_orm::{ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, IntoActiveModel, QueryFilter,
+};
 use tracing::warn;
 
 /// Numeric encoding of `integration.kind`.
@@ -64,20 +65,18 @@ pub async fn ensure_github_app_integrations<C: ConnectionTrait>(
             );
             continue;
         }
-        AIntegration {
-            id: Set(IntegrationId::now_v7()),
-            organization: Set(org_id),
-            name: Set(GITHUB_APP_INTEGRATION_NAME.into()),
-            display_name: Set(GITHUB_APP_INTEGRATION_DISPLAY_NAME.into()),
-            kind: Set(i16::from(kind)),
-            forge_type: Set(i16::from(ForgeType::GitHub)),
-            secret: Set(None),
-            endpoint_url: Set(None),
-            access_token: Set(None),
-            allowed_ips: Set(None),
-            created_by: Set(creator),
-            created_at: Set(chrono::Utc::now().naive_utc()),
+        MIntegration {
+            id: IntegrationId::now_v7(),
+            organization: org_id,
+            name: GITHUB_APP_INTEGRATION_NAME.into(),
+            display_name: GITHUB_APP_INTEGRATION_DISPLAY_NAME.into(),
+            kind: i16::from(kind),
+            forge_type: i16::from(ForgeType::GitHub),
+            created_by: creator,
+            created_at: chrono::Utc::now().naive_utc(),
+            ..Default::default()
         }
+        .into_active_model()
         .insert(db)
         .await?;
     }

--- a/backend/gradient-ci/src/trigger/flake_snapshot.rs
+++ b/backend/gradient-ci/src/trigger/flake_snapshot.rs
@@ -5,8 +5,9 @@
  */
 
 use gradient_types::*;
-use sea_orm::ActiveValue::Set;
-use sea_orm::{ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, IntoActiveModel, QueryFilter,
+};
 
 pub(super) async fn snapshot_flake_input_overrides<C: ConnectionTrait>(
     txn: &C,
@@ -19,12 +20,14 @@ pub(super) async fn snapshot_flake_input_overrides<C: ConnectionTrait>(
         .await?;
 
     for r in rows {
-        let am = AEvaluationFlakeInputOverride {
-            id: Set(EvaluationFlakeInputOverrideId::now_v7()),
-            evaluation: Set(evaluation_id),
-            input_name: Set(r.input_name),
-            url: Set(r.url),
-        };
+        let am = MEvaluationFlakeInputOverride {
+            id: EvaluationFlakeInputOverrideId::now_v7(),
+            evaluation: evaluation_id,
+            input_name: r.input_name,
+            url: r.url,
+        }
+        .into_active_model();
+
         am.insert(txn).await?;
     }
     Ok(())

--- a/backend/gradient-ci/src/trigger/new_evaluation.rs
+++ b/backend/gradient-ci/src/trigger/new_evaluation.rs
@@ -11,7 +11,8 @@ use gradient_types::*;
 use gradient_entity::evaluation::EvaluationStatus;
 use sea_orm::ActiveValue::Set;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, Condition, ConnectionTrait, EntityTrait, QueryFilter,
+    ActiveModelTrait, ColumnTrait, Condition, ConnectionTrait, EntityTrait, IntoActiveModel,
+    QueryFilter,
 };
 
 /// Rejects with [`TriggerError::AlreadyInProgress`] when `project` already has a
@@ -84,38 +85,34 @@ pub async fn trigger_evaluation<C: ConnectionTrait>(
 
     let now = gradient_types::now();
 
-    let acommit = ACommit {
-        id: Set(CommitId::now_v7()),
-        message: Set(commit_message.unwrap_or_default()),
-        hash: Set(commit_hash),
-        author: Set(None),
-        author_name: Set(author_name.unwrap_or_default()),
-    };
+    let acommit = MCommit {
+        id: CommitId::now_v7(),
+        message: commit_message.unwrap_or_default(),
+        hash: commit_hash,
+        author_name: author_name.unwrap_or_default(),
+        ..Default::default()
+    }
+    .into_active_model();
+
     let commit = acommit.insert(db).await?;
 
-    let aevaluation = AEvaluation {
-        id: Set(EvaluationId::now_v7()),
-        project: Set(Some(project.id)),
-        repository: Set(repository_override.unwrap_or_else(|| project.repository.clone())),
-        commit: Set(commit.id),
-        wildcard: Set(wildcard_override.unwrap_or_else(|| project.wildcard.clone())),
-        status: Set(EvaluationStatus::Queued),
-        previous: Set(previous),
-        next: Set(None),
-        created_at: Set(now),
-        updated_at: Set(now),
-        flake_source: Set(None),
-        check_run_ids: Set(None),
-        waiting_reason: Set(None),
-        trigger: Set(trigger),
-        concurrent: Set(concurrent),
-        source_comment: Set(source_comment),
-        fetch_started_at: Set(None),
-        eval_flake_started_at: Set(None),
-        eval_drv_started_at: Set(None),
-        building_started_at: Set(None),
-        finished_at: Set(None),
-    };
+    let aevaluation = MEvaluation {
+        id: EvaluationId::now_v7(),
+        project: Some(project.id),
+        repository: repository_override.unwrap_or_else(|| project.repository.clone()),
+        commit: commit.id,
+        wildcard: wildcard_override.unwrap_or_else(|| project.wildcard.clone()),
+        status: EvaluationStatus::Queued,
+        previous,
+        created_at: now,
+        updated_at: now,
+        trigger,
+        concurrent,
+        source_comment,
+        ..Default::default()
+    }
+    .into_active_model();
+
     let evaluation = aevaluation.insert(db).await?;
 
     snapshot_flake_input_overrides(db, project.id, evaluation.id).await?;

--- a/backend/gradient-ci/src/trigger/restart/build_mapping.rs
+++ b/backend/gradient-ci/src/trigger/restart/build_mapping.rs
@@ -9,8 +9,7 @@ use crate::trigger::TriggerError;
 use gradient_types::*;
 use chrono::NaiveDateTime;
 use gradient_entity::build::BuildStatus;
-use sea_orm::ActiveValue::Set;
-use sea_orm::{ActiveModelTrait, ConnectionTrait};
+use sea_orm::{ActiveModelTrait, ConnectionTrait, IntoActiveModel};
 use std::collections::HashMap;
 
 /// Inserts the restart's builds, mapping each previous build's status through
@@ -49,23 +48,22 @@ pub(super) async fn create_restart_builds<C: ConnectionTrait>(
         } else {
             leader_for_drv.get(&prev_build.derivation).copied()
         };
-        let abuild = ABuild {
-            id: Set(new_build_id),
-            evaluation: Set(new_eval_id),
-            derivation: Set(prev_build.derivation),
-            status: Set(new_status),
-            via: Set(via),
-            substitutable: Set(false),
-            attempt: Set(0),
-            timeout_secs: Set(prev_build.timeout_secs),
-            max_silent_secs: Set(prev_build.max_silent_secs),
-            prefer_local_build: Set(prev_build.prefer_local_build),
-            created_at: Set(now),
-            updated_at: Set(now),
-            queued_at: Set((new_status == BuildStatus::Queued).then_some(now)),
-            ready_at: Set(None),
-            dispatched_at: Set(None),
-        };
+        let abuild = MBuild {
+            id: new_build_id,
+            evaluation: new_eval_id,
+            derivation: prev_build.derivation,
+            status: new_status,
+            via,
+            timeout_secs: prev_build.timeout_secs,
+            max_silent_secs: prev_build.max_silent_secs,
+            prefer_local_build: prev_build.prefer_local_build,
+            created_at: now,
+            updated_at: now,
+            queued_at: (new_status == BuildStatus::Queued).then_some(now),
+            ..Default::default()
+        }
+        .into_active_model();
+
         abuild.insert(db).await?;
         build_id_map.insert(prev_build.id, new_build_id);
     }

--- a/backend/gradient-ci/src/trigger/restart/entry_points.rs
+++ b/backend/gradient-ci/src/trigger/restart/entry_points.rs
@@ -7,8 +7,9 @@
 use crate::trigger::TriggerError;
 use gradient_types::*;
 use chrono::NaiveDateTime;
-use sea_orm::ActiveValue::Set;
-use sea_orm::{ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, IntoActiveModel, QueryFilter,
+};
 use std::collections::HashMap;
 
 /// Copies the previous evaluation's entry points onto `new_eval_id`, remapping
@@ -28,15 +29,17 @@ pub(super) async fn copy_entry_points<C: ConnectionTrait>(
 
     for prev_ep in prev_entry_points {
         if let Some(&new_build_id) = build_id_map.get(&prev_ep.build) {
-            let aep = AEntryPoint {
-                id: Set(EntryPointId::now_v7()),
-                project: Set(prev_ep.project),
-                evaluation: Set(new_eval_id),
-                build: Set(new_build_id),
-                eval: Set(prev_ep.eval),
-                created_at: Set(now),
-                repo_check_id: Set(None),
-            };
+            let aep = MEntryPoint {
+                id: EntryPointId::now_v7(),
+                project: prev_ep.project,
+                evaluation: new_eval_id,
+                build: new_build_id,
+                eval: prev_ep.eval,
+                created_at: now,
+                ..Default::default()
+            }
+            .into_active_model();
+
             aep.insert(db).await?;
         }
     }

--- a/backend/gradient-ci/src/trigger/restart/mod.rs
+++ b/backend/gradient-ci/src/trigger/restart/mod.rs
@@ -15,7 +15,7 @@ use gradient_types::*;
 use gradient_entity::build::BuildStatus;
 use gradient_entity::evaluation::EvaluationStatus;
 use sea_orm::ActiveValue::Set;
-use sea_orm::{ActiveModelTrait, ConnectionTrait};
+use sea_orm::{ActiveModelTrait, ConnectionTrait, IntoActiveModel};
 
 /// Status mapping applied to each previous build when restarting.
 ///
@@ -67,29 +67,21 @@ pub async fn trigger_restart_builds<C: ConnectionTrait>(
     };
 
     let new_eval_id = EvaluationId::now_v7();
-    let aevaluation = AEvaluation {
-        id: Set(new_eval_id),
-        project: Set(Some(project.id)),
-        repository: Set(prev_eval.repository.clone()),
-        commit: Set(prev_eval.commit),
-        wildcard: Set(prev_eval.wildcard.clone()),
-        status: Set(initial_status),
-        previous: Set(Some(prev_eval.id)),
-        next: Set(None),
-        created_at: Set(now),
-        updated_at: Set(now),
-        flake_source: Set(prev_eval.flake_source.clone()),
-        check_run_ids: Set(None),
-        waiting_reason: Set(None),
-        trigger: Set(None),
-        concurrent: Set(false),
-        source_comment: Set(None),
-        fetch_started_at: Set(None),
-        eval_flake_started_at: Set(None),
-        eval_drv_started_at: Set(None),
-        building_started_at: Set(None),
-        finished_at: Set(None),
-    };
+    let aevaluation = MEvaluation {
+        id: new_eval_id,
+        project: Some(project.id),
+        repository: prev_eval.repository.clone(),
+        commit: prev_eval.commit,
+        wildcard: prev_eval.wildcard.clone(),
+        status: initial_status,
+        previous: Some(prev_eval.id),
+        created_at: now,
+        updated_at: now,
+        flake_source: prev_eval.flake_source.clone(),
+        ..Default::default()
+    }
+    .into_active_model();
+
     let new_eval = aevaluation.insert(db).await?;
 
     snapshot_flake_input_overrides(db, project.id, new_eval.id).await?;

--- a/backend/gradient-db/src/admin_tasks.rs
+++ b/backend/gradient-db/src/admin_tasks.rs
@@ -28,17 +28,16 @@ pub async fn insert_pending<C: ConnectionTrait>(
     kind: AdminTaskKind,
     created_by: Option<UserId>,
 ) -> std::result::Result<MAdminTask, InsertPendingError> {
-    let model = AAdminTask {
-        id: Set(AdminTaskId::now_v7()),
-        kind: Set(kind),
-        status: Set(AdminTaskStatus::Pending),
-        created_at: Set(now()),
-        started_at: Set(None),
-        finished_at: Set(None),
-        progress: Set(None),
-        error: Set(None),
-        created_by: Set(created_by),
-    };
+    let model = MAdminTask {
+        id: AdminTaskId::now_v7(),
+        kind,
+        status: AdminTaskStatus::Pending,
+        created_at: now(),
+        created_by,
+        ..Default::default()
+    }
+    .into_active_model();
+
     match model.insert(conn).await {
         Ok(m) => Ok(m),
         Err(DbErr::Exec(e)) if is_unique_violation(&e.to_string()) => {

--- a/backend/gradient-db/src/build_attempt.rs
+++ b/backend/gradient-db/src/build_attempt.rs
@@ -6,7 +6,7 @@
 
 use chrono::NaiveDateTime;
 use gradient_entity::build_attempt::{
-    ActiveModel, AttemptFailureReason, AttemptOutcome, Column, Entity, Model,
+    AttemptFailureReason, AttemptOutcome, Column, Entity, Model,
 };
 use gradient_entity::ids::{BuildAttemptId, BuildId, DispatchedJobId};
 use sea_orm::ActiveValue::Set;
@@ -23,16 +23,17 @@ pub async fn open_attempt<C: ConnectionTrait>(
     substitute: bool,
     build_context: serde_json::Value,
 ) -> Result<Model, DbErr> {
-    ActiveModel {
-        id: Set(BuildAttemptId::now_v7()),
-        build: Set(build),
-        dispatched_job: Set(dispatched_job),
-        substitute: Set(substitute),
-        outcome: Set(AttemptOutcome::Running),
-        build_context: Set(build_context),
-        created_at: Set(gradient_types::now()),
+    Model {
+        id: BuildAttemptId::now_v7(),
+        build,
+        dispatched_job,
+        substitute,
+        outcome: AttemptOutcome::Running,
+        build_context,
+        created_at: gradient_types::now(),
         ..Default::default()
     }
+    .into_active_model()
     .insert(db)
     .await
 }

--- a/backend/gradient-db/src/connection.rs
+++ b/backend/gradient-db/src/connection.rs
@@ -10,8 +10,8 @@ use gradient_entity::evaluation::EvaluationStatus;
 use gradient_migration::Migrator;
 use sea_orm::{
     ActiveModelTrait, ActiveValue::Set, ColumnTrait, ConnectOptions, ConnectionTrait, Database,
-    DatabaseBackend, DatabaseConnection, DbErr, EntityTrait, QueryFilter, QuerySelect, Statement,
-    Value,
+    DatabaseBackend, DatabaseConnection, DbErr, EntityTrait, IntoActiveModel, QueryFilter,
+    QuerySelect, Statement, Value,
 };
 use sea_orm_migration::prelude::*;
 use std::time::Duration;
@@ -231,13 +231,13 @@ async fn seed_builtin_role(
 ) -> Result<(), DbErr> {
     match ERole::find_by_id(role_id).one(db).await? {
         None => {
-            ARole {
-                id: Set(role_id),
-                name: Set(name.to_string()),
-                organization: Set(None),
-                permission: Set(permission),
-                managed: Set(false),
+            MRole {
+                id: role_id,
+                name: name.to_string(),
+                permission,
+                ..Default::default()
             }
+            .into_active_model()
             .insert(db)
             .await?;
         }
@@ -260,13 +260,13 @@ async fn seed_builtin_cache_role(
 ) -> Result<(), DbErr> {
     match ECacheRole::find_by_id(role_id).one(db).await? {
         None => {
-            ACacheRole {
-                id: Set(role_id),
-                name: Set(name.to_string()),
-                cache: Set(None),
-                permission: Set(permission),
-                managed: Set(false),
+            MCacheRole {
+                id: role_id,
+                name: name.to_string(),
+                permission,
+                ..Default::default()
             }
+            .into_active_model()
             .insert(db)
             .await?;
         }
@@ -298,11 +298,12 @@ pub async fn add_features(
         let feature = if let Some(f) = feature {
             f
         } else {
-            let afeature = AFeature {
-                id: Set(FeatureId::now_v7()),
-                name: Set(f),
-                kind: Set(kind.clone()),
-            };
+            let afeature = MFeature {
+                id: FeatureId::now_v7(),
+                name: f,
+                kind: kind.clone(),
+            }
+            .into_active_model();
 
             afeature
                 .insert(&ctx.worker_db)
@@ -311,11 +312,12 @@ pub async fn add_features(
         };
 
         if let Some(d_id) = derivation_id {
-            let aderivation_feature = ADerivationFeature {
-                id: Set(DerivationFeatureId::now_v7()),
-                derivation: Set(d_id),
-                feature: Set(feature.id),
-            };
+            let aderivation_feature = MDerivationFeature {
+                id: DerivationFeatureId::now_v7(),
+                derivation: d_id,
+                feature: feature.id,
+            }
+            .into_active_model();
 
             // `derivation_feature` has a UNIQUE (derivation, feature) index;
             // re-discovering an already-known edge during a fresh evaluation

--- a/backend/gradient-db/src/status/evaluation_status.rs
+++ b/backend/gradient-db/src/status/evaluation_status.rs
@@ -9,8 +9,7 @@ use crate::DbContext;
 use crate::state_machine::EvalStateMachine;
 use gradient_types::*;
 use gradient_entity::evaluation::EvaluationStatus;
-use sea_orm::ActiveValue::Set;
-use sea_orm::{Condition, ColumnTrait, EntityTrait, QueryFilter};
+use sea_orm::{Condition, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter};
 use tracing::{debug, error, warn};
 
 pub async fn update_evaluation_status(
@@ -157,14 +156,16 @@ pub async fn update_evaluation_status_with_error(
 
     debug!(evaluation_id = %evaluation.id, status = ?status, error = %error_message, ?source, "Updating evaluation status with error");
 
-    let msg = AEvaluationMessage {
-        id: Set(EvaluationMessageId::now_v7()),
-        evaluation: Set(evaluation.id),
-        level: Set(MessageLevel::Error),
-        message: Set(error_message),
-        source: Set(source),
-        created_at: Set(gradient_types::now()),
-    };
+    let msg = MEvaluationMessage {
+        id: EvaluationMessageId::now_v7(),
+        evaluation: evaluation.id,
+        level: MessageLevel::Error,
+        message: error_message,
+        source,
+        created_at: gradient_types::now(),
+    }
+    .into_active_model();
+
     if let Err(e) = EEvaluationMessage::insert(msg).exec(&ctx.worker_db).await {
         error!(error = %e, evaluation_id = %evaluation.id, "Failed to insert evaluation_message");
     }

--- a/backend/gradient-db/src/status/logging.rs
+++ b/backend/gradient-db/src/status/logging.rs
@@ -6,8 +6,7 @@
 
 use crate::DbContext;
 use gradient_types::*;
-use sea_orm::ActiveValue::Set;
-use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, IntoActiveModel, QueryFilter};
 use tracing::{error, warn};
 
 /// Compress a finalized build log into zstd chunks, persist the chunk index,
@@ -51,7 +50,7 @@ async fn replace_log_chunk_index(
     log_id: gradient_entity::ids::BuildId,
     descs: &[gradient_storage::log_chunk::StoredChunkDesc],
 ) -> Result<(), sea_orm::DbErr> {
-    use gradient_entity::build_log_chunk::{ActiveModel, Column, Entity};
+    use gradient_entity::build_log_chunk::{ActiveModel, Column, Entity, Model};
     Entity::delete_many()
         .filter(Column::Build.eq(log_id))
         .exec(db)
@@ -62,16 +61,19 @@ async fn replace_log_chunk_index(
     let rows: Vec<ActiveModel> = descs
         .iter()
         .enumerate()
-        .map(|(i, d)| ActiveModel {
-            id: Set(gradient_entity::ids::BuildLogChunkId::now_v7()),
-            build: Set(log_id),
-            chunk_index: Set(i as i32),
-            byte_start: Set(d.byte_start as i64),
-            byte_len: Set(d.byte_len as i32),
-            line_start: Set(d.line_start as i64),
-            line_count: Set(d.line_count as i32),
-            compressed_size: Set(d.compressed_size as i32),
-            color_prefix: Set(d.color_prefix.clone()),
+        .map(|(i, d)| {
+            Model {
+                id: gradient_entity::ids::BuildLogChunkId::now_v7(),
+                build: log_id,
+                chunk_index: i as i32,
+                byte_start: d.byte_start as i64,
+                byte_len: d.byte_len as i32,
+                line_start: d.line_start as i64,
+                line_count: d.line_count as i32,
+                compressed_size: d.compressed_size as i32,
+                color_prefix: d.color_prefix.clone(),
+            }
+            .into_active_model()
         })
         .collect();
     Entity::insert_many(rows).exec(db).await?;
@@ -92,16 +94,16 @@ pub async fn record_phase_event(
     worker_id: Option<String>,
     at: chrono::NaiveDateTime,
 ) {
-    let ev = gradient_entity::phase_event::ActiveModel {
-        id: Set(gradient_entity::ids::PhaseEventId::now_v7()),
-        subject_kind: Set(subject_kind),
-        subject_id: Set(subject_id),
-        phase: Set(phase),
-        event: Set(0),
-        at: Set(at),
-        worker_id: Set(worker_id),
-        detail: Set(None),
-    };
+    let ev = gradient_entity::phase_event::Model {
+        id: gradient_entity::ids::PhaseEventId::now_v7(),
+        subject_kind,
+        subject_id,
+        phase,
+        at,
+        worker_id,
+        ..Default::default()
+    }
+    .into_active_model();
     if let Err(e) = gradient_entity::phase_event::Entity::insert(ev)
         .exec(db)
         .await
@@ -118,14 +120,16 @@ pub async fn insert_evaluation_message<C: ConnectionTrait>(
     message: String,
     source: Option<String>,
 ) -> Result<(), sea_orm::DbErr> {
-    let msg = AEvaluationMessage {
-        id: Set(EvaluationMessageId::now_v7()),
-        evaluation: Set(evaluation_id),
-        level: Set(level),
-        message: Set(message),
-        source: Set(source),
-        created_at: Set(gradient_types::now()),
-    };
+    let msg = MEvaluationMessage {
+        id: EvaluationMessageId::now_v7(),
+        evaluation: evaluation_id,
+        level,
+        message,
+        source,
+        created_at: gradient_types::now(),
+    }
+    .into_active_model();
+
     EEvaluationMessage::insert(msg).exec(db).await?;
     Ok(())
 }

--- a/backend/gradient-proto/src/handler/cache.rs
+++ b/backend/gradient-proto/src/handler/cache.rs
@@ -11,7 +11,7 @@ use gradient_types::ids::{CacheId, CachedPathId, CachedPathSignatureId, Organiza
 use gradient_types::*;
 use gradient_core::ServerState;
 use sea_orm::sea_query::OnConflict;
-use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+use sea_orm::{ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter};
 use tracing::{error, warn};
 
 async fn build_local_cache_map(
@@ -108,14 +108,15 @@ async fn ensure_push_signatures(
     let rows: Vec<ACachedPathSignature> = cached_path_rows
         .iter()
         .flat_map(|cp| {
-            org_caches.iter().map(move |oc| ACachedPathSignature {
-                id: sea_orm::ActiveValue::Set(CachedPathSignatureId::now_v7()),
-                cached_path: sea_orm::ActiveValue::Set(cp.id),
-                cache: sea_orm::ActiveValue::Set(oc.cache),
-                signature: sea_orm::ActiveValue::Set(None),
-                created_at: sea_orm::ActiveValue::Set(now),
-                last_fetched_at: sea_orm::ActiveValue::Set(None),
-                fetch_count: sea_orm::ActiveValue::Set(0),
+            org_caches.iter().map(move |oc| {
+                MCachedPathSignature {
+                    id: CachedPathSignatureId::now_v7(),
+                    cached_path: cp.id,
+                    cache: oc.cache,
+                    created_at: now,
+                    ..Default::default()
+                }
+                .into_active_model()
             })
         })
         .collect();

--- a/backend/gradient-proto/src/handler/nar.rs
+++ b/backend/gradient-proto/src/handler/nar.rs
@@ -71,13 +71,15 @@ async fn upsert_cache_metric(
             am.update(&state.worker_db).await?;
         }
         None => {
-            let am = ACacheMetric {
-                id: Set(CacheMetricId::now_v7()),
-                cache: Set(cache_id),
-                bucket_time: Set(bucket),
-                bytes_sent: Set(bytes),
-                nar_count: Set(1),
-            };
+            let am = MCacheMetric {
+                id: CacheMetricId::now_v7(),
+                cache: cache_id,
+                bucket_time: bucket,
+                bytes_sent: bytes,
+                nar_count: 1,
+            }
+            .into_active_model();
+
             am.insert(&state.worker_db).await?;
         }
     }

--- a/backend/gradient-proto/src/ingest.rs
+++ b/backend/gradient-proto/src/ingest.rs
@@ -107,20 +107,22 @@ async fn upsert_and_sign<C: ConnectionTrait>(
             (id, false)
         }
         None => {
-            let am = ACachedPath {
-                id: Set(CachedPathId::now_v7()),
-                store_path: Set(input.store_path.to_owned()),
-                hash: Set(hash.to_owned()),
-                package: Set(package.to_owned()),
-                file_hash: Set(Some(normalize_nar_hash(input.file_hash))),
-                file_size: Set(Some(input.file_size)),
-                nar_size: Set(Some(input.nar_size)),
-                nar_hash: Set(Some(normalize_nar_hash(input.nar_hash))),
-                references: Set(references_str),
-                ca: Set(None),
-                deriver: Set(input.deriver.map(str::to_owned)),
-                created_at: Set(ts),
-            };
+            let am = MCachedPath {
+                id: CachedPathId::now_v7(),
+                store_path: input.store_path.to_owned(),
+                hash: hash.to_owned(),
+                package: package.to_owned(),
+                file_hash: Some(normalize_nar_hash(input.file_hash)),
+                file_size: Some(input.file_size),
+                nar_size: Some(input.nar_size),
+                nar_hash: Some(normalize_nar_hash(input.nar_hash)),
+                references: references_str,
+                deriver: input.deriver.map(str::to_owned),
+                created_at: ts,
+                ..Default::default()
+            }
+            .into_active_model();
+
             match am.insert(db).await {
                 Ok(row) => (row.id, true),
                 Err(e) => {
@@ -153,14 +155,15 @@ async fn upsert_and_sign<C: ConnectionTrait>(
     if !cache_ids.is_empty() {
         let rows: Vec<ACachedPathSignature> = cache_ids
             .into_iter()
-            .map(|cid| ACachedPathSignature {
-                id: Set(CachedPathSignatureId::now_v7()),
-                cached_path: Set(cached_path_id),
-                cache: Set(cid),
-                signature: Set(None),
-                created_at: Set(ts),
-                last_fetched_at: Set(None),
-                fetch_count: Set(0),
+            .map(|cid| {
+                MCachedPathSignature {
+                    id: CachedPathSignatureId::now_v7(),
+                    cached_path: cached_path_id,
+                    cache: cid,
+                    created_at: ts,
+                    ..Default::default()
+                }
+                .into_active_model()
             })
             .collect();
 

--- a/backend/gradient-scheduler/src/build.rs
+++ b/backend/gradient-scheduler/src/build.rs
@@ -155,16 +155,18 @@ impl<'a> BuildStateHandler<'a> {
 
                 // Insert new product rows.
                 for product in &output.products {
-                    let am = ABuildProduct {
-                        id: Set(BuildProductId::now_v7()),
-                        derivation_output: Set(row_id),
-                        file_type: Set(product.file_type.clone()),
-                        subtype: Set(product.subtype.clone()),
-                        name: Set(product.name.clone()),
-                        path: Set(product.path.clone()),
-                        size: Set(product.size.map(|s| s as i64)),
-                        created_at: Set(gradient_types::now()),
-                    };
+                    let am = MBuildProduct {
+                        id: BuildProductId::now_v7(),
+                        derivation_output: row_id,
+                        file_type: product.file_type.clone(),
+                        subtype: product.subtype.clone(),
+                        name: product.name.clone(),
+                        path: product.path.clone(),
+                        size: product.size.map(|s| s as i64),
+                        created_at: gradient_types::now(),
+                    }
+                    .into_active_model();
+
                     if let Err(e) = am.insert(&self.state.worker_db).await {
                         warn!(error = %e, %build_id, output_name = %output.name, "failed to insert build_product");
                     }
@@ -270,26 +272,27 @@ impl<'a> BuildStateHandler<'a> {
             }
         };
 
-        let metric = ADerivationMetric {
-            id: Set(DerivationMetricId::now_v7()),
-            derivation: Set(derivation_id),
-            pname: Set(pname),
-            closure_size: Set(closure_size),
-            peak_ram_mb: Set(metrics.peak_ram_mb.map(|v| v as i64)),
-            cpu_time_ms: Set(metrics.cpu_time_ms.map(|v| v as i64)),
-            avg_cpu_pct: Set(metrics.avg_cpu_pct.map(|v| v as f64)),
-            disk_read_bytes: Set(metrics.disk_read_bytes.map(|v| v as i64)),
-            disk_write_bytes: Set(metrics.disk_write_bytes.map(|v| v as i64)),
-            peak_network_mbps: Set(metrics.peak_network_mbps.map(|v| v as f64)),
-            oom_killed: Set(metrics.oom_killed),
-            build_time_ms: Set(metrics.build_time_ms.map(|v| v as i64)),
-            worker_id: Set(gradient_db::latest_attempt_worker(&self.state.worker_db, build.id)
+        let metric = MDerivationMetric {
+            id: DerivationMetricId::now_v7(),
+            derivation: derivation_id,
+            pname,
+            closure_size,
+            peak_ram_mb: metrics.peak_ram_mb.map(|v| v as i64),
+            cpu_time_ms: metrics.cpu_time_ms.map(|v| v as i64),
+            avg_cpu_pct: metrics.avg_cpu_pct.map(|v| v as f64),
+            disk_read_bytes: metrics.disk_read_bytes.map(|v| v as i64),
+            disk_write_bytes: metrics.disk_write_bytes.map(|v| v as i64),
+            peak_network_mbps: metrics.peak_network_mbps.map(|v| v as f64),
+            oom_killed: metrics.oom_killed,
+            build_time_ms: metrics.build_time_ms.map(|v| v as i64),
+            worker_id: gradient_db::latest_attempt_worker(&self.state.worker_db, build.id)
                 .await
                 .ok()
                 .flatten()
-                .unwrap_or_default()),
-            created_at: Set(gradient_types::now()),
-        };
+                .unwrap_or_default(),
+            created_at: gradient_types::now(),
+        }
+        .into_active_model();
 
         if let Err(e) = metric.insert(&self.state.worker_db).await {
             warn!(%derivation_id, error = %e, "failed to record derivation_metric");

--- a/backend/gradient-scheduler/src/eval.rs
+++ b/backend/gradient-scheduler/src/eval.rs
@@ -21,7 +21,7 @@ use gradient_exec::strip_nix_store_prefix;
 use gradient_sources::{get_hash_from_path, parse_drv_hash_name};
 use gradient_types::*;
 use gradient_core::ServerState;
-use sea_orm::{ActiveValue::Set, ColumnTrait, EntityTrait, QueryFilter};
+use sea_orm::{ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter};
 use tracing::{debug, error, info};
 
 use super::build::check_evaluation_done;
@@ -62,34 +62,31 @@ impl DerivationInsertBatch {
             drv_path_to_id.insert(d.drv_path.clone(), id);
             let (drv_hash, drv_name) = parse_drv_hash_name(&d.drv_path)
                 .unwrap_or_else(|_| ("unknown".to_owned(), d.drv_path.clone()));
-            new_derivations.push(ADerivation {
-                id: Set(id),
-                organization: Set(organization_id),
-                hash: Set(drv_hash),
-                name: Set(drv_name),
-                architecture: Set(d.architecture.clone()),
-                pname: Set(d.pname.clone()),
-                prefer_local_build: Set(d.prefer_local_build),
-                is_fixed_output: Set(d.is_fixed_output),
-                allow_substitutes: Set(d.allow_substitutes),
-                created_at: Set(now),
+            new_derivations.push(MDerivation {
+                id,
+                organization: organization_id,
+                hash: drv_hash,
+                name: drv_name,
+                architecture: d.architecture.clone(),
+                pname: d.pname.clone(),
+                prefer_local_build: d.prefer_local_build,
+                is_fixed_output: d.is_fixed_output,
+                allow_substitutes: d.allow_substitutes,
+                created_at: now,
                 ..Default::default()
-            });
+            }.into_active_model());
             for output in &d.outputs {
                 let (hash, package) = get_hash_from_path(output.path.clone())
                     .unwrap_or_else(|_| ("unknown".to_owned(), output.name.clone()));
-                new_outputs.push(ADerivationOutput {
-                    id: Set(DerivationOutputId::now_v7()),
-                    derivation: Set(id),
-                    name: Set(output.name.clone()),
-                    hash: Set(hash),
-                    package: Set(package),
-                    ca: Set(None),
-                    nar_size: Set(None),
-                    is_cached: Set(false),
-                    cached_path: Set(None),
-                    created_at: Set(now),
-                });
+                new_outputs.push(MDerivationOutput {
+                    id: DerivationOutputId::now_v7(),
+                    derivation: id,
+                    name: output.name.clone(),
+                    hash,
+                    package,
+                    created_at: now,
+                    ..Default::default()
+                }.into_active_model());
             }
         }
 
@@ -269,23 +266,21 @@ impl<'a> EvalResultProcessor<'a> {
                 spawn_inputs.push((build_id, drv_id, d.drv_path.clone()));
             }
 
-            builds.push(ABuild {
-                id: Set(build_id),
-                evaluation: Set(self.evaluation_id),
-                derivation: Set(drv_id),
-                status: Set(status),
-                via: Set(via),
-                substitutable: Set(substitutable),
-                attempt: Set(0),
-                timeout_secs: Set(d.timeout_secs.map(|v| v as i64)),
-                max_silent_secs: Set(d.max_silent_secs.map(|v| v as i64)),
-                prefer_local_build: Set(d.prefer_local_build),
-                created_at: Set(now),
-                updated_at: Set(now),
-                queued_at: Set(matches!(status, BuildStatus::Queued).then_some(now)),
-                ready_at: Set(None),
-                dispatched_at: Set(None),
-            });
+            builds.push(MBuild {
+                id: build_id,
+                evaluation: self.evaluation_id,
+                derivation: drv_id,
+                status,
+                via,
+                substitutable,
+                timeout_secs: d.timeout_secs.map(|v| v as i64),
+                max_silent_secs: d.max_silent_secs.map(|v| v as i64),
+                prefer_local_build: d.prefer_local_build,
+                created_at: now,
+                updated_at: now,
+                queued_at: matches!(status, BuildStatus::Queued).then_some(now),
+                ..Default::default()
+            }.into_active_model());
         }
 
         if !builds.is_empty() {
@@ -499,15 +494,15 @@ impl<'a> EvalResultProcessor<'a> {
             if let Some(&drv_id) = drv_path_to_id.get(&d.drv_path)
                 && let Some(&build_id) = drv_id_to_build.get(&drv_id)
             {
-                active_entry_points.push(AEntryPoint {
-                    id: Set(EntryPointId::now_v7()),
-                    project: Set(project_id),
-                    evaluation: Set(self.evaluation_id),
-                    build: Set(build_id),
-                    eval: Set(d.attr.clone()),
-                    created_at: Set(now),
-                    repo_check_id: Set(None),
-                });
+                active_entry_points.push(MEntryPoint {
+                    id: EntryPointId::now_v7(),
+                    project: project_id,
+                    evaluation: self.evaluation_id,
+                    build: build_id,
+                    eval: d.attr.clone(),
+                    created_at: now,
+                    ..Default::default()
+                }.into_active_model());
             }
         }
 
@@ -626,23 +621,17 @@ async fn expand_substituted_closure(
         if matches!(status, BuildStatus::Substituted) {
             spawn_inputs.push((build_id, drv_id));
         }
-        builds.push(ABuild {
-            id: Set(build_id),
-            evaluation: Set(evaluation_id),
-            derivation: Set(drv_id),
-            status: Set(status),
-            via: Set(None),
-            substitutable: Set(substitutable),
-            attempt: Set(0),
-            timeout_secs: Set(None),
-            max_silent_secs: Set(None),
-            prefer_local_build: Set(false),
-            created_at: Set(now),
-            updated_at: Set(now),
-            queued_at: Set(matches!(status, BuildStatus::Queued).then_some(now)),
-            ready_at: Set(None),
-            dispatched_at: Set(None),
-        });
+        builds.push(MBuild {
+            id: build_id,
+            evaluation: evaluation_id,
+            derivation: drv_id,
+            status,
+            substitutable,
+            created_at: now,
+            updated_at: now,
+            queued_at: matches!(status, BuildStatus::Queued).then_some(now),
+            ..Default::default()
+        }.into_active_model());
     }
 
     let count = builds.len();
@@ -891,11 +880,11 @@ pub async fn flush_deferred_deps(
         };
         for dep in deps {
             if let Some(&dep_id) = drv_path_to_id.get(dep) {
-                edges.push(ADerivationDependency {
-                    id: Set(DerivationDependencyId::now_v7()),
-                    derivation: Set(src_id),
-                    dependency: Set(dep_id),
-                });
+                edges.push(MDerivationDependency {
+                    id: DerivationDependencyId::now_v7(),
+                    derivation: src_id,
+                    dependency: dep_id,
+                }.into_active_model());
             } else {
                 unresolved += 1;
             }

--- a/backend/gradient-scheduler/src/job_handlers.rs
+++ b/backend/gradient-scheduler/src/job_handlers.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use gradient_entity::build::BuildStatus;
 use sea_orm::EntityTrait;
-use sea_orm::{ColumnTrait, QueryFilter, Set};
+use sea_orm::{ColumnTrait, IntoActiveModel, QueryFilter};
 use tracing::{debug, error, info, warn};
 
 use gradient_exec::strip_nix_store_prefix;
@@ -695,25 +695,26 @@ impl Scheduler {
 async fn persist_dispatched_job(state: &Arc<ServerState>, worker_id: &str, rec: DispatchRecord) {
     let now = now();
     let dispatched_job_id = gradient_entity::ids::DispatchedJobId::now_v7();
-    let row = gradient_entity::dispatched_job::ActiveModel {
-        id: Set(dispatched_job_id),
-        kind: Set(rec.kind),
-        evaluation_id: Set(rec.evaluation_id),
-        organization: Set(rec.organization),
-        project: Set(rec.project),
-        worker_id: Set(worker_id.to_owned()),
-        score: Set(rec.score),
-        queued_at: Set(rec.queued_at),
-        ready_at: Set(Some(rec.ready_at)),
-        dispatched_at: Set(now),
-        finished_at: Set(None),
-        score_breakdown: Set(rec.score_breakdown),
-        worker_context: Set(rec.worker_context),
-        job_context: Set(rec.job_context),
-        instance_context: Set(Some(rec.instance_context.clone())),
-        candidates: Set(None),
-        created_at: Set(now),
-    };
+    let row = gradient_entity::dispatched_job::Model {
+        id: dispatched_job_id,
+        kind: rec.kind,
+        evaluation_id: rec.evaluation_id,
+        organization: rec.organization,
+        project: rec.project,
+        worker_id: worker_id.to_owned(),
+        score: rec.score,
+        queued_at: rec.queued_at,
+        ready_at: Some(rec.ready_at),
+        dispatched_at: now,
+        score_breakdown: rec.score_breakdown,
+        worker_context: rec.worker_context,
+        job_context: rec.job_context,
+        instance_context: Some(rec.instance_context.clone()),
+        created_at: now,
+        ..Default::default()
+    }
+    .into_active_model();
+
     if let Err(e) = gradient_entity::dispatched_job::Entity::insert(row)
         .exec(&state.worker_db)
         .await

--- a/backend/gradient-scheduler/src/worker_lifecycle.rs
+++ b/backend/gradient-scheduler/src/worker_lifecycle.rs
@@ -29,23 +29,23 @@ pub(crate) async fn record_worker_sample(
     let Some(org) = info.organization else {
         return;
     };
-    let sample = gradient_entity::worker_sample::ActiveModel {
-        id: Set(gradient_entity::ids::WorkerSampleId::now_v7()),
-        worker_id: Set(info.id.clone()),
-        organization: Set(org),
-        at: Set(gradient_types::now()),
-        cpu_usage_pct: Set(Some(info.cpu_usage_pct)),
-        ram_free_mb: Set(Some(info.ram_free_mb as i64)),
-        ram_total_mb: Set(Some(info.ram_total_mb as i64)),
-        disk_speed_mbps: Set(info.disk_speed_mbps),
-        network_speed_mbps: Set(info.network_speed_mbps),
-        assigned_jobs: Set(info.assigned_job_count as i32),
-        max_concurrent_builds: Set(info.max_concurrent_builds as i32),
-        state: Set(i16::from(info.draining)),
-        capabilities: Set(
-            serde_json::to_value(&info.capabilities).unwrap_or(serde_json::Value::Null)
-        ),
-    };
+    let sample = gradient_entity::worker_sample::Model {
+        id: gradient_entity::ids::WorkerSampleId::now_v7(),
+        worker_id: info.id.clone(),
+        organization: org,
+        at: gradient_types::now(),
+        cpu_usage_pct: Some(info.cpu_usage_pct),
+        ram_free_mb: Some(info.ram_free_mb as i64),
+        ram_total_mb: Some(info.ram_total_mb as i64),
+        disk_speed_mbps: info.disk_speed_mbps,
+        network_speed_mbps: info.network_speed_mbps,
+        assigned_jobs: info.assigned_job_count as i32,
+        max_concurrent_builds: info.max_concurrent_builds as i32,
+        state: i16::from(info.draining),
+        capabilities: serde_json::to_value(&info.capabilities).unwrap_or(serde_json::Value::Null),
+    }
+    .into_active_model();
+
     if let Err(e) = gradient_entity::worker_sample::Entity::insert(sample).exec(db).await {
         warn!(error = %e, worker_id = %info.id, "failed to insert worker_sample");
     }
@@ -91,16 +91,17 @@ impl Scheduler {
             .write()
             .await
             .set_worker_org(peer_id, reg.peer_id);
-        let conn = gradient_entity::worker_connection::ActiveModel {
-            id: Set(gradient_entity::ids::WorkerConnectionId::now_v7()),
-            worker_id: Set(peer_id.to_string()),
-            organization: Set(reg.peer_id),
-            display_name: Set(reg.display_name),
-            connected_at: Set(gradient_types::now()),
-            disconnected_at: Set(None),
-            capabilities: Set(capabilities),
-            reason: Set(None),
-        };
+        let conn = gradient_entity::worker_connection::Model {
+            id: gradient_entity::ids::WorkerConnectionId::now_v7(),
+            worker_id: peer_id.to_string(),
+            organization: reg.peer_id,
+            display_name: reg.display_name,
+            connected_at: gradient_types::now(),
+            capabilities,
+            ..Default::default()
+        }
+        .into_active_model();
+
         if let Err(e) = gradient_entity::worker_connection::Entity::insert(conn)
             .exec(&self.state.worker_db)
             .await

--- a/backend/gradient-state/src/provisioning/entities/api_keys.rs
+++ b/backend/gradient-state/src/provisioning/entities/api_keys.rs
@@ -11,7 +11,7 @@ use crate::config::*;
 use gradient_types::*;
 use anyhow::Result;
 use gradient_entity::*;
-use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, Set};
 use std::collections::HashMap;
 
 impl<'a> StateApplicator<'a> {
@@ -84,21 +84,20 @@ impl<'a> StateApplicator<'a> {
                 api_key.update(self.db).await?;
                 tracing::info!(name = %state_api_key.name, "Updated managed API key");
             } else {
-                let api_key_model = api::ActiveModel {
-                    id: Set(ApiId::now_v7()),
-                    owned_by: Set(owned_by_id),
-                    name: Set(state_api_key.name.clone()),
-                    key: Set(key_hash),
-                    last_used_at: Set(now),
-                    created_at: Set(now),
-                    managed: Set(true),
-                    expires_at: Set(None),
-                    revoked_at: Set(None),
-                    permission: Set(mask),
-                    organization: Set(pinned_org),
-                    cache: Set(None),
-                    allowed_ips: Set(None),
-                };
+                let api_key_model = api::Model {
+                    id: ApiId::now_v7(),
+                    owned_by: owned_by_id,
+                    name: state_api_key.name.clone(),
+                    key: key_hash,
+                    last_used_at: now,
+                    created_at: now,
+                    managed: true,
+                    permission: mask,
+                    organization: pinned_org,
+                    ..Default::default()
+                }
+                .into_active_model();
+
                 api_key_model.insert(self.db).await?;
                 tracing::info!(name = %state_api_key.name, "Created managed API key");
             }

--- a/backend/gradient-state/src/provisioning/entities/caches.rs
+++ b/backend/gradient-state/src/provisioning/entities/caches.rs
@@ -16,7 +16,7 @@ use anyhow::Result;
 use base64::{Engine, engine::general_purpose};
 use gradient_entity::organization_cache::CacheSubscriptionMode;
 use gradient_entity::*;
-use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, Set};
 use std::collections::{HashMap, HashSet};
 
 impl<'a> StateApplicator<'a> {
@@ -87,22 +87,24 @@ impl<'a> StateApplicator<'a> {
                 existing.id
             } else {
                 let cache_id = CacheId::now_v7();
-                let cache_model = cache::ActiveModel {
-                    id: Set(cache_id),
-                    name: Set(state_cache.name.clone()),
-                    display_name: Set(state_cache.display_name.clone()),
-                    description: Set(state_cache.description.clone().unwrap_or_default()),
-                    active: Set(state_cache.active),
-                    priority: Set(state_cache.priority),
-                    local_priority: Set(state_cache.local_priority),
-                    public_key: Set(public_key),
-                    private_key: Set(encrypted_signing_key),
-                    public: Set(state_cache.public),
-                    created_by: Set(created_by_id),
-                    created_at: Set(now),
-                    managed: Set(true),
-                    max_storage_gb: Set(state_cache.max_storage_gb),
-                };
+                let cache_model = cache::Model {
+                    id: cache_id,
+                    name: state_cache.name.clone(),
+                    display_name: state_cache.display_name.clone(),
+                    description: state_cache.description.clone().unwrap_or_default(),
+                    active: state_cache.active,
+                    priority: state_cache.priority,
+                    local_priority: state_cache.local_priority,
+                    public_key,
+                    private_key: encrypted_signing_key,
+                    public: state_cache.public,
+                    created_by: created_by_id,
+                    created_at: now,
+                    managed: true,
+                    max_storage_gb: state_cache.max_storage_gb,
+                }
+                .into_active_model();
+
                 cache_model.insert(self.db).await?;
                 tracing::info!(name = %state_cache.name, "Created managed cache");
                 cache_id
@@ -126,12 +128,14 @@ impl<'a> StateApplicator<'a> {
                     .await?;
 
                 if existing_association.is_none() {
-                    let org_cache_model = organization_cache::ActiveModel {
-                        id: Set(OrganizationCacheId::now_v7()),
-                        organization: Set(org_id),
-                        cache: Set(cache_id),
-                        mode: Set(organization_cache::CacheSubscriptionMode::ReadWrite),
-                    };
+                    let org_cache_model = organization_cache::Model {
+                        id: OrganizationCacheId::now_v7(),
+                        organization: org_id,
+                        cache: cache_id,
+                        mode: organization_cache::CacheSubscriptionMode::ReadWrite,
+                    }
+                    .into_active_model();
+
                     org_cache_model.insert(self.db).await?;
                     tracing::info!(
                         organization = %org_name,
@@ -191,12 +195,14 @@ impl<'a> StateApplicator<'a> {
         if existing.is_some() {
             return Ok(());
         }
-        let active = ACacheUser {
-            id: Set(CacheUserId::now_v7()),
-            cache: Set(cache_id),
-            user: Set(created_by_id),
-            role: Set(BASE_CACHE_ROLE_ADMIN_ID),
-        };
+        let active = MCacheUser {
+            id: CacheUserId::now_v7(),
+            cache: cache_id,
+            user: created_by_id,
+            role: BASE_CACHE_ROLE_ADMIN_ID,
+        }
+        .into_active_model();
+
         active.insert(self.db).await?;
         tracing::info!(
             cache = %cache_name,
@@ -243,36 +249,34 @@ impl<'a> StateApplicator<'a> {
                     let name = display_name
                         .clone()
                         .unwrap_or_else(|| upstream_cache_name.clone());
-                    ACacheUpstream {
-                        id: Set(CacheUpstreamId::now_v7()),
-                        cache: Set(cache_id),
-                        display_name: Set(name),
-                        mode: Set(mode.clone()),
-                        kind: Set(cache_upstream::CacheUpstreamKind::Internal),
-                        upstream_cache: Set(Some(upstream_id)),
-                        url: Set(None),
-                        public_key: Set(None),
-                        remote_cache_name: Set(None),
-                        api_key: Set(None),
+                    MCacheUpstream {
+                        id: CacheUpstreamId::now_v7(),
+                        cache: cache_id,
+                        display_name: name,
+                        mode: mode.clone(),
+                        kind: cache_upstream::CacheUpstreamKind::Internal,
+                        upstream_cache: Some(upstream_id),
+                        ..Default::default()
                     }
+                    .into_active_model()
                 }
                 StateUpstream::External {
                     display_name,
                     url,
                     public_key,
-                } => ACacheUpstream {
-                    id: Set(CacheUpstreamId::now_v7()),
-                    cache: Set(cache_id),
-                    display_name: Set(display_name.clone()),
-                    mode: Set(CacheSubscriptionMode::ReadOnly),
-                    kind: Set(cache_upstream::CacheUpstreamKind::Http),
-                    upstream_cache: Set(None),
-                    url: Set(Some(url.clone())),
-                    public_key: Set(Some(public_key.clone())),
-                    remote_cache_name: Set(None),
-                    api_key: Set(None),
-                },
+                } => MCacheUpstream {
+                    id: CacheUpstreamId::now_v7(),
+                    cache: cache_id,
+                    display_name: display_name.clone(),
+                    mode: CacheSubscriptionMode::ReadOnly,
+                    kind: cache_upstream::CacheUpstreamKind::Http,
+                    url: Some(url.clone()),
+                    public_key: Some(public_key.clone()),
+                    ..Default::default()
+                }
+                .into_active_model(),
             };
+
             record.insert(self.db).await?;
         }
 
@@ -330,13 +334,15 @@ impl<'a> StateApplicator<'a> {
                 active.update(self.db).await?;
                 tracing::info!(cache = %cache_name, role = %entry.name, "Updated managed cache role");
             } else {
-                let active = ACacheRole {
-                    id: Set(RoleId::now_v7()),
-                    name: Set(entry.name.clone()),
-                    cache: Set(Some(cache_id)),
-                    permission: Set(mask),
-                    managed: Set(true),
-                };
+                let active = MCacheRole {
+                    id: RoleId::now_v7(),
+                    name: entry.name.clone(),
+                    cache: Some(cache_id),
+                    permission: mask,
+                    managed: true,
+                }
+                .into_active_model();
+
                 active.insert(self.db).await?;
                 tracing::info!(cache = %cache_name, role = %entry.name, "Created managed cache role");
             }
@@ -386,12 +392,14 @@ impl<'a> StateApplicator<'a> {
                     tracing::info!(cache = %cache_name, user = %entry.user, "Updated cache member role");
                 }
             } else {
-                let active = ACacheUser {
-                    id: Set(CacheUserId::now_v7()),
-                    cache: Set(cache_id),
-                    user: Set(user_id),
-                    role: Set(role_id),
-                };
+                let active = MCacheUser {
+                    id: CacheUserId::now_v7(),
+                    cache: cache_id,
+                    user: user_id,
+                    role: role_id,
+                }
+                .into_active_model();
+
                 active.insert(self.db).await?;
                 tracing::info!(cache = %cache_name, user = %entry.user, "Added cache member");
             }

--- a/backend/gradient-state/src/provisioning/entities/integrations.rs
+++ b/backend/gradient-state/src/provisioning/entities/integrations.rs
@@ -14,7 +14,7 @@ use crate::config::*;
 use gradient_types::*;
 use anyhow::Result;
 use gradient_entity::*;
-use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, Set};
 use std::collections::HashMap;
 
 impl<'a> StateApplicator<'a> {
@@ -119,20 +119,22 @@ impl<'a> StateApplicator<'a> {
                 active.update(self.db).await?;
                 tracing::info!(name = %state_int.name, "Updated managed integration");
             } else {
-                let row = integration::ActiveModel {
-                    id: Set(IntegrationId::now_v7()),
-                    organization: Set(org_id),
-                    name: Set(state_int.name.clone()),
-                    display_name: Set(display_name),
-                    kind: Set(i16::from(kind)),
-                    forge_type: Set(i16::from(forge)),
-                    secret: Set(encrypted_secret),
-                    endpoint_url: Set(endpoint),
-                    access_token: Set(encrypted_token),
-                    allowed_ips: Set(None),
-                    created_by: Set(created_by_id),
-                    created_at: Set(now()),
-                };
+                let row = integration::Model {
+                    id: IntegrationId::now_v7(),
+                    organization: org_id,
+                    name: state_int.name.clone(),
+                    display_name,
+                    kind: i16::from(kind),
+                    forge_type: i16::from(forge),
+                    secret: encrypted_secret,
+                    endpoint_url: endpoint,
+                    access_token: encrypted_token,
+                    created_by: created_by_id,
+                    created_at: now(),
+                    ..Default::default()
+                }
+                .into_active_model();
+
                 row.insert(self.db).await?;
                 tracing::info!(name = %state_int.name, "Created managed integration");
             }

--- a/backend/gradient-state/src/provisioning/entities/orgs.rs
+++ b/backend/gradient-state/src/provisioning/entities/orgs.rs
@@ -12,7 +12,7 @@ use gradient_types::consts::{BASE_ROLE_ADMIN_ID, BASE_ROLE_VIEW_ID, BASE_ROLE_WR
 use gradient_types::*;
 use anyhow::Result;
 use gradient_entity::*;
-use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, Set};
 use std::collections::{HashMap, HashSet};
 
 impl<'a> StateApplicator<'a> {
@@ -87,20 +87,22 @@ impl<'a> StateApplicator<'a> {
                 org_id
             } else {
                 let org_id = declared_id.unwrap_or_else(OrganizationId::now_v7);
-                let org = organization::ActiveModel {
-                    id: Set(org_id),
-                    name: Set(state_org.name.clone()),
-                    display_name: Set(state_org.display_name.clone()),
-                    description: Set(state_org.description.clone().unwrap_or_default()),
-                    public_key: Set(public_key),
-                    private_key: Set(encrypted_private_key),
-                    public: Set(state_org.public),
-                    hide_build_requests: Set(state_org.hide_build_requests),
-                    created_by: Set(created_by_id),
-                    created_at: Set(now),
-                    managed: Set(true),
-                    github_installation_id: Set(state_org.github_installation_id),
-                };
+                let org = organization::Model {
+                    id: org_id,
+                    name: state_org.name.clone(),
+                    display_name: state_org.display_name.clone(),
+                    description: state_org.description.clone().unwrap_or_default(),
+                    public_key,
+                    private_key: encrypted_private_key,
+                    public: state_org.public,
+                    hide_build_requests: state_org.hide_build_requests,
+                    created_by: created_by_id,
+                    created_at: now,
+                    managed: true,
+                    github_installation_id: state_org.github_installation_id,
+                }
+                .into_active_model();
+
                 org.insert(self.db).await?;
                 tracing::info!(name = %state_org.name, "Created managed organization");
                 org_id
@@ -151,12 +153,13 @@ impl<'a> StateApplicator<'a> {
                     .await?;
 
                 if existing.is_none() {
-                    organization_user::ActiveModel {
-                        id: Set(OrganizationUserId::now_v7()),
-                        organization: Set(org_id),
-                        user: Set(created_by_id),
-                        role: Set(BASE_ROLE_ADMIN_ID),
+                    organization_user::Model {
+                        id: OrganizationUserId::now_v7(),
+                        organization: org_id,
+                        user: created_by_id,
+                        role: BASE_ROLE_ADMIN_ID,
                     }
+                    .into_active_model()
                     .insert(self.db)
                     .await?;
                     tracing::info!(
@@ -244,12 +247,13 @@ impl<'a> StateApplicator<'a> {
                             );
                         }
                     } else {
-                        organization_user::ActiveModel {
-                            id: Set(OrganizationUserId::now_v7()),
-                            organization: Set(org_id),
-                            user: Set(user_id),
-                            role: Set(role_id),
+                        organization_user::Model {
+                            id: OrganizationUserId::now_v7(),
+                            organization: org_id,
+                            user: user_id,
+                            role: role_id,
                         }
+                        .into_active_model()
                         .insert(self.db)
                         .await?;
                         tracing::info!(

--- a/backend/gradient-state/src/provisioning/entities/projects.rs
+++ b/backend/gradient-state/src/provisioning/entities/projects.rs
@@ -14,7 +14,9 @@ use gradient_types::triggers::TriggerConfig;
 use gradient_types::*;
 use anyhow::{Context, Result};
 use gradient_entity::*;
-use sea_orm::{ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, Set};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, IntoActiveModel, QueryFilter, Set,
+};
 use std::collections::{HashMap, HashSet};
 
 impl<'a> StateApplicator<'a> {
@@ -62,25 +64,26 @@ impl<'a> StateApplicator<'a> {
                         format!("Project '{}' vanished after update", state_project.name)
                     })?
             } else {
-                let proj = project::ActiveModel {
-                    id: Set(ProjectId::now_v7()),
-                    organization: Set(org_id),
-                    name: Set(state_project.name.clone()),
-                    active: Set(state_project.active),
-                    display_name: Set(state_project.display_name.clone()),
-                    description: Set(state_project.description.clone().unwrap_or_default()),
-                    repository: Set(state_project.repository.clone()),
-                    wildcard: Set(state_project.wildcard.clone()),
-                    force_evaluation: Set(false),
-                    created_by: Set(created_by_id),
-                    last_evaluation: Set(None),
-                    last_check_at: Set(now),
-                    created_at: Set(now),
-                    managed: Set(true),
-                    keep_evaluations: Set(state_project.keep_evaluations),
-                    concurrency: Set(i16::from(state_project.concurrency)),
-                    sign_cache: Set(state_project.sign_cache),
-                };
+                let proj = project::Model {
+                    id: ProjectId::now_v7(),
+                    organization: org_id,
+                    name: state_project.name.clone(),
+                    active: state_project.active,
+                    display_name: state_project.display_name.clone(),
+                    description: state_project.description.clone().unwrap_or_default(),
+                    repository: state_project.repository.clone(),
+                    wildcard: state_project.wildcard.clone(),
+                    created_by: created_by_id,
+                    last_check_at: now,
+                    created_at: now,
+                    managed: true,
+                    keep_evaluations: state_project.keep_evaluations,
+                    concurrency: i16::from(state_project.concurrency),
+                    sign_cache: state_project.sign_cache,
+                    ..Default::default()
+                }
+                .into_active_model();
+
                 let inserted = proj.insert(self.db).await?;
                 tracing::info!(name = %state_project.name, "Created managed project");
                 inserted
@@ -198,19 +201,21 @@ impl<'a> StateApplicator<'a> {
                     );
                 }
                 None => {
-                    let am = AProjectAction {
-                        id: Set(ProjectActionId::now_v7()),
-                        project: Set(project_id),
-                        name: Set(action.name.clone()),
-                        action_type: Set(action_type_i16),
-                        config: Set(cfg_json),
-                        events: Set(events_json),
-                        active: Set(action.active),
-                        last_fired_at: Set(None),
-                        created_by: Set(created_by),
-                        created_at: Set(now),
-                        updated_at: Set(now),
-                    };
+                    let am = MProjectAction {
+                        id: ProjectActionId::now_v7(),
+                        project: project_id,
+                        name: action.name.clone(),
+                        action_type: action_type_i16,
+                        config: cfg_json,
+                        events: events_json,
+                        active: action.active,
+                        created_by,
+                        created_at: now,
+                        updated_at: now,
+                        ..Default::default()
+                    }
+                    .into_active_model();
+
                     am.insert(self.db).await?;
                     tracing::info!(
                         project = %project_name,
@@ -270,14 +275,15 @@ impl<'a> StateApplicator<'a> {
             let desired_url: Option<String> = if o.keep_url { None } else { o.url.clone() };
             match existing_map.get(name) {
                 None => {
-                    pfio::ActiveModel {
-                        id: Set(gradient_entity::ids::FlakeInputOverrideId::now_v7()),
-                        project: Set(project_id),
-                        input_name: Set(name.clone()),
-                        url: Set(desired_url),
-                        created_at: Set(now),
-                        updated_at: Set(now),
+                    pfio::Model {
+                        id: gradient_entity::ids::FlakeInputOverrideId::now_v7(),
+                        project: project_id,
+                        input_name: name.clone(),
+                        url: desired_url,
+                        created_at: now,
+                        updated_at: now,
                     }
+                    .into_active_model()
                     .insert(self.db)
                     .await?;
                 }
@@ -339,16 +345,17 @@ pub(crate) async fn apply_project_triggers<C: ConnectionTrait>(
         if existing_by_key.contains_key(key) {
             continue;
         }
-        AProjectTrigger {
-            id: Set(ProjectTriggerId::now_v7()),
-            project: Set(project.id),
-            trigger_type: Set(i16::from(cfg.trigger_type())),
-            config: Set(cfg.to_db_json()),
-            active: Set(*active),
-            last_fired_at: Set(None),
-            created_at: Set(now),
-            updated_at: Set(now),
+        MProjectTrigger {
+            id: ProjectTriggerId::now_v7(),
+            project: project.id,
+            trigger_type: i16::from(cfg.trigger_type()),
+            config: cfg.to_db_json(),
+            active: *active,
+            created_at: now,
+            updated_at: now,
+            ..Default::default()
         }
+        .into_active_model()
         .insert(db)
         .await?;
     }

--- a/backend/gradient-state/src/provisioning/entities/roles.rs
+++ b/backend/gradient-state/src/provisioning/entities/roles.rs
@@ -11,7 +11,7 @@ use crate::config::*;
 use gradient_types::*;
 use anyhow::Result;
 use gradient_entity::*;
-use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, Set};
 use std::collections::HashMap;
 
 impl<'a> StateApplicator<'a> {
@@ -62,13 +62,15 @@ impl<'a> StateApplicator<'a> {
                 id
             } else {
                 let id = RoleId::now_v7();
-                let active = role::ActiveModel {
-                    id: Set(id),
-                    name: Set(state_role.name.clone()),
-                    organization: Set(Some(org_id)),
-                    permission: Set(mask),
-                    managed: Set(true),
-                };
+                let active = role::Model {
+                    id,
+                    name: state_role.name.clone(),
+                    organization: Some(org_id),
+                    permission: mask,
+                    managed: true,
+                }
+                .into_active_model();
+
                 active.insert(self.db).await?;
                 tracing::info!(name = %state_role.name, "Created managed role");
                 id

--- a/backend/gradient-state/src/provisioning/entities/users.rs
+++ b/backend/gradient-state/src/provisioning/entities/users.rs
@@ -11,7 +11,7 @@ use crate::config::*;
 use gradient_types::*;
 use anyhow::Result;
 use gradient_entity::*;
-use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, Set};
 use std::collections::HashMap;
 
 impl<'a> StateApplicator<'a> {
@@ -54,22 +54,21 @@ impl<'a> StateApplicator<'a> {
                 user.update(self.db).await?;
                 tracing::info!(username = %state_user.username, "Updated managed user");
             } else {
-                let user = user::ActiveModel {
-                    id: Set(UserId::now_v7()),
-                    username: Set(state_user.username.clone()),
-                    name: Set(state_user.name.clone()),
-                    email: Set(state_user.email.clone()),
-                    password: Set(password_hash),
-                    last_login_at: Set(now),
-                    created_at: Set(now),
-                    email_verified: Set(state_user.email_verified),
-                    email_verification_token: Set(None),
-                    email_verification_token_expires: Set(None),
-                    managed: Set(true),
-                    superuser: Set(state_user.superuser),
-                    oidc_issuer: Set(None),
-                    oidc_subject: Set(None),
-                };
+                let user = user::Model {
+                    id: UserId::now_v7(),
+                    username: state_user.username.clone(),
+                    name: state_user.name.clone(),
+                    email: state_user.email.clone(),
+                    password: password_hash,
+                    last_login_at: now,
+                    created_at: now,
+                    email_verified: state_user.email_verified,
+                    managed: true,
+                    superuser: state_user.superuser,
+                    ..Default::default()
+                }
+                .into_active_model();
+
                 user.insert(self.db).await?;
                 tracing::info!(username = %state_user.username, "Created managed user");
             }

--- a/backend/gradient-state/src/provisioning/entities/workers.rs
+++ b/backend/gradient-state/src/provisioning/entities/workers.rs
@@ -11,7 +11,7 @@ use crate::config::*;
 use gradient_types::*;
 use anyhow::Result;
 use gradient_entity::*;
-use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, Set};
 use std::collections::HashMap;
 
 impl<'a> StateApplicator<'a> {
@@ -67,21 +67,23 @@ impl<'a> StateApplicator<'a> {
                         "Updated worker registration"
                     );
                 } else {
-                    let reg = worker_registration::ActiveModel {
-                        id: Set(WorkerRegistrationId::now_v7()),
-                        peer_id: Set(peer_id),
-                        worker_id: Set(state_worker.worker_id.clone()),
-                        token_hash: Set(token_hash.clone()),
-                        managed: Set(true),
-                        url: Set(url.clone()),
-                        display_name: Set(state_worker.display_name.clone()),
-                        active: Set(true),
-                        enable_fetch: Set(state_worker.enable_fetch),
-                        enable_eval: Set(state_worker.enable_eval),
-                        enable_build: Set(state_worker.enable_build),
-                        created_by: Set(Some(created_by_id)),
-                        created_at: Set(now()),
-                    };
+                    let reg = worker_registration::Model {
+                        id: WorkerRegistrationId::now_v7(),
+                        peer_id,
+                        worker_id: state_worker.worker_id.clone(),
+                        token_hash: token_hash.clone(),
+                        managed: true,
+                        url: url.clone(),
+                        display_name: state_worker.display_name.clone(),
+                        active: true,
+                        enable_fetch: state_worker.enable_fetch,
+                        enable_eval: state_worker.enable_eval,
+                        enable_build: state_worker.enable_build,
+                        created_by: Some(created_by_id),
+                        created_at: now(),
+                    }
+                    .into_active_model();
+
                     reg.insert(self.db).await?;
                     tracing::info!(
                         worker_id = %state_worker.worker_id,

--- a/backend/gradient-state/src/provisioning/mod.rs
+++ b/backend/gradient-state/src/provisioning/mod.rs
@@ -18,8 +18,8 @@ use crate::config::StateConfiguration;
 use gradient_types::*;
 use gradient_entity::*;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, ConnectionTrait, DatabaseConnection, EntityTrait, QueryFilter,
-    Set,
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, DatabaseConnection, EntityTrait,
+    IntoActiveModel, QueryFilter, Set,
 };
 use std::collections::HashMap;
 
@@ -133,12 +133,13 @@ pub async fn apply_pending_org_memberships<C: ConnectionTrait>(
                 applied += 1;
             }
             None => {
-                organization_user::ActiveModel {
-                    id: Set(OrganizationUserId::now_v7()),
-                    organization: Set(entry.organization),
-                    user: Set(user_id),
-                    role: Set(entry.role),
+                organization_user::Model {
+                    id: OrganizationUserId::now_v7(),
+                    organization: entry.organization,
+                    user: user_id,
+                    role: entry.role,
                 }
+                .into_active_model()
                 .insert(db)
                 .await?;
                 applied += 1;

--- a/backend/gradient-test-support/src/fixtures.rs
+++ b/backend/gradient-test-support/src/fixtures.rs
@@ -15,7 +15,7 @@ use gradient_entity::ids::{
 use gradient_entity::organization_cache::CacheSubscriptionMode;
 use gradient_entity::*;
 use gradient_types::consts::BASE_CACHE_ROLE_ADMIN_ID;
-use sea_orm::{ActiveModelTrait, ActiveValue::Set, DatabaseConnection, DbErr};
+use sea_orm::{ActiveModelTrait, DatabaseConnection, DbErr, IntoActiveModel};
 use uuid::Uuid;
 
 pub fn org_id() -> OrganizationId {
@@ -164,12 +164,13 @@ pub async fn insert_cache_creator_admin(
     cache_id: CacheId,
     user_id: UserId,
 ) -> Result<(), DbErr> {
-    cache_user::ActiveModel {
-        id: Set(CacheUserId::now_v7()),
-        cache: Set(cache_id),
-        user: Set(user_id),
-        role: Set(BASE_CACHE_ROLE_ADMIN_ID),
+    cache_user::Model {
+        id: CacheUserId::now_v7(),
+        cache: cache_id,
+        user: user_id,
+        role: BASE_CACHE_ROLE_ADMIN_ID,
     }
+    .into_active_model()
     .insert(db)
     .await?;
     Ok(())

--- a/backend/gradient-web/src/audit.rs
+++ b/backend/gradient-web/src/audit.rs
@@ -16,8 +16,7 @@ use axum::http::HeaderMap;
 use axum::http::request::Parts;
 use gradient_types::*;
 use gradient_core::ServerState;
-use sea_orm::ActiveValue::Set;
-use sea_orm::{ConnectionTrait, EntityTrait};
+use sea_orm::{ConnectionTrait, EntityTrait, IntoActiveModel};
 use std::convert::Infallible;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
@@ -129,15 +128,17 @@ pub async fn record<C: ConnectionTrait>(
         "security event",
     );
 
-    let row = AAuditLog {
-        id: Set(AuditLogId::now_v7()),
-        user_id: Set(user_id),
-        event: Set(event.to_string()),
-        ip: Set(info.ip.clone()),
-        user_agent: Set(info.user_agent.clone()),
-        metadata: Set(metadata),
-        created_at: Set(gradient_types::now()),
-    };
+    let row = MAuditLog {
+        id: AuditLogId::now_v7(),
+        user_id,
+        event: event.to_string(),
+        ip: info.ip.clone(),
+        user_agent: info.user_agent.clone(),
+        metadata,
+        created_at: gradient_types::now(),
+    }
+    .into_active_model();
+
     if let Err(e) = EAuditLog::insert(row).exec(db).await {
         tracing::warn!(event, error = %e, "failed to write audit_log entry");
     }

--- a/backend/gradient-web/src/authorization/jwt.rs
+++ b/backend/gradient-web/src/authorization/jwt.rs
@@ -12,7 +12,9 @@ use gradient_types::*;
 use gradient_core::ServerState;
 use jsonwebtoken::{DecodingKey, EncodingKey, Header, Validation, decode, encode};
 use rand::distr::{Alphanumeric, SampleString};
-use sea_orm::{ActiveModelTrait, ActiveValue::Set, ColumnTrait, EntityTrait, QueryFilter};
+use sea_orm::{
+    ActiveModelTrait, ActiveValue::Set, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter,
+};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::sync::Arc;
@@ -84,17 +86,19 @@ pub async fn create_session_and_token(
     let expires_at = now + lifetime;
 
     let session_id = SessionId::now_v7();
-    let session = ASession {
-        id: Set(session_id),
-        user_id: Set(user_id),
-        created_at: Set(now.naive_utc()),
-        expires_at: Set(expires_at.naive_utc()),
-        last_used_at: Set(now.naive_utc()),
-        revoked_at: Set(None),
-        user_agent: Set(user_agent),
-        ip: Set(ip),
-        remember_me: Set(remember_me),
-    };
+    let session = MSession {
+        id: session_id,
+        user_id,
+        created_at: now.naive_utc(),
+        expires_at: expires_at.naive_utc(),
+        last_used_at: now.naive_utc(),
+        user_agent,
+        ip,
+        remember_me,
+        ..Default::default()
+    }
+    .into_active_model();
+
     session
         .insert(&state.web_db)
         .await

--- a/backend/gradient-web/src/authorization/oidc.rs
+++ b/backend/gradient-web/src/authorization/oidc.rs
@@ -17,7 +17,8 @@ use jsonwebtoken::{
 };
 use rand::RngExt as _;
 use sea_orm::{
-    ActiveModelTrait, ActiveValue::Set, ColumnTrait, EntityTrait, QueryFilter, TransactionTrait,
+    ActiveModelTrait, ActiveValue::Set, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter,
+    TransactionTrait,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -109,12 +110,13 @@ async fn apply_oidc_group_grants<C: sea_orm::ConnectionTrait>(
                     .context("update org role from OIDC group")?;
             }
             None => {
-                AOrganizationUser {
-                    id: Set(OrganizationUserId::now_v7()),
-                    organization: Set(org_id),
-                    user: Set(user_id),
-                    role: Set(role_id),
+                MOrganizationUser {
+                    id: OrganizationUserId::now_v7(),
+                    organization: org_id,
+                    user: user_id,
+                    role: role_id,
                 }
+                .into_active_model()
                 .insert(tx)
                 .await
                 .context("insert org membership from OIDC group")?;
@@ -472,22 +474,19 @@ async fn create_or_update_user(
         return Ok(user);
     }
 
-    let user = AUser {
-        id: Set(UserId::now_v7()),
-        username: Set(login_name),
-        name: Set(display_name),
-        email: Set(email),
-        password: Set(None),
-        last_login_at: Set(gradient_types::now()),
-        created_at: Set(gradient_types::now()),
-        email_verified: Set(true),
-        email_verification_token: Set(None),
-        email_verification_token_expires: Set(None),
-        managed: Set(false),
-        superuser: Set(false),
-        oidc_issuer: Set(Some(claims.iss)),
-        oidc_subject: Set(Some(claims.sub)),
+    let user = MUser {
+        id: UserId::now_v7(),
+        username: login_name,
+        name: display_name,
+        email,
+        last_login_at: gradient_types::now(),
+        created_at: gradient_types::now(),
+        email_verified: true,
+        oidc_issuer: Some(claims.iss),
+        oidc_subject: Some(claims.sub),
+        ..Default::default()
     }
+    .into_active_model()
     .insert(&tx)
     .await
     .context("Failed to create user")?;

--- a/backend/gradient-web/src/endpoints/auth.rs
+++ b/backend/gradient-web/src/endpoints/auth.rs
@@ -110,22 +110,20 @@ pub async fn post_basic_register(
         (true, None, None)
     };
 
-    let user = AUser {
-        id: Set(UserId::now_v7()),
-        username: Set(body.username.clone()),
-        name: Set(body.name.clone()),
-        email: Set(body.email.clone()),
-        password: Set(Some(generate_hash(body.password.clone()))),
-        last_login_at: Set(*NULL_TIME),
-        created_at: Set(gradient_types::now()),
-        email_verified: Set(email_verified),
-        email_verification_token: Set(verification_token.clone()),
-        email_verification_token_expires: Set(verification_expires),
-        managed: Set(false),
-        superuser: Set(false),
-        oidc_issuer: Set(None),
-        oidc_subject: Set(None),
-    };
+    let user = MUser {
+        id: UserId::now_v7(),
+        username: body.username.clone(),
+        name: body.name.clone(),
+        email: body.email.clone(),
+        password: Some(generate_hash(body.password.clone())),
+        last_login_at: *NULL_TIME,
+        created_at: gradient_types::now(),
+        email_verified,
+        email_verification_token: verification_token.clone(),
+        email_verification_token_expires: verification_expires,
+        ..Default::default()
+    }
+    .into_active_model();
 
     let user = user
         .insert(&state.web_db)
@@ -796,19 +794,18 @@ pub async fn post_cli_device_start(
     let now = gradient_types::now();
     let expires_at = now + Duration::minutes(CLI_DEVICE_LIFETIME_MINUTES);
 
-    let row = ACliDeviceAuthorization {
-        id: Set(CliDeviceAuthorizationId::now_v7()),
-        device_code_hash: Set(hash_device_code(&device_code)),
-        user_code: Set(user_code.clone()),
-        user_id: Set(None),
-        token: Set(None),
-        denied_at: Set(None),
-        authorized_at: Set(None),
-        created_at: Set(now),
-        expires_at: Set(expires_at),
-        user_agent: Set(info.user_agent.clone()),
-        ip: Set(info.ip.clone()),
-    };
+    let row = MCliDeviceAuthorization {
+        id: CliDeviceAuthorizationId::now_v7(),
+        device_code_hash: hash_device_code(&device_code),
+        user_code: user_code.clone(),
+        created_at: now,
+        expires_at,
+        user_agent: info.user_agent.clone(),
+        ip: info.ip.clone(),
+        ..Default::default()
+    }
+    .into_active_model();
+
     row.insert(&state.web_db).await?;
 
     audit_record(

--- a/backend/gradient-web/src/endpoints/board.rs
+++ b/backend/gradient-web/src/endpoints/board.rs
@@ -22,8 +22,8 @@ use gradient_types::*;
 use gradient_core::ServerState;
 use gradient_scheduler::{BoardEvent, Scheduler};
 use sea_orm::{
-    ColumnTrait, ConnectionTrait, DatabaseBackend, EntityTrait, QueryFilter, QueryOrder,
-    QuerySelect, Set, Statement,
+    ColumnTrait, ConnectionTrait, DatabaseBackend, EntityTrait, IntoActiveModel, QueryFilter,
+    QueryOrder, QuerySelect, Statement,
 };
 use gradient_entity::build_attempt;
 use serde::{Deserialize, Serialize};
@@ -782,14 +782,15 @@ pub async fn create_acknowledged(
 ) -> WebResult<Json<BaseResponse<Uuid>>> {
     require_superuser(&user)?;
     let id = AcknowledgedDerivationId::now_v7();
-    let am = gradient_entity::acknowledged_derivation::ActiveModel {
-        id: Set(id),
-        derivation: Set(body.derivation.map(Into::into)),
-        pname: Set(body.pname),
-        note: Set(body.note),
-        created_by: Set(user.id),
-        created_at: Set(gradient_types::now()),
-    };
+    let am = gradient_entity::acknowledged_derivation::Model {
+        id,
+        derivation: body.derivation.map(Into::into),
+        pname: body.pname,
+        note: body.note,
+        created_by: user.id,
+        created_at: gradient_types::now(),
+    }
+    .into_active_model();
 
     gradient_entity::acknowledged_derivation::Entity::insert(am)
         .exec(&state.web_db)

--- a/backend/gradient-web/src/endpoints/build_requests/blobs.rs
+++ b/backend/gradient-web/src/endpoints/build_requests/blobs.rs
@@ -20,11 +20,11 @@ use axum::Json;
 use axum::extract::{Multipart, Path, State};
 use gradient_types::ids::{BuildRequestBlobId, UploadSessionId};
 use gradient_types::{
-    ABuildRequestBlob, AUploadSession, BaseResponse, EUploadSession, MUser, now,
+    AUploadSession, BaseResponse, EUploadSession, MBuildRequestBlob, MUser, now,
 };
 use gradient_core::ServerState;
 use sea_orm::ActiveValue::Set;
-use sea_orm::{ActiveModelTrait, DbErr, EntityTrait, RuntimeErr, sqlx};
+use sea_orm::{ActiveModelTrait, DbErr, EntityTrait, IntoActiveModel, RuntimeErr, sqlx};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -115,14 +115,15 @@ pub async fn post_blobs(
             .map_err(|e| WebError::internal(format!("Failed to persist blob: {}", e)))?;
 
         let now_ts = now();
-        let insert_result = ABuildRequestBlob {
-            id: Set(BuildRequestBlobId::now_v7()),
-            organization: Set(session.organization),
-            hash: Set(hash_bytes.clone()),
-            size: Set(size),
-            created_at: Set(now_ts),
-            last_used_at: Set(now_ts),
+        let insert_result = MBuildRequestBlob {
+            id: BuildRequestBlobId::now_v7(),
+            organization: session.organization,
+            hash: hash_bytes.clone(),
+            size,
+            created_at: now_ts,
+            last_used_at: now_ts,
         }
+        .into_active_model()
         .insert(&state.web_db)
         .await;
 

--- a/backend/gradient-web/src/endpoints/build_requests/dispatch.rs
+++ b/backend/gradient-web/src/endpoints/build_requests/dispatch.rs
@@ -27,16 +27,17 @@ use gradient_types::ids::{
     CachedPathId, CachedPathSignatureId, CommitId, EvaluationId, ProjectId, UploadSessionId,
 };
 use gradient_types::{
-    ACachedPath, ACachedPathSignature, ACommit, AEvaluation, AProject, AUploadSession,
-    BaseResponse, CCachedPath, CCachedPathSignature, COrganizationCache, CProject, ECachedPath,
-    ECachedPathSignature, EOrganizationCache, EProject, EUploadSession, MUser, NULL_TIME, now,
+    ACachedPathSignature, AUploadSession, BaseResponse, CCachedPath, CCachedPathSignature,
+    COrganizationCache, CProject, ECachedPath, ECachedPathSignature, EOrganizationCache, EProject,
+    EUploadSession, MCachedPath, MCachedPathSignature, MCommit, MEvaluation, MProject, MUser,
+    NULL_TIME, now,
 };
 use gradient_core::ServerState;
 use sea_orm::ActiveValue::Set;
 use sea_orm::sea_query::OnConflict;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, Condition, ConnectionTrait, DbErr, EntityTrait, QueryFilter,
-    RuntimeErr, TransactionTrait, sqlx,
+    ActiveModelTrait, ColumnTrait, Condition, ConnectionTrait, DbErr, EntityTrait, IntoActiveModel,
+    QueryFilter, RuntimeErr, TransactionTrait, sqlx,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -135,40 +136,30 @@ pub async fn post_dispatch(
         .filter(|t| !t.is_empty())
         .unwrap_or_else(|| project.wildcard.clone());
 
-    let commit = ACommit {
-        id: Set(CommitId::now_v7()),
-        message: Set(format!("Build request {}", session.id)),
-        hash: Set(vec![0; 20]),
-        author: Set(Some(user.id)),
-        author_name: Set(user.name.clone()),
+    let commit = MCommit {
+        id: CommitId::now_v7(),
+        message: format!("Build request {}", session.id),
+        hash: vec![0; 20],
+        author: Some(user.id),
+        author_name: user.name.clone(),
     }
+    .into_active_model()
     .insert(&tx)
     .await?;
 
     let now_ts = now();
-    let evaluation = AEvaluation {
-        id: Set(EvaluationId::now_v7()),
-        project: Set(Some(project.id)),
-        repository: Set(nar.store_path.clone()),
-        commit: Set(commit.id),
-        wildcard: Set(target),
-        status: Set(gradient_entity::evaluation::EvaluationStatus::Queued),
-        previous: Set(None),
-        next: Set(None),
-        created_at: Set(now_ts),
-        updated_at: Set(now_ts),
-        flake_source: Set(None),
-        check_run_ids: Set(None),
-        waiting_reason: Set(None),
-        trigger: Set(None),
-        concurrent: Set(false),
-        source_comment: Set(None),
-        fetch_started_at: Set(None),
-        eval_flake_started_at: Set(None),
-        eval_drv_started_at: Set(None),
-        building_started_at: Set(None),
-        finished_at: Set(None),
+    let evaluation = MEvaluation {
+        id: EvaluationId::now_v7(),
+        project: Some(project.id),
+        repository: nar.store_path.clone(),
+        commit: commit.id,
+        wildcard: target,
+        status: gradient_entity::evaluation::EvaluationStatus::Queued,
+        created_at: now_ts,
+        updated_at: now_ts,
+        ..Default::default()
     }
+    .into_active_model()
     .insert(&tx)
     .await?;
 
@@ -232,20 +223,19 @@ async fn ensure_cached_path<C: ConnectionTrait>(
     }
 
     let normalised_hash = normalize_nar_hash(&nar.nar_hash_sri);
-    let row = ACachedPath {
-        id: Set(CachedPathId::now_v7()),
-        store_path: Set(nar.store_path.clone()),
-        hash: Set(nar.store_hash.clone()),
-        package: Set("source".to_string()),
-        file_hash: Set(Some(normalised_hash.clone())),
-        file_size: Set(Some(nar.nar_size as i64)),
-        nar_size: Set(Some(nar.nar_size as i64)),
-        nar_hash: Set(Some(normalised_hash)),
-        references: Set(None),
-        ca: Set(None),
-        deriver: Set(None),
-        created_at: Set(now()),
-    };
+    let row = MCachedPath {
+        id: CachedPathId::now_v7(),
+        store_path: nar.store_path.clone(),
+        hash: nar.store_hash.clone(),
+        package: "source".to_string(),
+        file_hash: Some(normalised_hash.clone()),
+        file_size: Some(nar.nar_size as i64),
+        nar_size: Some(nar.nar_size as i64),
+        nar_hash: Some(normalised_hash),
+        created_at: now(),
+        ..Default::default()
+    }
+    .into_active_model();
 
     match row.insert(tx).await {
         Ok(model) => Ok(model),
@@ -274,14 +264,15 @@ async fn queue_signature_placeholders<C: ConnectionTrait>(
     let now_ts = now();
     let rows: Vec<ACachedPathSignature> = org_caches
         .into_iter()
-        .map(|oc| ACachedPathSignature {
-            id: Set(CachedPathSignatureId::now_v7()),
-            cached_path: Set(cached_path.id),
-            cache: Set(oc.cache),
-            signature: Set(None),
-            created_at: Set(now_ts),
-            last_fetched_at: Set(None),
-            fetch_count: Set(0),
+        .map(|oc| {
+            MCachedPathSignature {
+                id: CachedPathSignatureId::now_v7(),
+                cached_path: cached_path.id,
+                cache: oc.cache,
+                created_at: now_ts,
+                ..Default::default()
+            }
+            .into_active_model()
         })
         .collect();
 
@@ -317,25 +308,25 @@ async fn ensure_build_request_project<C: ConnectionTrait>(
         return Ok(existing);
     }
 
-    let project = AProject {
-        id: Set(ProjectId::now_v7()),
-        organization: Set(org_id),
-        name: Set(BUILD_REQUEST_PROJECT_NAME.to_string()),
-        active: Set(true),
-        display_name: Set("Build Requests".to_string()),
-        description: Set("Server-managed project for `gradient build` submissions.".to_string()),
-        repository: Set(BUILD_REQUEST_PROJECT_NAME.to_string()),
-        wildcard: Set("*".to_string()),
-        last_evaluation: Set(None),
-        last_check_at: Set(*NULL_TIME),
-        force_evaluation: Set(false),
-        created_by: Set(user_id),
-        created_at: Set(now()),
-        managed: Set(true),
-        keep_evaluations: Set(30),
-        concurrency: Set(i16::from(ConcurrencyPolicy::SoftAbort)),
-        sign_cache: Set(true),
-    };
+    let project = MProject {
+        id: ProjectId::now_v7(),
+        organization: org_id,
+        name: BUILD_REQUEST_PROJECT_NAME.to_string(),
+        active: true,
+        display_name: "Build Requests".to_string(),
+        description: "Server-managed project for `gradient build` submissions.".to_string(),
+        repository: BUILD_REQUEST_PROJECT_NAME.to_string(),
+        wildcard: "*".to_string(),
+        last_check_at: *NULL_TIME,
+        created_by: user_id,
+        created_at: now(),
+        managed: true,
+        keep_evaluations: 30,
+        concurrency: i16::from(ConcurrencyPolicy::SoftAbort),
+        sign_cache: true,
+        ..Default::default()
+    }
+    .into_active_model();
 
     match project.insert(tx).await {
         Ok(row) => Ok(row),

--- a/backend/gradient-web/src/endpoints/build_requests/manifest.rs
+++ b/backend/gradient-web/src/endpoints/build_requests/manifest.rs
@@ -23,12 +23,14 @@ use chrono::Duration;
 use gradient_types::constants::{MAX_BUILD_REQUEST_SIZE, UPLOAD_SESSION_TTL};
 use gradient_types::ids::UploadSessionId;
 use gradient_types::{
-    ABuildRequestBlob, AUploadSession, BaseResponse, CBuildRequestBlob, EBuildRequestBlob, MUser,
+    ABuildRequestBlob, BaseResponse, CBuildRequestBlob, EBuildRequestBlob, MUploadSession, MUser,
     now,
 };
 use gradient_core::ServerState;
 use sea_orm::ActiveValue::Set;
-use sea_orm::{ActiveModelTrait, ColumnTrait, Condition, EntityTrait, QueryFilter};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, Condition, EntityTrait, IntoActiveModel, QueryFilter,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -142,16 +144,17 @@ pub async fn post_manifest(
         + Duration::from_std(UPLOAD_SESSION_TTL)
             .map_err(|e| WebError::internal(format!("Invalid UPLOAD_SESSION_TTL: {}", e)))?;
 
-    AUploadSession {
-        id: Set(session_id),
-        organization: Set(org.id),
-        manifest: Set(manifest_value),
-        missing: Set(missing_value),
-        total_size: Set(total),
-        created_at: Set(now_ts),
-        expires_at: Set(expires_at),
-        dispatched_at: Set(None),
+    MUploadSession {
+        id: session_id,
+        organization: org.id,
+        manifest: manifest_value,
+        missing: missing_value,
+        total_size: total,
+        created_at: now_ts,
+        expires_at,
+        ..Default::default()
     }
+    .into_active_model()
     .insert(&state.web_db)
     .await?;
 

--- a/backend/gradient-web/src/endpoints/caches/management.rs
+++ b/backend/gradient-web/src/endpoints/caches/management.rs
@@ -23,7 +23,8 @@ use gradient_types::*;
 use gradient_core::ServerState;
 use sea_orm::ActiveValue::Set;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, Condition, EntityTrait, QueryFilter, TransactionTrait,
+    ActiveModelTrait, ColumnTrait, Condition, EntityTrait, IntoActiveModel, QueryFilter,
+    TransactionTrait,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -174,49 +175,50 @@ pub async fn put(
 
     let tx = state.web_db.inner().begin().await?;
 
-    let cache = ACache {
-        id: Set(CacheId::now_v7()),
-        name: Set(body.name.clone()),
-        active: Set(true),
-        display_name: Set(body.display_name.trim().to_string()),
-        description: Set(body.description.trim().to_string()),
-        priority: Set(body.priority),
-        local_priority: Set(body.local_priority),
-        public_key: Set(public_key),
-        private_key: Set(private_key),
-        public: Set(body.public.unwrap_or(false)),
-        created_by: Set(user.id),
-        created_at: Set(gradient_types::now()),
-        managed: Set(false),
-        max_storage_gb: Set(max_storage_gb),
+    let cache = MCache {
+        id: CacheId::now_v7(),
+        name: body.name.clone(),
+        active: true,
+        display_name: body.display_name.trim().to_string(),
+        description: body.description.trim().to_string(),
+        priority: body.priority,
+        local_priority: body.local_priority,
+        public_key,
+        private_key,
+        public: body.public.unwrap_or(false),
+        created_by: user.id,
+        created_at: gradient_types::now(),
+        max_storage_gb,
+        ..Default::default()
     }
+    .into_active_model()
     .insert(&tx)
     .await
     .map_err(|e| WebError::from_db_err(e, "Cache Name"))?;
 
-    ACacheUpstream {
-        id: Set(CacheUpstreamId::now_v7()),
-        cache: Set(cache.id),
-        display_name: Set("cache.nixos.org".to_string()),
-        mode: Set(CacheSubscriptionMode::ReadOnly),
-        kind: Set(CacheUpstreamKind::Http),
-        upstream_cache: Set(None),
-        url: Set(Some("https://cache.nixos.org".to_string())),
-        public_key: Set(Some(
+    MCacheUpstream {
+        id: CacheUpstreamId::now_v7(),
+        cache: cache.id,
+        display_name: "cache.nixos.org".to_string(),
+        mode: CacheSubscriptionMode::ReadOnly,
+        kind: CacheUpstreamKind::Http,
+        url: Some("https://cache.nixos.org".to_string()),
+        public_key: Some(
             "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=".to_string(),
-        )),
-        remote_cache_name: Set(None),
-        api_key: Set(None),
+        ),
+        ..Default::default()
     }
+    .into_active_model()
     .insert(&tx)
     .await?;
 
-    ACacheUser {
-        id: Set(CacheUserId::now_v7()),
-        cache: Set(cache.id),
-        user: Set(user.id),
-        role: Set(BASE_CACHE_ROLE_ADMIN_ID),
+    MCacheUser {
+        id: CacheUserId::now_v7(),
+        cache: cache.id,
+        user: user.id,
+        role: BASE_CACHE_ROLE_ADMIN_ID,
     }
+    .into_active_model()
     .insert(&tx)
     .await?;
 

--- a/backend/gradient-web/src/endpoints/caches/members.rs
+++ b/backend/gradient-web/src/endpoints/caches/members.rs
@@ -17,8 +17,8 @@ use gradient_types::*;
 use gradient_core::ServerState;
 use sea_orm::ActiveValue::Set;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, Condition, EntityTrait, JoinType, PaginatorTrait, QueryFilter,
-    QuerySelect, RelationTrait,
+    ActiveModelTrait, ColumnTrait, Condition, EntityTrait, IntoActiveModel, JoinType,
+    PaginatorTrait, QueryFilter, QuerySelect, RelationTrait,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -159,12 +159,13 @@ pub async fn post_cache_member(
         .await?
         .or_not_found("Role")?;
 
-    ACacheUser {
-        id: Set(CacheUserId::now_v7()),
-        cache: Set(cache.id),
-        user: Set(target_user.id),
-        role: Set(role.id),
+    MCacheUser {
+        id: CacheUserId::now_v7(),
+        cache: cache.id,
+        user: target_user.id,
+        role: role.id,
     }
+    .into_active_model()
     .insert(&state.web_db)
     .await?;
 

--- a/backend/gradient-web/src/endpoints/caches/roles.rs
+++ b/backend/gradient-web/src/endpoints/caches/roles.rs
@@ -172,13 +172,14 @@ pub async fn post_cache_role(
         return Err(WebError::already_exists("Role Name"));
     }
 
-    let role = ACacheRole {
-        id: Set(RoleId::now_v7()),
-        name: Set(body.name.clone()),
-        cache: Set(Some(cache.id)),
-        permission: Set(mask),
-        managed: Set(false),
+    let role = MCacheRole {
+        id: RoleId::now_v7(),
+        name: body.name.clone(),
+        cache: Some(cache.id),
+        permission: mask,
+        ..Default::default()
     }
+    .into_active_model()
     .insert(&state.web_db)
     .await?;
 

--- a/backend/gradient-web/src/endpoints/caches/upstreams.rs
+++ b/backend/gradient-web/src/endpoints/caches/upstreams.rs
@@ -206,18 +206,16 @@ pub async fn put_cache_upstream(
                 ));
             }
             let name = display_name.unwrap_or_else(|| upstream.display_name.clone());
-            ACacheUpstream {
-                id: Set(CacheUpstreamId::now_v7()),
-                cache: Set(cache.id),
-                display_name: Set(name),
-                mode: Set(mode.unwrap_or(CacheSubscriptionMode::ReadWrite)),
-                kind: Set(CacheUpstreamKind::Internal),
-                upstream_cache: Set(Some(upstream.id)),
-                url: Set(None),
-                public_key: Set(None),
-                remote_cache_name: Set(None),
-                api_key: Set(None),
+            MCacheUpstream {
+                id: CacheUpstreamId::now_v7(),
+                cache: cache.id,
+                display_name: name,
+                mode: mode.unwrap_or(CacheSubscriptionMode::ReadWrite),
+                kind: CacheUpstreamKind::Internal,
+                upstream_cache: Some(upstream.id),
+                ..Default::default()
             }
+            .into_active_model()
         }
         AddUpstreamRequest::Http {
             display_name,
@@ -225,18 +223,17 @@ pub async fn put_cache_upstream(
             public_key,
         } => {
             validate_http(&url, &public_key)?;
-            ACacheUpstream {
-                id: Set(CacheUpstreamId::now_v7()),
-                cache: Set(cache.id),
-                display_name: Set(display_name),
-                mode: Set(CacheSubscriptionMode::ReadOnly),
-                kind: Set(CacheUpstreamKind::Http),
-                upstream_cache: Set(None),
-                url: Set(Some(url.trim().to_string())),
-                public_key: Set(Some(public_key)),
-                remote_cache_name: Set(None),
-                api_key: Set(None),
+            MCacheUpstream {
+                id: CacheUpstreamId::now_v7(),
+                cache: cache.id,
+                display_name,
+                mode: CacheSubscriptionMode::ReadOnly,
+                kind: CacheUpstreamKind::Http,
+                url: Some(url.trim().to_string()),
+                public_key: Some(public_key),
+                ..Default::default()
             }
+            .into_active_model()
         }
         AddUpstreamRequest::GradientProto {
             url,
@@ -256,18 +253,18 @@ pub async fn put_cache_upstream(
                 ),
                 _ => None,
             };
-            ACacheUpstream {
-                id: Set(CacheUpstreamId::now_v7()),
-                cache: Set(cache.id),
-                display_name: Set(display_name),
-                mode: Set(mode.unwrap_or(CacheSubscriptionMode::ReadOnly)),
-                kind: Set(CacheUpstreamKind::GradientProto),
-                upstream_cache: Set(None),
-                url: Set(Some(url.trim().to_string())),
-                public_key: Set(None),
-                remote_cache_name: Set(Some(remote_cache.trim().to_string())),
-                api_key: Set(api_key_enc),
+            MCacheUpstream {
+                id: CacheUpstreamId::now_v7(),
+                cache: cache.id,
+                display_name,
+                mode: mode.unwrap_or(CacheSubscriptionMode::ReadOnly),
+                kind: CacheUpstreamKind::GradientProto,
+                url: Some(url.trim().to_string()),
+                remote_cache_name: Some(remote_cache.trim().to_string()),
+                api_key: api_key_enc,
+                ..Default::default()
             }
+            .into_active_model()
         }
     };
 

--- a/backend/gradient-web/src/endpoints/orgs/integrations.rs
+++ b/backend/gradient-web/src/endpoints/orgs/integrations.rs
@@ -332,20 +332,21 @@ pub async fn put_integration(
 
     let allowed_ips = normalize_allowed_ips(body.allowed_ips.clone())?
         .and_then(|v| if v.is_empty() { None } else { Some(v) });
-    let integration = AIntegration {
-        id: Set(IntegrationId::now_v7()),
-        organization: Set(org.id),
-        name: Set(body.name),
-        display_name: Set(display_name),
-        kind: Set(i16::from(kind)),
-        forge_type: Set(i16::from(forge)),
-        secret: Set(encrypted_secret),
-        endpoint_url: Set(endpoint_url),
-        access_token: Set(encrypted_token),
-        allowed_ips: Set(allowed_ips),
-        created_by: Set(user.id),
-        created_at: Set(gradient_types::now()),
-    };
+    let integration = MIntegration {
+        id: IntegrationId::now_v7(),
+        organization: org.id,
+        name: body.name,
+        display_name,
+        kind: i16::from(kind),
+        forge_type: i16::from(forge),
+        secret: encrypted_secret,
+        endpoint_url,
+        access_token: encrypted_token,
+        allowed_ips,
+        created_by: user.id,
+        created_at: gradient_types::now(),
+    }
+    .into_active_model();
 
     let integration = integration.insert(&state.web_db).await?;
 

--- a/backend/gradient-web/src/endpoints/orgs/management.rs
+++ b/backend/gradient-web/src/endpoints/orgs/management.rs
@@ -20,8 +20,8 @@ use gradient_types::*;
 use gradient_core::ServerState;
 use sea_orm::ActiveValue::Set;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, EntityTrait, JoinType, PaginatorTrait, QueryFilter, QueryOrder,
-    QuerySelect, TransactionTrait,
+    ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, JoinType, PaginatorTrait,
+    QueryFilter, QueryOrder, QuerySelect, TransactionTrait,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -250,30 +250,31 @@ pub async fn put(
 
     let tx = state.web_db.inner().begin().await?;
 
-    let organization = AOrganization {
-        id: Set(OrganizationId::now_v7()),
-        name: Set(body.name.clone()),
-        display_name: Set(body.display_name.trim().to_string()),
-        description: Set(body.description.trim().to_string()),
-        public_key: Set(public_key),
-        private_key: Set(private_key),
-        public: Set(body.public.unwrap_or(false)),
-        hide_build_requests: Set(body.hide_build_requests.unwrap_or(false)),
-        created_by: Set(user.id),
-        created_at: Set(gradient_types::now()),
-        managed: Set(false),
-        github_installation_id: Set(None),
+    let organization = MOrganization {
+        id: OrganizationId::now_v7(),
+        name: body.name.clone(),
+        display_name: body.display_name.trim().to_string(),
+        description: body.description.trim().to_string(),
+        public_key,
+        private_key,
+        public: body.public.unwrap_or(false),
+        hide_build_requests: body.hide_build_requests.unwrap_or(false),
+        created_by: user.id,
+        created_at: gradient_types::now(),
+        ..Default::default()
     }
+    .into_active_model()
     .insert(&tx)
     .await
     .map_err(|e| WebError::from_db_err(e, "Organization Name"))?;
 
-    AOrganizationUser {
-        id: Set(OrganizationUserId::now_v7()),
-        organization: Set(organization.id),
-        user: Set(user.id),
-        role: Set(BASE_ROLE_ADMIN_ID),
+    MOrganizationUser {
+        id: OrganizationUserId::now_v7(),
+        organization: organization.id,
+        user: user.id,
+        role: BASE_ROLE_ADMIN_ID,
     }
+    .into_active_model()
     .insert(&tx)
     .await?;
 

--- a/backend/gradient-web/src/endpoints/orgs/members.rs
+++ b/backend/gradient-web/src/endpoints/orgs/members.rs
@@ -16,8 +16,8 @@ use gradient_types::*;
 use gradient_core::ServerState;
 use sea_orm::ActiveValue::Set;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, Condition, EntityTrait, JoinType, QueryFilter, QuerySelect,
-    RelationTrait,
+    ActiveModelTrait, ColumnTrait, Condition, EntityTrait, IntoActiveModel, JoinType, QueryFilter,
+    QuerySelect, RelationTrait,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -159,12 +159,13 @@ pub async fn post_organization_users(
         .await?
         .or_not_found("Role")?;
 
-    AOrganizationUser {
-        id: Set(OrganizationUserId::now_v7()),
-        organization: Set(organization.id),
-        user: Set(target_user.id),
-        role: Set(role.id),
+    MOrganizationUser {
+        id: OrganizationUserId::now_v7(),
+        organization: organization.id,
+        user: target_user.id,
+        role: role.id,
     }
+    .into_active_model()
     .insert(&state.web_db)
     .await?;
 

--- a/backend/gradient-web/src/endpoints/orgs/roles.rs
+++ b/backend/gradient-web/src/endpoints/orgs/roles.rs
@@ -197,13 +197,14 @@ pub async fn post_organization_role(
         return Err(WebError::already_exists("Role Name"));
     }
 
-    let role = ARole {
-        id: Set(RoleId::now_v7()),
-        name: Set(body.name.clone()),
-        organization: Set(Some(org.id)),
-        permission: Set(mask),
-        managed: Set(false),
+    let role = MRole {
+        id: RoleId::now_v7(),
+        name: body.name.clone(),
+        organization: Some(org.id),
+        permission: mask,
+        ..Default::default()
     }
+    .into_active_model()
     .insert(&state.web_db)
     .await?;
 

--- a/backend/gradient-web/src/endpoints/orgs/settings.rs
+++ b/backend/gradient-web/src/endpoints/orgs/settings.rs
@@ -16,7 +16,7 @@ use gradient_db::permissions::CachePermission;
 use gradient_types::*;
 use gradient_core::ServerState;
 use sea_orm::ActiveValue::Set;
-use sea_orm::{ActiveModelTrait, ColumnTrait, Condition, EntityTrait, QueryFilter};
+use sea_orm::{ActiveModelTrait, ColumnTrait, Condition, EntityTrait, IntoActiveModel, QueryFilter};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -173,12 +173,13 @@ pub async fn post_organization_subscribe_cache(
         CacheSubscriptionMode::ReadWrite | CacheSubscriptionMode::WriteOnly
     );
 
-    AOrganizationCache {
-        id: Set(OrganizationCacheId::now_v7()),
-        organization: Set(org.id),
-        cache: Set(cache.id),
-        mode: Set(mode),
+    MOrganizationCache {
+        id: OrganizationCacheId::now_v7(),
+        organization: org.id,
+        cache: cache.id,
+        mode,
     }
+    .into_active_model()
     .insert(&state.web_db)
     .await?;
 
@@ -256,15 +257,15 @@ async fn enqueue_backfill_signatures(
         if exists {
             continue;
         }
-        let am = ACachedPathSignature {
-            id: Set(CachedPathSignatureId::now_v7()),
-            cached_path: Set(cp_id),
-            cache: Set(cache_id),
-            signature: Set(None),
-            created_at: Set(now),
-            last_fetched_at: Set(None),
-            fetch_count: Set(0),
-        };
+        let am = MCachedPathSignature {
+            id: CachedPathSignatureId::now_v7(),
+            cached_path: cp_id,
+            cache: cache_id,
+            created_at: now,
+            ..Default::default()
+        }
+        .into_active_model();
+
         if let Err(e) = am.insert(&state.web_db).await {
             tracing::warn!(cached_path = %cp_id, cache = %cache_id, error = %e, "backfill: placeholder insert failed");
         }

--- a/backend/gradient-web/src/endpoints/orgs/workers.rs
+++ b/backend/gradient-web/src/endpoints/orgs/workers.rs
@@ -12,6 +12,7 @@ use base64::Engine as _;
 use chrono::NaiveDateTime;
 use gradient_entity::worker_registration::{
     self, ActiveModel as AWorkerRegistration, Entity as EWorkerRegistration,
+    Model as MWorkerRegistration,
 };
 use gradient_types::ids::*;
 use gradient_types::proto::GradientCapabilities;
@@ -21,8 +22,8 @@ use rand::RngExt as _;
 use gradient_scheduler::{Scheduler, WorkerInfo};
 use sea_orm::ActiveValue::Set;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder,
-    QuerySelect,
+    ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, PaginatorTrait, QueryFilter,
+    QueryOrder, QuerySelect,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -160,21 +161,23 @@ pub async fn post_org_worker(
 
     let token_hash = password_auth::generate_hash(&token);
 
-    let row = AWorkerRegistration {
-        id: Set(WorkerRegistrationId::now_v7()),
-        peer_id: Set(org.id),
-        worker_id: Set(worker_id_str.clone()),
-        token_hash: Set(token_hash),
-        managed: Set(false),
-        url: Set(body.url),
-        display_name: Set(body.display_name.trim().to_string()),
-        active: Set(true),
-        enable_fetch: Set(body.enable_fetch),
-        enable_eval: Set(body.enable_eval),
-        enable_build: Set(body.enable_build),
-        created_by: Set(Some(user.id)),
-        created_at: Set(gradient_types::now()),
-    };
+    let row = MWorkerRegistration {
+        id: WorkerRegistrationId::now_v7(),
+        peer_id: org.id,
+        worker_id: worker_id_str.clone(),
+        token_hash,
+        url: body.url,
+        display_name: body.display_name.trim().to_string(),
+        active: true,
+        enable_fetch: body.enable_fetch,
+        enable_eval: body.enable_eval,
+        enable_build: body.enable_build,
+        created_by: Some(user.id),
+        created_at: gradient_types::now(),
+        ..Default::default()
+    }
+    .into_active_model();
+
     row.insert(&state.web_db).await?;
 
     // Trigger re-auth if the worker is already connected, so it picks up

--- a/backend/gradient-web/src/endpoints/projects/actions.rs
+++ b/backend/gradient-web/src/endpoints/projects/actions.rs
@@ -25,7 +25,8 @@ use gradient_types::*;
 use gradient_core::ServerState;
 use sea_orm::ActiveValue::Set;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, EntityTrait, Order, QueryFilter, QueryOrder, QuerySelect,
+    ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, Order, QueryFilter, QueryOrder,
+    QuerySelect,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
@@ -262,22 +263,22 @@ pub async fn create_action(
     };
 
     let now = Utc::now().naive_utc();
-    let am =
-        AProjectAction {
-            id: Set(ProjectActionId::now_v7()),
-            project: Set(proj.id),
-            name: Set(body.name),
-            action_type: Set(stored_config.action_type().to_i16()),
-            config: Set(serde_json::to_value(&stored_config)
-                .map_err(|e| WebError::internal(e.to_string()))?),
-            events: Set(serde_json::to_value(&body.events)
-                .map_err(|e| WebError::internal(e.to_string()))?),
-            active: Set(body.active),
-            last_fired_at: Set(None),
-            created_by: Set(user.id),
-            created_at: Set(now),
-            updated_at: Set(now),
-        };
+    let am = MProjectAction {
+        id: ProjectActionId::now_v7(),
+        project: proj.id,
+        name: body.name,
+        action_type: stored_config.action_type().to_i16(),
+        config: serde_json::to_value(&stored_config)
+            .map_err(|e| WebError::internal(e.to_string()))?,
+        events: serde_json::to_value(&body.events).map_err(|e| WebError::internal(e.to_string()))?,
+        active: body.active,
+        created_by: user.id,
+        created_at: now,
+        updated_at: now,
+        ..Default::default()
+    }
+    .into_active_model();
+
     let m = am
         .insert(&state.web_db)
         .await

--- a/backend/gradient-web/src/endpoints/projects/flake_inputs.rs
+++ b/backend/gradient-web/src/endpoints/projects/flake_inputs.rs
@@ -16,7 +16,9 @@ use chrono::Utc;
 use gradient_types::*;
 use gradient_core::ServerState;
 use sea_orm::ActiveValue::Set;
-use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, QueryOrder,
+};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -163,14 +165,15 @@ pub async fn create(
     }
 
     let now = Utc::now().naive_utc();
-    let row = AProjectFlakeInputOverride {
-        id: Set(FlakeInputOverrideId::now_v7()),
-        project: Set(proj.id),
-        input_name: Set(body.input_name),
-        url: Set(body.url),
-        created_at: Set(now),
-        updated_at: Set(now),
+    let row = MProjectFlakeInputOverride {
+        id: FlakeInputOverrideId::now_v7(),
+        project: proj.id,
+        input_name: body.input_name,
+        url: body.url,
+        created_at: now,
+        updated_at: now,
     }
+    .into_active_model()
     .insert(&state.web_db)
     .await?;
 

--- a/backend/gradient-web/src/endpoints/projects/management.rs
+++ b/backend/gradient-web/src/endpoints/projects/management.rs
@@ -25,7 +25,8 @@ use gradient_types::*;
 use gradient_core::ServerState;
 use sea_orm::ActiveValue::Set;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, Condition, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder,
+    ActiveModelTrait, ColumnTrait, Condition, EntityTrait, IntoActiveModel, PaginatorTrait,
+    QueryFilter, QueryOrder,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -241,27 +242,24 @@ pub async fn put(
         .map_err(|e| WebError::bad_request(e.to_string()))?
         .to_string();
 
-    let project = AProject {
-        id: Set(ProjectId::now_v7()),
-        organization: Set(organization.id),
-        name: Set(body.name.clone()),
-        active: Set(true),
-        display_name: Set(body.display_name.trim().to_string()),
-        description: Set(body.description.trim().to_string()),
-        repository: Set(body.repository.clone()),
-        wildcard: Set(wildcard),
-        last_evaluation: Set(None),
-        last_check_at: Set(*NULL_TIME),
-        force_evaluation: Set(false),
-        created_by: Set(user.id),
-        created_at: Set(gradient_types::now()),
-        managed: Set(false),
-        keep_evaluations: Set(30),
-        concurrency: Set(i16::from(
-            body.concurrency.unwrap_or(ConcurrencyPolicy::SoftAbort),
-        )),
-        sign_cache: Set(body.sign_cache.unwrap_or(true)),
-    };
+    let project = MProject {
+        id: ProjectId::now_v7(),
+        organization: organization.id,
+        name: body.name.clone(),
+        active: true,
+        display_name: body.display_name.trim().to_string(),
+        description: body.description.trim().to_string(),
+        repository: body.repository.clone(),
+        wildcard,
+        last_check_at: *NULL_TIME,
+        created_by: user.id,
+        created_at: gradient_types::now(),
+        keep_evaluations: 30,
+        concurrency: i16::from(body.concurrency.unwrap_or(ConcurrencyPolicy::SoftAbort)),
+        sign_cache: body.sign_cache.unwrap_or(true),
+        ..Default::default()
+    }
+    .into_active_model();
 
     let project = project.insert(&state.web_db).await?;
 
@@ -270,16 +268,17 @@ pub async fn put(
         interval_secs: 300,
         branch: None,
     };
-    AProjectTrigger {
-        id: Set(ProjectTriggerId::now_v7()),
-        project: Set(project.id),
-        trigger_type: Set(i16::from(TriggerType::Polling)),
-        config: Set(default_cfg.to_db_json()),
-        active: Set(true),
-        last_fired_at: Set(None),
-        created_at: Set(now),
-        updated_at: Set(now),
+    MProjectTrigger {
+        id: ProjectTriggerId::now_v7(),
+        project: project.id,
+        trigger_type: i16::from(TriggerType::Polling),
+        config: default_cfg.to_db_json(),
+        active: true,
+        created_at: now,
+        updated_at: now,
+        ..Default::default()
     }
+    .into_active_model()
     .insert(&state.web_db)
     .await?;
 

--- a/backend/gradient-web/src/endpoints/projects/triggers.rs
+++ b/backend/gradient-web/src/endpoints/projects/triggers.rs
@@ -23,7 +23,9 @@ use gradient_types::*;
 use gradient_core::ServerState;
 use gradient_scheduler::Scheduler;
 use sea_orm::ActiveValue::Set;
-use sea_orm::{ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, IntoActiveModel, QueryFilter,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -210,16 +212,17 @@ pub async fn create(
     let trigger_type = body.config.trigger_type();
     let config_json = body.config.to_db_json();
 
-    let row = AProjectTrigger {
-        id: Set(ProjectTriggerId::now_v7()),
-        project: Set(proj.id),
-        trigger_type: Set(i16::from(trigger_type)),
-        config: Set(config_json),
-        active: Set(body.active),
-        last_fired_at: Set(None),
-        created_at: Set(now),
-        updated_at: Set(now),
+    let row = MProjectTrigger {
+        id: ProjectTriggerId::now_v7(),
+        project: proj.id,
+        trigger_type: i16::from(trigger_type),
+        config: config_json,
+        active: body.active,
+        created_at: now,
+        updated_at: now,
+        ..Default::default()
     }
+    .into_active_model()
     .insert(&state.web_db)
     .await?;
 

--- a/backend/gradient-web/src/endpoints/user.rs
+++ b/backend/gradient-web/src/endpoints/user.rs
@@ -453,21 +453,22 @@ pub async fn post_keys(
 
     let allowed_ips = normalize_allowed_ips(body.allowed_ips.clone())?;
     let raw_key = generate_api_key();
-    let api_key = AApi {
-        id: Set(ApiId::now_v7()),
-        owned_by: Set(user.id),
-        name: Set(body.name.clone()),
-        key: Set(hash_api_key(&raw_key)),
-        last_used_at: Set(*NULL_TIME),
-        created_at: Set(gradient_types::now()),
-        managed: Set(false),
-        expires_at: Set(expires_at),
-        revoked_at: Set(None),
-        permission: Set(mask),
-        organization: Set(org_pin),
-        cache: Set(cache_pin),
-        allowed_ips: Set(allowed_ips),
-    };
+    let api_key = MApi {
+        id: ApiId::now_v7(),
+        owned_by: user.id,
+        name: body.name.clone(),
+        key: hash_api_key(&raw_key),
+        last_used_at: *NULL_TIME,
+        created_at: gradient_types::now(),
+        expires_at,
+        permission: mask,
+        organization: org_pin,
+        cache: cache_pin,
+        allowed_ips,
+        ..Default::default()
+    }
+    .into_active_model();
+
     let inserted = api_key.insert(&state.web_db).await?;
 
     audit_record(


### PR DESCRIPTION
Convert all ~91 sea-orm entity creation sites from `ActiveModel { field: Set(v), .. }` to `Model { .. }.into_active_model()` (type-default fields collapsed into `..Default::default()`). Behavior-preserving: update paths are untouched and clippy is clean.