### PR TITLE
fix(storage): shard log dir into 256 subfolders by last 2 uuid chars

### DIFF
--- a/backend/gradient-proto/src/handler/dispatch.rs
+++ b/backend/gradient-proto/src/handler/dispatch.rs
@@ -971,7 +971,7 @@ impl<'a> DispatchContext<'a> {
                 return;
             }
             nar.finish(&store_path).await;
-            info!(peer_id = %self.peer_id, %job_id, %store_path, file_size, "NAR stored");
+            debug!(peer_id = %self.peer_id, %job_id, %store_path, file_size, "NAR stored");
         }
 
         let file_size_i64 = file_size as i64;

--- a/backend/gradient-proto/src/handler/nar.rs
+++ b/backend/gradient-proto/src/handler/nar.rs
@@ -11,7 +11,7 @@ use gradient_types::*;
 use gradient_core::ServerState;
 use gradient_scheduler::Scheduler;
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, Set};
-use tracing::{info, warn};
+use tracing::{debug, warn};
 
 pub(super) struct NarUploadRecord<'a> {
     pub file_hash: &'a str,
@@ -136,7 +136,7 @@ pub(super) async fn mark_nar_stored(
         }
     }
     if marked > 0 {
-        info!(
+        debug!(
             store_path,
             file_size = record.file_size,
             count = marked,
@@ -144,6 +144,6 @@ pub(super) async fn mark_nar_stored(
         );
     }
 
-    info!(store_path, "cached_path metadata recorded after NarUploaded");
+    debug!(store_path, "cached_path metadata recorded after NarUploaded");
     Ok(())
 }

--- a/backend/gradient-storage/src/log.rs
+++ b/backend/gradient-storage/src/log.rs
@@ -86,20 +86,62 @@ impl FileLogStorage {
     pub async fn new(base_path: &Path) -> Result<Self> {
         let logs_dir = base_path.join("logs");
         fs::create_dir_all(&logs_dir).await?;
-        Ok(Self { logs_dir })
+        let storage = Self { logs_dir };
+        storage.shard_existing_logs().await?;
+        Ok(storage)
+    }
+
+    /// Two-char shard derived from the final UUID byte (e.g. `…8814fe` → `fe`),
+    /// fanning logs across 256 subfolders instead of one flat directory.
+    fn shard(build_id: BuildId) -> String {
+        format!("{:02x}", build_id.into_inner().as_bytes()[15])
+    }
+
+    fn shard_dir(&self, build_id: BuildId) -> PathBuf {
+        self.logs_dir.join(Self::shard(build_id))
     }
 
     pub fn log_path(&self, build_id: BuildId) -> PathBuf {
-        self.logs_dir.join(format!("{}.log", build_id))
+        self.shard_dir(build_id).join(format!("{}.log", build_id))
     }
 
     fn chunk_dir(&self, build_id: BuildId) -> PathBuf {
-        self.logs_dir.join(build_id.to_string())
+        self.shard_dir(build_id).join(build_id.to_string())
     }
 
     fn chunk_path(&self, build_id: BuildId, index: u32) -> PathBuf {
         self.chunk_dir(build_id)
             .join(format!("chunk_{:08}.zst", index))
+    }
+
+    /// One-time idempotent relocation of pre-sharding flat entries
+    /// (`<uuid>.log` files and bare `<uuid>` chunk dirs) into their shard
+    /// subfolder. Already-sharded two-char dirs fail the UUID parse and are skipped.
+    async fn shard_existing_logs(&self) -> Result<()> {
+        let mut flat: Vec<(BuildId, String)> = Vec::new();
+        let mut entries = fs::read_dir(&self.logs_dir).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            let name = entry.file_name();
+            let Some(s) = name.to_str() else { continue };
+            let stem = s.strip_suffix(".log").unwrap_or(s);
+            if let Ok(id) = stem.parse::<uuid::Uuid>() {
+                flat.push((BuildId::new(id), s.to_owned()));
+            }
+        }
+
+        for (build_id, name) in flat {
+            let dest = self.shard_dir(build_id);
+            if let Err(e) = async {
+                fs::create_dir_all(&dest).await?;
+                fs::rename(self.logs_dir.join(&name), dest.join(&name)).await
+            }
+            .await
+            {
+                warn!(error = %e, entry = %name, "failed to relocate log into shard subfolder");
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -107,6 +149,7 @@ impl LogStorage for FileLogStorage {
     fn append<'a>(&'a self, build_id: BuildId, text: &'a str) -> BoxFuture<'a, Result<()>> {
         Box::pin(async move {
             let path = self.log_path(build_id);
+            fs::create_dir_all(self.shard_dir(build_id)).await?;
             let mut file = OpenOptions::new()
                 .create(true)
                 .append(true)
@@ -146,19 +189,26 @@ impl LogStorage for FileLogStorage {
     fn list_logs<'a>(&'a self) -> BoxFuture<'a, Result<Vec<BuildId>>> {
         Box::pin(async move {
             let mut out = Vec::new();
-            let mut entries = match fs::read_dir(&self.logs_dir).await {
+            let mut shards = match fs::read_dir(&self.logs_dir).await {
                 Ok(e) => e,
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(out),
                 Err(e) => return Err(e.into()),
             };
-            while let Some(entry) = entries.next_entry().await? {
-                let name = entry.file_name();
-                let Some(s) = name.to_str() else { continue };
-                let Some(stem) = s.strip_suffix(".log") else {
+            while let Some(shard) = shards.next_entry().await? {
+                if !shard.file_type().await?.is_dir() {
                     continue;
-                };
-                if let Ok(id) = stem.parse::<uuid::Uuid>() {
-                    out.push(BuildId::new(id));
+                }
+
+                let mut entries = fs::read_dir(shard.path()).await?;
+                while let Some(entry) = entries.next_entry().await? {
+                    let name = entry.file_name();
+                    let Some(s) = name.to_str() else { continue };
+                    let Some(stem) = s.strip_suffix(".log") else {
+                        continue;
+                    };
+                    if let Ok(id) = stem.parse::<uuid::Uuid>() {
+                        out.push(BuildId::new(id));
+                    }
                 }
             }
             Ok(out)
@@ -403,5 +453,49 @@ mod chunk_tests {
         assert_eq!(storage.read_chunk(id, 1).await.unwrap(), b"world");
         storage.delete_chunks(id).await.unwrap();
         assert!(storage.read_chunk(id, 0).await.is_err());
+    }
+}
+
+#[cfg(test)]
+mod shard_tests {
+    use super::*;
+    use gradient_types::ids::BuildId;
+
+    const SAMPLE: &str = "019e884e-6430-7d83-86a1-3d0e6d8814fe";
+
+    fn sample_id() -> BuildId {
+        BuildId::new(SAMPLE.parse().unwrap())
+    }
+
+    #[tokio::test]
+    async fn log_lives_in_two_char_shard_subfolder() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = FileLogStorage::new(dir.path()).await.unwrap();
+        let id = sample_id();
+        storage.append(id, "hello").await.unwrap();
+
+        let expected = dir.path().join("logs").join("fe").join(format!("{SAMPLE}.log"));
+        assert!(expected.exists(), "log not sharded to logs/fe/{SAMPLE}.log");
+        assert_eq!(storage.read(id).await.unwrap(), "hello");
+        assert_eq!(storage.list_logs().await.unwrap(), vec![id]);
+    }
+
+    #[tokio::test]
+    async fn startup_migration_relocates_flat_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let logs = dir.path().join("logs");
+        let chunk_dir = logs.join(SAMPLE);
+        fs::create_dir_all(&chunk_dir).await.unwrap();
+        fs::write(logs.join(format!("{SAMPLE}.log")), "legacy").await.unwrap();
+        fs::write(chunk_dir.join("chunk_00000000.zst"), b"z").await.unwrap();
+
+        let storage = FileLogStorage::new(dir.path()).await.unwrap();
+        let id = sample_id();
+
+        assert!(!logs.join(format!("{SAMPLE}.log")).exists());
+        assert!(logs.join("fe").join(format!("{SAMPLE}.log")).exists());
+        assert!(logs.join("fe").join(SAMPLE).join("chunk_00000000.zst").exists());
+        assert_eq!(storage.read(id).await.unwrap(), "legacy");
+        assert_eq!(storage.list_logs().await.unwrap(), vec![id]);
     }
 }

--- a/backend/gradient-worker/src/executor/compress.rs
+++ b/backend/gradient-worker/src/executor/compress.rs
@@ -15,7 +15,7 @@
 
 use anyhow::Result;
 use tokio::sync::watch;
-use tracing::info;
+use tracing::debug;
 
 use crate::executor::check_abort;
 use crate::nix::store::LocalNixStore;
@@ -51,7 +51,7 @@ pub async fn compress_and_push_paths(
             Some(store),
         )
         .await?;
-        info!(store_path, "compressed and pushed NAR");
+        debug!(store_path, "compressed and pushed NAR");
     }
 
     Ok(())

--- a/backend/gradient-worker/src/proto/nar.rs
+++ b/backend/gradient-worker/src/proto/nar.rs
@@ -24,7 +24,7 @@ use harmonia_store_path::StorePath;
 use harmonia_store_remote::DaemonStore as _;
 use gradient_proto::messages::ClientMessage;
 use sha2::{Digest, Sha256};
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 
 use crate::connection::ProtoWriter;
 use crate::nix::store::{LocalNixStore, strip_store_prefix};
@@ -289,7 +289,7 @@ pub async fn push_direct(
         deriver: meta.deriver,
     })?;
 
-    info!(
+    debug!(
         store_path,
         compressed_bytes = produced,
         resumed_from = resume_from,
@@ -345,7 +345,7 @@ pub async fn upload_presigned(
     let file_hash = format!("sha256:{}", nix32_encode(&Sha256::digest(&compressed)));
     let nar_hash = format!("sha256:{}", nix32_encode(&nar_hasher.finalize()));
 
-    info!(
+    debug!(
         store_path,
         file_size, nar_size, "uploading NAR to presigned URL"
     );
@@ -387,7 +387,7 @@ pub async fn upload_presigned(
         deriver: meta.deriver,
     })?;
 
-    info!(
+    debug!(
         store_path,
         file_size, nar_size, "presigned NAR upload complete"
     );

--- a/backend/gradient-worker/src/proto/nar_import.rs
+++ b/backend/gradient-worker/src/proto/nar_import.rs
@@ -42,7 +42,7 @@ use harmonia_utils_hash::{Hash, HashView as _};
 use harmonia_utils_signature::Signature;
 use gradient_proto::messages::{BuildTask, CachedPath, EvalMessageLevel, QueryMode};
 use sha2::{Digest as _, Sha256};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, warn};
 
 use crate::nix::store::LocalNixStore;
 use crate::proto::job::JobUpdater;
@@ -493,7 +493,7 @@ impl<'a> InputPrefetcher<'a> {
     ) -> Result<()> {
         const MAX_ITERATIONS: usize = 1024;
 
-        info!(
+        debug!(
             build_id = %self.build_id,
             missing = initial_missing.len(),
             "prefetching missing paths from server cache (closure-expanding)"
@@ -605,7 +605,7 @@ impl<'a> InputPrefetcher<'a> {
         );
 
         let imported = self.import_all(all_results).await?;
-        info!(build_id = %self.build_id, imported, "prefetch complete");
+        debug!(build_id = %self.build_id, imported, "prefetch complete");
 
         Ok(())
     }

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -452,6 +452,12 @@ Storage (`cargo test -p gradient-storage`):
   GC).
 - `nar::tests::get_stream_from_*` - `NarStore::get_stream_from` returns the suffix from
   an offset, equals the full object at 0, and yields an empty stream past the end.
+- `log::shard_tests::log_lives_in_two_char_shard_subfolder` - `FileLogStorage` writes
+  to `logs/<last-2-hex>/<uuid>.log` (e.g. `…8814fe` → `logs/fe/`) and `read`/`list_logs`
+  resolve through the shard.
+- `log::shard_tests::startup_migration_relocates_flat_entries` - constructing
+  `FileLogStorage` relocates pre-sharding flat `<uuid>.log` files and `<uuid>` chunk
+  dirs into their shard subfolder.
 
 Proto (`cargo test -p gradient-proto`):
 - `tests::nar_stream_header_client_roundtrip` / `nar_request_resume_roundtrip` /


### PR DESCRIPTION
Fans build logs across `logs/<last-2-uuid-chars>/` (e.g. `…8814fe` → `logs/fe/`) instead of one flat directory, with a one-time idempotent startup migration that relocates existing flat `<uuid>.log` files and `<uuid>` chunk dirs. Also demotes NAR push/pull logs on workers and servers from `info` to `debug`.

Closes #394