### PR TITLE
worker: fix: push eval batch source closure before reporting it (#392)

### DIFF
--- a/backend/gradient-proto/src/traits.rs
+++ b/backend/gradient-proto/src/traits.rs
@@ -77,6 +77,15 @@ pub trait JobReporter: Send {
         warnings: Vec<String>,
         errors: Vec<String>,
     ) -> Result<()>;
+
+    /// Push the runtime closure of `drv_paths` (their `input_sources` and
+    /// transitive `.drv` files) into the gradient cache. Best-effort: failures
+    /// are logged, never propagated. Called per batch *before*
+    /// [`report_eval_result`](Self::report_eval_result) so every source a
+    /// downstream build worker prefetches is already cacheable by the time the
+    /// server can dispatch that build mid-evaluation.
+    async fn push_drv_closure(&mut self, drv_paths: &[String]);
+
     async fn report_building(&mut self, build_id: String) -> Result<()>;
     async fn report_build_output(
         &mut self,

--- a/backend/gradient-test-support/src/fakes/job_reporter.rs
+++ b/backend/gradient-test-support/src/fakes/job_reporter.rs
@@ -27,6 +27,9 @@ pub enum ReportedEvent {
         warnings: Vec<String>,
         errors: Vec<String>,
     },
+    DrvClosurePush {
+        drv_paths: Vec<String>,
+    },
     Building {
         build_id: String,
     },
@@ -94,6 +97,18 @@ impl RecordingJobReporter {
             .iter()
             .rev()
             .find(|e| matches!(e, ReportedEvent::EvalResult { .. }))
+    }
+
+    /// Collect every drv path pushed via `push_drv_closure`, across all batches.
+    pub fn all_pushed_drv_paths(&self) -> Vec<&String> {
+        self.events
+            .iter()
+            .filter_map(|e| match e {
+                ReportedEvent::DrvClosurePush { drv_paths } => Some(drv_paths.iter()),
+                _ => None,
+            })
+            .flatten()
+            .collect()
     }
 
     /// Collect all derivations across every `EvalResult` event (incremental batches).
@@ -189,6 +204,12 @@ impl JobReporter for RecordingJobReporter {
             errors,
         });
         Ok(())
+    }
+
+    async fn push_drv_closure(&mut self, drv_paths: &[String]) {
+        self.events.push(ReportedEvent::DrvClosurePush {
+            drv_paths: drv_paths.to_vec(),
+        });
     }
 
     async fn report_building(&mut self, build_id: String) -> Result<()> {

--- a/backend/gradient-worker/src/executor/eval.rs
+++ b/backend/gradient-worker/src/executor/eval.rs
@@ -178,7 +178,7 @@ pub async fn evaluate_derivations(
     local_flake_path: Option<&str>,
     updater: &mut JobUpdater,
     abort: &mut watch::Receiver<bool>,
-) -> Result<Vec<String>> {
+) -> Result<()> {
     let repo = build_flake_url(job, local_flake_path);
     let start = Instant::now();
 
@@ -216,10 +216,7 @@ pub async fn evaluate_derivations(
         }
     }
 
-    let EvalOutcome {
-        produced_drvs: produced,
-        flake_nodes,
-    } = evaluate_derivations_with(
+    let EvalOutcome { flake_nodes } = evaluate_derivations_with(
         &*evaluator.resolver,
         &FsDrvReader,
         job,
@@ -257,7 +254,7 @@ pub async fn evaluate_derivations(
         warn!(error = %e, "eval-cache push failed; continuing");
     }
 
-    Ok(produced)
+    Ok(())
 }
 
 /// Write a pulled eval-cache blob to `path`, creating its parent directory.
@@ -437,9 +434,10 @@ struct ClosureWalker<'a> {
     queue: VecDeque<(Option<String>, String)>,
     walked: usize,
     start: Instant,
-    /// Every `.drv` path the walker actually parsed (i.e. present in the
-    /// local store, not pruned via `known_set`). The caller uses this to
-    /// push each drv NAR into the cache and sign it.
+    /// `.drv` paths the walker parsed since the last flush (present in the
+    /// local store, not pruned via `known_set`). Drained at each flush to push
+    /// the batch's runtime closure to the cache *before* its `report_eval_result`
+    /// so a mid-eval build dispatch never races the source upload.
     produced_drvs: Vec<String>,
 }
 
@@ -580,8 +578,13 @@ impl<'a> ClosureWalker<'a> {
                 );
             }
 
-            // Mid-walk flush: let the server start queuing builds early.
+            // Mid-walk flush: let the server start queuing builds early. Push
+            // this batch's `.drv` runtime closure (input_sources + .drvs)
+            // BEFORE reporting it, so once #392 promotes and dispatches these
+            // builds mid-eval their sources are already in the cache.
             if self.batch.len() >= EVAL_BATCH_SIZE {
+                updater.push_drv_closure(&self.produced_drvs).await;
+                self.produced_drvs.clear();
                 mark_substituted(&mut self.batch, updater).await;
                 debug!(
                     count = self.batch.len(),
@@ -600,11 +603,11 @@ impl<'a> ClosureWalker<'a> {
 
 // ── Orchestrator ──────────────────────────────────────────────────────────────
 
-/// Result of one closure-walk eval: the produced `.drv` paths (pushed to the
-/// cache by the caller) plus the walked flake-output graph for eval metrics.
+/// Result of one closure-walk eval: the walked flake-output graph for eval
+/// metrics. Each batch's `.drv` runtime closure is pushed to the cache during
+/// the walk (before its `report_eval_result`), not by the caller afterwards.
 #[derive(Debug)]
 pub struct EvalOutcome {
-    pub produced_drvs: Vec<String>,
     pub flake_nodes: Vec<FlakeOutputNode>,
 }
 
@@ -727,7 +730,6 @@ pub async fn evaluate_derivations_with(
         warn!("no derivations found for evaluation");
         updater.report_eval_result(vec![], warnings, vec![]).await?;
         return Ok(EvalOutcome {
-            produced_drvs: Vec::new(),
             flake_nodes: Vec::new(),
         });
     }
@@ -768,7 +770,6 @@ pub async fn evaluate_derivations_with(
         warn!("all attr resolutions failed");
         updater.report_eval_result(vec![], warnings, errors).await?;
         return Ok(EvalOutcome {
-            produced_drvs: Vec::new(),
             flake_nodes: Vec::new(),
         });
     }
@@ -778,7 +779,7 @@ pub async fn evaluate_derivations_with(
     // ── Step 3+4+5: BFS closure walk with incremental flushes ────────────────
     let mut walker = ClosureWalker::new(drv_reader, &root_drvs);
     let mut remaining = walker.walk(updater, abort).await?;
-    let produced_drvs = std::mem::take(&mut walker.produced_drvs);
+    let remaining_drvs = std::mem::take(&mut walker.produced_drvs);
 
     // ── Final flush: remaining derivations + deduplicated warnings/errors ─────
     warnings.sort_unstable();
@@ -786,6 +787,9 @@ pub async fn evaluate_derivations_with(
     errors.sort_unstable();
     errors.dedup();
 
+    // Push the trailing batch's closure before its report, same as the mid-walk
+    // flushes, so the last builds' sources are cached before dispatch.
+    updater.push_drv_closure(&remaining_drvs).await;
     mark_substituted(&mut remaining, updater).await;
     debug!(
         count = remaining.len(),
@@ -796,10 +800,7 @@ pub async fn evaluate_derivations_with(
     updater
         .report_eval_result(remaining, warnings, errors)
         .await?;
-    Ok(EvalOutcome {
-        produced_drvs,
-        flake_nodes,
-    })
+    Ok(EvalOutcome { flake_nodes })
 }
 
 #[cfg(test)]
@@ -906,6 +907,54 @@ mod tests {
         if let ReportedEvent::EvalResult { warnings, .. } = reporter.last_eval_result().unwrap() {
             assert!(warnings.is_empty(), "unexpected warnings: {:?}", warnings);
         }
+    }
+
+    /// Regression (#392): every parsed derivation's `.drv` runtime closure must
+    /// be pushed to the cache BEFORE the batch that reports it. Reporting a
+    /// derivation is what lets the server promote+dispatch its build mid-eval,
+    /// so a build worker would otherwise prefetch input_sources that aren't in
+    /// the cache yet ("required input path missing").
+    #[tokio::test]
+    async fn pushes_batch_closure_before_reporting_it() {
+        let fixture = load_store(&fixture_dir());
+        let repo = "https://example.com/repo";
+        let (resolver, drv_reader) = setup_from_fixture(&fixture, repo, "hello");
+        let job = make_flake_job(repo);
+        let mut reporter = RecordingJobReporter::new();
+
+        evaluate_derivations_with(
+            &resolver,
+            &drv_reader,
+            &job,
+            None,
+            &mut reporter,
+            &mut never_abort(),
+        )
+        .await
+        .unwrap();
+
+        let mut pushed: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        for event in &reporter.events {
+            match event {
+                ReportedEvent::DrvClosurePush { drv_paths } => {
+                    pushed.extend(drv_paths.iter().map(|s| s.as_str()));
+                }
+                ReportedEvent::EvalResult { derivations, .. } => {
+                    for d in derivations {
+                        // Known/substituted entries are already cached server-side
+                        // and carry no closure to push; only parsed drvs matter.
+                        assert!(
+                            d.substituted || pushed.contains(d.drv_path.as_str()),
+                            "reported {} before pushing its source closure",
+                            d.drv_path
+                        );
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        assert!(!pushed.is_empty(), "expected at least one closure push");
     }
 
     #[tokio::test]

--- a/backend/gradient-worker/src/executor/mod.rs
+++ b/backend/gradient-worker/src/executor/mod.rs
@@ -82,7 +82,11 @@ async fn query_fetched_paths(updater: &mut JobUpdater, all_paths: Vec<String>) -
 /// Errors during closure expansion or individual NAR pushes are logged but
 /// not fatal - operators see them in the worker log, and downstream builds
 /// surface the missing path through their existing prefetch error path.
-async fn push_drv_closure(drv_paths: &[String], updater: &mut JobUpdater, store: &LocalNixStore) {
+pub(crate) async fn push_drv_closure(
+    drv_paths: &[String],
+    updater: &mut JobUpdater,
+    store: &LocalNixStore,
+) {
     if drv_paths.is_empty() {
         return;
     }
@@ -255,7 +259,13 @@ impl JobExecutor {
                         crate::proto::nar_import::ensure_path(&self.store, src, updater).await?;
                     }
 
-                    let produced_drvs = eval::evaluate_derivations(
+                    // Each batch's `.drv` runtime closure (input_sources + .drvs,
+                    // for narinfo substitution and downstream-build prefetch) is
+                    // pushed to the cache inside the walk, before that batch's
+                    // `report_eval_result` — so #392's mid-eval build dispatch
+                    // never races the source upload. The server keys cached_path
+                    // by hash, so NAR/row ordering is irrelevant.
+                    eval::evaluate_derivations(
                         &self.evaluator,
                         &job,
                         local_flake_path.as_deref(),
@@ -263,17 +273,6 @@ impl JobExecutor {
                         &mut abort.clone(),
                     )
                     .await?;
-
-                    // Push the full runtime closure of every produced
-                    // `.drv` to the cache so substituters can fetch
-                    // `<drv-hash>.narinfo` *and* downstream builds find
-                    // every `input_source` they need on prefetch. Runs
-                    // after eval so the server already has the derivation
-                    // rows; ordering between the NAR and the row doesn't
-                    // matter (the server keys cached_path by hash). The
-                    // server computes narinfo signatures from the uploaded
-                    // metadata.
-                    push_drv_closure(&produced_drvs, updater, &self.store).await;
                 }
             }
         }

--- a/backend/gradient-worker/src/proto/job.rs
+++ b/backend/gradient-worker/src/proto/job.rs
@@ -24,6 +24,7 @@ use tokio::sync::oneshot;
 use tracing::debug;
 
 use crate::connection::ProtoWriter;
+use crate::nix::store::LocalNixStore;
 use crate::proto::eval_cache_recv::EvalCacheReceiver;
 use crate::proto::nar_recv::NarReceiver;
 use gradient_proto::traits::JobReporter;
@@ -68,6 +69,9 @@ pub struct JobUpdater {
     /// Routes `EvalCachePullResult` / `EvalCacheChunk` / `EvalCachePushGrant`
     /// back to the job task during the eval-cache pull/push handshake.
     pub(crate) eval_cache_recv: EvalCacheReceiver,
+    /// Local store, set for jobs that push NARs (eval closure, build outputs).
+    /// `None` in proto round-trip unit tests that never touch the store.
+    pub(crate) store: Option<Arc<LocalNixStore>>,
 }
 
 impl JobUpdater {
@@ -78,6 +82,7 @@ impl JobUpdater {
         known_derivation_waiters: KnownDerivationWaiters,
         nar_recv: NarReceiver,
         eval_cache_recv: EvalCacheReceiver,
+        store: Option<Arc<LocalNixStore>>,
     ) -> Self {
         Self {
             job_id,
@@ -86,6 +91,7 @@ impl JobUpdater {
             known_derivation_waiters,
             nar_recv,
             eval_cache_recv,
+            store,
         }
     }
 
@@ -459,6 +465,14 @@ impl JobReporter for JobUpdater {
         })
     }
 
+    async fn push_drv_closure(&mut self, drv_paths: &[String]) {
+        let Some(store) = self.store.clone() else {
+            return;
+        };
+
+        crate::executor::push_drv_closure(drv_paths, self, &store).await;
+    }
+
     async fn report_building(&mut self, build_id: String) -> Result<()> {
         self.send_update(JobUpdateKind::Building { build_id })
     }
@@ -546,6 +560,7 @@ mod tests {
             known_derivation_waiters,
             nar_recv,
             eval_cache_recv,
+            None,
         );
         (updater, reader)
     }

--- a/backend/gradient-worker/src/worker/dispatch.rs
+++ b/backend/gradient-worker/src/worker/dispatch.rs
@@ -574,6 +574,7 @@ impl<'a> MessageHandler<'a> {
         self.abort_senders.insert(job_id.clone(), abort_tx);
 
         let executor = self.executor.clone();
+        let job_store = Arc::clone(&executor.store);
         let credentials = self.credentials.clone();
         let job_writer = self.writer.clone();
         let job_cache_waiters = Arc::clone(self.cache_waiters);
@@ -591,6 +592,7 @@ impl<'a> MessageHandler<'a> {
                 job_known_derivation_waiters,
                 job_nar_recv,
                 job_eval_cache_recv,
+                Some(job_store),
             );
             let result = run_job(executor, job, &mut updater, &credentials, abort_rx).await;
             let _ = job_done_tx.send((jid, result));

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -43,6 +43,15 @@ proven `flush_deferred_deps` query and the `update_build_status` promotion loop,
 so it is covered by the existing `handle_eval_job_completed` handler tests plus
 E2E CI rather than a new MockDatabase sequence.
 
+`backend/gradient-worker/src/executor/eval.rs` — `pushes_batch_closure_before_reporting_it`
+guards the worker side of the same change. Because #392 dispatches builds
+mid-evaluation, each batch's `.drv` runtime closure (its `input_sources`) must be
+pushed to the cache *before* `report_eval_result` lets the server promote and
+dispatch that batch's builds. Driving the walk with a `RecordingJobReporter`, the
+test asserts every reported (non-substituted) derivation was covered by an earlier
+`push_drv_closure`, so a build worker never prefetches a source the cache does not
+yet hold ("required input path missing").
+
 ## PostgreSQL minimum-version guard (#387)
 
 `connect_db` reads `server_version_num` at startup and aborts before running


### PR DESCRIPTION
Since #392 the server promotes and dispatches builds mid-evaluation, but the worker uploaded each derivation's `input_sources` only once after the whole walk, so a build worker prefetched sources not yet in the cache ("required input path missing", permanent). Each batch's `.drv` runtime closure is now pushed before its `report_eval_result`, so the report stays a truthful dispatch-ready signal.

Test: `pushes_batch_closure_before_reporting_it` asserts every reported non-substituted derivation had its closure pushed first.