### PR TITLE
Faster Created → Queued transitions (#392)

### DIFF
--- a/backend/gradient-scheduler/src/edge_readiness.rs
+++ b/backend/gradient-scheduler/src/edge_readiness.rs
@@ -1,0 +1,216 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Incremental edge-readiness tracker (#392).
+//!
+//! Decides, batch by batch, when a derivation's full set of direct dependency
+//! edges is writable — i.e. every dependency now has a row — so the owning
+//! build can be promoted `Created → Queued` mid-evaluation. Order-independent:
+//! a dependency may be observed before or after its dependents.
+
+use std::collections::{HashMap, HashSet};
+
+use gradient_types::proto::DiscoveredDerivation;
+
+/// Per-evaluation readiness tracker. Cheap, in-memory, single-eval (batches for
+/// one eval arrive in order on one connection); the caller guards cross-eval
+/// access with a lock.
+#[derive(Default)]
+pub(crate) struct EdgeReadiness {
+    /// drv_paths that now have a derivation row.
+    seen: HashSet<String>,
+    /// src -> its full direct-dep list, kept until the src becomes ready.
+    deps: HashMap<String, Vec<String>>,
+    /// src -> deps still missing a row.
+    pending: HashMap<String, HashSet<String>>,
+    /// dep -> srcs waiting on it.
+    waiters: HashMap<String, HashSet<String>>,
+}
+
+impl EdgeReadiness {
+    /// Feed one batch. Returns every derivation that became edge-complete in
+    /// this batch as `(drv_path, dependencies)`; leaves carry an empty dep list.
+    /// Each derivation is reported at most once across the tracker's lifetime.
+    pub(crate) fn observe(&mut self, batch: &[DiscoveredDerivation]) -> Vec<(String, Vec<String>)> {
+        let mut ready: Vec<(String, Vec<String>)> = Vec::new();
+
+        // 1. Mark every drv_path in this batch as seen; remember the new ones.
+        let mut newly_seen: Vec<String> = Vec::new();
+        for d in batch {
+            if self.seen.insert(d.drv_path.clone()) {
+                newly_seen.push(d.drv_path.clone());
+            }
+        }
+
+        // 2. Register each source against the post-step-1 seen set, so deps that
+        //    arrived in this same batch already count as satisfied.
+        for d in batch {
+            if d.dependencies.is_empty() {
+                ready.push((d.drv_path.clone(), Vec::new()));
+                continue;
+            }
+
+            let missing: HashSet<String> = d
+                .dependencies
+                .iter()
+                .filter(|dep| !self.seen.contains(*dep))
+                .cloned()
+                .collect();
+
+            if missing.is_empty() {
+                ready.push((d.drv_path.clone(), d.dependencies.clone()));
+            } else {
+                for dep in &missing {
+                    self.waiters.entry(dep.clone()).or_default().insert(d.drv_path.clone());
+                }
+                self.deps.insert(d.drv_path.clone(), d.dependencies.clone());
+                self.pending.insert(d.drv_path.clone(), missing);
+            }
+        }
+
+        // 3. A drv_path newly seen this batch may complete sources registered in
+        //    earlier batches. No cascade: becoming ready never marks a new seen.
+        for p in newly_seen {
+            let Some(srcs) = self.waiters.remove(&p) else {
+                continue;
+            };
+
+            for src in srcs {
+                if let Some(missing) = self.pending.get_mut(&src) {
+                    missing.remove(&p);
+                    if missing.is_empty() {
+                        self.pending.remove(&src);
+                        if let Some(deps) = self.deps.remove(&src) {
+                            ready.push((src, deps));
+                        }
+                    }
+                }
+            }
+        }
+
+        ready
+    }
+
+    /// Drain sources whose deps never all materialised, so the end-of-eval flush
+    /// can attempt their edges once the graph is final.
+    pub(crate) fn drain_pending(&mut self) -> Vec<(String, Vec<String>)> {
+        self.waiters.clear();
+        self.pending.clear();
+        self.deps.drain().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn drv(path: &str, deps: &[&str]) -> DiscoveredDerivation {
+        DiscoveredDerivation {
+            attr: String::new(),
+            drv_path: path.into(),
+            outputs: vec![],
+            dependencies: deps.iter().map(|s| s.to_string()).collect(),
+            architecture: "x86_64-linux".into(),
+            required_features: vec![],
+            timeout_secs: None,
+            max_silent_secs: None,
+            prefer_local_build: false,
+            is_fixed_output: false,
+            allow_substitutes: true,
+            pname: None,
+            substituted: false,
+        }
+    }
+
+    fn paths(ready: &[(String, Vec<String>)]) -> Vec<String> {
+        let mut v: Vec<String> = ready.iter().map(|(p, _)| p.clone()).collect();
+        v.sort();
+        v
+    }
+
+    #[test]
+    fn leaf_ready_in_same_batch() {
+        let mut t = EdgeReadiness::default();
+        let r = t.observe(&[drv("leaf", &[])]);
+        assert_eq!(paths(&r), vec!["leaf"]);
+        assert!(r[0].1.is_empty(), "leaf carries no edges");
+    }
+
+    #[test]
+    fn parent_waits_for_dep_in_later_batch() {
+        let mut t = EdgeReadiness::default();
+        assert!(
+            t.observe(&[drv("parent", &["dep"])]).is_empty(),
+            "parent not ready until dep has a row"
+        );
+
+        let r = t.observe(&[drv("dep", &[])]);
+        assert_eq!(paths(&r), vec!["dep", "parent"]);
+        let parent = r.iter().find(|(p, _)| p == "parent").unwrap();
+        assert_eq!(parent.1, vec!["dep".to_string()], "parent edge recorded once");
+    }
+
+    #[test]
+    fn parent_and_deps_same_batch_ready_together() {
+        let mut t = EdgeReadiness::default();
+        let r = t.observe(&[drv("parent", &["a", "b"]), drv("a", &[]), drv("b", &[])]);
+        assert_eq!(paths(&r), vec!["a", "b", "parent"]);
+    }
+
+    #[test]
+    fn multi_dep_ready_after_last_dep() {
+        let mut t = EdgeReadiness::default();
+        assert!(t.observe(&[drv("p", &["a", "b"])]).is_empty());
+        assert_eq!(paths(&t.observe(&[drv("a", &[])])), vec!["a"], "p still waits on b");
+        assert_eq!(paths(&t.observe(&[drv("b", &[])])), vec!["b", "p"]);
+    }
+
+    #[test]
+    fn diamond_each_ready_once_with_full_edge_set() {
+        let mut t = EdgeReadiness::default();
+        let mut all: Vec<(String, Vec<String>)> = Vec::new();
+        all.extend(t.observe(&[drv("a", &["b", "c"])]));
+        all.extend(t.observe(&[drv("b", &["d"]), drv("c", &["d"])]));
+        all.extend(t.observe(&[drv("d", &[])]));
+
+        assert_eq!(paths(&all), vec!["a", "b", "c", "d"], "each node ready exactly once");
+
+        let mut edges: Vec<(String, String)> = all
+            .iter()
+            .flat_map(|(src, deps)| deps.iter().map(move |dep| (src.clone(), dep.clone())))
+            .collect();
+        edges.sort();
+        assert_eq!(
+            edges,
+            vec![
+                ("a".into(), "b".into()),
+                ("a".into(), "c".into()),
+                ("b".into(), "d".into()),
+                ("c".into(), "d".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn reobserving_seen_drv_yields_nothing() {
+        let mut t = EdgeReadiness::default();
+        let _ = t.observe(&[drv("leaf", &[])]);
+        assert!(
+            t.observe(&[drv("leaf", &[])]).is_empty(),
+            "already-seen leaf not re-promoted"
+        );
+    }
+
+    #[test]
+    fn drain_pending_returns_unresolved_sources() {
+        let mut t = EdgeReadiness::default();
+        let _ = t.observe(&[drv("p", &["never"])]);
+        assert_eq!(
+            t.drain_pending(),
+            vec![("p".to_string(), vec!["never".to_string()])]
+        );
+    }
+}

--- a/backend/gradient-scheduler/src/edge_readiness.rs
+++ b/backend/gradient-scheduler/src/edge_readiness.rs
@@ -37,17 +37,18 @@ impl EdgeReadiness {
     pub(crate) fn observe(&mut self, batch: &[DiscoveredDerivation]) -> Vec<(String, Vec<String>)> {
         let mut ready: Vec<(String, Vec<String>)> = Vec::new();
 
-        // 1. Mark every drv_path in this batch as seen; remember the new ones.
-        let mut newly_seen: Vec<String> = Vec::new();
+        // 1. Mark every drv_path as seen; keep only the first sighting of each so
+        //    a re-observed derivation is never registered or reported twice.
+        let mut fresh: Vec<&DiscoveredDerivation> = Vec::new();
         for d in batch {
             if self.seen.insert(d.drv_path.clone()) {
-                newly_seen.push(d.drv_path.clone());
+                fresh.push(d);
             }
         }
 
-        // 2. Register each source against the post-step-1 seen set, so deps that
-        //    arrived in this same batch already count as satisfied.
-        for d in batch {
+        // 2. Register each fresh source against the post-step-1 seen set, so deps
+        //    that arrived in this same batch already count as satisfied.
+        for d in &fresh {
             if d.dependencies.is_empty() {
                 ready.push((d.drv_path.clone(), Vec::new()));
                 continue;
@@ -71,16 +72,16 @@ impl EdgeReadiness {
             }
         }
 
-        // 3. A drv_path newly seen this batch may complete sources registered in
-        //    earlier batches. No cascade: becoming ready never marks a new seen.
-        for p in newly_seen {
-            let Some(srcs) = self.waiters.remove(&p) else {
+        // 3. Each freshly seen drv_path may complete sources registered in earlier
+        //    batches. No cascade: becoming ready never marks a new seen.
+        for d in &fresh {
+            let Some(srcs) = self.waiters.remove(&d.drv_path) else {
                 continue;
             };
 
             for src in srcs {
                 if let Some(missing) = self.pending.get_mut(&src) {
-                    missing.remove(&p);
+                    missing.remove(&d.drv_path);
                     if missing.is_empty() {
                         self.pending.remove(&src);
                         if let Some(deps) = self.deps.remove(&src) {

--- a/backend/gradient-scheduler/src/eval.rs
+++ b/backend/gradient-scheduler/src/eval.rs
@@ -738,10 +738,10 @@ pub async fn handle_eval_result(
     let drv_path_to_id = batch.insert(state, &proc.evaluation).await?;
 
     // Dependency edges are NOT created here. The BFS walks roots→leaves, so
-    // batch N may contain derivation A whose dep B lands in batch N+1. Instead,
-    // deps are accumulated in `Scheduler::deferred_deps` and flushed in one
-    // shot by `flush_deferred_deps` inside `handle_eval_job_completed`, when
-    // every derivation row is guaranteed to be in the DB.
+    // batch N may contain derivation A whose dep B lands in batch N+1. Edges are
+    // written incrementally by `write_edges_and_promote` once both endpoints
+    // have rows, with any stragglers flushed by `flush_deferred_deps` at
+    // `handle_eval_job_completed`.
 
     proc.insert_build_rows(&derivations, &drv_path_to_id)
         .await?;
@@ -839,11 +839,10 @@ pub async fn handle_eval_job_completed(
     check_evaluation_done(state, evaluation_id).await
 }
 
-/// Flush all deferred dependency edges for `evaluation_id`.
-///
-/// Called once from `handle_eval_job_completed` after every derivation row is
-/// guaranteed to be in the DB. Resolves `(drv_path, Vec<dep_drv_path>)` pairs
-/// to `(derivation_uuid, dep_uuid)` edges and inserts them in bulk.
+/// Resolve `(drv_path, Vec<dep_drv_path>)` pairs to `(derivation_uuid,
+/// dep_uuid)` edges and insert them (conflict-do-nothing). Called per-batch from
+/// [`write_edges_and_promote`] for edge-complete sources, and once at
+/// `handle_eval_job_completed` to flush any stragglers.
 pub async fn flush_deferred_deps(
     state: &Arc<ServerState>,
     evaluation_id: EvaluationId,

--- a/backend/gradient-scheduler/src/eval.rs
+++ b/backend/gradient-scheduler/src/eval.rs
@@ -936,6 +936,90 @@ pub async fn flush_deferred_deps(
     Ok(())
 }
 
+/// Promote every `Created` build in `evaluation_id` whose derivation is one of
+/// `ready_paths` to `Queued`. Mirrors the bulk-promote loop in
+/// [`handle_eval_job_completed`], scoped to one batch's ready set. Returns the
+/// count promoted.
+async fn promote_ready_builds(
+    state: &Arc<ServerState>,
+    evaluation_id: EvaluationId,
+    organization_id: OrganizationId,
+    ready_paths: &[String],
+) -> Result<usize> {
+    if ready_paths.is_empty() {
+        return Ok(0);
+    }
+
+    let hashes: Vec<String> = ready_paths
+        .iter()
+        .filter_map(|p| parse_drv_hash_name(p).ok().map(|(h, _)| h))
+        .collect::<std::collections::HashSet<_>>()
+        .into_iter()
+        .collect();
+
+    let db = &state.worker_db;
+    let drv_ids: Vec<DerivationId> = gradient_db::fetch_in_chunks(&hashes, |chunk| async move {
+        EDerivation::find()
+            .filter(CDerivation::Organization.eq(organization_id))
+            .filter(CDerivation::Hash.is_in(chunk))
+            .all(db)
+            .await
+    })
+    .await
+    .context("promote_ready_builds: query derivations")?
+    .into_iter()
+    .map(|d| d.id)
+    .collect();
+    if drv_ids.is_empty() {
+        return Ok(0);
+    }
+
+    let created: Vec<MBuild> = gradient_db::fetch_in_chunks(&drv_ids, |chunk| async move {
+        EBuild::find()
+            .filter(CBuild::Evaluation.eq(evaluation_id))
+            .filter(CBuild::Derivation.is_in(chunk))
+            .filter(CBuild::Status.eq(BuildStatus::Created))
+            .all(db)
+            .await
+    })
+    .await
+    .context("promote_ready_builds: query builds")?;
+
+    let n = created.len();
+    for build in created {
+        update_build_status(&state.db(), build, BuildStatus::Queued).await;
+    }
+
+    Ok(n)
+}
+
+/// Per-batch incremental promotion (#392). Given the derivations that became
+/// edge-complete this batch (`ready` = `(drv_path, dependencies)`), write their
+/// dependency edges (reusing [`flush_deferred_deps`]) and promote their builds
+/// `Created → Queued`. Returns the number of builds promoted.
+pub async fn write_edges_and_promote(
+    state: &Arc<ServerState>,
+    evaluation_id: EvaluationId,
+    organization_id: OrganizationId,
+    ready: Vec<(String, Vec<String>)>,
+) -> Result<usize> {
+    if ready.is_empty() {
+        return Ok(0);
+    }
+
+    let edges: Vec<(String, Vec<String>)> = ready
+        .iter()
+        .filter(|(_, deps)| !deps.is_empty())
+        .cloned()
+        .collect();
+    if !edges.is_empty() {
+        flush_deferred_deps(state, evaluation_id, organization_id, edges).await?;
+    }
+
+    let promote: Vec<String> = ready.into_iter().map(|(p, _)| p).collect();
+    promote_ready_builds(state, evaluation_id, organization_id, &promote).await
+}
+
 pub async fn handle_eval_job_failed(
     state: &Arc<ServerState>,
     evaluation_id: EvaluationId,

--- a/backend/gradient-scheduler/src/job_handlers.rs
+++ b/backend/gradient-scheduler/src/job_handlers.rs
@@ -309,27 +309,28 @@ impl Scheduler {
             }
         }
 
-        // Accumulate dep edges to flush later (at eval-job-completed) when
-        // every derivation row is guaranteed to be in the DB. The BFS walks
-        // roots→leaves, so batch N may contain a derivation whose dep lands
-        // in batch N+1 - inserting the edge now would FK-fail or silently
-        // skip the dep because the row doesn't exist yet.
+        // #392: record this batch in the eval's readiness tracker (a pure,
+        // in-memory step) before inserting rows, then insert rows, then write
+        // the now-complete edges and promote their builds to Queued. The BFS
+        // walks roots→leaves, so a batch may reference a dep whose row lands
+        // later; the tracker reports a source only once all its deps have rows.
+        // The map lock is held only for the in-memory observe so other evals
+        // aren't blocked on this eval's DB work.
         let eval_id = job.evaluation_id;
-        let dep_pairs: Vec<(String, Vec<String>)> = derivations
-            .iter()
-            .filter(|d| !d.dependencies.is_empty())
-            .map(|d| (d.drv_path.clone(), d.dependencies.clone()))
-            .collect();
-        if !dep_pairs.is_empty() {
-            self.deferred_deps
-                .write()
-                .await
-                .entry(eval_id)
-                .or_default()
-                .extend(dep_pairs);
+        let ready = {
+            let mut trackers = self.edge_readiness.write().await;
+            trackers.entry(eval_id).or_default().observe(&derivations)
+        };
+
+        eval::handle_eval_result(&self.state, &job, derivations, warnings, errors).await?;
+
+        match eval::write_edges_and_promote(&self.state, eval_id, job.peer_id, ready).await {
+            Ok(n) if n > 0 => self.kick_dispatch(),
+            Ok(_) => {}
+            Err(e) => error!(error = %e, %eval_id, "write_edges_and_promote failed"),
         }
 
-        eval::handle_eval_result(&self.state, &job, derivations, warnings, errors).await
+        Ok(())
     }
 
     pub async fn handle_build_output(
@@ -393,13 +394,15 @@ impl Scheduler {
                     };
                 }
 
-                // Flush deferred dependency edges BEFORE promoting builds,
+                // Drain any edges the incremental path never resolved (a dep
+                // whose row never landed) and flush them before final promotion
                 // so the dispatch SQL's dep-gating sees the full graph.
                 let deferred = self
-                    .deferred_deps
+                    .edge_readiness
                     .write()
                     .await
                     .remove(&j.evaluation_id)
+                    .map(|mut t| t.drain_pending())
                     .unwrap_or_default();
                 if let Err(e) =
                     eval::flush_deferred_deps(&self.state, j.evaluation_id, j.peer_id, deferred)
@@ -440,6 +443,7 @@ impl Scheduler {
         let job = self.job_tracker.write().await.remove_active(job_id);
         match job {
             Some(PendingJob::Eval(j)) => {
+                self.edge_readiness.write().await.remove(&j.evaluation_id);
                 eval::handle_eval_job_failed(&self.state, j.evaluation_id, error).await
             }
             Some(PendingJob::Build(j)) => {

--- a/backend/gradient-scheduler/src/lib.rs
+++ b/backend/gradient-scheduler/src/lib.rs
@@ -37,12 +37,14 @@ use gradient_types::*;
 use gradient_core::ServerState;
 use tokio::sync::RwLock;
 
+use edge_readiness::EdgeReadiness;
 use jobs::JobTracker;
 use worker_pool::WorkerPool;
 
-/// Per-evaluation deferred dependency edges accumulated during eval result
-/// processing and flushed once all derivation rows are in the DB.
-type DeferredDeps = Arc<RwLock<HashMap<EvaluationId, Vec<(String, Vec<String>)>>>>;
+/// Per-evaluation edge-readiness trackers driving incremental `Created → Queued`
+/// promotion (#392). Entries are dropped when the eval completes, fails, or is
+/// aborted.
+type EdgeReadinessMap = Arc<RwLock<HashMap<EvaluationId, EdgeReadiness>>>;
 
 pub use gradient_types::BoardEvent;
 pub use jobs::PendingJobInfo;
@@ -72,16 +74,11 @@ pub struct Scheduler {
     /// completion speed rather than one level per interval. `notify_one` keeps a
     /// single permit, so a kick fired mid-pass is still serviced next iteration.
     pub(crate) dispatch_kick: Arc<tokio::sync::Notify>,
-    /// Per-evaluation deferred dependency edges.
-    ///
-    /// The worker's BFS walks roots→leaves, so batch N may contain a
-    /// derivation whose dependency lands in batch N+1. Trying to insert the
-    /// edge immediately would FK-fail (dep row doesn't exist yet) or silently
-    /// skip (dep not in `drv_path_to_id`). We accumulate `(drv_path,
-    /// Vec<dep_drv_path>)` per eval here and flush them all at once in
-    /// `handle_eval_job_completed` when every derivation row is guaranteed
-    /// to be in the DB.
-    pub(crate) deferred_deps: DeferredDeps,
+    /// Per-evaluation edge-readiness trackers (#392). The worker's BFS walks
+    /// roots→leaves, so a batch may reference a dep whose row lands later; the
+    /// tracker records seen derivations and reports which become edge-complete
+    /// each batch so their builds promote to `Queued` mid-evaluation.
+    pub(crate) edge_readiness: EdgeReadinessMap,
     /// Scoring policy used when selecting which pending job to assign to a
     /// requesting worker.  Shared via `Arc` so it can be read lock-free.
     pub(crate) policy: Arc<dyn gradient_score::ScoringPolicy>,
@@ -105,7 +102,7 @@ impl Scheduler {
             job_tracker: Arc::new(RwLock::new(JobTracker::new())),
             job_notify: Arc::new(tokio::sync::watch::channel(0u64).0),
             dispatch_kick: Arc::new(tokio::sync::Notify::new()),
-            deferred_deps: Arc::new(RwLock::new(HashMap::new())),
+            edge_readiness: Arc::new(RwLock::new(HashMap::new())),
             policy,
             instance: Arc::new(arc_swap::ArcSwap::from_pointee(gradient_score::InstanceContext::default())),
         }
@@ -121,6 +118,8 @@ impl Scheduler {
         for bid in build_ids {
             tracker.remove_job(&format!("build:{bid}"));
         }
+
+        self.edge_readiness.write().await.remove(&eval_id);
     }
 
     /// Spawn background project polling, eval dispatch, and build dispatch loops.

--- a/backend/gradient-scheduler/src/lib.rs
+++ b/backend/gradient-scheduler/src/lib.rs
@@ -25,6 +25,7 @@ pub mod worker_pool;
 pub mod worker_state;
 
 mod dispatch_mode;
+mod edge_readiness;
 mod job_handlers;
 pub(crate) mod trigger_dispatch;
 mod worker_lifecycle;

--- a/docs/src/development/internals.md
+++ b/docs/src/development/internals.md
@@ -69,6 +69,8 @@ evaluation:  Queued → Fetching → EvaluatingFlake → EvaluatingDerivation �
 
 `Substituted` is distinct from `Completed`: it means the derivation was already in the local Nix store at evaluation time and never ran on a builder.
 
+Builds promote `Created → Queued` incrementally (#392): as soon as a derivation's full set of direct dependency edges is in the DB — which may happen mid-walk — its build is queued, and the dispatcher (which gates on dependencies, not evaluation status) may start it while later derivations still evaluate. The evaluation row stays in `EvaluatingDerivation` until the walk finishes, then moves to `Building`.
+
 ---
 
 ## Build Dispatcher

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -2,6 +2,19 @@
 
 This page tracks notable tests added to Gradient and where they live.
 
+## Incremental Created → Queued promotion (#392)
+
+`backend/gradient-scheduler/src/edge_readiness.rs` unit-tests the pure
+`EdgeReadiness` tracker that decides when a derivation's full direct-dependency
+edge set is in the DB so its build can be queued mid-evaluation: leaves promote
+in the same batch, a parent promotes only once its last dependency row appears
+(in any discovery order), a diamond graph reports each node exactly once with the
+complete edge set, re-observing a seen derivation is a no-op, and unresolved
+sources drain at eval end. The DB wiring (`write_edges_and_promote`) reuses the
+proven `flush_deferred_deps` query and the `update_build_status` promotion loop,
+so it is covered by the existing `handle_eval_job_completed` handler tests plus
+E2E CI rather than a new MockDatabase sequence.
+
 ## PostgreSQL minimum-version guard (#387)
 
 `connect_db` reads `server_version_num` at startup and aborts before running


### PR DESCRIPTION
Closes #392. Promote each build to `Queued` as soon as its full dependency-edge set is in the DB, incrementally per eval batch, so builds dispatch while the rest of the graph still evaluates; evaluation status stays `Evaluating*` until the walk finishes and the end-of-eval reconcile is retained as a safety net.