### PR TITLE
Fix nix run command

### DIFF
--- a/frontend/src/app/features/caches/cache-detail/cache-detail.component.ts
+++ b/frontend/src/app/features/caches/cache-detail/cache-detail.component.ts
@@ -82,7 +82,7 @@ export class CacheDetailComponent implements OnInit {
   serverUrl = '';
 
   get installNetrcCommand(): string {
-    return `nix run wavelens/gradient#gradient-cli -- cache install-netrc --server ${this.serverUrl} --token <YOUR_TOKEN> --cache ${this.cacheName}`;
+    return `nix run github:wavelens/gradient#gradient-cli -- cache install-netrc --server ${this.serverUrl} --token <YOUR_TOKEN> --cache ${this.cacheName}`;
   }
 
   readonly windows: { key: Window; label: string }[] = [


### PR DESCRIPTION
```
 ➜ nix run wavelens/gradient#gradient-cli
error: cannot find flake 'flake:wavelens/gradient' in the flake registries
```