### PR TITLE
scheduler: fix: bulk evaluation abort + dispatch race

### DIFF
--- a/backend/gradient-db/src/status/abort.rs
+++ b/backend/gradient-db/src/status/abort.rs
@@ -4,30 +4,45 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-use super::build_status::update_build_status;
 use super::evaluation_status::update_evaluation_status;
 use super::leader_election::reelect_leader;
-use crate::DbContext;
-use gradient_types::*;
+use super::logging::{PHASE_SUBJECT_BUILD, finalize_build_log, record_phase_events};
+use crate::dep_closure::reconcile_eval_dep_counts;
+use crate::state_machine::EvalStateMachine;
+use crate::{DbContext, fetch_in_chunks, for_each_chunk};
 use gradient_entity::build::BuildStatus;
+use gradient_entity::build_attempt::{Column as CAttempt, Entity as EAttempt};
 use gradient_entity::evaluation::EvaluationStatus;
-use sea_orm::ActiveValue::Set;
-use sea_orm::{ActiveModelTrait, ColumnTrait, Condition, EntityTrait, IntoActiveModel, QueryFilter};
+use gradient_types::*;
+use sea_orm::sea_query::Expr;
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QuerySelect};
+use std::collections::HashSet;
 use tracing::error;
 
+/// Abort an evaluation's in-flight builds in bulk. Aborting an evaluation with
+/// tens of thousands of builds used to walk them one at a time (a follower
+/// lookup, a row update, and several spawned side-effects per build), so the
+/// request blocked for the whole closure. This resolves the whole set with a
+/// handful of set-based statements: one follower-leader query, one status
+/// update, one attempt stamp, and one dependency-count reconcile.
 pub async fn abort_evaluation(ctx: &DbContext, evaluation: MEvaluation) {
-    if evaluation.status == EvaluationStatus::Completed {
+    if EvalStateMachine::is_terminal(&evaluation.status) {
         return;
     }
 
+    // Park the evaluation before touching its builds: the dispatcher's queue
+    // finder skips Waiting evaluations, so this stops new builds being handed
+    // to workers while we abort. Direct update (no status-change side effects);
+    // the terminal transition to Aborted below fires those.
+    gate_evaluation_aborting(ctx, evaluation.id).await;
+
     let builds = match EBuild::find()
         .filter(CBuild::Evaluation.eq(evaluation.id))
-        .filter(
-            Condition::any()
-                .add(CBuild::Status.eq(BuildStatus::Created))
-                .add(CBuild::Status.eq(BuildStatus::Queued))
-                .add(CBuild::Status.eq(BuildStatus::Building)),
-        )
+        .filter(CBuild::Status.is_in([
+            BuildStatus::Created,
+            BuildStatus::Queued,
+            BuildStatus::Building,
+        ]))
         .all(&ctx.worker_db)
         .await
     {
@@ -38,61 +53,267 @@ pub async fn abort_evaluation(ctx: &DbContext, evaluation: MEvaluation) {
         }
     };
 
-    for build in builds {
-        if build.via.is_some() {
-            // Follower: aborting it does not interrupt the leader's work in
-            // another evaluation. Clear `via` so the eventual leader-completion
-            // sweep skips it, then mark Aborted.
-            abort_follower(ctx, build).await;
-            continue;
-        }
-
-        // Leader (or plain build).
-        let has_followers = match EBuild::find()
-            .filter(CBuild::Via.eq(build.id))
-            .one(&ctx.worker_db)
-            .await
-        {
-            Ok(opt) => opt.is_some(),
-            Err(e) => {
-                error!(error = %e, build_id = %build.id, "Failed to query followers for abort");
-                false
-            }
-        };
-
-        if has_followers && build.status == BuildStatus::Building {
-            // Already running on a worker - let it finish so followers in
-            // other (non-aborted) evaluations get the result.
-            continue;
-        }
-
-        if has_followers && matches!(build.status, BuildStatus::Queued | BuildStatus::Created) {
-            // Hand off leadership before aborting.
-            if let Err(e) = reelect_leader(ctx, &build).await {
-                error!(error = %e, build_id = %build.id, "Failed to re-elect leader on abort");
-            }
-        }
-
-        update_build_status(ctx, build, BuildStatus::Aborted).await;
+    if !builds.is_empty() {
+        abort_builds(ctx, &evaluation, builds).await;
     }
 
     update_evaluation_status(ctx, evaluation, EvaluationStatus::Aborted).await;
 }
 
-async fn abort_follower(ctx: &DbContext, build: MBuild) {
-    let mut active: ABuild = build.clone().into_active_model();
-    active.via = Set(None);
-    if let Err(e) = active.update(&ctx.worker_db).await {
-        error!(error = %e, build_id = %build.id, "Failed to clear via on follower abort");
+/// Park the evaluation as `Waiting` with the `Aborting` reason so the dispatcher
+/// stops handing out its builds. A direct filtered update: the eventual
+/// transition to `Aborted` carries the user-facing status-change side effects.
+async fn gate_evaluation_aborting(ctx: &DbContext, evaluation_id: EvaluationId) {
+    let res = EEvaluation::update_many()
+        .col_expr(
+            CEvaluation::Status,
+            Expr::value(EvaluationStatus::Waiting),
+        )
+        .col_expr(
+            CEvaluation::WaitingReason,
+            Expr::value(WaitingReason::Aborting.to_json()),
+        )
+        .col_expr(CEvaluation::UpdatedAt, Expr::value(gradient_types::now()))
+        .filter(CEvaluation::Id.eq(evaluation_id))
+        .filter(CEvaluation::Status.is_not_in([
+            EvaluationStatus::Completed,
+            EvaluationStatus::Failed,
+            EvaluationStatus::Aborted,
+        ]))
+        .exec(&ctx.worker_db)
+        .await;
+
+    if let Err(e) = res {
+        error!(error = %e, %evaluation_id, "Failed to park evaluation for abort");
+    }
+}
+
+async fn abort_builds(ctx: &DbContext, evaluation: &MEvaluation, builds: Vec<MBuild>) {
+    let build_ids: Vec<BuildId> = builds.iter().map(|b| b.id).collect();
+    let leaders = leader_ids_with_followers(ctx, &build_ids).await;
+    let plan = partition_for_abort(builds, &leaders);
+
+    // Hand leadership off so followers in other, non-aborted evaluations still
+    // get a result. Always a small set, so a per-build call is fine.
+    for leader in &plan.reelect {
+        if let Err(e) = reelect_leader(ctx, leader).await {
+            error!(error = %e, build_id = %leader.id, "Failed to re-elect leader on abort");
+        }
+    }
+
+    let abort_ids = plan.abort_ids();
+    if abort_ids.is_empty() {
         return;
     }
-    let reloaded = match EBuild::find_by_id(build.id).one(&ctx.worker_db).await {
-        Ok(Some(b)) => b,
-        Ok(None) => return,
+
+    let now = gradient_types::now();
+
+    // Mark Aborted and detach followers from their (external) leader in one pass.
+    if let Err(e) = for_each_chunk(&abort_ids, |chunk| async move {
+        EBuild::update_many()
+            .col_expr(CBuild::Status, Expr::value(BuildStatus::Aborted))
+            .col_expr(CBuild::Via, Expr::value(Option::<BuildId>::None))
+            .col_expr(CBuild::UpdatedAt, Expr::value(now))
+            .filter(CBuild::Id.is_in(chunk))
+            .exec(&ctx.worker_db)
+            .await
+    })
+    .await
+    {
+        error!(error = %e, evaluation_id = %evaluation.id, "Failed to bulk-abort builds");
+        return;
+    }
+
+    // Only executing builds have an open attempt to stamp finished.
+    let building_ids = plan.building_ids();
+    if !building_ids.is_empty()
+        && let Err(e) = for_each_chunk(&building_ids, |chunk| async move {
+            EAttempt::update_many()
+                .col_expr(CAttempt::BuildFinishedAt, Expr::value(Some(now)))
+                .filter(CAttempt::Build.is_in(chunk))
+                .filter(CAttempt::BuildFinishedAt.is_null())
+                .exec(&ctx.worker_db)
+                .await
+        })
+        .await
+    {
+        error!(error = %e, evaluation_id = %evaluation.id, "Failed to stamp aborted attempts");
+    }
+
+    // One reconcile replaces the per-build dep-count delta (#383).
+    if let Err(e) = reconcile_eval_dep_counts(&ctx.worker_db, evaluation.id).await {
+        error!(error = %e, evaluation_id = %evaluation.id, "Failed to reconcile dep counts after abort");
+    }
+
+    let pe_ids: Vec<uuid::Uuid> = abort_ids.iter().map(|&id| id.into_inner()).collect();
+    record_phase_events(
+        &ctx.worker_db,
+        PHASE_SUBJECT_BUILD,
+        &pe_ids,
+        i32::from(BuildStatus::Aborted) as i16,
+        now,
+    )
+    .await;
+
+    finalize_aborted_logs(ctx, &building_ids).await;
+
+    // One coarse ping; live subscribers refetch their own scope.
+    let _ = ctx
+        .board_events
+        .send(gradient_types::BoardEvent::EvaluationProgress {
+            project: evaluation.project.map(|p| p.into_inner()),
+            evaluation_id: evaluation.id.into_inner(),
+        });
+}
+
+/// The ids of this evaluation's builds that other builds follow (the `via`
+/// targets). One query replaces the former per-leader follower lookup.
+async fn leader_ids_with_followers(ctx: &DbContext, build_ids: &[BuildId]) -> HashSet<BuildId> {
+    let rows = fetch_in_chunks(build_ids, |chunk| async move {
+        EBuild::find()
+            .select_only()
+            .column(CBuild::Via)
+            .distinct()
+            .filter(CBuild::Via.is_in(chunk))
+            .into_tuple::<Option<BuildId>>()
+            .all(&ctx.worker_db)
+            .await
+    })
+    .await;
+
+    match rows {
+        Ok(rows) => rows.into_iter().flatten().collect(),
         Err(e) => {
-            error!(error = %e, build_id = %build.id, "Failed to reload follower for abort");
-            return;
+            error!(error = %e, "Failed to query build followers for abort");
+            HashSet::new()
         }
-    };
-    update_build_status(ctx, reloaded, BuildStatus::Aborted).await;
+    }
+}
+
+/// Compress the build log of each executing build that was aborted. Spawned so
+/// log I/O never blocks the abort; Created/Queued builds never produced a log.
+async fn finalize_aborted_logs(ctx: &DbContext, building_ids: &[BuildId]) {
+    if building_ids.is_empty() {
+        return;
+    }
+
+    let attempts = crate::build_attempt::latest_attempts(&ctx.worker_db, building_ids)
+        .await
+        .unwrap_or_default();
+    for &build_id in building_ids {
+        let log_id = attempts
+            .get(&build_id)
+            .and_then(|a| a.log_id)
+            .unwrap_or(build_id);
+        let log_ctx = ctx.clone();
+        ctx.shutdown.spawn(async move {
+            finalize_build_log(&log_ctx, log_id).await;
+        });
+    }
+}
+
+/// What to do with each in-flight build when its evaluation is aborted.
+struct AbortPlan {
+    /// Leaders with followers that are still Queued/Created: hand leadership off
+    /// before aborting. Always small.
+    reelect: Vec<MBuild>,
+    /// Every build to mark Aborted (followers, plain builds, and the re-elected
+    /// leaders). Building leaders with followers are excluded so they keep
+    /// running for dependent evaluations.
+    abort: Vec<MBuild>,
+}
+
+impl AbortPlan {
+    fn abort_ids(&self) -> Vec<BuildId> {
+        self.abort.iter().map(|b| b.id).collect()
+    }
+
+    fn building_ids(&self) -> Vec<BuildId> {
+        self.abort
+            .iter()
+            .filter(|b| b.status == BuildStatus::Building)
+            .map(|b| b.id)
+            .collect()
+    }
+}
+
+fn partition_for_abort(builds: Vec<MBuild>, leaders_with_followers: &HashSet<BuildId>) -> AbortPlan {
+    let mut reelect = Vec::new();
+    let mut abort = Vec::new();
+
+    for build in builds {
+        if build.via.is_some() {
+            abort.push(build);
+            continue;
+        }
+
+        if leaders_with_followers.contains(&build.id) {
+            match build.status {
+                BuildStatus::Building => continue,
+                BuildStatus::Queued | BuildStatus::Created => {
+                    reelect.push(build.clone());
+                    abort.push(build);
+                }
+                _ => abort.push(build),
+            }
+        } else {
+            abort.push(build);
+        }
+    }
+
+    AbortPlan { reelect, abort }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gradient_types::ids::{BuildId, DerivationId, EvaluationId};
+
+    fn build(status: BuildStatus, via: Option<BuildId>) -> MBuild {
+        MBuild {
+            id: BuildId::now_v7(),
+            evaluation: EvaluationId::now_v7(),
+            derivation: DerivationId::now_v7(),
+            status,
+            via,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn partition_skips_busy_leaders_reelects_idle_leaders_and_aborts_the_rest() {
+        let plain = build(BuildStatus::Queued, None);
+        let follower = build(BuildStatus::Building, Some(BuildId::now_v7()));
+        let idle_leader = build(BuildStatus::Queued, None);
+        let busy_leader = build(BuildStatus::Building, None);
+
+        let leaders: HashSet<BuildId> = [idle_leader.id, busy_leader.id].into_iter().collect();
+        let plan = partition_for_abort(
+            vec![
+                plain.clone(),
+                follower.clone(),
+                idle_leader.clone(),
+                busy_leader.clone(),
+            ],
+            &leaders,
+        );
+
+        let abort_ids: HashSet<BuildId> = plan.abort_ids().into_iter().collect();
+        assert!(abort_ids.contains(&plain.id));
+        assert!(abort_ids.contains(&follower.id));
+        assert!(abort_ids.contains(&idle_leader.id));
+        assert!(
+            !abort_ids.contains(&busy_leader.id),
+            "a running leader with followers must keep running"
+        );
+
+        assert_eq!(plan.reelect.len(), 1);
+        assert_eq!(plan.reelect[0].id, idle_leader.id);
+
+        assert_eq!(
+            plan.building_ids(),
+            vec![follower.id],
+            "only executing aborted builds need attempt/log finalization"
+        );
+    }
 }

--- a/backend/gradient-db/src/status/logging.rs
+++ b/backend/gradient-db/src/status/logging.rs
@@ -112,6 +112,45 @@ pub async fn record_phase_event(
     }
 }
 
+/// Batch-record the same phase transition for many subjects, one multi-row
+/// insert per chunk. Used by bulk status writes (e.g. evaluation abort) instead
+/// of one spawned [`record_phase_event`] per subject. Best-effort.
+pub async fn record_phase_events(
+    db: &impl ConnectionTrait,
+    subject_kind: i16,
+    subject_ids: &[uuid::Uuid],
+    phase: i16,
+    at: chrono::NaiveDateTime,
+) {
+    // Stay well under Postgres' 65535-bind-parameter cap (6 columns per row).
+    const INSERT_CHUNK: usize = 8192;
+    let rows: Vec<_> = subject_ids
+        .iter()
+        .map(|&subject_id| {
+            gradient_entity::phase_event::Model {
+                id: gradient_entity::ids::PhaseEventId::now_v7(),
+                subject_kind,
+                subject_id,
+                phase,
+                at,
+                worker_id: None,
+                ..Default::default()
+            }
+            .into_active_model()
+        })
+        .collect();
+
+    for chunk in rows.chunks(INSERT_CHUNK) {
+        if let Err(e) = gradient_entity::phase_event::Entity::insert_many(chunk.to_vec())
+            .exec(db)
+            .await
+        {
+            warn!(error = %e, "failed to record phase_events batch");
+            return;
+        }
+    }
+}
+
 /// Inserts a single `evaluation_message` row, propagating any DB error.
 pub async fn insert_evaluation_message<C: ConnectionTrait>(
     db: &C,

--- a/backend/gradient-scheduler/src/build.rs
+++ b/backend/gradient-scheduler/src/build.rs
@@ -741,7 +741,10 @@ impl<'a> BuildStateHandler<'a> {
             for eval in evals {
                 let reason = eval.waiting_reason.as_ref().and_then(WaitingReason::from_json);
                 if eval.status == EvaluationStatus::Waiting
-                    && reason == Some(WaitingReason::Draining)
+                    && matches!(
+                        reason,
+                        Some(WaitingReason::Draining) | Some(WaitingReason::Aborting)
+                    )
                 {
                     continue;
                 }
@@ -770,8 +773,8 @@ impl<'a> BuildStateHandler<'a> {
             let reason = eval.waiting_reason.as_ref().and_then(WaitingReason::from_json);
 
             // Approval, no-cache and storage-full parks are owned by webhook +
-            // cache hooks. The reconciler must not unpark them just because
-            // workers showed up.
+            // cache hooks; an Aborting park is owned by the abort path. The
+            // reconciler must not unpark any of them just because workers showed up.
             if eval.status == EvaluationStatus::Waiting
                 && reason.as_ref().is_some_and(|r| {
                     matches!(
@@ -779,6 +782,7 @@ impl<'a> BuildStateHandler<'a> {
                         WaitingReason::Approval { .. }
                             | WaitingReason::NoCache
                             | WaitingReason::CacheStorageFull
+                            | WaitingReason::Aborting
                     )
                 })
             {

--- a/backend/gradient-scheduler/src/dispatch.rs
+++ b/backend/gradient-scheduler/src/dispatch.rs
@@ -736,7 +736,9 @@ pub(crate) async fn dispatch_ready_builds(scheduler: &Scheduler) -> anyhow::Resu
 
     let state = &scheduler.state;
 
-    // Ready builds: status = Queued AND every dependency build is Completed or Substituted.
+    // Ready builds: status = Queued, owning evaluation not parked (Waiting), and
+    // every dependency build is Completed or Substituted. The Waiting guard keeps
+    // an aborting evaluation's builds from being dispatched while it is torn down.
     // Ordered by dependency count desc (integration builds first), then by age.
     // Driven off the `idx-build-ready-queue` partial index for the outer
     // filter, and the `idx-build-evaluation-derivation` composite for the
@@ -750,6 +752,12 @@ pub(crate) async fn dispatch_ready_builds(scheduler: &Scheduler) -> anyhow::Resu
             FROM public.build b
             WHERE b.status = {queued}
               AND b.via IS NULL
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM public.evaluation e
+                  WHERE e.id = b.evaluation
+                    AND e.status = {waiting}
+              )
               AND NOT EXISTS (
                   SELECT 1
                   FROM public.derivation_dependency dep_edge
@@ -771,6 +779,7 @@ pub(crate) async fn dispatch_ready_builds(scheduler: &Scheduler) -> anyhow::Resu
             queued = i32::from(BuildStatus::Queued),
             completed = i32::from(BuildStatus::Completed),
             substituted = i32::from(BuildStatus::Substituted),
+            waiting = i32::from(EvaluationStatus::Waiting),
         ),
     );
 

--- a/backend/gradient-scheduler/src/job_handlers.rs
+++ b/backend/gradient-scheduler/src/job_handlers.rs
@@ -304,7 +304,7 @@ impl Scheduler {
         }
     }
 
-    pub async fn handle_build_status_update(&self, build_id_str: &str, _worker_id: &str) {
+    pub async fn handle_build_status_update(&self, build_id_str: &str, worker_id: &str) {
         let build_id = match build_id_str.parse::<BuildId>() {
             Ok(id) => id,
             Err(_) => {
@@ -318,6 +318,21 @@ impl Scheduler {
             .await
         {
             Ok(Some(build)) => {
+                // Backstop for the dispatch/abort race: a build dispatched by an
+                // in-flight pass just before its evaluation was aborted reports
+                // started here. Its status is already Aborted, so tell the worker
+                // to stop instead of letting it build to completion.
+                if build.status == BuildStatus::Aborted {
+                    let job_id = format!("build:{build_id}");
+                    self.worker_pool.read().await.send_abort(
+                        worker_id,
+                        job_id,
+                        "evaluation aborted".to_owned(),
+                    );
+                    info!(%build_id, %worker_id, "aborting build that started after its evaluation was aborted");
+                    return;
+                }
+
                 gradient_db::update_build_status(
                     &self.state.db(),
                     build,

--- a/backend/gradient-types/src/waiting_reason.rs
+++ b/backend/gradient-types/src/waiting_reason.rs
@@ -66,6 +66,10 @@ pub enum WaitingReason {
     /// The instance is draining: scheduling is paused and this evaluation is
     /// parked until draining is disabled or the server restarts.
     Draining,
+    /// The evaluation is being aborted: it is parked first so the dispatcher
+    /// stops handing out its builds, then its builds are aborted and the eval
+    /// transitions to `Aborted`. The reconciler never unparks this reason.
+    Aborting,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -174,6 +178,14 @@ mod tests {
         let r = WaitingReason::Draining;
         let v = r.to_json();
         assert_eq!(v["kind"], "draining");
+        assert_eq!(WaitingReason::from_json(&v).unwrap(), r);
+    }
+
+    #[test]
+    fn aborting_round_trip() {
+        let r = WaitingReason::Aborting;
+        let v = r.to_json();
+        assert_eq!(v["kind"], "aborting");
         assert_eq!(WaitingReason::from_json(&v).unwrap(), r);
     }
 

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -66,6 +66,13 @@ a banner when draining, and the button click calls `AdminService.setDraining(tru
 - `saturation_is_lenient_for_builtin_and_exempts_evals_and_no_metrics` - at `85%` CPU (between the two thresholds) a `builtin` fetch scores `0` while a real build scores `-1000`; eval jobs and workers reporting no metrics score `0` regardless of saturation.
 - `ram_prediction_exceeding_free_penalizes_and_stacks_with_saturation` - a build whose predicted peak RAM x1.1 exceeds free RAM scores `-1000`, `0` when it fits, and `-2000` when the worker is also saturated.
 
+## Bulk evaluation abort + dispatch race
+
+Aborting an evaluation now parks it as `Waiting` with `WaitingReason::Aborting` before touching its builds, then aborts all in-flight builds in a handful of set-based statements instead of one round-trip per build. The dispatcher's queue finder skips `Waiting` evaluations, so it stops handing out the aborting eval's builds; any build that already escaped to a worker is aborted when it reports started.
+
+- `backend/gradient-types/src/waiting_reason.rs`: `aborting_round_trip` asserts `WaitingReason::Aborting` serialises to `kind: "aborting"` and decodes back.
+- `backend/gradient-db/src/status/abort.rs`: `partition_skips_busy_leaders_reelects_idle_leaders_and_aborts_the_rest` asserts the abort partition keeps a running leader with followers alive, re-elects an idle leader with followers, aborts followers and plain builds, and reports only executing builds as needing attempt/log finalization.
+
 ## Worker shadows base worker of same id (#407)
 
 `backend/gradient-web/src/endpoints/orgs/workers.rs` - `registration_shadows_base_worker_of_same_id` asserts `unshadowed_base_workers` drops a base worker whose `worker_id` matches one of the org's normal registrations, so `GET /orgs/{org}/workers` lists the conflicting worker only once (as the org registration). `delete_org_worker` deletes the registration first, so the normal worker is removed even when a base worker shares its id, and the `409` base-worker guard fires only when no registration exists.


### PR DESCRIPTION
Aborting an evaluation walked its builds one at a time (a follower lookup, a row update, and several spawned side-effects each), so a 10k-build abort blocked for the whole closure while the dispatcher kept handing the eval's builds to workers, which then escaped the abort.

The abort now parks the eval as `Waiting(Aborting)` first (the queue finder skips `Waiting` evals, so it stops dispatching its builds), then aborts every in-flight build in a handful of set-based statements (one status update, one attempt stamp, one dep-count reconcile). A build that already reached a worker is aborted when it reports started. The reconciler leaves `Aborting` evals parked.