### PR TITLE
backend: fix: self-heal builds when a required input is missing from cache (#410)

### DIFF
--- a/backend/gradient-db/src/cache_storage.rs
+++ b/backend/gradient-db/src/cache_storage.rs
@@ -9,7 +9,7 @@
 //! bytes): per-cache via the `cached_path_signature` join, instance-wide as a
 //! global sum. Backend-agnostic (works for local FS and S3).
 
-use gradient_types::ids::{CacheId, OrganizationId};
+use gradient_types::ids::{CacheId, DerivationId, OrganizationId};
 use gradient_entity::cache::Model as MCache;
 use gradient_entity::organization_cache::CacheSubscriptionMode;
 use sea_orm::sea_query::{Alias, SimpleExpr};
@@ -153,6 +153,43 @@ pub async fn org_caches_all_full<C: ConnectionTrait>(
         }
     }
     Ok(true)
+}
+
+/// Demote a cached output proven unfetchable: null the `cached_path` size/hash
+/// fields (so `Model::is_fully_cached()` flips to `false`) and clear
+/// `derivation_output.is_cached` / `cached_path` for every output with this
+/// store-path `hash`. Returns the derivations that produce the output so the
+/// caller can re-queue them for a real rebuild.
+pub async fn demote_cached_output<C: ConnectionTrait>(
+    db: &C,
+    hash: &str,
+) -> Result<Vec<DerivationId>, sea_orm::DbErr> {
+    use gradient_entity::cached_path::{ActiveModel as ACachedPath, Column as CCP, Entity as ECP};
+    use gradient_entity::derivation_output::{
+        ActiveModel as ADerivationOutput, Column as CDO, Entity as EDO,
+    };
+    use sea_orm::{ActiveModelTrait, ActiveValue::Set, IntoActiveModel};
+
+    if let Some(row) = ECP::find().filter(CCP::Hash.eq(hash)).one(db).await? {
+        let mut active: ACachedPath = row.into_active_model();
+        active.file_hash = Set(None);
+        active.nar_hash = Set(None);
+        active.file_size = Set(None);
+        active.nar_size = Set(None);
+        active.update(db).await?;
+    }
+
+    let outputs = EDO::find().filter(CDO::Hash.eq(hash)).all(db).await?;
+    let mut producers = Vec::with_capacity(outputs.len());
+    for o in outputs {
+        producers.push(o.derivation);
+        let mut active: ADerivationOutput = o.into_active_model();
+        active.is_cached = Set(false);
+        active.cached_path = Set(None);
+        active.update(db).await?;
+    }
+
+    Ok(producers)
 }
 
 #[cfg(test)]

--- a/backend/gradient-db/src/lib.rs
+++ b/backend/gradient-db/src/lib.rs
@@ -38,8 +38,8 @@ pub use self::build::builds_with_satisfied_deps;
 pub use self::build_attempt::*;
 pub use self::cache_reach::*;
 pub use self::cache_storage::{
-    STORAGE_HEADROOM_BYTES, cache_used_bytes, instance_used_bytes, org_caches_all_full,
-    org_writable_caches,
+    STORAGE_HEADROOM_BYTES, cache_used_bytes, demote_cached_output, instance_used_bytes,
+    org_caches_all_full, org_writable_caches,
 };
 pub use self::cache_upstream::{
     GradientProtoUpstream, gradient_proto_upstreams_for_org, upstream_urls_for_org,

--- a/backend/gradient-proto/src/handler/cache_session.rs
+++ b/backend/gradient-proto/src/handler/cache_session.rs
@@ -230,6 +230,7 @@ mod tests {
                 job_id: "job".into(),
                 error: "x".into(),
                 kind: crate::messages::BuildFailureKind::Permanent,
+                missing_paths: vec![],
             })
             .is_some()
         );

--- a/backend/gradient-proto/src/handler/dispatch.rs
+++ b/backend/gradient-proto/src/handler/dispatch.rs
@@ -334,8 +334,9 @@ impl<'a> DispatchContext<'a> {
                 job_id,
                 error,
                 kind,
+                missing_paths,
             } => {
-                self.on_job_failed(job_id, error, kind).await;
+                self.on_job_failed(job_id, error, kind, missing_paths).await;
                 true
             }
             ClientMessage::Draining => {
@@ -794,11 +795,12 @@ impl<'a> DispatchContext<'a> {
         job_id: String,
         error: String,
         kind: gradient_types::proto::BuildFailureKind,
+        missing_paths: Vec<String>,
     ) {
         warn!(peer_id = %self.peer_id, %job_id, %error, ?kind, "job failed");
         if let Err(e) = self
             .scheduler
-            .handle_job_failed(self.peer_id, &job_id, &error, kind)
+            .handle_job_failed(self.peer_id, &job_id, &error, kind, &missing_paths)
             .await
         {
             error!(peer_id = %self.peer_id, %job_id, error = %e, "handle_job_failed failed");

--- a/backend/gradient-proto/src/handler/socket.rs
+++ b/backend/gradient-proto/src/handler/socket.rs
@@ -19,7 +19,7 @@ use futures::StreamExt;
 use gradient_types::ids::OrganizationId;
 use gradient_types::*;
 use gradient_core::ServerState;
-use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
+use sea_orm::EntityTrait;
 use tracing::{debug, error, warn};
 
 use crate::messages::ServerMessage;
@@ -280,53 +280,14 @@ pub(super) async fn serve_nar_request(
 /// stops claiming the path is available - letting the next build either
 /// rebuild from source or pick the path up from a configured upstream.
 async fn invalidate_cached_path(state: &Arc<ServerState>, hash: &str, store_path: &str) {
-    let row = match ECachedPath::find()
-        .filter(CCachedPath::Hash.eq(hash))
-        .one(&state.worker_db)
-        .await
-    {
-        Ok(Some(row)) => row,
-        Ok(None) => return,
-        Err(e) => {
-            warn!(%hash, %store_path, error = %e, "self-heal: cached_path lookup failed");
-            return;
-        }
-    };
-    let cached_path_id = row.id;
-    let mut active: ACachedPath = row.into();
-    active.file_hash = Set(None);
-    active.nar_hash = Set(None);
-    active.file_size = Set(None);
-    active.nar_size = Set(None);
-    if let Err(e) = active.update(&state.worker_db).await {
-        warn!(%hash, %store_path, error = %e, "self-heal: failed to demote cached_path row");
-        return;
+    match gradient_db::demote_cached_output(&state.worker_db, hash).await {
+        Ok(_) => warn!(
+            %hash,
+            %store_path,
+            "self-heal: NAR missing from storage; cached_path demoted so the path will be rebuilt"
+        ),
+        Err(e) => warn!(%hash, %store_path, error = %e, "self-heal: failed to demote cached output"),
     }
-
-    let outputs = match EDerivationOutput::find()
-        .filter(CDerivationOutput::CachedPath.eq(cached_path_id))
-        .all(&state.worker_db)
-        .await
-    {
-        Ok(rows) => rows,
-        Err(e) => {
-            warn!(%hash, %store_path, error = %e, "self-heal: derivation_output lookup failed");
-            return;
-        }
-    };
-    for o in outputs {
-        let mut active: ADerivationOutput = o.into();
-        active.is_cached = Set(false);
-        if let Err(e) = active.update(&state.worker_db).await {
-            warn!(%hash, %store_path, error = %e, "self-heal: failed to clear derivation_output.is_cached");
-        }
-    }
-
-    warn!(
-        %hash,
-        %store_path,
-        "self-heal: NAR missing from storage; cached_path demoted so the path will be rebuilt"
-    );
 }
 
 async fn send_nar_unavailable(

--- a/backend/gradient-proto/src/messages/client.rs
+++ b/backend/gradient-proto/src/messages/client.rs
@@ -103,6 +103,9 @@ pub enum ClientMessage {
         job_id: String,
         error: String,
         kind: BuildFailureKind,
+        /// For `BuildFailureKind::InputsUnavailable`: the required input store
+        /// paths the cache could not serve. Empty for every other kind.
+        missing_paths: Vec<String>,
     },
 
     /// Worker is draining - it will finish in-flight jobs then disconnect.

--- a/backend/gradient-scheduler/src/build.rs
+++ b/backend/gradient-scheduler/src/build.rs
@@ -53,6 +53,9 @@ pub(crate) fn decide_failure_outcome(
         BuildFailureKind::Timeout => FailureOutcome::Timeout,
         BuildFailureKind::Permanent => FailureOutcome::Permanent,
         BuildFailureKind::SubstituteUnavailable => FailureOutcome::Requeue,
+        // The build itself is terminal for this eval; the self-heal that
+        // re-queues the missing inputs' producers runs separately.
+        BuildFailureKind::InputsUnavailable => FailureOutcome::Permanent,
         BuildFailureKind::Transient => {
             if (attempt + 1) < max_attempts as i32 {
                 FailureOutcome::Retry
@@ -67,7 +70,9 @@ pub(crate) fn decide_failure_outcome(
 /// `build_attempt.reason`. `Transient` has no single cause, so it stays `None`.
 fn attempt_reason(kind: BuildFailureKind) -> Option<AttemptFailureReason> {
     match kind {
-        BuildFailureKind::SubstituteUnavailable => Some(AttemptFailureReason::SubstituteUnavailable),
+        BuildFailureKind::SubstituteUnavailable | BuildFailureKind::InputsUnavailable => {
+            Some(AttemptFailureReason::SubstituteUnavailable)
+        }
         BuildFailureKind::Permanent => Some(AttemptFailureReason::BuilderNonzero),
         BuildFailureKind::Timeout => Some(AttemptFailureReason::WallClockTimeout),
         BuildFailureKind::Transient => None,
@@ -86,6 +91,14 @@ pub(crate) fn retry_backoff_elapsed(
     let shift = (attempt.max(1) - 1).min(16) as u32;
     let window = base_secs.saturating_mul(1u64 << shift);
     (now - failed_at).num_seconds() >= window as i64
+}
+
+/// Extract the 32-char hash from a `/nix/store/<hash>-<name>` store path.
+fn store_path_hash(store_path: &str) -> Option<&str> {
+    store_path
+        .strip_prefix("/nix/store/")
+        .and_then(|s| s.split('-').next())
+        .filter(|h| !h.is_empty())
 }
 
 /// Wraps `&ServerState` so build-lifecycle helpers don't repeat `state` as a parameter.
@@ -304,6 +317,7 @@ impl<'a> BuildStateHandler<'a> {
         build_id: BuildId,
         error: &str,
         kind: BuildFailureKind,
+        missing_paths: &[String],
     ) -> Result<()> {
         let build = match EBuild::find_by_id(build_id)
             .one(&self.state.worker_db)
@@ -346,6 +360,19 @@ impl<'a> BuildStateHandler<'a> {
         .await
         {
             warn!(%build_id, error = %e, "failed to record attempt failure reason");
+        }
+
+        // Self-heal: a required input was reported absent from the cache while
+        // its producer was marked done/substituted. Demote those outputs and
+        // re-queue their producers before this build is marked terminal, so the
+        // next evaluation finds them genuinely cached.
+        if matches!(kind, BuildFailureKind::InputsUnavailable)
+            && !missing_paths.is_empty()
+            && let Err(e) = self
+                .reconcile_missing_inputs(evaluation_id, missing_paths)
+                .await
+        {
+            warn!(%build_id, error = %e, "failed to reconcile missing inputs");
         }
 
         match decide_failure_outcome(kind, attempt, max_attempts) {
@@ -429,35 +456,8 @@ impl<'a> BuildStateHandler<'a> {
         }
 
         if is_success {
-            let now = gradient_types::now();
             for follower in followers {
-                let follower_id = follower.id;
-                let (old_status, evaluation, derivation) =
-                    (follower.status, follower.evaluation, follower.derivation);
-                let mut active: ABuild = follower.into_active_model();
-                active.status = Set(BuildStatus::Queued);
-                active.via = Set(None);
-                active.updated_at = Set(now);
-                if let Err(e) = active.update(&self.state.worker_db).await {
-                    error!(error = %e, %follower_id, "failed to release follower for re-dispatch");
-                    continue;
-                }
-
-                // This force-set bypasses `update_build_status`, so maintain the
-                // dependency-closure counts directly (#383).
-                if old_status != BuildStatus::Queued {
-                    let state = Arc::clone(self.state);
-                    self.state.shutdown.spawn(async move {
-                        let _ = gradient_db::apply_dep_count_delta(
-                            &state.worker_db,
-                            evaluation,
-                            derivation,
-                            i32::from(old_status),
-                            i32::from(BuildStatus::Queued),
-                        )
-                        .await;
-                    });
-                }
+                self.force_requeue(follower).await;
             }
 
             return Ok(());
@@ -493,6 +493,96 @@ impl<'a> BuildStateHandler<'a> {
             self.check_evaluation_done(evaluation_id).await?;
         }
 
+        Ok(())
+    }
+
+    /// Force a build back to `Queued`, bypassing the state machine (which
+    /// forbids leaving a terminal state) and maintaining the entry-point
+    /// dep-closure counts directly (#383). Used to release followers on leader
+    /// success and to re-queue producers of inputs the cache could not serve.
+    async fn force_requeue(&self, build: MBuild) {
+        let build_id = build.id;
+        let (old_status, evaluation, derivation, has_queued_at) = (
+            build.status,
+            build.evaluation,
+            build.derivation,
+            build.queued_at.is_some(),
+        );
+        let now = gradient_types::now();
+        let mut active: ABuild = build.into_active_model();
+        active.status = Set(BuildStatus::Queued);
+        active.via = Set(None);
+        active.updated_at = Set(now);
+        if !has_queued_at {
+            active.queued_at = Set(Some(now));
+        }
+
+        if let Err(e) = active.update(&self.state.worker_db).await {
+            error!(error = %e, %build_id, "failed to re-queue build");
+            return;
+        }
+
+        if old_status != BuildStatus::Queued {
+            let state = Arc::clone(self.state);
+            self.state.shutdown.spawn(async move {
+                let _ = gradient_db::apply_dep_count_delta(
+                    &state.worker_db,
+                    evaluation,
+                    derivation,
+                    i32::from(old_status),
+                    i32::from(BuildStatus::Queued),
+                )
+                .await;
+            });
+        }
+    }
+
+    /// Self-heal for `BuildFailureKind::InputsUnavailable`. A build attempt
+    /// proved these input outputs are unfetchable from the cache, so demote
+    /// them (`is_cached = false`, drop the stale `cached_path`) and re-queue any
+    /// build in this evaluation that produces them yet sits in a done state
+    /// (`Substituted`/`Completed`). The scheduler then builds and caches them
+    /// for real, so the dependent succeeds on the next evaluation.
+    async fn reconcile_missing_inputs(
+        &self,
+        evaluation_id: EvaluationId,
+        missing_paths: &[String],
+    ) -> Result<()> {
+        let db = &self.state.worker_db;
+        let mut producers: std::collections::HashSet<DerivationId> = std::collections::HashSet::new();
+        for path in missing_paths {
+            let Some(hash) = store_path_hash(path) else {
+                continue;
+            };
+
+            match gradient_db::demote_cached_output(db, hash).await {
+                Ok(drvs) => producers.extend(drvs),
+                Err(e) => warn!(%path, error = %e, "reconcile: demote_cached_output failed"),
+            }
+        }
+
+        if producers.is_empty() {
+            return Ok(());
+        }
+
+        let producer_ids: Vec<DerivationId> = producers.into_iter().collect();
+        let stale = gradient_db::fetch_in_chunks(&producer_ids, |chunk| async move {
+            EBuild::find()
+                .filter(CBuild::Evaluation.eq(evaluation_id))
+                .filter(CBuild::Status.is_in(vec![BuildStatus::Substituted, BuildStatus::Completed]))
+                .filter(CBuild::Derivation.is_in(chunk))
+                .all(db)
+                .await
+        })
+        .await
+        .context("reconcile: fetch producing builds")?;
+
+        let count = stale.len();
+        for build in stale {
+            self.force_requeue(build).await;
+        }
+
+        info!(%evaluation_id, requeued = count, paths = missing_paths.len(), "reconciled missing inputs; producers re-queued for rebuild");
         Ok(())
     }
 
@@ -936,9 +1026,10 @@ pub async fn handle_build_job_failed(
     build_id: BuildId,
     error: &str,
     kind: BuildFailureKind,
+    missing_paths: &[String],
 ) -> Result<()> {
     BuildStateHandler::new(state)
-        .handle_build_job_failed(build_id, error, kind)
+        .handle_build_job_failed(build_id, error, kind, missing_paths)
         .await
 }
 
@@ -1180,7 +1271,7 @@ impl BuildabilityChecker {
 
 #[cfg(test)]
 mod retry_tests {
-    use super::{FailureOutcome, decide_failure_outcome, retry_backoff_elapsed};
+    use super::{FailureOutcome, decide_failure_outcome, retry_backoff_elapsed, store_path_hash};
     use gradient_types::proto::BuildFailureKind;
 
     #[test]
@@ -1236,6 +1327,24 @@ mod retry_tests {
         assert!(matches!(decide_failure_outcome(BuildFailureKind::Transient, 0, 3), FailureOutcome::Retry));
         assert!(matches!(decide_failure_outcome(BuildFailureKind::Transient, 1, 3), FailureOutcome::Retry));
         assert!(matches!(decide_failure_outcome(BuildFailureKind::Transient, 2, 3), FailureOutcome::Permanent));
+    }
+    #[test]
+    fn inputs_unavailable_is_terminal_no_retry() {
+        for attempt in [0, 1, 99] {
+            assert_eq!(
+                decide_failure_outcome(BuildFailureKind::InputsUnavailable, attempt, 3),
+                FailureOutcome::Permanent
+            );
+        }
+    }
+    #[test]
+    fn store_path_hash_extracts_32_char_hash() {
+        assert_eq!(
+            store_path_hash("/nix/store/g9y0fvqh2c991vjprgz9mvdm0zj7ggij-python3-static-3.13"),
+            Some("g9y0fvqh2c991vjprgz9mvdm0zj7ggij")
+        );
+        assert_eq!(store_path_hash("not-a-store-path"), None);
+        assert_eq!(store_path_hash("/nix/store/"), None);
     }
 }
 

--- a/backend/gradient-scheduler/src/eval.rs
+++ b/backend/gradient-scheduler/src/eval.rs
@@ -558,12 +558,14 @@ async fn expand_substituted_closure(
     // recurse through derivation_dependency until the closure is exhausted.
     // The outer SELECT filters to derivations without a build row yet, and
     // tags each result with the kind of seed it descends from:
-    //  - 'sub' - reached from a `Substituted` (status=7) build; outputs are
-    //    in our cache, transitive deps are too (Nix substitution invariant)
-    //  - 'ext' - reached from a `Created + substitutable = true` build;
-    //    outputs are in upstream only, transitive deps too. New rows for
-    //    these get inserted with `substitutable = true` so the worker
-    //    fetches them from upstream rather than trying to rebuild.
+    //  - 'sub' - reached from a `Substituted` (status=7) build. The Nix
+    //    invariant says its closure is in our cache too, but that can be false
+    //    when the cache was populated unevenly (#410), so we verify each drv's
+    //    own outputs are actually cached before trusting it (the `cached` flag
+    //    below). A 'sub' drv that is NOT cached is treated like 'ext'.
+    //  - 'ext' (or uncached 'sub') - inserted `Created + substitutable = true`
+    //    so the worker substitute-attempts it; a miss reports
+    //    `SubstituteUnavailable`, which re-queues and escalates to a real build.
     //
     // When a drv is reachable via both kinds of seed simultaneously, prefer
     // 'sub' (already retrievable from our cache).
@@ -582,7 +584,12 @@ async fn expand_substituted_closure(
             FROM derivation_dependency dd2
             JOIN sub_closure sc ON sc.drv_id = dd2.derivation
         )
-        SELECT sc.drv_id, MIN(sc.kind) AS kind
+        SELECT sc.drv_id, MIN(sc.kind) AS kind,
+            (EXISTS (SELECT 1 FROM derivation_output o WHERE o.derivation = sc.drv_id)
+             AND NOT EXISTS (
+                 SELECT 1 FROM derivation_output o
+                 WHERE o.derivation = sc.drv_id AND o.is_cached = false
+             )) AS cached
         FROM sub_closure sc
         WHERE NOT EXISTS (
             SELECT 1 FROM build WHERE derivation = sc.drv_id AND evaluation = $1
@@ -612,9 +619,13 @@ async fn expand_substituted_closure(
         let Ok(kind) = row.try_get::<String>("", "kind") else {
             continue;
         };
-        let (status, substitutable) = if kind == "sub" {
+        let cached = row.try_get::<bool>("", "cached").unwrap_or(false);
+        let (status, substitutable) = if kind == "sub" && cached {
             (BuildStatus::Substituted, false)
         } else {
+            // 'ext', or a 'sub' dep whose output is not actually in our cache:
+            // dispatch as a substitute attempt so it self-heals (substitute or
+            // escalate-to-build) instead of being falsely trusted (#410).
             (BuildStatus::Created, true)
         };
         let build_id = BuildId::now_v7();

--- a/backend/gradient-scheduler/src/handler_tests.rs
+++ b/backend/gradient-scheduler/src/handler_tests.rs
@@ -1026,7 +1026,7 @@ async fn build_failed_cascades_to_direct_dependent() {
         .into_connection();
 
     let state = make_state(db);
-    let result = build_handler::handle_build_job_failed(&state, build_a_id, "build error", BuildFailureKind::Permanent).await;
+    let result = build_handler::handle_build_job_failed(&state, build_a_id, "build error", BuildFailureKind::Permanent, &[]).await;
     assert!(result.is_ok());
 }
 
@@ -1087,7 +1087,7 @@ async fn build_failed_appends_worker_error_to_log() {
 
     let worker_error = "input prefetch failed: acquire local store for import: timeout: \
                         acquiring connection from pool";
-    let result = build_handler::handle_build_job_failed(&state, build_id, worker_error, BuildFailureKind::Permanent).await;
+    let result = build_handler::handle_build_job_failed(&state, build_id, worker_error, BuildFailureKind::Permanent, &[]).await;
     assert!(result.is_ok(), "handler returned error: {result:?}");
 
     let entries = log.entries();
@@ -1150,7 +1150,7 @@ async fn build_failed_no_dependents() {
         .into_connection();
 
     let state = make_state(db);
-    let result = build_handler::handle_build_job_failed(&state, build_id, "error", BuildFailureKind::Permanent).await;
+    let result = build_handler::handle_build_job_failed(&state, build_id, "error", BuildFailureKind::Permanent, &[]).await;
     assert!(result.is_ok());
 }
 
@@ -1217,7 +1217,7 @@ async fn build_failed_cascade_only_direct_dependents() {
         .into_connection();
 
     let state = make_state(db);
-    let result = build_handler::handle_build_job_failed(&state, build_a_id, "error", BuildFailureKind::Permanent).await;
+    let result = build_handler::handle_build_job_failed(&state, build_a_id, "error", BuildFailureKind::Permanent, &[]).await;
     assert!(result.is_ok());
 }
 
@@ -1231,7 +1231,7 @@ async fn build_failed_unknown_build_noop() {
         .into_connection();
 
     let state = make_state(db);
-    let result = build_handler::handle_build_job_failed(&state, build_id, "error", BuildFailureKind::Permanent).await;
+    let result = build_handler::handle_build_job_failed(&state, build_id, "error", BuildFailureKind::Permanent, &[]).await;
     assert!(result.is_ok());
 }
 
@@ -1276,7 +1276,7 @@ async fn build_failed_cascade_skips_building_status() {
         .into_connection();
 
     let state = make_state(db);
-    let result = build_handler::handle_build_job_failed(&state, build_a_id, "err", BuildFailureKind::Permanent).await;
+    let result = build_handler::handle_build_job_failed(&state, build_a_id, "err", BuildFailureKind::Permanent, &[]).await;
     assert!(result.is_ok());
 }
 
@@ -2260,7 +2260,7 @@ async fn action_not_dispatched_for_dep_failed() {
         .into_connection();
 
     let state = make_state(db);
-    let result = build_handler::handle_build_job_failed(&state, build_a_id, "build error", BuildFailureKind::Permanent).await;
+    let result = build_handler::handle_build_job_failed(&state, build_a_id, "build error", BuildFailureKind::Permanent, &[]).await;
     assert!(result.is_ok());
     tokio::task::yield_now().await;
 }
@@ -2762,7 +2762,7 @@ async fn build_failed_cascades_transitively_through_graph() {
         .into_connection();
 
     let state = gradient_test_support::prelude::test_state(db);
-    let result = build_handler::handle_build_job_failed(&state, build_c, "nix build failed", BuildFailureKind::Permanent).await;
+    let result = build_handler::handle_build_job_failed(&state, build_c, "nix build failed", BuildFailureKind::Permanent, &[]).await;
     assert!(
         result.is_ok(),
         "transitive cascade should succeed: {:?}",

--- a/backend/gradient-scheduler/src/job_handlers.rs
+++ b/backend/gradient-scheduler/src/job_handlers.rs
@@ -493,6 +493,7 @@ impl Scheduler {
         job_id: &str,
         error: &str,
         kind: BuildFailureKind,
+        missing_paths: &[String],
     ) -> Result<()> {
         self.worker_pool.write().await.release_job(peer_id, job_id);
         let job = self.job_tracker.write().await.remove_active(job_id);
@@ -502,7 +503,8 @@ impl Scheduler {
                 eval::handle_eval_job_failed(&self.state, j.evaluation_id, error).await
             }
             Some(PendingJob::Build(j)) => {
-                build::handle_build_job_failed(&self.state, j.build_id, error, kind).await
+                build::handle_build_job_failed(&self.state, j.build_id, error, kind, missing_paths)
+                    .await
             }
             None => {
                 warn!(%job_id, "job_failed for unknown job");

--- a/backend/gradient-types/src/proto.rs
+++ b/backend/gradient-types/src/proto.rs
@@ -523,4 +523,10 @@ pub enum BuildFailureKind {
     /// A substitute attempt could not pull the output from cache. Penalty-free
     /// re-queue; escalates to a real arch-bound build after repeated misses.
     SubstituteUnavailable,
+    /// Prefetch found required input paths that the gradient cache cannot
+    /// serve: a transitive dependency is marked done/substituted yet its NAR is
+    /// absent. Terminal for this build; the server demotes those outputs and
+    /// re-queues their producers so the next evaluation succeeds. Carries the
+    /// offending paths on `ClientMessage::JobFailed.missing_paths`.
+    InputsUnavailable,
 }

--- a/backend/gradient-worker/src/executor/build.rs
+++ b/backend/gradient-worker/src/executor/build.rs
@@ -58,6 +58,9 @@ const CGROUP_SAMPLE_MS: u64 = 200;
 pub struct BuildError {
     pub kind: BuildFailureKind,
     pub source: anyhow::Error,
+    /// For `BuildFailureKind::InputsUnavailable`: the required input store paths
+    /// the cache could not serve. Empty for every other kind.
+    pub missing_paths: Vec<String>,
 }
 
 impl std::fmt::Display for BuildError {
@@ -68,40 +71,45 @@ impl std::fmt::Display for BuildError {
 impl std::error::Error for BuildError {}
 
 impl BuildError {
-    pub(crate) fn transient(e: impl Into<anyhow::Error>) -> Self {
+    fn new(kind: BuildFailureKind, source: anyhow::Error) -> Self {
         Self {
-            kind: BuildFailureKind::Transient,
-            source: e.into(),
+            kind,
+            source,
+            missing_paths: Vec::new(),
         }
+    }
+    pub(crate) fn transient(e: impl Into<anyhow::Error>) -> Self {
+        Self::new(BuildFailureKind::Transient, e.into())
     }
     pub(crate) fn permanent(e: impl Into<anyhow::Error>) -> Self {
-        Self {
-            kind: BuildFailureKind::Permanent,
-            source: e.into(),
-        }
+        Self::new(BuildFailureKind::Permanent, e.into())
     }
     pub(crate) fn timeout(e: impl Into<anyhow::Error>) -> Self {
-        Self {
-            kind: BuildFailureKind::Timeout,
-            source: e.into(),
-        }
+        Self::new(BuildFailureKind::Timeout, e.into())
     }
     /// A substitute attempt missed: this worker could not pull the output from
     /// cache. Never falls back to a local build (wrong-arch); the scheduler
     /// re-dispatches or escalates to a real build.
     pub(crate) fn substitute_unavailable(e: impl Into<anyhow::Error>) -> Self {
+        Self::new(BuildFailureKind::SubstituteUnavailable, e.into())
+    }
+    /// Prefetch found required inputs the gradient cache cannot serve. Carries
+    /// the offending paths so the server demotes them and re-queues their
+    /// producers; terminal for this build.
+    pub(crate) fn inputs_unavailable(missing_paths: Vec<String>, e: impl Into<anyhow::Error>) -> Self {
         Self {
-            kind: BuildFailureKind::SubstituteUnavailable,
+            kind: BuildFailureKind::InputsUnavailable,
             source: e.into(),
+            missing_paths,
         }
     }
     /// The server sent `AbortJob` while the daemon was building. Terminal: the
     /// build is already in a terminal state server-side, so retrying is wrong.
     pub(crate) fn aborted(drv_path: &str) -> Self {
-        Self {
-            kind: BuildFailureKind::Permanent,
-            source: anyhow::anyhow!("build aborted by server: {}", drv_path),
-        }
+        Self::new(
+            BuildFailureKind::Permanent,
+            anyhow::anyhow!("build aborted by server: {}", drv_path),
+        )
     }
 }
 
@@ -530,10 +538,10 @@ impl ParsedDerivation {
                 let msg = String::from_utf8_lossy(&f.error_msg).to_string();
                 warn!(drv = %drv_path, error = %msg, "build failed");
                 let kind = classify_build_error(&msg);
-                Err(BuildError {
+                Err(BuildError::new(
                     kind,
-                    source: anyhow::anyhow!("build failed: {}", msg),
-                })
+                    anyhow::anyhow!("build failed: {}", msg),
+                ))
             }
         }
     }

--- a/backend/gradient-worker/src/executor/mod.rs
+++ b/backend/gradient-worker/src/executor/mod.rs
@@ -375,7 +375,17 @@ impl JobExecutor {
                         error = %e,
                         "input prefetch failed; aborting build"
                     );
-                    crate::executor::build::BuildError::transient(e)
+                    // A "required inputs not in cache" miss is terminal and
+                    // self-healing server-side: forward the paths so the server
+                    // demotes them and re-queues their producers. Every other
+                    // prefetch error is infrastructure-transient.
+                    match e.downcast_ref::<crate::proto::nar_import::MissingInputs>() {
+                        Some(mi) => crate::executor::build::BuildError::inputs_unavailable(
+                            mi.0.clone(),
+                            e,
+                        ),
+                        None => crate::executor::build::BuildError::transient(e),
+                    }
                 })?;
             let outputs = build::build_derivation(
                 &self.store,

--- a/backend/gradient-worker/src/proto/job.rs
+++ b/backend/gradient-worker/src/proto/job.rs
@@ -706,6 +706,7 @@ mod tests {
                 job_id: updater.job_id.clone(),
                 error: "something went wrong".to_owned(),
                 kind: gradient_proto::messages::BuildFailureKind::Permanent,
+                missing_paths: vec![],
             })
             .unwrap();
         server_task.await.unwrap();

--- a/backend/gradient-worker/src/proto/nar_import.rs
+++ b/backend/gradient-worker/src/proto/nar_import.rs
@@ -57,6 +57,26 @@ const HTTP_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(600);
 /// and we don't want to swamp the AddToStoreNar queue.
 const PREFETCH_CONCURRENCY: usize = 8;
 
+/// Required input store paths the gradient cache could not serve. Carried as a
+/// typed error so the executor classifies the failure as
+/// `BuildFailureKind::InputsUnavailable` and forwards the paths to the server,
+/// which demotes those outputs and re-queues their producers (#410).
+#[derive(Debug)]
+pub struct MissingInputs(pub Vec<String>);
+
+impl std::fmt::Display for MissingInputs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} required input path(s) are missing from local store and not available in the gradient cache; cannot build (first: {})",
+            self.0.len(),
+            self.0.first().map(String::as_str).unwrap_or("<none>")
+        )
+    }
+}
+
+impl std::error::Error for MissingInputs {}
+
 /// How the closure walker treats `.drv` content seeds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ClosureMode {
@@ -262,12 +282,7 @@ impl<'a> InputPrefetcher<'a> {
                 sample = ?uncached.iter().take(5).collect::<Vec<_>>(),
                 "prefetch: server cannot serve required inputs (not in gradient cache)"
             );
-            return Err(anyhow::anyhow!(
-                "{} required input path(s) are missing from local store and \
-                 not available in the gradient cache; cannot build (first: {})",
-                uncached.len(),
-                uncached.first().map(String::as_str).unwrap_or("<none>")
-            ));
+            return Err(anyhow::Error::new(MissingInputs(uncached)));
         }
 
         Ok((by_url, by_request))
@@ -1474,5 +1489,22 @@ mod tests {
             seeds.contains(&"/nix/store/cccccccccccccccccccccccccccccccc-src".to_string()),
             "input_source still present: {seeds:?}"
         );
+    }
+
+    #[test]
+    fn missing_inputs_message_and_downcast() {
+        let paths = vec![
+            "/nix/store/g9y0fvqh2c991vjprgz9mvdm0zj7ggij-python3-static".to_string(),
+            "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-other".to_string(),
+        ];
+        let err = anyhow::Error::new(MissingInputs(paths.clone()));
+        let msg = format!("{err}");
+        assert!(msg.contains("2 required input path(s)"), "msg: {msg}");
+        assert!(msg.contains("python3-static"), "msg: {msg}");
+
+        let recovered = err
+            .downcast_ref::<MissingInputs>()
+            .expect("MissingInputs survives anyhow boxing");
+        assert_eq!(recovered.0, paths);
     }
 }

--- a/backend/gradient-worker/src/worker/dispatch.rs
+++ b/backend/gradient-worker/src/worker/dispatch.rs
@@ -175,15 +175,19 @@ fn on_job_done(
         }
         Err(e) => {
             let error_chain = format!("{e:#}");
-            let kind = e
+            let (kind, missing_paths) = e
                 .downcast_ref::<crate::executor::build::BuildError>()
-                .map(|be| be.kind)
-                .unwrap_or(gradient_proto::messages::BuildFailureKind::Permanent);
+                .map(|be| (be.kind, be.missing_paths.clone()))
+                .unwrap_or((
+                    gradient_proto::messages::BuildFailureKind::Permanent,
+                    Vec::new(),
+                ));
             error!(%job_id, error = %error_chain, ?kind, "job failed");
             writer.send(ClientMessage::JobFailed {
                 job_id,
                 error: error_chain,
                 kind,
+                missing_paths,
             })?;
         }
     }

--- a/docs/src/development/proto.md
+++ b/docs/src/development/proto.md
@@ -883,7 +883,7 @@ enum ClientMessage {
     RequestAllCandidates,                       // startup-only: ask server to re-send all active candidates once
     JobUpdate { job_id: Uuid, update: JobUpdateKind },
     JobCompleted { job_id: Uuid },              // all tasks done; results already sent via JobUpdate. Per-build metrics travel on JobUpdate::BuildOutput
-    JobFailed { job_id: Uuid, error: String },
+    JobFailed { job_id: Uuid, error: String, kind: BuildFailureKind, missing_paths: Vec<String> }, // missing_paths set only for kind=InputsUnavailable
     Draining,                                   // no more jobs; finishing in-flight work then disconnecting
 
     // Streaming
@@ -1255,6 +1255,12 @@ After a successful build, the worker reads `<output>/nix-support/hydra-build-pro
 Outputs with no `hydra-build-products` file send `products: []` and have no `build_product` rows.
 
 ---
+
+## Missing-input self-heal (`InputsUnavailable`)
+
+A build's prefetch can find that a transitive input output is marked done/`Substituted` yet its NAR is absent from the cache (e.g. it was never fully uploaded, or was GC'd). The worker reports `JobFailed { kind: InputsUnavailable, missing_paths }` listing those paths. The server demotes each output (`derivation_output.is_cached = false`, drops the stale `cached_path`) and re-queues every build in that evaluation that produces them yet sits in a done state, so the scheduler rebuilds and caches them for real. The failing build is terminal for this evaluation; the next evaluation finds the inputs genuinely cached and succeeds.
+
+Preventively, `expand_substituted_closure` (`gradient-scheduler/src/eval.rs`) only marks a closure dep `Substituted` when its own `derivation_output` rows are all `is_cached = true`; a dep reached via the substitution invariant but not actually cached is inserted `Created + substitutable = true` instead, so the worker substitute-attempts it and the `SubstituteUnavailable` miss path re-queues and escalates it to a real build rather than trusting a NAR that is not there.
 
 ## DependencyFailed Cascade
 

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -737,6 +737,37 @@ Backend (`cargo test -p worker --tests`):
 - `proto::nar_import::tests::classify_empty_input_is_empty_output` - empty
   cache responses produce empty buckets.
 
+## Missing-input self-heal (#410)
+
+A build whose prefetch finds a required input absent from the cache no longer
+dies as an opaque permanent failure that recurs every evaluation. The worker
+classifies it as `BuildFailureKind::InputsUnavailable` and forwards the
+offending paths on `JobFailed.missing_paths`; the server demotes those outputs
+and re-queues their producers so the next evaluation builds them for real.
+
+Backend (`cargo test -p gradient-worker -p gradient-scheduler --tests`):
+- `proto::nar_import::tests::missing_inputs_message_and_downcast` - the typed
+  `MissingInputs` error renders the human message (count + first path) and
+  survives `anyhow` boxing, so the executor can `downcast_ref` it and forward
+  the exact paths to the server.
+- `build::retry_tests::inputs_unavailable_is_terminal_no_retry` -
+  `decide_failure_outcome(InputsUnavailable, ..)` is always `Permanent`: the
+  build fails this evaluation rather than burning the retry budget against an
+  input that will not appear until its producer is rebuilt.
+- `build::retry_tests::store_path_hash_extracts_32_char_hash` - the helper that
+  maps a missing `/nix/store/<hash>-<name>` path to the `derivation_output`
+  hash used to demote and locate its producer.
+
+The demotion path itself (`gradient_db::demote_cached_output`) is shared with
+the NAR-serve self-heal in `socket.rs` and is exercised end-to-end in CI.
+
+Preventively, `expand_substituted_closure` now only marks a closure dep
+`Substituted` when its `derivation_output` rows are all `is_cached = true`;
+otherwise it inserts a `Created + substitutable = true` build so the dep
+substitute-attempts and escalates to a real build on a miss. The `cached` flag
+is computed in the recursive-CTE query and is covered by E2E CI (the scheduler
+has no real-Postgres unit harness for raw SQL).
+
 ## State configuration - optional fields for OIDC-only users
 
 Backend (`cargo test -p core --lib state::tests`):


### PR DESCRIPTION
When a transitive input is marked Substituted but its NAR isn't actually cached, builds no longer fail permanently every evaluation.

- Preventive: `expand_substituted_closure` only marks a dep Substituted when its outputs are genuinely `is_cached`; otherwise it inserts a substitutable build that substitute-attempts and escalates to a real build on a `SubstituteUnavailable` miss.
- Reactive: a prefetch miss reports `JobFailed { kind: InputsUnavailable, missing_paths }`; the server demotes those outputs (shared `demote_cached_output`, also used by the NAR-serve self-heal) and re-queues their producers.