### PR TITLE
fix(web,frontend): live evaluation progress + project-page perf/UX fixes

### DIFF
--- a/backend/gradient-scheduler/src/eval.rs
+++ b/backend/gradient-scheduler/src/eval.rs
@@ -769,6 +769,15 @@ pub async fn handle_eval_result(
         tracing::warn!(error = %e, "failed to dispatch build.substituted events");
     }
 
+    // Builds and entry-points are inserted directly (no status transition), so
+    // the live channels would otherwise stay silent for the whole evaluation
+    // phase. Ping subscribers so the project/eval pages refetch and grow their
+    // build totals as each batch lands.
+    let _ = state.board_events.send(BoardEvent::EvaluationProgress {
+        project: job.project_id.map(|p| p.into_inner()),
+        evaluation_id: evaluation_id.into_inner(),
+    });
+
     debug!(
         %evaluation_id,
         new_derivations = derivations.len(),

--- a/backend/gradient-types/src/board_events.rs
+++ b/backend/gradient-types/src/board_events.rs
@@ -49,6 +49,14 @@ pub enum BoardEvent {
         build_id: Uuid,
         status: i16,
     },
+    /// New builds/entry-points were persisted for an in-progress evaluation. A
+    /// content-free ping (subscribers refetch their own scope) that lets the
+    /// live UI grow the build/dependency totals during the evaluation phase,
+    /// before any build reaches a status change.
+    EvaluationProgress {
+        project: Option<Uuid>,
+        evaluation_id: Uuid,
+    },
     /// Cache contents or stats changed (build cached, NAR deleted, GC). A
     /// content-free ping: subscribers refetch their own scope-filtered view.
     CacheChanged,

--- a/backend/gradient-web/src/endpoints/board.rs
+++ b/backend/gradient-web/src/endpoints/board.rs
@@ -729,6 +729,7 @@ fn mask_event(ev: &BoardEvent, scope: &MetricsScope) -> Option<String> {
         // Resource-scoped events are served by the per-resource /live channels.
         BoardEvent::EvaluationStatusChanged { .. }
         | BoardEvent::BuildStatusChanged { .. }
+        | BoardEvent::EvaluationProgress { .. }
         | BoardEvent::CacheChanged => false,
     };
 

--- a/backend/gradient-web/src/endpoints/builds/log.rs
+++ b/backend/gradient-web/src/endpoints/builds/log.rs
@@ -28,8 +28,8 @@ pub async fn get_build_log(
     Extension(api_key): Extension<MaybeApiKey>,
     Path(build_id): Path<BuildId>,
 ) -> WebResult<Json<BaseResponse<String>>> {
-    let _ctx = BuildAccessContext::load(&state, build_id, &maybe_user, api_key.as_ref()).await?;
-    let log_key = latest_attempt_log_id(&state.web_db, build_id).await?;
+    let ctx = BuildAccessContext::load(&state, build_id, &maybe_user, api_key.as_ref()).await?;
+    let log_key = super::effective_log_id(&state, &ctx.build).await;
     let log = state.log_storage.read(log_key).await.unwrap_or_default();
 
     Ok(ok_json(log))

--- a/backend/gradient-web/src/endpoints/builds/log_chunks.rs
+++ b/backend/gradient-web/src/endpoints/builds/log_chunks.rs
@@ -21,7 +21,6 @@ use serde::Deserialize;
 use std::sync::Arc;
 
 use super::BuildAccessContext;
-use gradient_db::latest_attempt_log_id;
 
 type ChunkRow = gradient_entity::build_log_chunk::Model;
 
@@ -45,8 +44,8 @@ pub async fn get_build_log_chunks(
     Extension(api_key): Extension<MaybeApiKey>,
     Path(build_id): Path<BuildId>,
 ) -> WebResult<Json<BaseResponse<LogChunkIndex>>> {
-    let _ctx = BuildAccessContext::load(&state, build_id, &maybe_user, api_key.as_ref()).await?;
-    let log_key = latest_attempt_log_id(&state.web_db, build_id).await?;
+    let ctx = BuildAccessContext::load(&state, build_id, &maybe_user, api_key.as_ref()).await?;
+    let log_key = super::effective_log_id(&state, &ctx.build).await;
     let rows = load_chunk_rows(&state, log_key).await?;
 
     let chunks: Vec<LogChunkMeta> = rows
@@ -82,8 +81,8 @@ pub async fn get_build_log_chunk(
     Extension(api_key): Extension<MaybeApiKey>,
     Path((build_id, index)): Path<(BuildId, u32)>,
 ) -> Result<Response, WebError> {
-    let _ctx = BuildAccessContext::load(&state, build_id, &maybe_user, api_key.as_ref()).await?;
-    let log_key = latest_attempt_log_id(&state.web_db, build_id).await?;
+    let ctx = BuildAccessContext::load(&state, build_id, &maybe_user, api_key.as_ref()).await?;
+    let log_key = super::effective_log_id(&state, &ctx.build).await;
 
     let row = gradient_entity::build_log_chunk::Entity::find()
         .filter(gradient_entity::build_log_chunk::Column::Build.eq(log_key))
@@ -137,8 +136,8 @@ pub async fn get_build_log_lines(
     Path(build_id): Path<BuildId>,
     Query(q): Query<LineRangeQuery>,
 ) -> Result<Response, WebError> {
-    let _ctx = BuildAccessContext::load(&state, build_id, &maybe_user, api_key.as_ref()).await?;
-    let log_key = latest_attempt_log_id(&state.web_db, build_id).await?;
+    let ctx = BuildAccessContext::load(&state, build_id, &maybe_user, api_key.as_ref()).await?;
+    let log_key = super::effective_log_id(&state, &ctx.build).await;
     let rows = load_chunk_rows(&state, log_key).await?;
 
     let (start, end_opt) = parse_line_range(&q)?;
@@ -205,8 +204,8 @@ pub async fn get_build_log_search(
     Path(build_id): Path<BuildId>,
     Query(query): Query<SearchQuery>,
 ) -> Result<Response, WebError> {
-    let _ctx = BuildAccessContext::load(&state, build_id, &maybe_user, api_key.as_ref()).await?;
-    let log_key = latest_attempt_log_id(&state.web_db, build_id).await?;
+    let ctx = BuildAccessContext::load(&state, build_id, &maybe_user, api_key.as_ref()).await?;
+    let log_key = super::effective_log_id(&state, &ctx.build).await;
     let rows = load_chunk_rows(&state, log_key).await?;
     let state = Arc::clone(&state);
 

--- a/backend/gradient-web/src/endpoints/builds/mod.rs
+++ b/backend/gradient-web/src/endpoints/builds/mod.rs
@@ -32,9 +32,11 @@ use crate::access::is_org_member;
 use crate::authorization::ApiKeyContext;
 use crate::error::{WebError, WebResult};
 use crate::helpers::OptionExt;
+use gradient_db::latest_attempt_log_id;
+use gradient_entity::build::BuildStatus;
 use gradient_types::*;
 use gradient_core::ServerState;
-use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect};
 use std::sync::Arc;
 
 /// Resolved access context for a build.
@@ -176,4 +178,49 @@ async fn follower_orgs_accessible(
         }
     }
     Ok(false)
+}
+
+/// The build whose stored log should be served for `build`.
+///
+/// A `Substituted` (or cache-completed) build produces no log of its own, so
+/// fall back to the most recent prior build of the same derivation that has one
+/// - the build that originally produced those outputs.
+pub(super) async fn effective_log_id(state: &Arc<ServerState>, build: &MBuild) -> BuildId {
+    let own = latest_attempt_log_id(&state.web_db, build.id)
+        .await
+        .unwrap_or(build.id);
+    if log_has_content(state, own).await {
+        return own;
+    }
+    if matches!(build.status, BuildStatus::Substituted | BuildStatus::Completed) {
+        let siblings = EBuild::find()
+            .filter(CBuild::Derivation.eq(build.derivation))
+            .filter(CBuild::Id.ne(build.id))
+            .filter(CBuild::Status.is_in([BuildStatus::Completed, BuildStatus::Substituted]))
+            .order_by_desc(CBuild::CreatedAt)
+            .limit(8)
+            .all(&state.web_db)
+            .await
+            .unwrap_or_default();
+        for sib in siblings {
+            let key = latest_attempt_log_id(&state.web_db, sib.id)
+                .await
+                .unwrap_or(sib.id);
+            if log_has_content(state, key).await {
+                return key;
+            }
+        }
+    }
+    own
+}
+
+/// A log exists either as finalized zstd chunks or an in-progress inline blob.
+async fn log_has_content(state: &Arc<ServerState>, log_key: BuildId) -> bool {
+    let has_chunk = gradient_entity::build_log_chunk::Entity::find()
+        .filter(gradient_entity::build_log_chunk::Column::Build.eq(log_key))
+        .one(&state.web_db)
+        .await
+        .map(|r| r.is_some())
+        .unwrap_or(false);
+    has_chunk || matches!(state.log_storage.read(log_key).await, Ok(b) if !b.is_empty())
 }

--- a/backend/gradient-web/src/endpoints/live.rs
+++ b/backend/gradient-web/src/endpoints/live.rs
@@ -98,6 +98,10 @@ fn project_frame(ev: &BoardEvent, project_id: Uuid, known: &mut HashSet<Uuid>) -
             project: Some(p),
             evaluation_id,
             ..
+        }
+        | BoardEvent::EvaluationProgress {
+            project: Some(p),
+            evaluation_id,
         } if *p == project_id => {
             known.insert(*evaluation_id);
             frame(ev)
@@ -143,6 +147,7 @@ fn eval_frame(ev: &BoardEvent, eval_id: Uuid) -> Option<String> {
     match ev {
         BoardEvent::EvaluationStatusChanged { evaluation_id, .. }
         | BoardEvent::BuildStatusChanged { evaluation_id, .. }
+        | BoardEvent::EvaluationProgress { evaluation_id, .. }
             if *evaluation_id == eval_id =>
         {
             frame(ev)
@@ -181,6 +186,12 @@ mod tests {
             status: 2,
         }
     }
+    fn progress(eval: Uuid, project: Option<Uuid>) -> BoardEvent {
+        BoardEvent::EvaluationProgress {
+            project,
+            evaluation_id: eval,
+        }
+    }
 
     #[test]
     fn eval_channel_matches_only_its_evaluation() {
@@ -188,6 +199,8 @@ mod tests {
         let other = Uuid::from_u128(2);
         assert!(eval_frame(&eval_changed(me, None), me).is_some());
         assert!(eval_frame(&build_changed(me), me).is_some());
+        assert!(eval_frame(&progress(me, None), me).is_some());
+        assert!(eval_frame(&progress(other, None), me).is_none());
         assert!(eval_frame(&build_changed(other), me).is_none());
         assert!(eval_frame(&BoardEvent::CacheChanged, me).is_none());
     }
@@ -215,6 +228,20 @@ mod tests {
         let eval = Uuid::from_u128(8);
         let mut known = HashSet::from([eval]);
         assert!(project_frame(&build_changed(eval), project, &mut known).is_some());
+    }
+
+    #[test]
+    fn project_channel_forwards_progress_and_learns_its_eval() {
+        let project = Uuid::from_u128(7);
+        let eval = Uuid::from_u128(8);
+        let mut known = HashSet::new();
+
+        // A progress ping for our project is forwarded and remembers the eval,
+        // so subsequent build events for it flow even before any status change.
+        assert!(project_frame(&progress(eval, Some(project)), project, &mut known).is_some());
+        assert!(project_frame(&build_changed(eval), project, &mut known).is_some());
+        // Another project's progress is ignored.
+        assert!(project_frame(&progress(eval, Some(Uuid::from_u128(5))), project, &mut HashSet::new()).is_none());
     }
 
     #[test]

--- a/backend/gradient-web/src/endpoints/projects/evaluations.rs
+++ b/backend/gradient-web/src/endpoints/projects/evaluations.rs
@@ -26,7 +26,10 @@ use gradient_storage::nar_extract::{ExtractError, Extracted, extract_path_from_n
 use gradient_types::input::vec_to_hex;
 use gradient_types::*;
 use gradient_core::ServerState;
-use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect};
+use sea_orm::{
+    ColumnTrait, DbBackend, EntityTrait, FromQueryResult, QueryFilter, QueryOrder, QuerySelect,
+    Statement,
+};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -495,19 +498,24 @@ impl EntryPointRelatedData {
 
         let build_time_ms: HashMap<BuildId, Option<i64>> = {
             let ids: Vec<BuildId> = entry_points.iter().map(|ep| ep.build).collect();
+            // Latest attempt per build via DISTINCT ON, so the list never loads
+            // every historical attempt just to keep the newest one.
             let attempts = gradient_db::fetch_in_chunks(&ids, |chunk| async move {
-                EBuildAttempt::find()
-                    .filter(CBuildAttempt::Build.is_in(chunk))
-                    .order_by_desc(CBuildAttempt::CreatedAt)
+                let in_list = chunk
+                    .iter()
+                    .map(|id| format!("'{}'", id.into_inner()))
+                    .collect::<Vec<_>>()
+                    .join(",");
+                let sql = format!(
+                    "SELECT DISTINCT ON (build) * FROM build_attempt \
+                     WHERE build IN ({in_list}) ORDER BY build, created_at DESC"
+                );
+                MBuildAttempt::find_by_statement(Statement::from_string(DbBackend::Postgres, sql))
                     .all(db)
                     .await
             })
             .await?;
-            let mut latest: HashMap<BuildId, MBuildAttempt> = HashMap::new();
-            for a in attempts {
-                latest.entry(a.build).or_insert(a);
-            }
-            latest.into_iter().map(|(b, a)| (b, a.duration_ms())).collect()
+            attempts.into_iter().map(|a| (a.build, a.duration_ms())).collect()
         };
 
         let seeds: Vec<(EntryPointId, uuid::Uuid)> = entry_points

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -74,6 +74,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,7 +150,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -152,7 +161,16 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -202,6 +220,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -266,6 +305,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,12 +332,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
 
 [[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
-
-[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -373,7 +418,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -418,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -519,16 +564,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossterm"
-version = "0.28.1"
+name = "critical-section"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "crossterm_winapi",
+ "derive_more",
+ "document-features",
  "mio",
  "parking_lot",
- "rustix 0.38.44",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -563,6 +616,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,7 +649,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -609,7 +672,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -620,7 +683,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -648,6 +711,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,6 +724,15 @@ checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -676,7 +754,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -703,7 +781,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
 ]
@@ -737,7 +815,16 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -802,6 +889,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,10 +926,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "float-cmp"
@@ -839,6 +974,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -911,7 +1052,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1000,7 +1141,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -1032,8 +1173,8 @@ dependencies = [
  "rpassword",
  "serde",
  "serde_json",
- "strum 0.28.0",
- "strum_macros 0.28.0",
+ "strum",
+ "strum_macros",
  "tempfile",
  "tokio",
  "toml",
@@ -1062,17 +1203,17 @@ dependencies = [
 [[package]]
 name = "harmonia-file-core"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#cd48b0110b714ddb9b9e60addb97d8a69d431a3c"
+source = "git+https://github.com/nix-community/harmonia.git#f0dd1094cdc8d72e038cf9347cacfa9272a8f72d"
 dependencies = [
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "harmonia-file-nar"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#cd48b0110b714ddb9b9e60addb97d8a69d431a3c"
+source = "git+https://github.com/nix-community/harmonia.git#f0dd1094cdc8d72e038cf9347cacfa9272a8f72d"
 dependencies = [
  "bstr",
  "bytes",
@@ -1082,11 +1223,11 @@ dependencies = [
  "futures-util",
  "harmonia-file-core",
  "harmonia-utils-io",
- "nix",
+ "nix 0.31.3",
  "pin-project-lite",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1096,7 +1237,7 @@ dependencies = [
 [[package]]
 name = "harmonia-protocol"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#cd48b0110b714ddb9b9e60addb97d8a69d431a3c"
+source = "git+https://github.com/nix-community/harmonia.git#f0dd1094cdc8d72e038cf9347cacfa9272a8f72d"
 dependencies = [
  "async-stream",
  "bstr",
@@ -1121,7 +1262,7 @@ dependencies = [
  "pin-project-lite",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1130,17 +1271,17 @@ dependencies = [
 [[package]]
 name = "harmonia-protocol-derive"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#cd48b0110b714ddb9b9e60addb97d8a69d431a3c"
+source = "git+https://github.com/nix-community/harmonia.git#f0dd1094cdc8d72e038cf9347cacfa9272a8f72d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "harmonia-store-aterm"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#cd48b0110b714ddb9b9e60addb97d8a69d431a3c"
+source = "git+https://github.com/nix-community/harmonia.git#f0dd1094cdc8d72e038cf9347cacfa9272a8f72d"
 dependencies = [
  "bytes",
  "harmonia-store-content-address",
@@ -1150,13 +1291,13 @@ dependencies = [
  "harmonia-utils-hash",
  "memchr",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "harmonia-store-build-result"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#cd48b0110b714ddb9b9e60addb97d8a69d431a3c"
+source = "git+https://github.com/nix-community/harmonia.git#f0dd1094cdc8d72e038cf9347cacfa9272a8f72d"
 dependencies = [
  "harmonia-store-derivation",
  "num_enum",
@@ -1167,19 +1308,19 @@ dependencies = [
 [[package]]
 name = "harmonia-store-content-address"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#cd48b0110b714ddb9b9e60addb97d8a69d431a3c"
+source = "git+https://github.com/nix-community/harmonia.git#f0dd1094cdc8d72e038cf9347cacfa9272a8f72d"
 dependencies = [
  "derive_more",
  "harmonia-store-path",
  "harmonia-utils-hash",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "harmonia-store-derivation"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#cd48b0110b714ddb9b9e60addb97d8a69d431a3c"
+source = "git+https://github.com/nix-community/harmonia.git#f0dd1094cdc8d72e038cf9347cacfa9272a8f72d"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -1191,27 +1332,27 @@ dependencies = [
  "harmonia-utils-signature",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "zerocopy",
 ]
 
 [[package]]
 name = "harmonia-store-path"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#cd48b0110b714ddb9b9e60addb97d8a69d431a3c"
+source = "git+https://github.com/nix-community/harmonia.git#f0dd1094cdc8d72e038cf9347cacfa9272a8f72d"
 dependencies = [
  "derive_more",
  "harmonia-utils-base-encoding",
  "harmonia-utils-hash",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
  "zerocopy",
 ]
 
 [[package]]
 name = "harmonia-store-path-info"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#cd48b0110b714ddb9b9e60addb97d8a69d431a3c"
+source = "git+https://github.com/nix-community/harmonia.git#f0dd1094cdc8d72e038cf9347cacfa9272a8f72d"
 dependencies = [
  "harmonia-store-content-address",
  "harmonia-store-path",
@@ -1223,7 +1364,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-remote"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#cd48b0110b714ddb9b9e60addb97d8a69d431a3c"
+source = "git+https://github.com/nix-community/harmonia.git#f0dd1094cdc8d72e038cf9347cacfa9272a8f72d"
 dependencies = [
  "async-stream",
  "futures-core",
@@ -1243,7 +1384,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-base-encoding"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#cd48b0110b714ddb9b9e60addb97d8a69d431a3c"
+source = "git+https://github.com/nix-community/harmonia.git#f0dd1094cdc8d72e038cf9347cacfa9272a8f72d"
 dependencies = [
  "data-encoding",
  "derive_more",
@@ -1253,7 +1394,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-hash"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#cd48b0110b714ddb9b9e60addb97d8a69d431a3c"
+source = "git+https://github.com/nix-community/harmonia.git#f0dd1094cdc8d72e038cf9347cacfa9272a8f72d"
 dependencies = [
  "blake3",
  "data-encoding",
@@ -1264,19 +1405,19 @@ dependencies = [
  "serde",
  "sha1",
  "sha2 0.11.0",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
 [[package]]
 name = "harmonia-utils-io"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#cd48b0110b714ddb9b9e60addb97d8a69d431a3c"
+source = "git+https://github.com/nix-community/harmonia.git#f0dd1094cdc8d72e038cf9347cacfa9272a8f72d"
 dependencies = [
  "bytes",
  "futures-util",
  "libc",
- "nix",
+ "nix 0.31.3",
  "pin-project-lite",
  "tokio",
 ]
@@ -1284,7 +1425,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-signature"
 version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#cd48b0110b714ddb9b9e60addb97d8a69d431a3c"
+source = "git+https://github.com/nix-community/harmonia.git#f0dd1094cdc8d72e038cf9347cacfa9272a8f72d"
 dependencies = [
  "data-encoding",
  "ed25519-dalek",
@@ -1292,7 +1433,7 @@ dependencies = [
  "harmonia-utils-base-encoding",
  "serde",
  "subtle",
- "thiserror",
+ "thiserror 2.0.18",
  "zeroize",
 ]
 
@@ -1302,9 +1443,18 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1312,6 +1462,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -1324,6 +1479,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -1587,7 +1748,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1613,9 +1774,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1638,7 +1799,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
  "windows-link",
 ]
@@ -1653,7 +1814,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1672,7 +1833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1687,14 +1848,31 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.100"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
 name = "lazy_static"
@@ -1727,6 +1905,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1748,10 +1932,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
+name = "line-clipping"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.13.0",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1764,6 +1951,12 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -1782,11 +1975,11 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1796,6 +1989,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix 0.29.0",
+ "winapi",
+]
+
+[[package]]
 name = "md5"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1803,9 +2006,15 @@ checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
 
 [[package]]
 name = "memoffset"
@@ -1833,6 +2042,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1846,11 +2061,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1858,10 +2073,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "num-traits"
@@ -1901,7 +2156,16 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1927,6 +2191,39 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1975,16 +2272,105 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2009,6 +2395,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2016,6 +2408,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2063,7 +2461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2095,7 +2493,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "parking_lot",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2112,7 +2510,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -2134,7 +2532,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2174,6 +2572,15 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "rand_core 0.6.4",
+]
 
 [[package]]
 name = "rand"
@@ -2232,23 +2639,92 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ratatui"
-version = "0.29.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+checksum = "1695748e3a735b34968c887ceea5a380b43545903868ae8f5b666593100f6b68"
 dependencies = [
- "bitflags",
- "cassowary",
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+ "serde",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3603f354bba8c595fa47860e60142d7372b7210c27044c6a7d0e1a4336b44"
+dependencies = [
+ "bitflags 2.13.0",
  "compact_str",
+ "critical-section",
+ "hashbrown 0.17.1",
+ "indoc",
+ "itertools",
+ "kasuari",
+ "lru",
+ "palette",
+ "serde",
+ "strum",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2867bedcbd6a690ca4f8672a687b730ec07660c79844517b084311b529980c"
+dependencies = [
+ "cfg-if",
  "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80fac59720679490d89d200df411faa249be728681adcabed3d047ae72c48f1d"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "386b8ff8f74ed749509391c56d549761a2fcdb408e1f42e467286bcb7dac8967"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef4f17dd7ac3abf5adc2b920a03c61eee4bfe6a88fa5191936895525371d79c"
+dependencies = [
+ "bitflags 2.13.0",
+ "hashbrown 0.17.1",
  "indoc",
  "instability",
  "itertools",
- "lru",
- "paste",
- "strum 0.26.3",
+ "line-clipping",
+ "ratatui-core",
+ "serde",
+ "strum",
+ "time",
  "unicode-segmentation",
- "unicode-truncate",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2257,7 +2733,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -2268,7 +2744,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2347,9 +2823,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest-streams"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d0509f5876cb611af097bf121e5bef76085140a1c455022a6eb794c35d463d"
+checksum = "fb5341f43189905b6ad1db3870a443424a5ae39a2ddab38123307ce98d43e7de"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2413,27 +2889,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -2554,7 +3017,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -2604,7 +3067,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2743,6 +3206,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2750,9 +3219,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
@@ -2794,30 +3263,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
+ "strum_macros",
 ]
 
 [[package]]
@@ -2829,7 +3279,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2837,6 +3287,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2866,7 +3327,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2875,7 +3336,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -2899,8 +3360,29 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2910,12 +3392,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.13.0",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix 0.29.0",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2 0.10.9",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2926,8 +3470,29 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tinystr"
@@ -2978,7 +3543,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3076,7 +3641,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
@@ -3119,7 +3684,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3144,6 +3709,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3163,26 +3734,20 @@ checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -3221,6 +3786,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+dependencies = [
+ "atomic",
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3231,6 +3808,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "wait-timeout"
@@ -3268,9 +3854,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen 0.57.1",
 ]
@@ -3286,9 +3872,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3299,9 +3885,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.73"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3309,9 +3895,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3319,22 +3905,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
@@ -3380,7 +3966,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3388,9 +3974,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.100"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3422,6 +4008,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
 ]
 
 [[package]]
@@ -3723,7 +4381,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3739,7 +4397,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3751,7 +4409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.13.0",
  "indexmap",
  "log",
  "serde",
@@ -3806,7 +4464,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3827,7 +4485,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3847,15 +4505,15 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
@@ -3887,7 +4545,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -34,7 +34,7 @@ anyhow = "1"
 futures = "0.3"
 git2 = "0.21"
 reqwest = { version = "0.13", features = ["multipart"] }
-ratatui = "0.29"
+ratatui = "0.30"
 
 [features]
 default = []

--- a/cli/connector/Cargo.toml
+++ b/cli/connector/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/lib.rs"
 bytes = "1"
 futures = "0.3"
 reqwest = { version = "0.13", features = ["json", "multipart", "query"] }
-reqwest-streams = { version = "0.16", features=["json"] }
+reqwest-streams = { version = "0.17", features=["json"] }
 rustls = { version = "0.23", default-features = false, features = ["std", "aws-lc-rs", "tls12"] }
 rustls-native-certs = "0.8"
 serde = { version = "1.0", features = ["derive"] }

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -3275,6 +3275,10 @@ paths:
       description: |-
         Returns the complete build log as a single string. Empty string if no log is available yet.
 
+        A `Substituted` build (its outputs came from a cache) has no log of its
+        own, so the log of the most recent prior build of the same derivation is
+        returned instead. The chunk/lines endpoints fall back the same way.
+
         **Access:** Accessible to members of the build's organization. Additionally, when this build is the leader of a follower build in a cache-connected organization, members of that follower organization are granted read access. See `docs/src/scheduler.md#cross-cache-deduplication`.
       operationId: getBuildLog
       responses:

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -5877,9 +5877,12 @@ paths:
       tags: [projects]
       summary: Project live updates (WebSocket)
       description: |-
-        Upgrades to a WebSocket emitting `evaluation_status_changed` and
-        `build_status_changed` events for this project, so the project page
-        refetches on change instead of polling. Requires read access.
+        Upgrades to a WebSocket emitting `evaluation_status_changed`,
+        `build_status_changed` and `evaluation_progress` events for this project,
+        so the project page refetches on change instead of polling.
+        `evaluation_progress` fires as builds and entry-points are persisted
+        during the evaluation phase, before any build changes status, so the
+        build/dependency totals grow live. Requires read access.
       operationId: projectLive
       parameters:
         - { name: organization, in: path, required: true, schema: { type: string } }
@@ -5893,8 +5896,11 @@ paths:
       tags: [evals]
       summary: Evaluation live updates (WebSocket)
       description: |-
-        Upgrades to a WebSocket emitting `evaluation_status_changed` and
-        `build_status_changed` events for this evaluation. Requires read access.
+        Upgrades to a WebSocket emitting `evaluation_status_changed`,
+        `build_status_changed` and `evaluation_progress` events for this
+        evaluation. `evaluation_progress` fires as builds and entry-points are
+        persisted during the evaluation phase so the build list grows live.
+        Requires read access.
       operationId: evaluationLive
       parameters:
         - { name: evaluation, in: path, required: true, schema: { type: string, format: uuid } }

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -3905,3 +3905,19 @@ Frontend (`evaluation-log/evaluation-log.component.spec.ts`,
 - Frontend `project-detail.component.spec.ts` — explicit eval selection is persisted in the `eval` query param (back-navigation restores it) and `barCounts` folds the entry point's own build status into its dep-closure counts.
 - `backend/gradient-web/src/endpoints/projects/evaluations.rs::tests::checked_at_maps_null_time_sentinel_to_none` — `last_check_at` epoch sentinel (re-check pending) serialises as `null`, not 1970.
 - SQL helpers in `gradient-db/src/project_board.rs` (grouped counts, queue summary, dependency-closure CTE) are covered end-to-end by CI; no local DB unit harness exists.
+
+## Live evaluation progress (#295)
+
+Build/dependency totals now grow live during evaluation: the backend was silent
+while the evaluator inserted build rows (no status change), so the project and
+evaluation pages stayed frozen until the eval phase finished.
+
+- `backend/gradient-web/src/endpoints/live.rs::tests::eval_channel_matches_only_its_evaluation`
+  and `project_channel_forwards_progress_and_learns_its_eval` assert the new
+  `evaluation_progress` frame is forwarded on the `/evals/{id}/live` and
+  `/projects/{org}/{project}/live` channels (and learnt into the project
+  channel's known-eval set), while a progress ping for another evaluation /
+  project is dropped.
+- `backend/gradient-scheduler/src/eval.rs::handle_eval_result` emits
+  `BoardEvent::EvaluationProgress` after each batch of builds/entry-points is
+  persisted, so the silent insert phase no longer leaves the UI frozen.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -3921,3 +3921,11 @@ evaluation pages stayed frozen until the eval phase finished.
 - `backend/gradient-scheduler/src/eval.rs::handle_eval_result` emits
   `BoardEvent::EvaluationProgress` after each batch of builds/entry-points is
   persisted, so the silent insert phase no longer leaves the UI frozen.
+
+## Substituted-build log fallback
+
+`backend/gradient-web/src/endpoints/builds/mod.rs::effective_log_id` resolves the
+build whose stored log the `/builds/{id}/log*` endpoints serve: a `Substituted`
+build has no log of its own, so it falls back to the most recent prior build of
+the same derivation that does (chunked or inline). Read-side, DB-dependent;
+covered end-to-end by CI, no local DB unit harness.

--- a/docs/src/usage/api.md
+++ b/docs/src/usage/api.md
@@ -284,6 +284,9 @@ Set `GRADIENT_WORKER_PEERS_FILE` (or the NixOS `peersFile` option) to this path.
 | `GET` | `/builds/{id}/downloads` | List artefacts |
 | `GET` | `/builds/{id}/download/{filename}` | Download artefact |
 
+The `/log*` endpoints fall back to the most recent prior build of the same
+derivation for a `Substituted` build (which has no log of its own).
+
 ### Caches
 
 | Method | Path | Description |

--- a/docs/src/usage/api.md
+++ b/docs/src/usage/api.md
@@ -309,13 +309,17 @@ channel only forwards events for its resource (authorized at connect).
 | Path | Events |
 |---|---|
 | `/board/live` | `queue_depth`, `job_dispatched`, `worker_connected`, `worker_disconnected` (scope-masked) |
-| `/projects/{org}/{project}/live` | `evaluation_status_changed`, `build_status_changed` for the project |
-| `/evals/{evaluation}/live` | `evaluation_status_changed`, `build_status_changed` for the evaluation |
+| `/projects/{org}/{project}/live` | `evaluation_status_changed`, `build_status_changed`, `evaluation_progress` for the project |
+| `/evals/{evaluation}/live` | `evaluation_status_changed`, `build_status_changed`, `evaluation_progress` for the evaluation |
 | `/builds/{build}/live` | `build_status_changed` for the build's evaluation (its dependency graph) |
 | `/board/cache/live` | `cache_changed` (content-free ping; refetch `/board/cache`) |
 
 Frames are JSON with a `type` field, e.g.
 `{"type":"build_status_changed","evaluation_id":"…","build_id":"…","status":2}`.
+`evaluation_progress` (`{"type":"evaluation_progress","project":"…","evaluation_id":"…"}`)
+is a content-free ping emitted as builds and entry-points are persisted during
+the evaluation phase - before any build changes status - so the build and
+dependency totals grow live instead of only appearing once evaluation finishes.
 
 ### Nix Binary Cache (root, no `/api/v1` prefix)
 

--- a/frontend/src/app/core/services/live.service.ts
+++ b/frontend/src/app/core/services/live.service.ts
@@ -12,6 +12,7 @@ export interface LiveEvent {
   type:
     | 'evaluation_status_changed'
     | 'build_status_changed'
+    | 'evaluation_progress'
     | 'cache_changed'
     | string;
   project?: string | null;

--- a/frontend/src/app/features/evaluations/closure-graph/closure-graph.component.ts
+++ b/frontend/src/app/features/evaluations/closure-graph/closure-graph.component.ts
@@ -8,7 +8,7 @@ import {
   Component, OnInit, OnDestroy, inject, signal, computed,
   ViewChild, ElementRef, NgZone, ChangeDetectorRef,
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { CommonModule, Location } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ButtonModule } from 'primeng/button';
 import { EvaluationsService, ClosureGraph } from '@core/services/evaluations.service';
@@ -35,6 +35,7 @@ type LaidLink = { source: LaidNode; target: LaidNode; width?: number; value: num
 export class ClosureGraphComponent implements OnInit, OnDestroy {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
+  private location = inject(Location);
   private evalService = inject(EvaluationsService);
   private zone = inject(NgZone);
   private cdr = inject(ChangeDetectorRef);
@@ -283,6 +284,12 @@ export class ClosureGraphComponent implements OnInit, OnDestroy {
   }
 
   goBack(): void {
-    this.router.navigate(['/organization', this.orgName]);
+    // Return to wherever the user came from; fall back to the org overview when
+    // the closure page was opened directly (no in-app history to pop).
+    if (history.length > 1) {
+      this.location.back();
+    } else {
+      this.router.navigate(['/organization', this.orgName]);
+    }
   }
 }

--- a/frontend/src/app/features/projects/project-detail/project-detail.component.html
+++ b/frontend/src/app/features/projects/project-detail/project-detail.component.html
@@ -50,7 +50,7 @@
           <a [href]="proj.repository" target="_blank" rel="noopener noreferrer">{{ proj.repository }}</a>
         } @else { {{ proj.repository }} }
       </span>
-      <span class="chip mono" [title]="proj.wildcard">{{ proj.wildcard }}</span>
+      <span class="chip mono" [title]="proj.wildcard">{{ truncate(proj.wildcard) }}</span>
       @if (proj.last_check_at) {
         <span class="chip">checked {{ proj.last_check_at + 'Z' | date: 'MMM d, HH:mm' }}</span>
       }
@@ -108,8 +108,6 @@
               </div>
             </div>
             <div class="panel-actions">
-              <button pButton size="small" label="Eval log" icon="pi pi-file" severity="secondary"
-                      [routerLink]="['/organization', orgName, 'log', sel.id]"></button>
               <button pButton size="small" icon="pi pi-ellipsis-v" severity="secondary"
                       (click)="panelMenu.toggle($event)" aria-label="More"></button>
               <p-menu #panelMenu [model]="panelMenuModel()" [popup]="true" appendTo="body" />

--- a/frontend/src/app/features/projects/project-detail/project-detail.component.ts
+++ b/frontend/src/app/features/projects/project-detail/project-detail.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, OnDestroy, computed, inject, signal } from '@angular/core';
+import { Component, OnInit, OnDestroy, ElementRef, HostListener, computed, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { interval, Subscription } from 'rxjs';
@@ -43,6 +43,7 @@ import { SegmentedBarComponent } from './segmented-bar/segmented-bar.component';
 export class ProjectDetailComponent implements OnInit, OnDestroy {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
+  private host = inject(ElementRef);
   protected authService = inject(AuthService);
   private orgsService = inject(OrganizationsService);
   private projectsService = inject(ProjectsService);
@@ -67,6 +68,14 @@ export class ProjectDetailComponent implements OnInit, OnDestroy {
 
   private liveSub?: Subscription;
   private tickSubscription?: Subscription;
+
+  // Content signatures + a throttle so a running evaluation's rapid live pings
+  // don't re-render the cards or re-run the expensive entry-point query.
+  private projectSig = '';
+  private entryPointsEvalId?: string;
+  private entryPointsSig = '';
+  private lastEntryPointsFetch = 0;
+  private readonly ENTRY_POINTS_LIVE_INTERVAL_MS = 4000;
 
   evaluations = computed(() => this.project()?.last_evaluations ?? []);
   selected = computed<EvaluationSummary | null>(() => {
@@ -99,11 +108,15 @@ export class ProjectDetailComponent implements OnInit, OnDestroy {
     this.tickSubscription?.unsubscribe();
   }
 
-  loadProjectData(showLoading = true): void {
+  loadProjectData(showLoading = true, live = false): void {
     if (showLoading) this.loading.set(true);
     this.projectsService.getProject(this.orgName, this.projectName).subscribe({
       next: (project) => {
-        this.project.set(project);
+        const sig = this.projectSignature(project);
+        if (sig !== this.projectSig) {
+          this.projectSig = sig;
+          this.project.set(project);
+        }
         if (showLoading) this.loading.set(false);
         if (this.starting() && project.last_evaluations.some(e => this.isRunning(e.status))) {
           this.starting.set(false);
@@ -111,13 +124,31 @@ export class ProjectDetailComponent implements OnInit, OnDestroy {
         if (!this.selectedId() && project.last_evaluations.length) {
           this.selectedId.set(project.last_evaluations[0].id);
         }
-        this.loadEntryPoints(this.selected()?.id);
+        // The entry-point query (dep-closure CTE) is expensive; on live pings
+        // throttle it so a running evaluation's rapid status stream doesn't
+        // hammer the backend. The cheap summary above keeps headline counts live.
+        if (!live || Date.now() - this.lastEntryPointsFetch >= this.ENTRY_POINTS_LIVE_INTERVAL_MS) {
+          this.loadEntryPoints(this.selected()?.id);
+        }
       },
       error: (error) => {
         console.error('Failed to load project:', error);
         if (showLoading) this.loading.set(false);
       },
     });
+  }
+
+  /// Fields whose change should re-render the header / eval strip / panel.
+  private projectSignature(p: ProjectDetail): string {
+    const evals = (p.last_evaluations ?? [])
+      .map(e => `${e.id}:${e.status}:${e.errors}:${e.warnings}:${e.updated_at}:${JSON.stringify(e.builds)}`)
+      .join('|');
+    return [p.active, p.can_edit, p.can_trigger, p.display_name, p.description, p.repository,
+      p.wildcard, p.last_check_at, JSON.stringify(p.queue), evals].join('§');
+  }
+
+  truncate(value: string, max = 42): string {
+    return value.length > max ? value.slice(0, max) + '…' : value;
   }
 
   select(evaluation: EvaluationSummary): void {
@@ -133,11 +164,24 @@ export class ProjectDetailComponent implements OnInit, OnDestroy {
   }
 
   private loadEntryPoints(evaluationId?: string): void {
-    if (!evaluationId) { this.entryPoints.set([]); return; }
+    if (!evaluationId) {
+      this.entryPoints.set([]);
+      this.entryPointsEvalId = undefined;
+      this.entryPointsSig = '';
+      return;
+    }
+    this.lastEntryPointsFetch = Date.now();
     this.projectsService.getEntryPoints(this.orgName, this.projectName, evaluationId).subscribe({
-      next: (eps) => this.entryPoints.set(
-        [...eps].sort((a, b) => this.getDerivationName(a.derivation_path).localeCompare(this.getDerivationName(b.derivation_path))),
-      ),
+      next: (eps) => {
+        const sorted = [...eps].sort((a, b) =>
+          this.getDerivationName(a.derivation_path).localeCompare(this.getDerivationName(b.derivation_path)));
+        // Skip the re-render (and its enter animation) when nothing changed.
+        const sig = sorted.map(e => `${e.id}:${e.build_status}:${e.build_time_ms}:${e.has_artefacts}:${JSON.stringify(e.deps)}`).join('|');
+        if (evaluationId === this.entryPointsEvalId && sig === this.entryPointsSig) return;
+        this.entryPointsEvalId = evaluationId;
+        this.entryPointsSig = sig;
+        this.entryPoints.set(sorted);
+      },
       error: (error) => console.error('Failed to load entry points:', error),
     });
   }
@@ -182,7 +226,26 @@ export class ProjectDetailComponent implements OnInit, OnDestroy {
     this.liveSub = this.live
       .connect(`/projects/${this.orgName}/${this.projectName}/live`)
       .pipe(auditTime(500))
-      .subscribe(() => this.loadProjectData(false));
+      .subscribe(() => this.loadProjectData(false, true));
+  }
+
+  /// Left/right arrows step through the evaluation strip.
+  @HostListener('document:keydown', ['$event'])
+  onKeydown(e: KeyboardEvent): void {
+    if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+    const target = e.target as HTMLElement | null;
+    if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) return;
+    const list = this.evaluations();
+    if (!list.length) return;
+    const cur = this.selected();
+    const idx = cur ? list.findIndex(x => x.id === cur.id) : 0;
+    const next = e.key === 'ArrowLeft' ? idx - 1 : idx + 1;
+    if (next < 0 || next >= list.length) return;
+    e.preventDefault();
+    this.select(list[next]);
+    requestAnimationFrame(() =>
+      this.host.nativeElement.querySelector('.eval-card.selected')
+        ?.scrollIntoView({ inline: 'nearest', block: 'nearest', behavior: 'smooth' }));
   }
 
   isRunning(status: EvaluationStatus): boolean { return isRunningEvaluationStatus(status); }


### PR DESCRIPTION
Adds an `evaluation_progress` live event so build/dependency totals grow during evaluation; throttles and dedupes the project page's live refetch (fixes the running-eval backend overload and package-list flicker); plus wildcard truncation, removed "Eval log" button, closure-graph Back navigation, ←/→ evaluation nav, and a leaner entry-point query.