### PR TITLE
nix: docs: fix option description formatting and mkEnableOption grammar (#408)

### DIFF
--- a/nix/modules/gradient-state.nix
+++ b/nix/modules/gradient-state.nix
@@ -783,7 +783,7 @@
         default = [ ];
         description = ''
           Organizations this worker is registered under. The provisioner
-          creates one <literal>worker_registration</literal> row per
+          creates one `worker_registration` row per
           (worker_id, organization) pair so the same physical worker can
           serve builds for multiple organizations from a single state
           entry. For a base worker, lists organizations to pre-enable;

--- a/nix/modules/gradient-worker.nix
+++ b/nix/modules/gradient-worker.nix
@@ -62,7 +62,7 @@ in {
     };
 
     useTls = lib.mkEnableOption "TLS" // { default = true; };
-    discoverable = lib.mkEnableOption "accept incoming connections on /proto";
+    discoverable = lib.mkEnableOption "incoming connections on `/proto`";
     domain = lib.mkOption {
       description = "Domain under which the worker's nginx vhost is served. Only used when a reverseProxy is enabled";
       type = lib.types.str;
@@ -97,16 +97,11 @@ in {
 
     workerId = lib.mkOption {
       description = ''
-        Override the worker's persistent UUID. When set, this value is used as
-        the worker identity instead of the UUID auto-generated and stored in
-        <literal>$StateDirectory/worker-id</literal> on first start.
-
-        Useful for declarative deployments where the worker UUID must be known
-        ahead of time (e.g. to pre-register it in <literal>state.workers</literal>).
-        Must be a valid UUID.
-
-        When null (default) the worker reads or generates its ID from the state
-        directory as usual.
+        Override the worker's persistent UUID. When set, this UUID is used as
+        the worker identity instead of the one auto-generated and stored in
+        `$StateDirectory/worker-id` on first start. Useful for declarative
+        deployments that must know the worker UUID ahead of time (e.g. to
+        pre-register it in `state.workers`).
       '';
       type = lib.types.nullOr lib.types.str;
       default = null;
@@ -115,38 +110,33 @@ in {
 
     peersFile = lib.mkOption {
       description = ''
-        Path to a file containing peer-to-token pairs for challenge-response
-        auth with the Gradient server, one entry per line:
+        Path to a file of peer-to-token pairs for challenge-response auth with
+        the Gradient server, one `peer_id:token` per line (lines starting with
+        `#` are ignored):
 
-        <literal>
-        # one peer_id:token per line; lines starting with # are ignored
-        &lt;uuid&gt;:&lt;token&gt;
-        *:&lt;token&gt;
-        </literal>
+        ```
+        <uuid>:<token>
+        *:<token>
+        ```
 
-        The special peer ID <literal>*</literal> matches any UUID the server
-        challenges, so a single token works for any org. Each token must be
-        a 48-byte random secret (e.g. <literal>openssl rand -base64 48</literal>)
-        and is registered via <literal>POST /api/v1/orgs/{org}/workers</literal>.
+        The special peer ID `*` matches any UUID the server challenges, so a
+        single token works for any org. Each token is a 48-byte random secret
+        (e.g. `openssl rand -base64 48`) registered via
+        `POST /api/v1/orgs/{org}/workers`. Pin the org UUID with
+        `services.gradient.state.organizations.<name>.id` to reference it here.
 
-        In a fully declarative deployment, pin the org UUID with
-        <literal>services.gradient.state.organizations.&lt;name&gt;.id</literal>
-        on the server and reference the same value here, so the peer id is
-        known ahead of the first server start.
-
-        When null (default), the worker connects in open/discoverable mode -
-        the server accepts the connection without token validation. Suitable
-        for local co-located workers.
+        When null (default), the worker connects in open/discoverable mode and
+        the server accepts it without token validation.
       '';
       type = lib.types.nullOr lib.types.path;
       default = null;
     };
 
     capabilities = {
-      federate = lib.mkEnableOption "federate capability - relay work and NAR traffic between workers and servers (requires discoverable)";
-      fetch = lib.mkEnableOption "fetch capability - prefetch flake inputs and sources" // { default = true; };
-      eval  = lib.mkEnableOption "eval capability - run Nix flake evaluations" // { default = true; };
-      build = lib.mkEnableOption "build capability - execute Nix store builds" // { default = true; };
+      federate = lib.mkEnableOption "the federate capability (relay work and NAR traffic between workers and servers; requires discoverable)";
+      fetch = lib.mkEnableOption "the fetch capability (prefetch flake inputs and sources)" // { default = true; };
+      eval  = lib.mkEnableOption "the eval capability (run Nix flake evaluations)" // { default = true; };
+      build = lib.mkEnableOption "the build capability (execute Nix store builds)" // { default = true; };
     };
 
     settings = {
@@ -251,16 +241,11 @@ in {
 
       gcrootsDir = lib.mkOption {
         description = ''
-          Directory under which the worker writes one indirect GC root
-          symlink per active build (drv + outputs). Pins inputs and
-          just-built outputs through the local nix-daemon so a concurrent
-          <literal>nix-collect-garbage</literal> cannot delete them
-          mid-build. A systemd-tmpfiles rule creates the directory under
-          the worker user and adds it to the unit's
-          <literal>ReadWritePaths</literal>.
-
-          Set to an empty string to disable GC root pinning (the worker
-          still builds, but a concurrent GC may race the build).
+          Directory under which the worker writes one indirect GC root symlink
+          per active build (drv + outputs), pinning inputs and just-built
+          outputs so a concurrent `nix-collect-garbage` cannot delete them
+          mid-build. Set to an empty string to disable pinning (the worker
+          still builds, but a concurrent GC may race it).
         '';
         type = lib.types.str;
         default = "/nix/var/nix/gcroots/gradient";
@@ -268,33 +253,29 @@ in {
 
       buildMetrics = lib.mkOption {
         description = ''
-          Capture per-build resource metrics (peak RAM, CPU time, disk I/O).
-          Enables Nix's experimental <literal>cgroups</literal> feature and
-          <literal>use-cgroups</literal> on the daemon. CPU time comes from the
-          daemon build result; peak RAM and disk I/O are sampled live from the
-          build's cgroup (located via <literal>buildCgroupStateDir</literal>) -
-          reliable at build concurrency 1, best-effort under concurrency.
-          Wall-clock build time is always reported.
+          Capture per-build resource metrics (peak RAM, CPU time, disk I/O) by
+          enabling Nix's experimental `cgroups` feature and `use-cgroups` on the
+          daemon. CPU time comes from the daemon build result; peak RAM and disk
+          I/O are sampled live from the build's cgroup (located via
+          `buildCgroupStateDir`), reliable at concurrency 1 and best-effort
+          above. Wall-clock build time is always reported.
         '';
         type = lib.types.bool;
         default = false;
       };
 
       buildCgroupRoot = lib.mkOption {
-        description = ''
-          Cgroup-v2 mount root searched for per-build cgroups when
-          <literal>buildMetrics</literal> is enabled.
-        '';
+        description = "Cgroup-v2 mount root searched for per-build cgroups when `buildMetrics` is enabled.";
         type = lib.types.str;
         default = "/sys/fs/cgroup";
       };
 
       buildCgroupStateDir = lib.mkOption {
         description = ''
-          Nix's <literal>&lt;nix-state-dir&gt;/cgroups</literal> directory, where
-          the daemon records each build's cgroup path (`<uid>` files). The worker
-          reads the newest entry to locate a running build's cgroup for metrics.
-          Granted read access via <literal>ReadOnlyPaths</literal>.
+          Nix's `<nix-state-dir>/cgroups` directory, where the daemon records
+          each build's cgroup path (`<uid>` files). The worker reads the newest
+          entry to locate a running build's cgroup for metrics. Granted read
+          access via `ReadOnlyPaths`.
         '';
         type = lib.types.str;
         default = "/nix/var/nix/cgroups";
@@ -322,8 +303,8 @@ in {
       logFetchFromStore = lib.mkOption {
         description = ''
           When a derivation is already built in the local store (so the daemon
-          produces no fresh log), read nix's stored <literal>.bz2</literal> build
-          log and forward it so the UI still shows output.
+          produces no fresh log), read nix's stored `.bz2` build log and forward
+          it so the UI still shows output.
         '';
         type = lib.types.bool;
         default = true;

--- a/nix/modules/gradient.nix
+++ b/nix/modules/gradient.nix
@@ -127,8 +127,8 @@ in {
       configurePostgres = lib.mkEnableOption "PostgreSQL configuration";
       reportErrors = lib.mkEnableOption "error reporting to Sentry";
       useTls = lib.mkEnableOption "TLS" // { default = true; };
-      enableQuic = lib.mkEnableOption "Quic support";
-      discoverable = lib.mkEnableOption "accept incoming connections on /proto" // { default = true; };
+      enableQuic = lib.mkEnableOption "QUIC support";
+      discoverable = lib.mkEnableOption "incoming connections on `/proto`" // { default = true; };
       packages = {
         server = lib.mkPackageOption pkgs "gradient" { };
         frontend = lib.mkPackageOption pkgs "gradient-frontend" { };
@@ -222,8 +222,8 @@ in {
       };
 
       proto = {
-        public = lib.mkEnableOption "publicly accessible proto endpoint for federated builds and remote workers";
-        federate = lib.mkEnableOption "federate Gradient Proto";
+        public = lib.mkEnableOption "a publicly accessible `/proto` endpoint for federated builds and remote workers";
+        federate = lib.mkEnableOption "Gradient Proto federation";
       };
 
       frontend = {
@@ -239,7 +239,7 @@ in {
 
       oidc = {
         enable = lib.mkEnableOption "OIDC";
-        required = lib.mkEnableOption "OIDC requirement for registration";
+        required = lib.mkEnableOption "the OIDC requirement for registration";
         clientId = lib.mkOption {
           description = "Client ID for OIDC";
           type = lib.types.str;
@@ -274,12 +274,12 @@ in {
           description = "Path to the file holding the SCIM provisioning bearer token";
           type = lib.types.path;
         };
-        hardDelete = lib.mkEnableOption "hard-delete users on SCIM DELETE (default: soft-disable)";
+        hardDelete = lib.mkEnableOption "hard-deletion of users on SCIM DELETE (default: soft-disable)";
       };
 
       email = {
         enable = lib.mkEnableOption "email functionality";
-        requireVerification = lib.mkEnableOption "email verification requirement for registrations";
+        requireVerification = lib.mkEnableOption "the email-verification requirement for registrations";
         enableTls = lib.mkEnableOption "TLS for SMTP connections";
         smtpHost = lib.mkOption {
           description = "SMTP server hostname";
@@ -377,13 +377,12 @@ in {
         virtualHostedStyle = lib.mkOption {
           description = ''
             Use virtual-hosted-style requests
-            (`https://<bucket>.<endpoint>/key`) when a custom endpoint is
-            configured. Defaults to `false`, which produces path-style URLs
-            (`https://<endpoint>/<bucket>/key`) — required by MinIO,
-            Garage, and most self-hosted S3-compatible backends. Set to
-            `true` for providers that demand virtual-hosted addressing
-            (Cloudflare R2 with a custom domain, certain Backblaze B2
-            setups). Ignored when `endpoint` is null (AWS direct).
+            (`https://<bucket>.<endpoint>/key`) instead of the default
+            path-style (`https://<endpoint>/<bucket>/key`) when a custom
+            `endpoint` is set. Path-style is required by MinIO, Garage and most
+            self-hosted backends; enable this only for providers that demand
+            virtual-hosted addressing (e.g. Cloudflare R2 with a custom domain).
+            Ignored when `endpoint` is null.
           '';
           type = lib.types.bool;
           default = false;
@@ -391,7 +390,7 @@ in {
       };
 
       settings = {
-        enableRegistration = lib.mkEnableOption "registration. Users must be registered via OIDC." // { default = true; };
+        enableRegistration = lib.mkEnableOption "self-service user registration (when disabled, accounts are provisioned only via OIDC or state)" // { default = true; };
         sentryDsn = lib.mkOption {
           description = ''
             Override the Sentry DSN used when `reportErrors` is true.
@@ -537,13 +536,12 @@ in {
 
         schedulerScoringPolicy = lib.mkOption {
           description = ''
-            Scheduler scoring policy used to rank queued jobs against a
+            Scheduler scoring policy for ranking queued jobs against a
             requesting worker. `simple` weighs path availability, NAR size,
-            dependency count, wait-time anti-starvation, builtin
-            de-prioritization and fetch-worker reservation. `resource-aware`
-            adds RAM/OOM-fit, CPU affinity, preferLocalBuild affinity and
-            per-org fair-share, and is the default. Unknown values fall back to
-            `resource-aware`.
+            dependency count, anti-starvation, builtin de-prioritization and
+            fetch-worker reservation; `resource-aware` (the default) also adds
+            RAM/OOM-fit, CPU affinity, preferLocalBuild affinity and per-org
+            fair-share.
           '';
           type = lib.types.enum [ "simple" "resource-aware" ];
           default = "resource-aware";


### PR DESCRIPTION
Closes #408.

Convert `<literal>` docbook tags to markdown backticks (incl. a fenced code block for `peersFile`), reword every `mkEnableOption` string so it completes "Whether to enable …", and trim the wordiest descriptions. Drops one stray em-dash.

The Job Board pending/active query perf note in the issue is a separate concern and left for its own issue.