### PR TITLE
fix: minor frontend issues (#401)

### DIFF
--- a/backend/gradient-forge/src/reporter.rs
+++ b/backend/gradient-forge/src/reporter.rs
@@ -268,6 +268,21 @@ pub trait CiReporter: Send + Sync + std::fmt::Debug + 'static {
     async fn default_branch(&self, _owner: &str, _repo: &str) -> Result<String> {
         anyhow::bail!("this reporter does not support opening pull requests")
     }
+
+    /// Submit an approving review on a pull request, reflecting Gradient's
+    /// maintainer-approval gate back onto the forge.
+    ///
+    /// Default impl is a no-op so forges/reporters that don't model PR reviews
+    /// simply swallow the request.
+    async fn approve_pull_request(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _pr_number: u64,
+        _body: &str,
+    ) -> Result<()> {
+        Ok(())
+    }
 }
 
 // ── NoopCiReporter ────────────────────────────────────────────────────────────
@@ -986,6 +1001,53 @@ fn github_comment_url(base_url: &str, owner: &str, repo: &str, pr_number: u64) -
     )
 }
 
+fn github_reviews_url(base_url: &str, owner: &str, repo: &str, pr_number: u64) -> String {
+    format!(
+        "{}/repos/{}/{}/pulls/{}/reviews",
+        base_url, owner, repo, pr_number
+    )
+}
+
+#[derive(serde::Serialize)]
+struct GithubReviewPayload<'a> {
+    event: &'static str,
+    body: &'a str,
+}
+
+/// POST an `APPROVE` review to the GitHub PR reviews endpoint, sharing the
+/// request shape between the token and GitHub App reporters.
+async fn post_github_approval(
+    client: &reqwest::Client,
+    base_url: &str,
+    token: &str,
+    owner: &str,
+    repo: &str,
+    pr_number: u64,
+    body: &str,
+) -> Result<()> {
+    let url = github_reviews_url(base_url, owner, repo, pr_number);
+    let payload = GithubReviewPayload { event: "APPROVE", body };
+
+    let resp = client
+        .post(&url)
+        .header("Authorization", format!("Bearer {}", token))
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .json(&payload)
+        .send()
+        .await
+        .context("Failed to send GitHub PR review request")?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let resp_body = resp.text().await.unwrap_or_default();
+        warn!(github_url = %url, http_status = %status, body = %resp_body, "GitHub PR approval review failed");
+        anyhow::bail!("GitHub returned {}: {}", status, resp_body);
+    }
+
+    Ok(())
+}
+
 impl GithubReporter {
     const DEFAULT_API_URL: &'static str = "https://api.github.com";
 
@@ -1147,6 +1209,25 @@ impl CiReporter for GithubReporter {
             anyhow::bail!("GitHub returned {}: {}", status, resp_body);
         }
         Ok(())
+    }
+
+    async fn approve_pull_request(
+        &self,
+        owner: &str,
+        repo: &str,
+        pr_number: u64,
+        body: &str,
+    ) -> Result<()> {
+        post_github_approval(
+            &self.client,
+            &self.base_url,
+            &self.token,
+            owner,
+            repo,
+            pr_number,
+            body,
+        )
+        .await
     }
 
     async fn get_pull_request(
@@ -1651,6 +1732,34 @@ impl CiReporter for GithubAppReporter {
             anyhow::bail!("GitHub App returned {}: {}", status, resp_body);
         }
         Ok(())
+    }
+
+    async fn approve_pull_request(
+        &self,
+        owner: &str,
+        repo: &str,
+        pr_number: u64,
+        body: &str,
+    ) -> Result<()> {
+        let token = crate::github_app::get_installation_token(
+            &self.client,
+            self.app_id,
+            &self.private_key_pem,
+            self.installation_id,
+        )
+        .await
+        .context("Failed to mint GitHub App installation token")?;
+
+        post_github_approval(
+            &self.client,
+            &self.api_base_url,
+            &token,
+            owner,
+            repo,
+            pr_number,
+            body,
+        )
+        .await
     }
 
     async fn get_pull_request(

--- a/backend/gradient-forge/src/webhook.rs
+++ b/backend/gradient-forge/src/webhook.rs
@@ -27,12 +27,38 @@ pub enum WebhookEventKind {
 
 // ── GitHub push payload ────────────────────────────────────────────────────
 
+/// Commit fields shared across the forge push payloads (`head_commit` on
+/// GitHub/Gitea, entries of `commits` on GitLab).
+#[derive(Deserialize)]
+pub struct WebhookCommit {
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub message: Option<String>,
+    #[serde(default)]
+    pub author: Option<WebhookCommitAuthor>,
+}
+
+#[derive(Deserialize)]
+pub struct WebhookCommitAuthor {
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
+/// First, trimmed line of a commit message - the subject shown in the frontend.
+fn commit_subject(commit: &WebhookCommit) -> Option<String> {
+    let subject = commit.message.as_deref()?.lines().next()?.trim();
+    (!subject.is_empty()).then(|| subject.to_string())
+}
+
 #[derive(Deserialize)]
 pub struct GitHubPushPayload {
     #[serde(rename = "ref")]
     pub git_ref: String,
     pub after: String,
     pub repository: GitHubRepository,
+    #[serde(default)]
+    pub head_commit: Option<WebhookCommit>,
 }
 
 #[derive(Deserialize)]
@@ -51,6 +77,8 @@ pub struct GiteaPushPayload {
     pub git_ref: String,
     pub after: String,
     pub repository: GiteaRepository,
+    #[serde(default)]
+    pub head_commit: Option<WebhookCommit>,
 }
 
 #[derive(Deserialize)]
@@ -69,6 +97,8 @@ pub struct GitLabPushPayload {
     pub git_ref: String,
     pub after: String,
     pub project: GitLabProject,
+    #[serde(default)]
+    pub commits: Vec<WebhookCommit>,
 }
 
 #[derive(Deserialize)]
@@ -476,11 +506,12 @@ impl ParsedPushEvent {
             }
         };
         let pc = decode_push_commit(&payload.git_ref, &payload.after, "github")?;
+        let head = payload.head_commit.as_ref();
         Some(Self {
             commit_hash: pc.hash,
             repository_urls: vec![payload.repository.clone_url, payload.repository.ssh_url],
-            commit_message: None,
-            author_name: None,
+            commit_message: head.and_then(commit_subject),
+            author_name: head.and_then(|c| c.author.as_ref()).and_then(|a| a.name.clone()),
             ref_name: pc.ref_name,
             is_tag: pc.is_tag,
         })
@@ -499,11 +530,13 @@ impl ParsedPushEvent {
         if let Some(ssh) = payload.repository.ssh_url {
             urls.push(ssh);
         }
+
+        let head = payload.head_commit.as_ref();
         Some(Self {
             commit_hash: pc.hash,
             repository_urls: urls,
-            commit_message: None,
-            author_name: None,
+            commit_message: head.and_then(commit_subject),
+            author_name: head.and_then(|c| c.author.as_ref()).and_then(|a| a.name.clone()),
             ref_name: pc.ref_name,
             is_tag: pc.is_tag,
         })
@@ -522,11 +555,17 @@ impl ParsedPushEvent {
         if let Some(ssh) = payload.project.ssh_url {
             urls.push(ssh);
         }
+
+        let head = payload
+            .commits
+            .iter()
+            .find(|c| c.id.as_deref() == Some(payload.after.as_str()))
+            .or_else(|| payload.commits.last());
         Some(Self {
             commit_hash: pc.hash,
             repository_urls: urls,
-            commit_message: None,
-            author_name: None,
+            commit_message: head.and_then(commit_subject),
+            author_name: head.and_then(|c| c.author.as_ref()).and_then(|a| a.name.clone()),
             ref_name: pc.ref_name,
             is_tag: pc.is_tag,
         })
@@ -1342,5 +1381,54 @@ mod tests {
         }"#;
         let ev = ParsedPullRequestReviewEvent::from_gitea(body.as_bytes()).unwrap();
         assert!(!ev.approved);
+    }
+
+    // ── Push commit subject ───────────────────────────────────────────────
+
+    #[test]
+    fn github_push_extracts_commit_subject_and_author() {
+        let body = format!(
+            r#"{{
+                "ref": "refs/heads/main",
+                "after": "{VALID_SHA}",
+                "repository": {{ "clone_url": "https://github.com/org/repo.git", "ssh_url": "git@github.com:org/repo.git" }},
+                "head_commit": {{ "id": "{VALID_SHA}", "message": "feat: add thing\n\nlong body", "author": {{ "name": "Octo Cat" }} }}
+            }}"#
+        );
+        let ev = ParsedPushEvent::from_github(body.as_bytes()).unwrap();
+        assert_eq!(ev.commit_message.as_deref(), Some("feat: add thing"));
+        assert_eq!(ev.author_name.as_deref(), Some("Octo Cat"));
+    }
+
+    #[test]
+    fn github_push_without_head_commit_has_no_message() {
+        let body = format!(
+            r#"{{
+                "ref": "refs/heads/main",
+                "after": "{VALID_SHA}",
+                "repository": {{ "clone_url": "https://github.com/org/repo.git", "ssh_url": "git@github.com:org/repo.git" }}
+            }}"#
+        );
+        let ev = ParsedPushEvent::from_github(body.as_bytes()).unwrap();
+        assert_eq!(ev.commit_message, None);
+        assert_eq!(ev.author_name, None);
+    }
+
+    #[test]
+    fn gitlab_push_picks_commit_matching_after() {
+        let body = format!(
+            r#"{{
+                "ref": "refs/heads/main",
+                "after": "{VALID_SHA}",
+                "project": {{ "http_url": "https://gitlab.example.com/org/repo.git" }},
+                "commits": [
+                    {{ "id": "ffffffffffffffffffffffffffffffffffffffff", "message": "old" }},
+                    {{ "id": "{VALID_SHA}", "message": "fix: the bug\nwith detail", "author": {{ "name": "Dev" }} }}
+                ]
+            }}"#
+        );
+        let ev = ParsedPushEvent::from_gitlab(body.as_bytes()).unwrap();
+        assert_eq!(ev.commit_message.as_deref(), Some("fix: the bug"));
+        assert_eq!(ev.author_name.as_deref(), Some("Dev"));
     }
 }

--- a/backend/gradient-types/src/actions.rs
+++ b/backend/gradient-types/src/actions.rs
@@ -168,7 +168,7 @@ mod tests {
     fn open_pr_defaults_apply() {
         let json = serde_json::json!({
             "type": "open_pr",
-            "integration_id": Uuid::new_v4(),
+            "integration_id": IntegrationId::now_v7(),
         });
         let cfg: ActionConfig = serde_json::from_value(json).unwrap();
         assert_eq!(cfg.action_type(), ActionType::OpenPr);
@@ -194,7 +194,7 @@ mod tests {
     #[test]
     fn open_pr_round_trip() {
         let cfg = ActionConfig::OpenPr {
-            integration_id: IntegrationId::from(Uuid::new_v4()),
+            integration_id: IntegrationId::now_v7(),
             generator: PatchGeneratorKind::FlakeLock,
             granularity: PrGranularity::PerInput,
             verify_gate: VerifyGate::Eval,

--- a/backend/gradient-web/src/endpoints/forge_hooks/trigger.rs
+++ b/backend/gradient-web/src/endpoints/forge_hooks/trigger.rs
@@ -856,6 +856,9 @@ pub(super) async fn handle_github_check_run(
                 "PR approval gate cleared via GitHub action"
             );
             dispatch_approval_granted(state, &unparked).await;
+            if let Some(pr_number) = approval_pr_number(&eval) {
+                submit_pr_approval_review(state, project_id, owner, repo, pr_number).await;
+            }
         }
         Ok(None) => {
             warn!(
@@ -979,6 +982,41 @@ async fn unpark_pr_approval_eval(
             warn!(error = %e, evaluation_id = %eval.id, "Failed to unpark approval gate via review");
             None
         }
+    }
+}
+
+/// PR number carried by an approval-gated evaluation's waiting reason.
+fn approval_pr_number(eval: &MEvaluation) -> Option<u64> {
+    match eval.waiting_reason.as_ref().and_then(WaitingReason::from_json)? {
+        WaitingReason::Approval { pr_number, .. } => Some(pr_number),
+        _ => None,
+    }
+}
+
+/// Reflect a Gradient maintainer approval back onto the forge by submitting an
+/// approving PR review (GitHub only; other forges no-op). Best-effort - a forge
+/// hiccup never undoes the local unpark.
+async fn submit_pr_approval_review(
+    state: &Arc<ServerState>,
+    project_id: ProjectId,
+    owner: &str,
+    repo: &str,
+    pr_number: u64,
+) {
+    let reporter = match gradient_ci::actions::reporter_for_project(&state.ci(), project_id).await {
+        Ok(Some(r)) => r,
+        Ok(None) => return,
+        Err(e) => {
+            warn!(error = %e, %project_id, "resolving reporter for PR approval review");
+            return;
+        }
+    };
+
+    if let Err(e) = reporter
+        .approve_pull_request(owner, repo, pr_number, "Approved via Gradient maintainer approval gate.")
+        .await
+    {
+        warn!(error = %e, %project_id, pr_number, "submitting forge PR approval review failed");
     }
 }
 
@@ -1356,6 +1394,10 @@ pub(super) async fn handle_issue_comment(
                         }
                     }
                     dispatch_approval_granted(state, &unparked).await;
+                    if matches!(cmd, GradientCommand::Approve) {
+                        submit_pr_approval_review(state, *project_id, owner, repo, pr_number).await;
+                    }
+
                     parked_unparked_in_integration = true;
                     action_taken = true;
                 }

--- a/backend/gradient-web/src/endpoints/projects/auto_attach.rs
+++ b/backend/gradient-web/src/endpoints/projects/auto_attach.rs
@@ -1,0 +1,226 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Best-effort wiring of a freshly created project to the org's forge
+//! integrations. When the repository URL unambiguously belongs to one inbound
+//! and/or one outbound integration, a push trigger and a status-report action
+//! are attached so the project works with the forge without extra setup.
+
+use gradient_ci::IntegrationKind;
+use gradient_types::actions::ActionConfig;
+use gradient_types::triggers::{TriggerConfig, TriggerType};
+use gradient_types::{
+    ForgeType, MIntegration, MProject, MProjectAction, MProjectTrigger, ProjectActionId,
+    ProjectTriggerId,
+};
+use sea_orm::{ActiveModelTrait, ConnectionTrait, IntoActiveModel};
+
+#[derive(Debug, Default, PartialEq)]
+pub(super) struct AutoAttach {
+    pub inbound: Option<MIntegration>,
+    pub outbound: Option<MIntegration>,
+}
+
+/// Lowercased host of a git repository or forge endpoint URL. Handles
+/// `https://`, `http://`, `ssh://`, `git://`, a `git+<scheme>` prefix and the
+/// SCP form `git@host:owner/repo`.
+fn url_host(url: &str) -> Option<String> {
+    let s = url.trim();
+    let s = s.strip_prefix("git+").unwrap_or(s);
+
+    for scheme in ["https://", "http://", "ssh://", "git://"] {
+        if let Some(rest) = s.strip_prefix(scheme) {
+            let rest = rest.rsplit('@').next().unwrap_or(rest);
+            let host = rest.split(['/', ':']).next().unwrap_or("");
+            return (!host.is_empty()).then(|| host.to_ascii_lowercase());
+        }
+    }
+
+    let (prefix, _) = s.split_once(':')?;
+    let host = prefix.rsplit('@').next().unwrap_or(prefix);
+    (!host.is_empty()).then(|| host.to_ascii_lowercase())
+}
+
+fn public_forge_for_host(host: &str) -> Option<ForgeType> {
+    match host {
+        "github.com" => Some(ForgeType::GitHub),
+        "gitlab.com" => Some(ForgeType::GitLab),
+        _ => None,
+    }
+}
+
+/// Forge identity behind `host`: a well-known public host, otherwise the forge
+/// type of any integration whose endpoint URL points at the same host.
+fn infer_forge(host: &str, integrations: &[MIntegration]) -> Option<ForgeType> {
+    public_forge_for_host(host).or_else(|| {
+        integrations.iter().find_map(|i| {
+            let endpoint = i.endpoint_url.as_deref()?;
+            (url_host(endpoint).as_deref() == Some(host))
+                .then(|| ForgeType::try_from(i.forge_type).ok())
+                .flatten()
+        })
+    })
+}
+
+/// An integration with a custom endpoint matches strictly by host; one without
+/// (public forges, inbound rows) matches by the inferred forge type.
+fn integration_matches(i: &MIntegration, host: &str, inferred: Option<ForgeType>) -> bool {
+    if let Some(endpoint) = &i.endpoint_url {
+        return url_host(endpoint).as_deref() == Some(host);
+    }
+
+    inferred.is_some_and(|f| i16::from(f) == i.forge_type)
+}
+
+/// The single integration of `kind` matching the repo, or `None` when zero or
+/// more than one match (ambiguous wiring is left to the user).
+fn pick_one(
+    integrations: &[MIntegration],
+    kind: IntegrationKind,
+    host: &str,
+    inferred: Option<ForgeType>,
+) -> Option<MIntegration> {
+    let mut matched = integrations
+        .iter()
+        .filter(|i| i.kind == i16::from(kind) && integration_matches(i, host, inferred));
+    let first = matched.next()?;
+    matched.next().is_none().then(|| first.clone())
+}
+
+pub(super) fn match_integrations_for_repo(repo: &str, integrations: &[MIntegration]) -> AutoAttach {
+    let Some(host) = url_host(repo) else {
+        return AutoAttach::default();
+    };
+    let inferred = infer_forge(&host, integrations);
+
+    AutoAttach {
+        inbound: pick_one(integrations, IntegrationKind::Inbound, &host, inferred),
+        outbound: pick_one(integrations, IntegrationKind::Outbound, &host, inferred),
+    }
+}
+
+/// Insert the trigger/action wiring for the matched integrations. Best-effort:
+/// callers log and swallow errors so a wiring hiccup never blocks creation.
+pub(super) async fn apply<C: ConnectionTrait>(
+    db: &C,
+    project: &MProject,
+    integrations: &[MIntegration],
+) -> Result<(), sea_orm::DbErr> {
+    let attach = match_integrations_for_repo(&project.repository, integrations);
+    let now = gradient_types::now();
+
+    if let Some(inbound) = attach.inbound {
+        let cfg = TriggerConfig::ReporterPush {
+            integration_id: inbound.id,
+            branches: vec![],
+            tags: vec![],
+            releases_only: false,
+        };
+        MProjectTrigger {
+            id: ProjectTriggerId::now_v7(),
+            project: project.id,
+            trigger_type: i16::from(TriggerType::ReporterPush),
+            config: cfg.to_db_json(),
+            active: true,
+            created_at: now,
+            updated_at: now,
+            ..Default::default()
+        }
+        .into_active_model()
+        .insert(db)
+        .await?;
+    }
+
+    if let Some(outbound) = attach.outbound {
+        let cfg = ActionConfig::ForgeStatusReport {
+            integration_id: outbound.id,
+        };
+        MProjectAction {
+            id: ProjectActionId::now_v7(),
+            project: project.id,
+            name: "Report status to forge".into(),
+            action_type: cfg.action_type().to_i16(),
+            config: serde_json::to_value(&cfg).unwrap_or_default(),
+            events: serde_json::json!([]),
+            active: true,
+            created_by: project.created_by,
+            created_at: now,
+            updated_at: now,
+            ..Default::default()
+        }
+        .into_active_model()
+        .insert(db)
+        .await?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn integ(kind: IntegrationKind, forge: ForgeType, endpoint: Option<&str>) -> MIntegration {
+        MIntegration {
+            kind: i16::from(kind),
+            forge_type: i16::from(forge),
+            endpoint_url: endpoint.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn host_parsing_covers_url_shapes() {
+        assert_eq!(url_host("https://github.com/foo/bar").as_deref(), Some("github.com"));
+        assert_eq!(url_host("git@gitea.example.com:foo/bar.git").as_deref(), Some("gitea.example.com"));
+        assert_eq!(url_host("ssh://git@gitlab.com/foo/bar").as_deref(), Some("gitlab.com"));
+        assert_eq!(url_host("git+https://Gitea.Example.com/foo").as_deref(), Some("gitea.example.com"));
+        assert_eq!(url_host("not-a-url"), None);
+    }
+
+    #[test]
+    fn self_hosted_pairs_inbound_and_outbound() {
+        let integrations = vec![
+            integ(IntegrationKind::Inbound, ForgeType::Gitea, None),
+            integ(IntegrationKind::Outbound, ForgeType::Gitea, Some("https://gitea.example.com")),
+        ];
+        let m = match_integrations_for_repo("git@gitea.example.com:foo/bar.git", &integrations);
+        assert!(m.inbound.is_some(), "inbound matched via inferred forge");
+        assert!(m.outbound.is_some(), "outbound matched via endpoint host");
+    }
+
+    #[test]
+    fn public_github_matches_by_forge_type() {
+        let integrations = vec![
+            integ(IntegrationKind::Inbound, ForgeType::GitHub, None),
+            integ(IntegrationKind::Outbound, ForgeType::GitHub, None),
+        ];
+        let m = match_integrations_for_repo("https://github.com/foo/bar", &integrations);
+        assert!(m.inbound.is_some());
+        assert!(m.outbound.is_some());
+    }
+
+    #[test]
+    fn ambiguous_inbound_is_skipped() {
+        let integrations = vec![
+            integ(IntegrationKind::Inbound, ForgeType::GitHub, None),
+            integ(IntegrationKind::Inbound, ForgeType::GitHub, None),
+        ];
+        let m = match_integrations_for_repo("https://github.com/foo/bar", &integrations);
+        assert!(m.inbound.is_none(), "two inbound matches is ambiguous");
+    }
+
+    #[test]
+    fn unrelated_forge_does_not_match() {
+        let integrations = vec![integ(
+            IntegrationKind::Outbound,
+            ForgeType::Gitea,
+            Some("https://other-gitea.example.com"),
+        )];
+        let m = match_integrations_for_repo("https://github.com/foo/bar", &integrations);
+        assert_eq!(m, AutoAttach::default());
+    }
+}

--- a/backend/gradient-web/src/endpoints/projects/management.rs
+++ b/backend/gradient-web/src/endpoints/projects/management.rs
@@ -5,6 +5,7 @@
  */
 
 use super::ProjectResponse;
+use super::auto_attach;
 use crate::access::{Caller, OrgAccess, ProjectAccess, has_permission, load_org, load_project};
 use crate::audit::{RequestInfo, events, record as audit_record};
 use crate::authorization::{MaybeApiKey, MaybeUser};
@@ -281,6 +282,15 @@ pub async fn put(
     .into_active_model()
     .insert(&state.web_db)
     .await?;
+
+    let integrations = EIntegration::find()
+        .filter(CIntegration::Organization.eq(organization.id))
+        .all(&state.web_db)
+        .await
+        .unwrap_or_default();
+    if let Err(e) = auto_attach::apply(&state.web_db, &project, &integrations).await {
+        tracing::warn!("auto-attaching integrations to project {} failed: {e}", project.id);
+    }
 
     let res = BaseResponse {
         error: false,

--- a/backend/gradient-web/src/endpoints/projects/mod.rs
+++ b/backend/gradient-web/src/endpoints/projects/mod.rs
@@ -5,6 +5,7 @@
  */
 
 pub mod actions;
+mod auto_attach;
 pub mod evaluations;
 pub mod flake_inputs;
 pub mod management;

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -2,6 +2,18 @@
 
 This page tracks notable tests added to Gradient and where they live.
 
+## Minor frontend issues (#401)
+
+`backend/gradient-web/src/endpoints/projects/auto_attach.rs`: `host_parsing_covers_url_shapes`,
+`self_hosted_pairs_inbound_and_outbound`, `public_github_matches_by_forge_type`,
+`ambiguous_inbound_is_skipped`, and `unrelated_forge_does_not_match` cover the
+repository-URL → org-integration matcher that auto-attaches a push trigger and a
+status-report action on project creation.
+
+`backend/gradient-forge/src/webhook.rs`: `github_push_extracts_commit_subject_and_author`,
+`github_push_without_head_commit_has_no_message`, and `gitlab_push_picks_commit_matching_after`
+cover push webhooks now writing the commit subject + author (previously only Pull/PR triggers did).
+
 ## Draining server + board fixes (#411)
 
 `backend/gradient-types/src/waiting_reason.rs`: `draining_round_trip` asserts the

--- a/docs/src/usage/caches.md
+++ b/docs/src/usage/caches.md
@@ -1,0 +1,49 @@
+<!--
+SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
+# Caches
+
+Gradient serves build outputs from per-organization binary caches. Each cache
+exposes a substituter URL and a set of trusted public keys that clients add to
+their Nix configuration. The cache detail page renders the exact snippet for a
+given cache.
+
+## Authentication
+
+Private caches require credentials. Install them on the client as root with the
+Gradient CLI:
+
+```bash
+nix run wavelens/gradient#gradient-cli -- cache install-netrc \
+  --server <SERVER_URL> --token <YOUR_TOKEN> --cache <CACHE_NAME>
+```
+
+Replace `<YOUR_TOKEN>` with your API key or login token. The command writes the
+credentials to `/etc/nix/netrc` so the Nix daemon can authenticate against the
+cache.
+
+### Declarative netrc
+
+To manage the netrc file declaratively on NixOS, render it from a secret. The
+example below uses [sops-nix](https://github.com/Mic92/sops-nix):
+
+```nix
+{ config, ... }: {
+  sops.secrets."gradient-api-token" = { };
+  sops.templates."nix-netrc" = {
+    content = ''
+      machine <SERVER_HOSTNAME>
+      login gradient
+      password ${config.sops.placeholder."gradient-api-token"}
+    '';
+    owner = "<YOUR_USERNAME>";
+    path = "/etc/nix/netrc";
+  };
+}
+```
+
+Replace `<SERVER_HOSTNAME>` with the Gradient host and `<YOUR_USERNAME>` with the
+user that should be able to use this cache.

--- a/docs/src/usage/integration.md
+++ b/docs/src/usage/integration.md
@@ -54,6 +54,8 @@ integration.
 
 To report build status back to a forge, create a `forge_status_report` action on the project (see [Actions](./actions.md)).
 
+When a project is created and its repository URL unambiguously matches one of the organization's integrations, Gradient auto-attaches the wiring: a push trigger for the matching inbound integration and a `forge_status_report` action for the matching outbound integration (at most one of each). Ambiguous matches are left for manual setup.
+
 ## 3. Configure the forge webhook
 
 ### Gitea / Forgejo

--- a/frontend/src/app/features/board/job-detail/job-detail.component.ts
+++ b/frontend/src/app/features/board/job-detail/job-detail.component.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import { Component, OnInit, DestroyRef, inject, signal, computed } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { DialogModule } from 'primeng/dialog';
@@ -335,6 +336,7 @@ export class BoardJobDetailComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private board = inject(BoardService);
   private evaluations = inject(EvaluationsService);
+  private destroyRef = inject(DestroyRef);
 
   job = signal<DispatchedJobDetail | null>(null);
   pending = signal<PendingJobSummary | null>(null);
@@ -387,11 +389,23 @@ export class BoardJobDetailComponent implements OnInit {
   });
 
   ngOnInit(): void {
-    const id = this.route.snapshot.paramMap.get('id');
-    if (!id) return;
     this.board
       .getScoringRules()
       .subscribe((rules) => this.descriptions.set(new Map(rules.map((r) => [r.rule, r.description]))));
+    // Navigating between Previous Build Attempts reuses this component, so react
+    // to param changes rather than reading the snapshot once.
+    this.route.paramMap.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((pm) => {
+      const id = pm.get('id');
+      if (id) this.loadJob(id);
+    });
+  }
+
+  private loadJob(id: string): void {
+    this.job.set(null);
+    this.pending.set(null);
+    this.notFound.set(false);
+    this.build.set(null);
+    this.buildDialog.set(false);
     this.board.getJob(id).subscribe({
       next: (d) => {
         this.job.set(d);

--- a/frontend/src/app/features/board/live-jobs/live-jobs.component.ts
+++ b/frontend/src/app/features/board/live-jobs/live-jobs.component.ts
@@ -122,6 +122,9 @@ type StatusFilter = 'all' | 'pending' | 'dispatched';
 })
 export class BoardLiveJobsComponent implements OnInit, OnDestroy {
   private static readonly STATE_KEY = 'board.live-jobs.filters';
+  // Mirror the server's `board/jobs/dispatched` cap so optimistic live rows and
+  // the reconciled API list converge instead of flipping the count.
+  private static readonly MAX_DISPATCHED = 500;
 
   private board = inject(BoardService);
   private live = inject(BoardLiveService);
@@ -196,7 +199,7 @@ export class BoardLiveJobsComponent implements OnInit, OnDestroy {
                 pname: null,
               },
               ...list,
-            ].slice(0, 200)
+            ].slice(0, BoardLiveJobsComponent.MAX_DISPATCHED)
           );
           this.scheduleRefresh();
         }

--- a/frontend/src/app/features/caches/cache-detail/cache-detail.component.html
+++ b/frontend/src/app/features/caches/cache-detail/cache-detail.component.html
@@ -31,12 +31,12 @@
           </span>
         </div>
       </div>
-      @if (c.can_edit) {
-        <div class="header-actions">
-          <button pButton label="NARs" icon="pi pi-database" severity="secondary" [routerLink]="['/caches', cacheName, 'nars']"></button>
+      <div class="header-actions">
+        <button pButton label="NARs" icon="pi pi-database" severity="secondary" [routerLink]="['/caches', cacheName, 'nars']"></button>
+        @if (c.can_edit) {
           <button pButton label="Settings" icon="pi pi-cog" severity="secondary" [routerLink]="['/caches', cacheName, 'settings']"></button>
-        </div>
-      }
+        }
+      </div>
     </div>
 
     <!-- Stats -->
@@ -177,7 +177,10 @@ trusted-public-keys = &lt;unavailable&gt;</pre>
 
         @if (!c.public) {
           <div class="usage-divider"></div>
-          <h3 class="usage-section-title">Authentication</h3>
+          <h3 class="usage-section-title">
+            Authentication
+            <gr-label-help href="https://wavelens.github.io/gradient/usage/caches/#authentication" title="Cache authentication docs" />
+          </h3>
           <p class="text-secondary">This cache is private. Run the following command as root to install the credentials Nix needs to access it:</p>
           <div class="usage-row">
             <span class="usage-label">Install netrc</span>
@@ -189,20 +192,10 @@ trusted-public-keys = &lt;unavailable&gt;</pre>
             </div>
             <p class="text-secondary usage-hint">Replace <code>&lt;YOUR_TOKEN&gt;</code> with your API key or login token. The command writes the credentials to <code>/etc/nix/netrc</code> so the Nix daemon can authenticate against this cache.</p>
           </div>
-          <div class="usage-row">
-            <span class="usage-label">Or install <code>/etc/nix/netrc</code> decleratively</span>
-            <div class="code-block multiline">
-              <pre>
-                {{ declerativeNetrcCode }}
-              </pre>
-              <button class="copy-btn" (click)="copy(declerativeNetrcCode, 'netrc-code')" [title]="copied() === 'netrc-code' ? 'Copied!' : 'Copy'">
-                <span class="material-symbols-outlined">{{ copied() === 'netrc-code' ? 'check' : 'content_copy' }}</span>
-              </button>
-            </div>
-            <p class="text-secondary usage-hint">
-              This example uses <a href="https://github.com/Mic92/sops-nix">sops-nix</a>.
-              Replace <code>&lt;YOUR_USERNAME&gt;</code> with the user who should be able to use this cache. </p>
-          </div>
+          <p class="text-secondary usage-hint">
+            Prefer a declarative NixOS setup? See the
+            <a href="https://wavelens.github.io/gradient/usage/caches/#declarative-netrc" target="_blank" rel="noopener noreferrer">declarative netrc example</a> in the docs.
+          </p>
         }
       </div>
     </div>

--- a/frontend/src/app/features/caches/cache-detail/cache-detail.component.ts
+++ b/frontend/src/app/features/caches/cache-detail/cache-detail.component.ts
@@ -11,6 +11,7 @@ import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';
 import { CachesService, CacheStats, CacheMetricPoint, StorageMetricPoint, UpstreamCache } from '@core/services/caches.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
+import { LabelHelpComponent } from '@shared/components/form';
 import { Cache } from '@core/models';
 import {
   NgApexchartsModule,
@@ -47,6 +48,7 @@ const CHART_COLORS = {
     ButtonModule,
     CardModule,
     LoadingSpinnerComponent,
+    LabelHelpComponent,
     NgApexchartsModule,
   ],
   templateUrl: './cache-detail.component.html',
@@ -81,23 +83,6 @@ export class CacheDetailComponent implements OnInit {
 
   get installNetrcCommand(): string {
     return `nix run wavelens/gradient#gradient-cli -- cache install-netrc --server ${this.serverUrl} --token <YOUR_TOKEN> --cache ${this.cacheName}`;
-  }
-
-  get declerativeNetrcCode(): string {
-    return `
-      { config, ... }: {
-        sops.secrets."gradient-api-token" = { };
-        sops.templates."nix-netrc" = {
-          content = ''
-            machine ${window.location.hostname}
-            login gradient
-            password \${config.sops.placeholder."gradient-api-token"}
-          '';
-          owner = "YOUR_USERNAME";
-          path = "/etc/nix/netrc";
-        };
-      }
-    `;
   }
 
   readonly windows: { key: Window; label: string }[] = [
@@ -142,6 +127,7 @@ export class CacheDetailComponent implements OnInit {
         height: 220,
         background: CHART_COLORS.background,
         toolbar: { show: false },
+        zoom: { allowMouseWheelZoom: false },
         sparkline: { enabled: false },
         animations: { enabled: true, speed: 400 },
       },
@@ -222,6 +208,7 @@ export class CacheDetailComponent implements OnInit {
         height: 220,
         background: CHART_COLORS.background,
         toolbar: { show: false },
+        zoom: { allowMouseWheelZoom: false },
         sparkline: { enabled: false },
         animations: { enabled: true, speed: 400 },
       },

--- a/frontend/src/app/features/caches/cache-list/cache-list.component.html
+++ b/frontend/src/app/features/caches/cache-list/cache-list.component.html
@@ -199,38 +199,6 @@
     </div>
 
     <div class="form-group">
-      <label for="cache-priority">Priority</label>
-      <input
-        type="number"
-        id="cache-priority"
-        [(ngModel)]="newCache.priority"
-        [class.input-invalid]="priorityInvalid"
-        class="w-full"
-        min="0"
-        max="255"
-      />
-      @if (priorityInvalid) {
-        <small class="text-danger">Priority must be between 0 and 255</small>
-      } @else {
-        <small class="text-secondary">Higher priority caches are used first (0-255)</small>
-      }
-    </div>
-
-    <div class="form-group">
-      <label for="cache-local-priority">Local Priority</label>
-      <input
-        type="number"
-        id="cache-local-priority"
-        [(ngModel)]="newCache.local_priority"
-        class="w-full"
-      />
-      <small class="text-secondary">
-        Advertised to clients in the server's local-IPs allowlist.
-        Leave empty (or set 0) to always advertise the default priority.
-      </small>
-    </div>
-
-    <div class="form-group">
       <label for="cache-visibility">Visibility</label>
       <select id="cache-visibility" [(ngModel)]="newCache.public" class="visibility-select w-full">
         <option [ngValue]="false">Private</option>
@@ -252,7 +220,7 @@
       pButton
       label="Create"
       (click)="createCache()"
-      [disabled]="!newCache.name || !newCache.display_name || priorityInvalid || nameCheckState() === 'taken' || nameCheckState() === 'invalid' || nameCheckState() === 'checking' || creating()"
+      [disabled]="!newCache.name || !newCache.display_name || nameCheckState() === 'taken' || nameCheckState() === 'invalid' || nameCheckState() === 'checking' || creating()"
       [loading]="creating()"
     ></button>
   </ng-template>

--- a/frontend/src/app/features/caches/cache-list/cache-list.component.ts
+++ b/frontend/src/app/features/caches/cache-list/cache-list.component.ts
@@ -70,11 +70,6 @@ export class CacheListComponent implements OnInit, OnDestroy {
   publicCaches = signal<Cache[]>([]);
   publicLoading = signal(false);
 
-  get priorityInvalid(): boolean {
-    const p = this.newCache.priority;
-    return p === null || p === undefined || isNaN(Number(p)) || p < 0 || p > 255;
-  }
-
   ngOnInit(): void {
     if (this.authService.isAuthenticated()) {
       this.loadCaches();

--- a/frontend/src/app/features/caches/cache-nars/cache-nars.component.html
+++ b/frontend/src/app/features/caches/cache-nars/cache-nars.component.html
@@ -85,7 +85,7 @@
             <i class="pi" [class.pi-sort-amount-up]="order() === 'asc'" [class.pi-sort-amount-down]="order() === 'desc'"></i>
           }
         </span>
-        <span class="col col-size">File size</span>
+        <span class="col col-size">Compressed size</span>
         <span class="col col-time sortable" (click)="sortBy('created_at')">
           Created
           @if (sort() === 'created_at') {
@@ -109,7 +109,7 @@
           <span class="col col-time text-secondary">{{ formatDate(row.created_at) }}</span>
           <span class="col col-time text-secondary">{{ formatDate(row.last_fetched_at, 'never') }}</span>
           <span class="col col-actions" (click)="$event.stopPropagation()">
-            <button pButton icon="pi pi-eye" severity="secondary" [text]="true" (click)="show(row)" title="Show details"></button>
+            <button pButton icon="pi pi-info-circle" severity="secondary" [text]="true" (click)="show(row)" title="Show details"></button>
             <button
               *appWritable="access()"
               pButton

--- a/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.html
+++ b/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.html
@@ -176,7 +176,7 @@
           </div>
           <div class="info-metric">
             <span class="metric-label">Commit</span>
-            <code class="commit-hash">{{ (ev.commit || '').slice(0, 8) }}</code>
+            <code class="commit-hash" [title]="ev.commit || ''">{{ (ev.commit || '').slice(0, 8) }}</code>
           </div>
           <div class="info-metric nav-btns">
             <button pButton icon="pi pi-arrow-left" severity="secondary" size="small"
@@ -197,6 +197,15 @@
 
       <!-- Log area -->
       <div class="log-area">
+        @if (ev.status === 'Waiting' && selectedSection() !== 'messages' && selectedBuildId()) {
+          <div class="waiting-banner">
+            <span class="material-symbols-outlined">pause_circle</span>
+            <span class="waiting-banner-title">{{ waitingTitle(ev.waiting_reason) }}</span>
+            @if (ev.waiting_reason) {
+              <span class="waiting-banner-sub">{{ formatWaitingReason(ev.waiting_reason) }}</span>
+            }
+          </div>
+        }
         @if (selectedSection() === 'messages') {
           <div class="messages-panel">
             <div class="messages-panel-header">Evaluation Messages</div>

--- a/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.ts
+++ b/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.ts
@@ -210,21 +210,21 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
 
   private readonly buildStatusOrder: Record<string, number> = {
     building: 0,
-    queued: 1,
+    failed: 1,
+    dependencyfailed: 1,
     aborted: 2,
-    failed: 3,
-    dependencyfailed: 3,
+    queued: 3,
     completed: 4,
     substituted: 4,
   };
 
-  /// Sidebar sections, in display order. `Completed` absorbs `Substituted`,
-  /// `Failed` absorbs `DependencyFailed` - matching the dot colours.
+  /// Sidebar sections, in display order. Failures sort above queued so they stay
+  /// visible. `Completed` absorbs `Substituted`, `Failed` absorbs `DependencyFailed`.
   private readonly buildGroups: { key: string; label: string; members: string[] }[] = [
     { key: 'building', label: 'Building', members: ['building'] },
-    { key: 'queued', label: 'Queued', members: ['queued'] },
-    { key: 'aborted', label: 'Aborted', members: ['aborted'] },
     { key: 'failed', label: 'Failed', members: ['failed', 'dependencyfailed'] },
+    { key: 'aborted', label: 'Aborted', members: ['aborted'] },
+    { key: 'queued', label: 'Queued', members: ['queued'] },
     { key: 'completed', label: 'Completed', members: ['completed', 'substituted'] },
   ];
 

--- a/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.log.scss
+++ b/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.log.scss
@@ -37,6 +37,21 @@
   color: $color-warning;
 }
 
+.waiting-banner {
+  display: flex;
+  align-items: center;
+  gap: $spacing-sm;
+  padding: $spacing-sm $spacing-md;
+  background: rgba($color-warning, 0.08);
+  border-bottom: 1px solid rgba($color-warning, 0.35);
+  color: $text-secondary;
+  flex-shrink: 0;
+
+  .material-symbols-outlined { font-size: 20px; color: $color-warning; }
+  .waiting-banner-title { font-weight: 600; color: $text-primary; }
+  .waiting-banner-sub { font-size: $font-size-sm; color: $text-light; }
+}
+
 .queued-hint {
   display: flex;
   flex-direction: column;

--- a/frontend/src/app/features/organizations/integrations/integrations.component.html
+++ b/frontend/src/app/features/organizations/integrations/integrations.component.html
@@ -210,9 +210,16 @@
     </div>
   }
   <div class="form-group">
-    <label for="int-name">Name</label>
-    <input pInputText id="int-name" [(ngModel)]="formData.name" class="w-full" placeholder="e.g. main-gitea" />
-    <small class="text-secondary">Used in the webhook URL. Use letters, digits, and dashes.</small>
+    <label for="int-name">
+      Name
+      <gr-label-help href="https://wavelens.github.io/gradient/usage/integration/" title="Learn about forge integrations" />
+    </label>
+    <input pInputText id="int-name" [(ngModel)]="formData.name" [class.input-invalid]="nameInvalid" class="w-full" placeholder="e.g. main-gitea" />
+    @if (nameInvalid) {
+      <small class="text-danger">Lowercase letters, digits, and dashes only. Cannot start or end with a dash.</small>
+    } @else {
+      <small class="text-secondary">Used in the webhook URL. Lowercase letters, digits, and dashes.</small>
+    }
   </div>
   <div class="form-group">
     <label for="int-display-name">Display Name</label>
@@ -220,7 +227,10 @@
     <small class="text-secondary">Human-readable label shown in the integrations list.</small>
   </div>
   <div class="form-group">
-    <label for="int-kind">Kind</label>
+    <label for="int-kind">
+      Kind
+      <gr-label-help href="https://wavelens.github.io/gradient/usage/integration/" title="Inbound vs outbound integrations" />
+    </label>
     <p-select
       inputId="int-kind"
       [(ngModel)]="formData.kind"
@@ -276,7 +286,7 @@
 
   <ng-template pTemplate="footer">
     <button pButton label="Cancel" severity="secondary" (click)="showCreateDialog.set(false)" [disabled]="saving()"></button>
-    <button pButton label="Create" icon="pi pi-check" (click)="createIntegration()" [loading]="saving()" [disabled]="saving() || !formData.name.trim()"></button>
+    <button pButton label="Create" icon="pi pi-check" (click)="createIntegration()" [loading]="saving()" [disabled]="saving() || !formData.name.trim() || nameInvalid"></button>
   </ng-template>
 </p-dialog>
 

--- a/frontend/src/app/features/organizations/integrations/integrations.component.ts
+++ b/frontend/src/app/features/organizations/integrations/integrations.component.ts
@@ -24,6 +24,7 @@ import {
   Organization,
 } from '@core/models';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
+import { LabelHelpComponent } from '@shared/components/form';
 import { WritableDirective, ManagedDisableDirective } from '@shared/access';
 
 interface Option<T> {
@@ -43,6 +44,7 @@ interface Option<T> {
     InputTextModule,
     SelectModule,
     LoadingSpinnerComponent,
+    LabelHelpComponent,
     WritableDirective,
     ManagedDisableDirective,
   ],
@@ -65,6 +67,13 @@ export class IntegrationsComponent implements OnInit {
   orgDisplayName = signal('');
   organization = signal<Organization | null>(null);
   integrations = signal<Integration[]>([]);
+
+  private readonly namePattern = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+
+  get nameInvalid(): boolean {
+    const n = this.formData.name.trim();
+    return n.length > 0 && !this.namePattern.test(n);
+  }
 
   showCreateDialog = signal(false);
   showEditDialog = signal(false);
@@ -196,7 +205,7 @@ export class IntegrationsComponent implements OnInit {
   }
 
   createIntegration(): void {
-    if (!this.formData.name.trim()) return;
+    if (!this.formData.name.trim() || this.nameInvalid) return;
     this.saving.set(true);
     this.errorMessage.set(null);
     const body: any = {

--- a/frontend/src/app/features/organizations/organization-detail/organization-detail.component.html
+++ b/frontend/src/app/features/organizations/organization-detail/organization-detail.component.html
@@ -156,9 +156,7 @@
     <div class="form-group">
       <label for="proj-wildcard">
         Evaluation Wildcard
-        <a href="https://wavelens.github.io/gradient/usage/overview/#evaluation-wildcard" target="_blank" rel="noopener noreferrer" class="label-help" title="Learn about evaluation wildcards">
-          <span class="material-symbols-outlined">help</span>
-        </a>
+        <gr-label-help href="https://wavelens.github.io/gradient/usage/overview/#evaluation-wildcard" title="Learn about evaluation wildcards" />
       </label>
       <input
         pInputText

--- a/frontend/src/app/features/organizations/organization-detail/organization-detail.component.ts
+++ b/frontend/src/app/features/organizations/organization-detail/organization-detail.component.ts
@@ -19,6 +19,7 @@ import { OrganizationsService } from '@core/services/organizations.service';
 import { ProjectsService } from '@core/services/projects.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { EmptyStateComponent } from '@shared/components/empty-state/empty-state.component';
+import { LabelHelpComponent } from '@shared/components/form';
 import { Organization, Project, EvaluationStatus } from '@core/models';
 
 const RESERVED_PROJECT_NAMES = ['build-request'];
@@ -36,6 +37,7 @@ const RESERVED_PROJECT_NAMES = ['build-request'];
     TextareaModule,
     LoadingSpinnerComponent,
     EmptyStateComponent,
+    LabelHelpComponent,
   ],
   templateUrl: './organization-detail.component.html',
   styleUrl: './organization-detail.component.scss',

--- a/frontend/src/app/features/projects/entry-point-metrics/entry-point-metrics.component.ts
+++ b/frontend/src/app/features/projects/entry-point-metrics/entry-point-metrics.component.ts
@@ -108,7 +108,7 @@ export class EntryPointMetricsComponent implements OnInit {
         background: CHART_COLORS.background,
         toolbar: { show: false },
         animations: { enabled: true, speed: 400 },
-        zoom: { enabled: false },
+        zoom: { enabled: false, allowMouseWheelZoom: false },
       },
       theme: { mode: 'dark' },
       stroke: { curve: 'smooth', width: 2 },

--- a/frontend/src/app/features/projects/project-actions/action-form.component.html
+++ b/frontend/src/app/features/projects/project-actions/action-form.component.html
@@ -27,21 +27,15 @@
 
   <div class="form-group">
     <label>Type</label>
-    <div class="radio-row">
-      @for (opt of typeOptions(); track opt.value) {
-        <label class="radio-option">
-          <input
-            type="radio"
-            name="action-type"
-            [value]="opt.value"
-            [checked]="type() === opt.value"
-            [disabled]="typeRadioDisabled()"
-            (change)="onTypeChange(opt.value)"
-          />
-          {{ opt.label }}
-        </label>
-      }
-    </div>
+    <p-selectbutton
+      [options]="typeOptions()"
+      [ngModel]="type()"
+      (ngModelChange)="onTypeChange($event)"
+      optionLabel="label"
+      optionValue="value"
+      [allowEmpty]="false"
+      [disabled]="typeRadioDisabled()"
+    />
     @if (typeRadioDisabled()) {
       <small class="text-secondary">Action type cannot be changed after creation.</small>
     }

--- a/frontend/src/app/features/projects/project-actions/action-form.component.scss
+++ b/frontend/src/app/features/projects/project-actions/action-form.component.scss
@@ -24,20 +24,6 @@
   }
 }
 
-.radio-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: $spacing-md;
-}
-
-.radio-option {
-  display: inline-flex;
-  align-items: center;
-  gap: $spacing-xs;
-  font-weight: normal;
-  margin-bottom: 0;
-}
-
 .token-row {
   display: flex;
   gap: $spacing-sm;

--- a/frontend/src/app/features/projects/project-actions/action-form.component.ts
+++ b/frontend/src/app/features/projects/project-actions/action-form.component.ts
@@ -11,6 +11,7 @@ import { DialogModule } from 'primeng/dialog';
 import { ButtonModule } from 'primeng/button';
 import { InputTextModule } from 'primeng/inputtext';
 import { SelectModule } from 'primeng/select';
+import { SelectButtonModule } from 'primeng/selectbutton';
 import { CheckboxModule } from 'primeng/checkbox';
 import { TextareaModule } from 'primeng/textarea';
 import { ConfigService } from '@core/services/config.service';
@@ -44,6 +45,7 @@ interface IntegrationOption {
     ButtonModule,
     InputTextModule,
     SelectModule,
+    SelectButtonModule,
     CheckboxModule,
     TextareaModule,
     ActionEventsComponent,

--- a/frontend/src/app/features/projects/project-detail/project-detail.component.html
+++ b/frontend/src/app/features/projects/project-detail/project-detail.component.html
@@ -11,7 +11,6 @@
     <div>
       <div class="breadcrumb">
         <a [routerLink]="['/organization', orgName]">{{ orgDisplayName() || orgName }}</a>
-        <span class="sep">/</span><b>{{ proj.display_name }}</b>
       </div>
       <h1>{{ proj.display_name }}</h1>
     </div>
@@ -86,7 +85,7 @@
                 <div>
                   <h2>{{ evalTitle(sel) }}</h2>
                   <div class="sub">
-                    <span class="mono">{{ sel.commit.substring(0, 8) }}</span> ·
+                    <span class="mono" [title]="sel.commit">{{ sel.commit.substring(0, 8) }}</span> ·
                     {{ triggerLabel(sel) }} · started {{ sel.created_at + 'Z' | date: 'MMM d, HH:mm' }}
                   </div>
                 </div>

--- a/frontend/src/app/features/projects/project-detail/project-detail.evaluations.scss
+++ b/frontend/src/app/features/projects/project-detail/project-detail.evaluations.scss
@@ -17,7 +17,7 @@
 .mono { font-family: 'JetBrains Mono', 'Fira Code', monospace; }
 
 .pp-head { display: flex; justify-content: space-between; align-items: center; padding-top: 26px; margin-bottom: 18px; }
-.breadcrumb { color: #818181; font-size: 13px; a { color: #abb0b4; text-decoration: none; } .sep { margin: 0 6px; } b { color: #abb0b4; font-weight: 500; } }
+.breadcrumb { color: #818181; font-size: 13px; a { color: #abb0b4; text-decoration: none; &:hover { color: $text-primary; text-decoration: underline; } } }
 h1 { font-size: $font-size-xxl; margin: 0; }
 .head-actions { display: flex; gap: 8px; flex-wrap: wrap; }
 

--- a/frontend/src/app/features/projects/project-metrics/project-metrics.component.ts
+++ b/frontend/src/app/features/projects/project-metrics/project-metrics.component.ts
@@ -104,7 +104,7 @@ export class ProjectMetricsComponent implements OnInit {
         background: CHART_COLORS.background,
         toolbar: { show: false },
         animations: { enabled: true, speed: 400 },
-        zoom: { enabled: false },
+        zoom: { enabled: false, allowMouseWheelZoom: false },
       },
       theme: { mode: 'dark' },
       stroke: { curve: 'smooth', width: 2 },

--- a/frontend/src/app/shared/components/metric-chart/metric-chart.component.ts
+++ b/frontend/src/app/shared/components/metric-chart/metric-chart.component.ts
@@ -21,7 +21,7 @@ import { NgApexchartsModule, ApexAxisChartSeries } from 'ng-apexcharts';
       }
       <apx-chart
         [series]="series"
-        [chart]="{ type: type, height: height, background: 'transparent', toolbar: { show: false }, animations: { enabled: false } }"
+        [chart]="{ type: type, height: height, background: 'transparent', toolbar: { show: false }, animations: { enabled: false }, zoom: { allowMouseWheelZoom: false } }"
         [theme]="{ mode: 'dark' }"
         [plotOptions]="{ bar: { horizontal: horizontal } }"
         [xaxis]="{ categories: categories, labels: { rotate: -45, style: { colors: '#abb0b4', fontSize: '10px' } } }"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
     - Pull Deployment: usage/pull-deployment.md
     - Forge Integration: usage/integration.md
     - Actions: usage/actions.md
+    - Caches: usage/caches.md
     - Cache NARs: usage/cache-nars.md
     - Closure View: usage/closure-view.md
   - Development:


### PR DESCRIPTION
Closes #401 (capability/feature/architecture load metrics split out to #417).

Addressed:
- Eval page: waiting reason pinned on top, Failed sorts above Queued, full commit on hover
- Cache create: drop Priority/Local Priority; auth nix example moved to docs behind a `?` link; NAR browser icon + "Compressed size" label; NARs button visible to read-only members
- Integration popup: name validation + docs `?` link
- Project create: wildcard `?` uses `gr-label-help`; auto-attach a matching org integration (push trigger + status-report action)
- Project page: breadcrumb hover + drop redundant name; full commit on hover
- Board: disable chart wheel-zoom; fix live-jobs 200/500 banner flip; previous-attempt links now navigate
- Actions form: type radio replaced with `p-selectbutton`
- Backend: GitHub PR auto-approve on maintainer approval; push triggers write the commit subject + author