### PR TITLE
board: feat: scoring-rule descriptions popup and base-worker state export

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2501,6 +2501,7 @@ dependencies = [
  "gradient-nix",
  "gradient-proto",
  "gradient-scheduler",
+ "gradient-score",
  "gradient-sources",
  "gradient-state",
  "gradient-storage",

--- a/backend/gradient-score/src/lib.rs
+++ b/backend/gradient-score/src/lib.rs
@@ -15,5 +15,5 @@ pub use context::{
     BuildContext, BuildContextLazy, DerivationRef, EvalContext, HistoryPrediction, InstanceContext,
     JobKindContext, LazyProviders, ScoredJob, Windowed, WorkerMetricsView,
 };
-pub use policy::{policy_by_name, RulePolicy, ScoringPolicy};
+pub use policy::{policy_by_name, rule_catalog, RulePolicy, ScoringPolicy};
 pub use rule::{JobContext, ScoreRule, WorkerContext};

--- a/backend/gradient-score/src/policy.rs
+++ b/backend/gradient-score/src/policy.rs
@@ -108,6 +108,16 @@ pub fn resource_aware_rules() -> Vec<Box<dyn ScoreRule>> {
     rules
 }
 
+/// `(name, description)` for every known scoring rule, so the board UI can show
+/// what each rule does. Built from the superset policy and deduplicated by name.
+pub fn rule_catalog() -> Vec<(&'static str, &'static str)> {
+    let mut catalog: Vec<(&'static str, &'static str)> =
+        resource_aware_rules().iter().map(|r| (r.name(), r.description())).collect();
+    catalog.sort_by_key(|(name, _)| *name);
+    catalog.dedup_by_key(|(name, _)| *name);
+    catalog
+}
+
 pub fn policy_by_name(name: &str) -> std::sync::Arc<dyn ScoringPolicy> {
     match name {
         "simple" => std::sync::Arc::new(RulePolicy::new("simple", simple_rules(), false)),
@@ -142,6 +152,25 @@ mod tests {
 
     fn worker_ctx<'a>(archs: &'a [String], feats: &'a [String]) -> WorkerContext<'a> {
         WorkerContext { architectures: archs, system_features: feats, fetch: false, metrics: None }
+    }
+
+    #[test]
+    fn rule_catalog_covers_every_rule_with_a_description() {
+        let catalog = rule_catalog();
+        let rules = resource_aware_rules();
+
+        assert_eq!(catalog.len(), rules.len(), "catalog must list every rule once");
+        for (name, description) in &catalog {
+            assert!(!name.is_empty(), "rule name must not be empty");
+            assert!(!description.is_empty(), "{name} is missing a description");
+        }
+        for r in &rules {
+            assert!(
+                catalog.iter().any(|(n, _)| *n == r.name()),
+                "{} missing from catalog",
+                r.name()
+            );
+        }
     }
 
     #[test]

--- a/backend/gradient-score/src/rule.rs
+++ b/backend/gradient-score/src/rule.rs
@@ -41,4 +41,7 @@ pub trait ScoreRule: Send + Sync + std::fmt::Debug {
         let full = std::any::type_name::<Self>();
         full.rsplit("::").next().unwrap_or(full)
     }
+    /// Human-readable explanation of what the rule rewards or penalizes, surfaced
+    /// in the board UI next to the rule name.
+    fn description(&self) -> &'static str;
 }

--- a/backend/gradient-score/src/rules/affinity.rs
+++ b/backend/gradient-score/src/rules/affinity.rs
@@ -40,6 +40,10 @@ impl ScoreRule for NetworkAffinityRule {
         let reference = instance.network_mbps.w24h_or(self.reference_mbps);
         self.bonus * (net as f64 / reference).min(1.0)
     }
+
+    fn description(&self) -> &'static str {
+        "Steers fixed-output (network-fetching) derivations towards workers with faster measured network throughput."
+    }
 }
 
 /// Disk-heavy builds (by history) prefer faster-disk workers. Bonus scales to
@@ -75,6 +79,10 @@ impl ScoreRule for DiskAffinityRule {
             return 0.0;
         };
         self.bonus * (disk as f64 / self.reference_mbps).min(1.0)
+    }
+
+    fn description(&self) -> &'static str {
+        "Steers builds that have historically been disk-heavy towards workers with faster measured disk throughput."
     }
 }
 

--- a/backend/gradient-score/src/rules/builtin.rs
+++ b/backend/gradient-score/src/rules/builtin.rs
@@ -36,6 +36,10 @@ impl ScoreRule for MissingPathsRule {
             }
         }
     }
+
+    fn description(&self) -> &'static str {
+        "Rewards jobs whose dependencies are mostly already on the worker, so fewer store paths must be substituted before the build can start."
+    }
 }
 
 #[derive(Debug)]
@@ -68,6 +72,10 @@ impl ScoreRule for MissingNarSizeRule {
             }
         }
     }
+
+    fn description(&self) -> &'static str {
+        "Rewards jobs with little or no data left to download, favouring small substitution transfers over large ones."
+    }
 }
 
 #[derive(Debug)]
@@ -95,6 +103,10 @@ impl ScoreRule for BuiltinDeprioritizeRule {
         }
 
         0.0
+    }
+
+    fn description(&self) -> &'static str {
+        "Penalizes Nix builtin derivations (fetchers and the like) so they yield worker slots to real compilation jobs."
     }
 }
 
@@ -126,6 +138,10 @@ impl ScoreRule for DependencyCountRule {
 
         self.cap * (job.dependency_count as f64 / base).clamp(0.0, 1.0)
     }
+
+    fn description(&self) -> &'static str {
+        "Rewards jobs that many other queued builds depend on, so unblocking work is scheduled ahead of leaf builds."
+    }
 }
 
 #[derive(Debug)]
@@ -153,6 +169,10 @@ impl ScoreRule for WaitTimeRule {
         let avg = instance.wait_secs.w1h_or(self.fallback_avg_secs);
 
         (self.gain * (waited / avg)).min(self.cap)
+    }
+
+    fn description(&self) -> &'static str {
+        "Grows with how long a job has been waiting in the queue, preventing starvation of jobs the other rules keep deprioritizing."
     }
 }
 
@@ -187,6 +207,10 @@ impl ScoreRule for ReserveFetchWorkersRule {
 
         -self.penalty * (1.0 - spare).clamp(0.0, 1.0)
     }
+
+    fn description(&self) -> &'static str {
+        "Keeps fetch-capable workers free for flake fetches by penalizing them for cached evaluations, easing off as idle workers appear."
+    }
 }
 
 #[derive(Debug)]
@@ -217,6 +241,10 @@ impl ScoreRule for RescoreWaitRule {
         } else {
             0.0
         }
+    }
+
+    fn description(&self) -> &'static str {
+        "Briefly holds back builds whose substitution cost has not been measured yet, letting them be rescored once the data lands."
     }
 }
 

--- a/backend/gradient-score/src/rules/fair_share.rs
+++ b/backend/gradient-score/src/rules/fair_share.rs
@@ -33,6 +33,10 @@ impl ScoreRule for FairShareRule {
             None => 0.0,
         }
     }
+
+    fn description(&self) -> &'static str {
+        "Penalizes a job by how large a share of currently-active builds its organization already holds, so a busy org cannot starve a quiet one."
+    }
 }
 
 #[cfg(test)]

--- a/backend/gradient-score/src/rules/prefer_local.rs
+++ b/backend/gradient-score/src/rules/prefer_local.rs
@@ -39,6 +39,10 @@ impl ScoreRule for PreferLocalBuildRule {
             None => 0.0,
         }
     }
+
+    fn description(&self) -> &'static str {
+        "Rewards keeping a `preferLocalBuild` derivation on a worker that already has its inputs, since shipping it elsewhere rarely pays off."
+    }
 }
 
 #[cfg(test)]

--- a/backend/gradient-score/src/rules/resource.rs
+++ b/backend/gradient-score/src/rules/resource.rs
@@ -48,6 +48,10 @@ impl ScoreRule for ResourceFitRule {
         }
         s
     }
+
+    fn description(&self) -> &'static str {
+        "Uses historical RAM and CPU usage to penalize workers that would likely run out of memory and reward CPU-strong workers for compute-heavy builds."
+    }
 }
 
 #[cfg(test)]

--- a/backend/gradient-state/src/export.rs
+++ b/backend/gradient-state/src/export.rs
@@ -58,6 +58,9 @@ pub async fn export_state<C: ConnectionTrait>(db: &C) -> Result<StateConfigurati
     let cache_roles = gradient_entity::cache_role::Entity::find().all(db).await?;
     let api_keys = gradient_entity::api::Entity::find().all(db).await?;
     let registrations = gradient_entity::worker_registration::Entity::find().all(db).await?;
+    let base_workers = gradient_entity::base_worker::Entity::find().all(db).await?;
+    let base_worker_orgs =
+        gradient_entity::organization_base_worker::Entity::find().all(db).await?;
     let integrations = gradient_entity::integration::Entity::find().all(db).await?;
     let org_users = gradient_entity::organization_user::Entity::find().all(db).await?;
     let cache_users = gradient_entity::cache_user::Entity::find().all(db).await?;
@@ -308,6 +311,14 @@ pub async fn export_state<C: ConnectionTrait>(db: &C) -> Result<StateConfigurati
         );
     }
 
+    // Server-level base workers live in their own table; emit them with their
+    // pre-enabled orgs so `base_worker = true` entries survive a state round-trip.
+    for bw in &base_workers {
+        config
+            .workers
+            .insert(bw.worker_id.clone(), export_base_worker(bw, &base_worker_orgs, &org_name, &username));
+    }
+
     for i in &integrations {
         let (Ok(kind), Ok(forge)) = (
             IntegrationKind::try_from(i.kind),
@@ -342,6 +353,37 @@ pub async fn export_state<C: ConnectionTrait>(db: &C) -> Result<StateConfigurati
     }
 
     Ok(config)
+}
+
+/// Reconstruct a base-worker [`StateWorker`] from its row plus the per-org
+/// opt-ins. `token_file` is unrecoverable from the stored hash, so it is blank
+/// (redacted to `null`), same as the registered-worker export.
+fn export_base_worker(
+    bw: &gradient_entity::base_worker::Model,
+    org_links: &[gradient_entity::organization_base_worker::Model],
+    org_name: &HashMap<OrganizationId, String>,
+    username: &HashMap<UserId, String>,
+) -> StateWorker {
+    let organizations = org_links
+        .iter()
+        .filter(|l| l.base_worker == bw.id)
+        .filter_map(|l| org_name.get(&l.organization).cloned())
+        .collect();
+
+    StateWorker {
+        worker_id: bw.worker_id.clone(),
+        url: bw.url.clone(),
+        organizations,
+        token_file: String::new(),
+        display_name: bw.display_name.clone(),
+        created_by: bw.created_by.and_then(|id| username.get(&id).cloned()).unwrap_or_default(),
+        enable_fetch: bw.enable_fetch,
+        enable_eval: bw.enable_eval,
+        enable_build: bw.enable_build,
+        base_worker: true,
+        authorize_against: bw.authorize_against.map(|u| u.to_string()),
+        enabled: bw.enabled,
+    }
 }
 
 fn export_trigger(
@@ -605,6 +647,54 @@ fn nix_string(s: &str) -> String {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn export_base_worker_emits_flag_orgs_and_authorize_against() {
+        let org_a = OrganizationId::now_v7();
+        let org_b = OrganizationId::now_v7();
+        let user = UserId::now_v7();
+        let bw_id = BaseWorkerId::now_v7();
+        let auth = uuid::Uuid::now_v7();
+
+        let bw = gradient_entity::base_worker::Model {
+            id: bw_id,
+            worker_id: "bw-1".to_string(),
+            token_hash: "hash".to_string(),
+            url: Some("https://bw.example".to_string()),
+            display_name: "Base".to_string(),
+            enable_fetch: true,
+            enable_eval: false,
+            enable_build: true,
+            enabled: true,
+            authorize_against: Some(auth),
+            created_by: Some(user),
+            ..Default::default()
+        };
+        let links = vec![
+            gradient_entity::organization_base_worker::Model {
+                organization: org_a,
+                base_worker: bw_id,
+                ..Default::default()
+            },
+            gradient_entity::organization_base_worker::Model {
+                organization: org_b,
+                base_worker: BaseWorkerId::now_v7(),
+                ..Default::default()
+            },
+        ];
+        let org_name = HashMap::from([(org_a, "org-a".to_string()), (org_b, "org-b".to_string())]);
+        let username = HashMap::from([(user, "alice".to_string())]);
+
+        let sw = export_base_worker(&bw, &links, &org_name, &username);
+
+        assert!(sw.base_worker);
+        assert!(sw.enabled);
+        assert!(!sw.enable_eval);
+        assert_eq!(sw.created_by, "alice");
+        assert_eq!(sw.authorize_against, Some(auth.to_string()));
+        assert_eq!(sw.organizations, vec!["org-a".to_string()]);
+        assert!(sw.token_file.is_empty());
+    }
 
     #[test]
     fn redact_nulls_secret_files_at_any_depth() {

--- a/backend/gradient-web/Cargo.toml
+++ b/backend/gradient-web/Cargo.toml
@@ -27,6 +27,7 @@ gradient-util = { workspace = true }
 gradient-types = { workspace = true }
 gradient-proto = { workspace = true }
 gradient-scheduler = { workspace = true }
+gradient-score = { workspace = true }
 gradient-cache = { workspace = true }
 gradient-entity = { workspace = true }
 

--- a/backend/gradient-web/src/endpoints/board.rs
+++ b/backend/gradient-web/src/endpoints/board.rs
@@ -443,6 +443,26 @@ pub struct ScoringSummary {
     pub rules: Vec<RuleContribution>,
 }
 
+#[derive(Serialize)]
+pub struct RuleDescription {
+    pub rule: String,
+    pub description: String,
+}
+
+/// Static catalog of every scoring rule and what it rewards or penalizes, so the
+/// board UI can explain rule names in a help popup without duplicating the text.
+pub async fn get_scoring_rules() -> WebResult<Json<BaseResponse<Vec<RuleDescription>>>> {
+    let rules = gradient_score::rule_catalog()
+        .into_iter()
+        .map(|(rule, description)| RuleDescription {
+            rule: rule.to_string(),
+            description: description.to_string(),
+        })
+        .collect();
+
+    Ok(ok_json(rules))
+}
+
 /// Aggregate scoring view over recently dispatched jobs: a score histogram plus
 /// the mean per-rule contribution, so operators can see how the policy scored
 /// real dispatches without opening every job. Scope-masked to the caller's orgs.

--- a/backend/gradient-web/src/endpoints/orgs/workers.rs
+++ b/backend/gradient-web/src/endpoints/orgs/workers.rs
@@ -246,6 +246,19 @@ fn base_worker_entry(
     }
 }
 
+/// A normal per-org registration shadows a base worker with the same
+/// `worker_id` (#407): the org manages its own entry, so the redundant base
+/// worker is dropped from that org's list.
+fn unshadowed_base_workers(
+    base_workers: Vec<base_worker::Model>,
+    registered_worker_ids: &std::collections::HashSet<String>,
+) -> Vec<base_worker::Model> {
+    base_workers
+        .into_iter()
+        .filter(|bw| !registered_worker_ids.contains(&bw.worker_id))
+        .collect()
+}
+
 pub async fn get_org_workers(
     state: State<Arc<ServerState>>,
     Path(organization): Path<String>,
@@ -326,7 +339,10 @@ pub async fn get_org_workers(
         .map(|r| r.base_worker)
         .collect();
 
-    entries.extend(base_workers.into_iter().map(|bw| {
+    let registered_ids: std::collections::HashSet<String> =
+        entries.iter().map(|e| e.worker_id.clone()).collect();
+
+    entries.extend(unshadowed_base_workers(base_workers, &registered_ids).into_iter().map(|bw| {
         let live = live_for(&bw.worker_id);
         let active = enabled_ids.contains(&bw.id);
         base_worker_entry(bw, active, live)
@@ -630,15 +646,9 @@ pub async fn delete_org_worker(
     )
     .await?;
 
-    if gradient_db::base_workers::enabled_base_worker_by_worker_id(&state.web_db, &worker_id)
-        .await?
-        .is_some()
-    {
-        return Err(WebError::conflict(
-            "base workers cannot be deleted; manage them via server state",
-        ));
-    }
-
+    // A normal registration shadows a base worker of the same id (#407), so
+    // delete it first; only fall back to the base-worker guard when the org has
+    // no registration to remove.
     let result = EWorkerRegistration::delete_many()
         .filter(worker_registration::Column::PeerId.eq(org.id))
         .filter(worker_registration::Column::WorkerId.eq(&worker_id))
@@ -646,6 +656,15 @@ pub async fn delete_org_worker(
         .await?;
 
     if result.rows_affected == 0 {
+        if gradient_db::base_workers::enabled_base_worker_by_worker_id(&state.web_db, &worker_id)
+            .await?
+            .is_some()
+        {
+            return Err(WebError::conflict(
+                "base workers cannot be deleted; manage them via server state",
+            ));
+        }
+
         return Err(WebError::not_found("worker registration"));
     }
 
@@ -789,5 +808,19 @@ mod tests {
         let opted_out = base_worker_entry(base_worker_model(), false, None);
         assert!(opted_out.is_base);
         assert!(!opted_out.active);
+    }
+
+    #[test]
+    fn registration_shadows_base_worker_of_same_id() {
+        let shadowed = base_worker_model();
+        let mut other = base_worker_model();
+        other.id = BaseWorkerId::now_v7();
+        other.worker_id = "bw2".into();
+
+        let registered = HashSet::from(["bw1".to_string()]);
+        let visible = unshadowed_base_workers(vec![shadowed, other], &registered);
+
+        assert_eq!(visible.len(), 1, "the registered worker_id is hidden");
+        assert_eq!(visible[0].worker_id, "bw2");
     }
 }

--- a/backend/gradient-web/src/lib.rs
+++ b/backend/gradient-web/src/lib.rs
@@ -564,6 +564,7 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
         )
         .route("/board/jobs/{id}", get(board::get_dispatched_job))
         .route("/board/scoring/summary", get(board::get_scoring_summary))
+        .route("/board/scoring/rules", get(board::get_scoring_rules))
         .route("/board/cache", get(board_metrics::get_board_cache))
         .route("/board/network", get(board_metrics::get_board_network))
         .route("/board/fleet", get(board_metrics::get_board_fleet))

--- a/backend/gradient-web/tests/admin_state.rs
+++ b/backend/gradient-web/tests/admin_state.rs
@@ -41,7 +41,7 @@ fn with_user(db: MockDatabase, session_id: SessionId, caller: gradient_entity::u
         .append_query_results([vec![caller]])
 }
 
-/// Append the sixteen (all-empty) table reads `export_state` issues, in order.
+/// Append the eighteen (all-empty) table reads `export_state` issues, in order.
 fn with_empty_export(db: MockDatabase) -> MockDatabase {
     db.append_query_results([Vec::<gradient_entity::user::Model>::new()])
         .append_query_results([Vec::<gradient_entity::organization::Model>::new()])
@@ -51,6 +51,8 @@ fn with_empty_export(db: MockDatabase) -> MockDatabase {
         .append_query_results([Vec::<gradient_entity::cache_role::Model>::new()])
         .append_query_results([Vec::<gradient_entity::api::Model>::new()])
         .append_query_results([Vec::<gradient_entity::worker_registration::Model>::new()])
+        .append_query_results([Vec::<gradient_entity::base_worker::Model>::new()])
+        .append_query_results([Vec::<gradient_entity::organization_base_worker::Model>::new()])
         .append_query_results([Vec::<gradient_entity::integration::Model>::new()])
         .append_query_results([Vec::<gradient_entity::organization_user::Model>::new()])
         .append_query_results([Vec::<gradient_entity::cache_user::Model>::new()])

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -3775,9 +3775,12 @@ paths:
       summary: List registered workers for an organization
       description: |
         Returns all workers registered under this organization (peer), merged with
-        live status from the scheduler for currently connected workers.
+        live status from the scheduler for currently connected workers, plus the
+        server-level base workers (`is_base: true`) the org can opt into.
         Live fields (`architectures`, `system_features`, etc.) are only populated
-        for build-capable workers that have sent `WorkerCapabilities`.
+        for build-capable workers that have sent `WorkerCapabilities`. A base
+        worker is omitted when the org already has a normal registration with the
+        same `worker_id` - that registration shadows it.
       operationId: listOrgWorkers
       security:
         - bearerAuth: []
@@ -3937,6 +3940,9 @@ paths:
       description: |
         Removes the worker registration. The worker may still be connected until
         it disconnects naturally - it will not be able to reconnect after that.
+        The org's own registration is removed first, so a normal worker is deleted
+        even when a base worker shares its `worker_id`; `409` is only returned when
+        the id resolves solely to a base worker (managed via server state).
       operationId: deleteOrgWorker
       security:
         - bearerAuth: []
@@ -3956,6 +3962,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          description: The id resolves only to a base worker, which is managed via server state.
 
   /orgs/{organization}/workers/{worker_id}/test:
     post:

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -4038,9 +4038,10 @@ paths:
       summary: Export the live state configuration
       description: |
         Reconstructs the current users, organizations, projects, caches,
-        custom roles, API keys, workers and integrations into a declarative
-        `services.gradient.state` shape, so operators can codify the running
-        system back into their nix configuration.
+        custom roles, API keys, workers (including server-level base workers
+        with their pre-enabled organizations) and integrations into a
+        declarative `services.gradient.state` shape, so operators can codify
+        the running system back into their nix configuration.
 
         Every credential-file field (`password_file`, `private_key_file`,
         `signing_key_file`, `token_file`, `key_file`, `secret_file`,
@@ -6051,6 +6052,31 @@ paths:
       responses:
         '200':
           description: Scoring summary
+
+  /board/scoring/rules:
+    get:
+      tags: [board]
+      summary: Scoring rule catalog
+      description: Static name and human-readable description for every scheduler scoring rule, used by the board UI to explain rule names.
+      operationId: getBoardScoringRules
+      responses:
+        '200':
+          description: Rule catalog
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BaseResponse'
+                  - type: object
+                    properties:
+                      message:
+                        type: array
+                        items:
+                          type: object
+                          required: [rule, description]
+                          properties:
+                            rule: { type: string }
+                            description: { type: string }
 
   /board/workers:
     get:

--- a/docs/src/development/scheduler-scoring.md
+++ b/docs/src/development/scheduler-scoring.md
@@ -21,7 +21,10 @@ unset, and unknown names log a warning and fall back to `resource-aware`.
   `score(&JobContext, &WorkerContext, &InstanceContext) -> f64`.
 - `RulePolicy`: a named `Vec<Box<dyn ScoreRule>>` whose `score` sums each rule.
 - `ScoreRule` (`rule.rs`): one
-  `score(&JobContext, &WorkerContext, &InstanceContext) -> f64` contribution.
+  `score(&JobContext, &WorkerContext, &InstanceContext) -> f64` contribution
+  plus a `description()` explaining what it rewards or penalizes. The board UI
+  reads these via `GET /board/scoring/rules` (`rule_catalog()`) to show a help
+  popup next to each rule name.
 - Three scoring inputs:
   - `JobContext` — per-candidate: kind, architecture, missing-path count,
     missing NAR size, dependency count, `queued_at`/`ready_at`, `rescore_count`
@@ -121,7 +124,8 @@ affinity rules are no-ops.
 
 ## Adding a rule or policy
 
-Implement `ScoreRule` for a new contribution, add it to a rule list in
-`policy.rs` (or a new list), and register the named policy in `policy_by_name`.
-Each rule has unit tests in `backend/score/src/rules`; run them with
-`cargo test -p score`.
+Implement `ScoreRule` (including `description()`) for a new contribution, add it
+to a rule list in `policy.rs` (or a new list), and register the named policy in
+`policy_by_name`. The rule is automatically picked up by `rule_catalog()` and so
+appears in the board's rule-help popup. Each rule has unit tests in
+`backend/gradient-score/src/rules`; run them with `cargo test -p gradient-score`.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -16,6 +16,16 @@ This page tracks notable tests added to Gradient and where they live.
 
 `nix/tests/gradient/api` — E2E NixOS VM test provisions a base worker via state, calls `GET /orgs/{org}/workers` and asserts `is_base: true` in the response, then calls `POST /orgs/{org}/workers/{id}/test` and checks `ok: true`.
 
+## State export includes base workers (#405)
+
+`backend/gradient-state/src/export.rs` — `export_base_worker_emits_flag_orgs_and_authorize_against` asserts the exporter reconstructs a base worker as a `StateWorker` with `base_worker = true`, the `enabled` and `enable_*` gates, the stringified `authorize_against` UUID, and only the orgs linked via `organization_base_worker` (other base workers' links excluded); `token_file` stays blank because it cannot be recovered from the stored hash.
+
+## Scoring rule descriptions (#403)
+
+`backend/gradient-score/src/policy.rs` — `rule_catalog_covers_every_rule_with_a_description` asserts every `ScoreRule` in the superset policy appears once in `rule_catalog()` with a non-empty name and description, guarding against a new rule shipping without help text.
+
+`frontend/src/app/core/services/board.service.spec.ts` — `getScoringRules()` test verifies the catalog is fetched from `board/scoring/rules`, unwrapped from the response envelope, and cached so repeat subscribers do not refetch.
+
 ## Incremental Created → Queued promotion (#392)
 
 `backend/gradient-scheduler/src/edge_readiness.rs` unit-tests the pure

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -26,6 +26,10 @@ This page tracks notable tests added to Gradient and where they live.
 
 `frontend/src/app/core/services/board.service.spec.ts` — `getScoringRules()` test verifies the catalog is fetched from `board/scoring/rules`, unwrapped from the response envelope, and cached so repeat subscribers do not refetch.
 
+## Worker shadows base worker of same id (#407)
+
+`backend/gradient-web/src/endpoints/orgs/workers.rs` — `registration_shadows_base_worker_of_same_id` asserts `unshadowed_base_workers` drops a base worker whose `worker_id` matches one of the org's normal registrations, so `GET /orgs/{org}/workers` lists the conflicting worker only once (as the org registration). `delete_org_worker` deletes the registration first, so the normal worker is removed even when a base worker shares its id, and the `409` base-worker guard fires only when no registration exists.
+
 ## Incremental Created → Queued promotion (#392)
 
 `backend/gradient-scheduler/src/edge_readiness.rs` unit-tests the pure

--- a/docs/src/usage/job-board.md
+++ b/docs/src/usage/job-board.md
@@ -14,13 +14,13 @@ breakdown, connected workers, throughput, and the most expensive builds.
 
 - **Overview** — live KPIs (connected workers, pending/active jobs, dispatched count) and builds-completed-per-hour.
 - **Live Jobs** — the in-flight dispatched jobs you can see, updated live over a WebSocket. Click a persisted job to open its **inspection page** (`/board/jobs/{id}`): the per-rule scoring breakdown with contribution bars, queue→dispatch wait, and the job/worker context captured at dispatch time. Jobs in orgs you can't access are shown only as an aggregate count.
-- **Scheduler & Scoring** — wait breakdown (**queue wait excluding dependency wait** vs dependency wait) plus an aggregate scoring view: score-distribution histogram and mean per-rule contribution over recent dispatches (`GET /api/v1/board/scoring/summary`). The **?** next to a rule name opens a popup explaining what that rule rewards or penalizes, served by `GET /api/v1/board/scoring/rules`.
+- **Scheduler** — wait breakdown (**queue wait excluding dependency wait** vs dependency wait) plus an aggregate scoring view: score-distribution histogram and mean per-rule contribution over recent dispatches (`GET /api/v1/board/scoring/summary`). The **?** next to a rule name opens a popup explaining what that rule rewards or penalizes, served by `GET /api/v1/board/scoring/rules`.
 - **Throughput** — build pipeline (created/completed/failed) and evaluation rates per hour, plus active jobs per worker.
 - **Durations** — build-duration trend (avg vs max) and the queue-vs-dependency wait split.
 - **Workers** — fleet over time (connected vs draining), capability trend, load-by-capability radar, per-worker slot utilisation, and the live worker table.
 - **Cache** — cache totals, traffic, and storage-growth series (`GET /api/v1/board/cache`).
-- **Network & API** — NAR egress, per-worker network/disk speeds, and a per-route HTTP latency/throughput table (`GET /api/v1/board/network`).
-- **Expensive Jobs** — tabbed rankings of the costliest builds in a window: longest wall-clock, **peak RAM**, **CPU time**, **disk I/O** (all per-build via cgroup v2), and **network** (host-level peak during the build window — cgroup v2 has no per-build network), plus top-orgs-by-build-time for superusers. Acknowledged (muted) derivations can be excluded.
+- **Network** — NAR egress, per-worker network/disk speeds, and a per-route HTTP latency/throughput table (`GET /api/v1/board/network`).
+- **Jobs** — tabbed rankings of the costliest builds in a window: longest wall-clock, **peak RAM**, **CPU time**, **disk I/O** (all per-build via cgroup v2), and **network** (host-level peak during the build window — cgroup v2 has no per-build network), plus top-orgs-by-build-time for superusers. Acknowledged (muted) derivations can be excluded.
 - **System Health** (superuser) — process/runtime snapshot, rollup-pipeline lag, and HTTP route stats (`GET /api/v1/board/health`).
 
 Per-worker deep metrics (CPU/RAM/disk/network time-series, connection history) live under **Organization → Workers → Metrics** (`GET /api/v1/orgs/{org}/workers/{worker_id}/metrics`).

--- a/docs/src/usage/job-board.md
+++ b/docs/src/usage/job-board.md
@@ -14,7 +14,7 @@ breakdown, connected workers, throughput, and the most expensive builds.
 
 - **Overview** — live KPIs (connected workers, pending/active jobs, dispatched count) and builds-completed-per-hour.
 - **Live Jobs** — the in-flight dispatched jobs you can see, updated live over a WebSocket. Click a persisted job to open its **inspection page** (`/board/jobs/{id}`): the per-rule scoring breakdown with contribution bars, queue→dispatch wait, and the job/worker context captured at dispatch time. Jobs in orgs you can't access are shown only as an aggregate count.
-- **Scheduler & Scoring** — wait breakdown (**queue wait excluding dependency wait** vs dependency wait) plus an aggregate scoring view: score-distribution histogram and mean per-rule contribution over recent dispatches (`GET /api/v1/board/scoring/summary`).
+- **Scheduler & Scoring** — wait breakdown (**queue wait excluding dependency wait** vs dependency wait) plus an aggregate scoring view: score-distribution histogram and mean per-rule contribution over recent dispatches (`GET /api/v1/board/scoring/summary`). The **?** next to a rule name opens a popup explaining what that rule rewards or penalizes, served by `GET /api/v1/board/scoring/rules`.
 - **Throughput** — build pipeline (created/completed/failed) and evaluation rates per hour, plus active jobs per worker.
 - **Durations** — build-duration trend (avg vs max) and the queue-vs-dependency wait split.
 - **Workers** — fleet over time (connected vs draining), capability trend, load-by-capability radar, per-worker slot utilisation, and the live worker table.

--- a/docs/src/usage/state.md
+++ b/docs/src/usage/state.md
@@ -528,6 +528,8 @@ services.gradient.state.workers = {
 
 `enabled` is a global gate: setting it to `false` hides the base worker from every org until it is turned back on.
 
+If an organization already has a normal worker registered under the same `worker_id`, that registration shadows the base worker: the base entry is hidden from that org's list and deleting the worker removes the org's own registration instead of erroring about state management.
+
 `authorize_against` pins the UUID identity the base worker authenticates as. When set, the worker's `peersFile` only needs a single `<authorize_against>:<token>` line rather than per-org entries. When omitted the worker must present per-org tokens or use the `*:<token>` wildcard form.
 
 The `peerFile` options for a base worker in order of preference:

--- a/frontend/src/app/core/services/board.service.spec.ts
+++ b/frontend/src/app/core/services/board.service.spec.ts
@@ -8,7 +8,7 @@ import { TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { HttpTestingController } from '@angular/common/http/testing';
-import { BoardService, ExpensiveEval, FlakeGraphNode } from './board.service';
+import { BoardService, ExpensiveEval, FlakeGraphNode, RuleDescription } from './board.service';
 import { environment } from '@environments/environment';
 
 const apiUrl = environment.apiUrl;
@@ -67,5 +67,21 @@ describe('BoardService', () => {
     req.flush({ error: false, message: [sampleNode] });
 
     expect(result).toEqual([sampleNode]);
+  });
+
+  it('getScoringRules() unwraps the catalog and caches it across subscribers', () => {
+    const rules: RuleDescription[] = [{ rule: 'WaitTimeRule', description: 'Grows with queue wait.' }];
+    let first: RuleDescription[] | undefined;
+    service.getScoringRules().subscribe((v) => (first = v));
+
+    const req = httpMock.expectOne(`${apiUrl}/board/scoring/rules`);
+    expect(req.request.method).toBe('GET');
+    req.flush({ error: false, message: rules });
+    expect(first).toEqual(rules);
+
+    let second: RuleDescription[] | undefined;
+    service.getScoringRules().subscribe((v) => (second = v));
+    httpMock.expectNone(`${apiUrl}/board/scoring/rules`);
+    expect(second).toEqual(rules);
   });
 });

--- a/frontend/src/app/core/services/board.service.ts
+++ b/frontend/src/app/core/services/board.service.ts
@@ -5,7 +5,7 @@
  */
 
 import { Injectable, inject } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, shareReplay } from 'rxjs';
 import { ApiService } from './api.service';
 
 export interface DispatchedJobSummary {
@@ -184,6 +184,11 @@ export interface ScoringSummary {
   rules: RuleContribution[];
 }
 
+export interface RuleDescription {
+  rule: string;
+  description: string;
+}
+
 export interface SeriesPoint {
   bucket_start: string;
   count: number;
@@ -295,6 +300,7 @@ export interface FlakeGraphNode {
 @Injectable({ providedIn: 'root' })
 export class BoardService {
   private api = inject(ApiService);
+  private scoringRules$?: Observable<RuleDescription[]>;
 
   getDispatchedJobs(): Observable<DispatchedJobsResponse> {
     return this.api.get<DispatchedJobsResponse>('board/jobs/dispatched');
@@ -324,6 +330,14 @@ export class BoardService {
 
   getScoringSummary(windowHours = 24): Observable<ScoringSummary> {
     return this.api.get<ScoringSummary>(`board/scoring/summary?window_hours=${windowHours}`);
+  }
+
+  getScoringRules(): Observable<RuleDescription[]> {
+    this.scoringRules$ ??= this.api
+      .get<RuleDescription[]>('board/scoring/rules')
+      .pipe(shareReplay({ bufferSize: 1, refCount: false }));
+
+    return this.scoringRules$;
   }
 
   getCache(windowHours = 24): Observable<BoardCacheStats> {

--- a/frontend/src/app/features/board/board-layout.component.ts
+++ b/frontend/src/app/features/board/board-layout.component.ts
@@ -18,14 +18,14 @@ import { RouterModule } from '@angular/router';
       <nav class="board-nav">
         <a routerLink="overview" routerLinkActive="active">Overview</a>
         <a routerLink="live" routerLinkActive="active">Live Jobs</a>
-        <a routerLink="scheduler" routerLinkActive="active">Scheduler &amp; Scoring</a>
+        <a routerLink="scheduler" routerLinkActive="active">Scheduler</a>
         <a routerLink="throughput" routerLinkActive="active">Throughput</a>
         <a routerLink="durations" routerLinkActive="active">Durations</a>
         <a routerLink="workers" routerLinkActive="active">Workers</a>
         <a routerLink="cache" routerLinkActive="active">Cache</a>
-        <a routerLink="network" routerLinkActive="active">Network &amp; API</a>
-        <a routerLink="expensive" routerLinkActive="active">Expensive Jobs</a>
-        <a routerLink="expensive-evals" routerLinkActive="active">Expensive Evals</a>
+        <a routerLink="network" routerLinkActive="active">Network</a>
+        <a routerLink="expensive" routerLinkActive="active">Jobs</a>
+        <a routerLink="expensive-evals" routerLinkActive="active">Evals</a>
         <a routerLink="health" routerLinkActive="active">System Health</a>
       </nav>
       <router-outlet></router-outlet>

--- a/frontend/src/app/features/board/job-detail/job-detail.component.ts
+++ b/frontend/src/app/features/board/job-detail/job-detail.component.ts
@@ -9,12 +9,14 @@ import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { DialogModule } from 'primeng/dialog';
 import { ButtonModule } from 'primeng/button';
+import { PopoverModule, Popover } from 'primeng/popover';
 import {
   BoardService,
   DispatchedJobDetail,
   GradientCapabilities,
   InstanceContextView,
   PendingJobSummary,
+  RuleDescription,
   Windowed,
 } from '@core/services/board.service';
 import { EvaluationsService, BuildWithOutputs } from '@core/services/evaluations.service';
@@ -24,12 +26,13 @@ interface RuleRow {
   value: number;
   share: number;
   positive: boolean;
+  description: string;
 }
 
 @Component({
   selector: 'app-board-job-detail',
   standalone: true,
-  imports: [CommonModule, RouterModule, DialogModule, ButtonModule],
+  imports: [CommonModule, RouterModule, DialogModule, ButtonModule, PopoverModule],
   template: `
     <a routerLink="/board/live" class="back">← Live Jobs</a>
 
@@ -66,7 +69,12 @@ interface RuleRow {
         <tbody>
           @for (r of rules(); track r.name) {
             <tr>
-              <td class="mono">{{ r.name }}</td>
+              <td class="mono">
+                {{ r.name }}
+                @if (r.description) {
+                  <button type="button" class="help" aria-label="Explain rule" (click)="showHelp($event, r, rulePop)">?</button>
+                }
+              </td>
               <td class="num" [class.neg]="!r.positive">{{ r.value | number: '1.2-2' }}</td>
               <td class="bar-cell">
                 <div class="bar" [class.neg]="!r.positive" [style.width.%]="r.share"></div>
@@ -77,6 +85,12 @@ interface RuleRow {
           }
         </tbody>
       </table>
+
+      <p-popover #rulePop>
+        @if (activeRule(); as a) {
+          <div class="rule-help"><strong>{{ a.rule }}</strong><p>{{ a.description }}</p></div>
+        }
+      </p-popover>
 
       @if (j.candidates) {
         <h2>Runner-up candidates</h2>
@@ -309,6 +323,11 @@ interface RuleRow {
       .drv-row .path { color: #818181; font-size: 0.8rem; word-break: break-all; }
       tbody tr.clickable { cursor: pointer; transition: background 0.1s; }
       tbody tr.clickable:hover { background: #2d333b; }
+      .help { margin-left: 0.4rem; width: 1.1rem; height: 1.1rem; padding: 0; border-radius: 50%; border: 1px solid #3d444d; background: #2d333b; color: #abb0b4; font-size: 0.7rem; line-height: 1; cursor: pointer; }
+      .help:hover { color: #fff; border-color: #6f42c1; }
+      .rule-help { max-width: 22rem; }
+      .rule-help strong { display: block; font-family: monospace; color: #fff; margin-bottom: 0.35rem; }
+      .rule-help p { margin: 0; color: #abb0b4; font-size: 0.85rem; line-height: 1.4; }
     `,
   ],
 })
@@ -320,6 +339,8 @@ export class BoardJobDetailComponent implements OnInit {
   job = signal<DispatchedJobDetail | null>(null);
   pending = signal<PendingJobSummary | null>(null);
   notFound = signal(false);
+  private descriptions = signal<Map<string, string>>(new Map());
+  activeRule = signal<RuleDescription | null>(null);
   build = signal<BuildWithOutputs | null>(null);
   buildDialog = signal(false);
   buildLoading = signal(false);
@@ -338,6 +359,7 @@ export class BoardJobDetailComponent implements OnInit {
 
   rules = computed<RuleRow[]>(() => {
     const rules = this.job()?.score_breakdown?.rules ?? {};
+    const descriptions = this.descriptions();
     const entries = Object.entries(rules);
     const maxAbs = Math.max(1e-9, ...entries.map(([, v]) => Math.abs(v)));
     return entries
@@ -346,9 +368,15 @@ export class BoardJobDetailComponent implements OnInit {
         value,
         share: (Math.abs(value) / maxAbs) * 100,
         positive: value >= 0,
+        description: descriptions.get(name) ?? '',
       }))
       .sort((a, b) => Math.abs(b.value) - Math.abs(a.value));
   });
+
+  showHelp(event: Event, row: RuleRow, popover: Popover): void {
+    this.activeRule.set({ rule: row.name, description: row.description });
+    popover.toggle(event);
+  }
 
   waitLabel = computed(() => {
     const j = this.job();
@@ -361,6 +389,9 @@ export class BoardJobDetailComponent implements OnInit {
   ngOnInit(): void {
     const id = this.route.snapshot.paramMap.get('id');
     if (!id) return;
+    this.board
+      .getScoringRules()
+      .subscribe((rules) => this.descriptions.set(new Map(rules.map((r) => [r.rule, r.description]))));
     this.board.getJob(id).subscribe({
       next: (d) => {
         this.job.set(d);

--- a/frontend/src/app/features/board/scheduler/scheduler.component.ts
+++ b/frontend/src/app/features/board/scheduler/scheduler.component.ts
@@ -6,13 +6,14 @@
 
 import { Component, OnInit, inject, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { BoardService, MetricPoint, ScoringSummary } from '@core/services/board.service';
+import { PopoverModule, Popover } from 'primeng/popover';
+import { BoardService, MetricPoint, RuleDescription, ScoringSummary } from '@core/services/board.service';
 import { MetricChartComponent } from '@shared/components/metric-chart/metric-chart.component';
 
 @Component({
   selector: 'app-board-scheduler',
   standalone: true,
-  imports: [CommonModule, MetricChartComponent],
+  imports: [CommonModule, PopoverModule, MetricChartComponent],
   template: `
     <div class="kpis">
       <div class="kpi"><span class="label">Scored dispatches (24h)</span><span class="value">{{ summary()?.sample_size ?? 0 }}</span></div>
@@ -42,7 +43,12 @@ import { MetricChartComponent } from '@shared/components/metric-chart/metric-cha
       <tbody>
         @for (r of ruleRows(); track r.rule) {
           <tr>
-            <td class="mono">{{ r.rule }}</td>
+            <td class="mono">
+              {{ r.rule }}
+              @if (r.description) {
+                <button type="button" class="help" aria-label="Explain rule" (click)="showHelp($event, r, rulePop)">?</button>
+              }
+            </td>
             <td class="num" [class.neg]="r.avg < 0">{{ r.avg | number: '1.2-2' }}</td>
             <td class="num">{{ r.min | number: '1.2-2' }}</td>
             <td class="num">{{ r.max | number: '1.2-2' }}</td>
@@ -53,6 +59,12 @@ import { MetricChartComponent } from '@shared/components/metric-chart/metric-cha
         }
       </tbody>
     </table>
+
+    <p-popover #rulePop>
+      @if (activeRule(); as a) {
+        <div class="rule-help"><strong>{{ a.rule }}</strong><p>{{ a.description }}</p></div>
+      }
+    </p-popover>
   `,
   styles: [
     `
@@ -73,6 +85,11 @@ import { MetricChartComponent } from '@shared/components/metric-chart/metric-cha
       .bar { height: 10px; background: #28a745; border-radius: 3px; min-width: 2px; }
       .bar.neg { background: #dc3545; }
       .muted { color: #818181; }
+      .help { margin-left: 0.4rem; width: 1.1rem; height: 1.1rem; padding: 0; border-radius: 50%; border: 1px solid #3d444d; background: #2d333b; color: #abb0b4; font-size: 0.7rem; line-height: 1; cursor: pointer; }
+      .help:hover { color: #fff; border-color: #6f42c1; }
+      .rule-help { max-width: 22rem; }
+      .rule-help strong { display: block; font-family: monospace; color: #fff; margin-bottom: 0.35rem; }
+      .rule-help p { margin: 0; color: #abb0b4; font-size: 0.85rem; line-height: 1.4; }
     `,
   ],
 })
@@ -82,6 +99,8 @@ export class BoardSchedulerComponent implements OnInit {
   private wait = signal<MetricPoint[]>([]);
   private deps = signal<MetricPoint[]>([]);
   summary = signal<ScoringSummary | null>(null);
+  private descriptions = signal<Map<string, string>>(new Map());
+  activeRule = signal<RuleDescription | null>(null);
 
   waitCategories = computed(() => this.wait().map((p) => p.bucket_start.slice(11, 16)));
   waitSeries = computed(() => {
@@ -101,13 +120,26 @@ export class BoardSchedulerComponent implements OnInit {
 
   ruleRows = computed(() => {
     const rules = this.summary()?.rules ?? [];
+    const descriptions = this.descriptions();
     const maxAbs = Math.max(1e-9, ...rules.map((r) => Math.abs(r.avg)));
-    return rules.map((r) => ({ ...r, share: (Math.abs(r.avg) / maxAbs) * 100 }));
+    return rules.map((r) => ({
+      ...r,
+      share: (Math.abs(r.avg) / maxAbs) * 100,
+      description: descriptions.get(r.rule) ?? '',
+    }));
   });
+
+  showHelp(event: Event, row: { rule: string; description: string }, popover: Popover): void {
+    this.activeRule.set({ rule: row.rule, description: row.description });
+    popover.toggle(event);
+  }
 
   ngOnInit(): void {
     this.board.query('dispatch.wait_ms', 'hour').subscribe((p) => this.wait.set(p));
     this.board.query('deps.wait_ms', 'hour').subscribe((p) => this.deps.set(p));
     this.board.getScoringSummary(24).subscribe((s) => this.summary.set(s));
+    this.board
+      .getScoringRules()
+      .subscribe((rules) => this.descriptions.set(new Map(rules.map((r) => [r.rule, r.description]))));
   }
 }


### PR DESCRIPTION
Adds a `ScoreRule::description()` surfaced via `GET /board/scoring/rules` and a `?` help popup next to rule names in the scheduler and job-detail views (#403); makes `GET /state` export server-level base workers with their pre-enabled orgs (#405); and resolves the base-worker/normal-worker id conflict (#407) by shadowing the base worker for any org that already registered the same `worker_id` (hidden from the list, and deleted registration-first).

Closes #403, closes #405, closes #407.