### PR TITLE
fix: gradient build end-to-end + nix NAR pack & result (#422)

### DIFF
--- a/backend/gradient-scheduler/src/dispatch.rs
+++ b/backend/gradient-scheduler/src/dispatch.rs
@@ -200,31 +200,19 @@ pub(crate) async fn dispatch_queued_evals(scheduler: &Scheduler) -> anyhow::Resu
         };
 
         let split_fetch = scheduler.worker_pool.read().await.has_idle_eval_only_worker();
-        let tasks = if split_fetch {
-            vec![FlakeTask::FetchFlake]
-        } else {
-            vec![
-                FlakeTask::FetchFlake,
-                FlakeTask::EvaluateFlake,
-                FlakeTask::EvaluateDerivations,
-            ]
-        };
-
-        let flake_job = FlakeJob {
-            tasks,
-            source: gradient_types::proto::FlakeSource::Repository {
-                url: eval.repository.clone(),
-                commit: commit_sha,
-            },
-            wildcards: eval
-                .wildcard
-                .parse::<Wildcard>()
-                .map(|w| w.patterns().to_vec())
-                .unwrap_or_else(|_| vec![eval.wildcard.clone()]),
-            timeout_secs: None,
+        let wildcards = eval
+            .wildcard
+            .parse::<Wildcard>()
+            .map(|w| w.patterns().to_vec())
+            .unwrap_or_else(|_| vec![eval.wildcard.clone()]);
+        let (flake_job, required_paths) = flake_job_for_eval_source(
+            &eval.repository,
+            commit_sha,
+            wildcards,
+            split_fetch,
             input_overrides,
             input_update,
-        };
+        );
 
         let organization_id = organization_id_for_eval(state, &eval).await;
         let org_id = match organization_id {
@@ -247,7 +235,7 @@ pub(crate) async fn dispatch_queued_evals(scheduler: &Scheduler) -> anyhow::Resu
             commit_id: eval.commit,
             repository: eval.repository.clone(),
             job: flake_job,
-            required_paths: vec![],
+            required_paths,
             queued_at: eval.updated_at,
             ready_at: eval.updated_at,
             rescore_count: 0,
@@ -259,6 +247,63 @@ pub(crate) async fn dispatch_queued_evals(scheduler: &Scheduler) -> anyhow::Resu
     }
 
     Ok(())
+}
+
+/// Build the eval `FlakeJob` and its `required_paths` from the evaluation's
+/// recorded source. A `/nix/store/...` repository is an already-materialised
+/// build-request source: dispatch it as `FlakeSource::Cached` (the worker
+/// substitutes the NAR and evaluates via `path:`) instead of git-cloning it.
+pub(crate) fn flake_job_for_eval_source(
+    repository: &str,
+    commit_sha: String,
+    wildcards: Vec<String>,
+    split_fetch: bool,
+    input_overrides: Vec<gradient_types::proto::FlakeInputOverride>,
+    input_update: Option<gradient_types::proto::InputUpdateSpec>,
+) -> (FlakeJob, Vec<RequiredPath>) {
+    use gradient_types::proto::FlakeSource;
+
+    if repository.starts_with("/nix/store/") {
+        let job = FlakeJob {
+            tasks: vec![FlakeTask::EvaluateFlake, FlakeTask::EvaluateDerivations],
+            source: FlakeSource::Cached {
+                store_path: repository.to_owned(),
+            },
+            wildcards,
+            timeout_secs: None,
+            input_overrides,
+            input_update,
+        };
+        let required = vec![RequiredPath {
+            path: repository.to_owned(),
+            cache_info: None,
+        }];
+
+        return (job, required);
+    }
+
+    let tasks = if split_fetch {
+        vec![FlakeTask::FetchFlake]
+    } else {
+        vec![
+            FlakeTask::FetchFlake,
+            FlakeTask::EvaluateFlake,
+            FlakeTask::EvaluateDerivations,
+        ]
+    };
+    let job = FlakeJob {
+        tasks,
+        source: FlakeSource::Repository {
+            url: repository.to_owned(),
+            commit: commit_sha,
+        },
+        wildcards,
+        timeout_secs: None,
+        input_overrides,
+        input_update,
+    };
+
+    (job, Vec::new())
 }
 
 // ── Build dispatch ────────────────────────────────────────────────────────────
@@ -887,6 +932,50 @@ mod dispatch_mode_tests {
     fn stalled_substitute_stays_builtin() {
         assert_eq!(decide_dispatch_mode(true, 2, 2, false), BuildDispatchMode::SubstituteStalled);
         assert_eq!(decide_dispatch_mode(true, 2, 2, true), BuildDispatchMode::RealArch);
+    }
+}
+
+#[cfg(test)]
+mod eval_source_tests {
+    use super::flake_job_for_eval_source;
+    use gradient_types::proto::{FlakeSource, FlakeTask};
+
+    #[test]
+    fn cached_source_dispatches_without_fetch() {
+        let (job, required) = flake_job_for_eval_source(
+            "/nix/store/qgzxagd5bql1iqx0w8qzljwdlb06sn6n-source",
+            "0".repeat(40),
+            vec!["*".into()],
+            false,
+            vec![],
+            None,
+        );
+        assert!(matches!(job.source, FlakeSource::Cached { .. }));
+        assert_eq!(
+            job.tasks,
+            vec![FlakeTask::EvaluateFlake, FlakeTask::EvaluateDerivations]
+        );
+        assert!(!job.tasks.contains(&FlakeTask::FetchFlake));
+        assert_eq!(required.len(), 1);
+        assert_eq!(
+            required[0].path,
+            "/nix/store/qgzxagd5bql1iqx0w8qzljwdlb06sn6n-source"
+        );
+    }
+
+    #[test]
+    fn repository_source_keeps_fetch() {
+        let (job, required) = flake_job_for_eval_source(
+            "git@github.com:org/repo.git",
+            "abc".into(),
+            vec!["*".into()],
+            false,
+            vec![],
+            None,
+        );
+        assert!(matches!(job.source, FlakeSource::Repository { .. }));
+        assert!(job.tasks.contains(&FlakeTask::FetchFlake));
+        assert!(required.is_empty());
     }
 }
 

--- a/backend/gradient-storage/src/source_nar.rs
+++ b/backend/gradient-storage/src/source_nar.rs
@@ -29,7 +29,7 @@ pub struct SourceNar {
     pub nar_hash_nix32: String,
 }
 
-pub async fn materialise_source_nar(staging_dir: &Path) -> Result<SourceNar> {
+async fn nar_bytes_from_dir(staging_dir: &Path) -> Result<Vec<u8>> {
     let mut stream = NarByteStream::new(staging_dir.to_path_buf());
     let mut nar_bytes: Vec<u8> = Vec::new();
     while let Some(chunk) = stream.next().await {
@@ -37,6 +37,17 @@ pub async fn materialise_source_nar(staging_dir: &Path) -> Result<SourceNar> {
         nar_bytes.extend_from_slice(&chunk);
     }
 
+    Ok(nar_bytes)
+}
+
+pub async fn materialise_source_nar(staging_dir: &Path) -> Result<SourceNar> {
+    source_nar_from_bytes(nar_bytes_from_dir(staging_dir).await?).await
+}
+
+/// Compute the `/nix/store/<hash>-source` path and metadata from a NAR packed
+/// elsewhere (e.g. the `nix`-feature CLI), keeping the server authoritative on
+/// the store path.
+pub async fn source_nar_from_bytes(nar_bytes: Vec<u8>) -> Result<SourceNar> {
     let nar_size = nar_bytes.len() as u64;
     let raw_hash = Sha256::digest(&nar_bytes);
 
@@ -90,6 +101,20 @@ mod tests {
             .expect("second call");
         assert_eq!(a.store_path, b.store_path);
         assert_eq!(a.nar_hash_nix32, b.nar_hash_nix32);
+    }
+
+    #[tokio::test]
+    async fn from_bytes_matches_dir() {
+        let dir = make_staging_dir();
+        let from_dir = materialise_source_nar(dir.path()).await.unwrap();
+        let from_bytes = source_nar_from_bytes(from_dir.nar_bytes.clone())
+            .await
+            .unwrap();
+        assert_eq!(from_dir.store_path, from_bytes.store_path);
+        assert_eq!(from_dir.store_hash, from_bytes.store_hash);
+        assert_eq!(from_dir.nar_hash_nix32, from_bytes.nar_hash_nix32);
+        assert_eq!(from_dir.nar_hash_sri, from_bytes.nar_hash_sri);
+        assert_eq!(from_dir.nar_size, from_bytes.nar_size);
     }
 
     #[tokio::test]

--- a/backend/gradient-web/src/endpoints/build_requests/dispatch.rs
+++ b/backend/gradient-web/src/endpoints/build_requests/dispatch.rs
@@ -28,9 +28,9 @@ use gradient_types::ids::{
 };
 use gradient_types::{
     ACachedPathSignature, AUploadSession, BaseResponse, CCachedPath, CCachedPathSignature,
-    COrganizationCache, CProject, ECachedPath, ECachedPathSignature, EOrganizationCache, EProject,
-    EUploadSession, MCachedPath, MCachedPathSignature, MCommit, MEvaluation, MProject, MUser,
-    NULL_TIME, now,
+    COrganizationCache, CProject, ECache, ECachedPath, ECachedPathSignature, EOrganizationCache,
+    EProject, EUploadSession, MCachedPath, MCachedPathSignature, MCommit, MEvaluation, MProject,
+    MUser, NULL_TIME, now,
 };
 use gradient_core::ServerState;
 use sea_orm::ActiveValue::Set;
@@ -59,6 +59,7 @@ pub struct DispatchResponse {
     pub evaluation: EvaluationId,
     pub project: ProjectId,
     pub commit: CommitId,
+    pub cache: Option<String>,
 }
 
 pub async fn post_dispatch(
@@ -118,6 +119,29 @@ pub async fn post_dispatch(
         .await
         .map_err(|e| WebError::internal(format!("Failed to materialise source NAR: {}", e)))?;
 
+    let response =
+        finalize_build_request(&state, session.organization, &user, &nar, body.target, body.system)
+            .await?;
+
+    let mut active: AUploadSession = session.into();
+    active.dispatched_at = Set(Some(now()));
+    active.update(&state.web_db).await?;
+
+    Ok(ok_json(response))
+}
+
+/// Materialise a source NAR into the cache and queue a build-request evaluation.
+/// Shared by the blob-manifest dispatch and the `nix`-feature source-NAR upload.
+pub(super) async fn finalize_build_request(
+    state: &ServerState,
+    organization: gradient_types::ids::OrganizationId,
+    user: &MUser,
+    nar: &SourceNar,
+    target: Option<String>,
+    system: Option<String>,
+) -> WebResult<DispatchResponse> {
+    let _ = system;
+
     state
         .nar_storage
         .put(&nar.store_hash, nar.nar_bytes.clone())
@@ -126,19 +150,18 @@ pub async fn post_dispatch(
 
     let tx = state.web_db.inner().begin().await?;
 
-    let cached_path = ensure_cached_path(&tx, &nar).await?;
-    queue_signature_placeholders(&tx, &cached_path, &session.organization).await?;
-    let project = ensure_build_request_project(&tx, session.organization, user.id).await?;
+    let cached_path = ensure_cached_path(&tx, nar).await?;
+    queue_signature_placeholders(&tx, &cached_path, &organization).await?;
+    let project = ensure_build_request_project(&tx, organization, user.id).await?;
 
-    let target = body
-        .target
+    let target = target
         .map(|t| t.trim().to_string())
         .filter(|t| !t.is_empty())
         .unwrap_or_else(|| project.wildcard.clone());
 
     let commit = MCommit {
         id: CommitId::now_v7(),
-        message: format!("Build request {}", session.id),
+        message: format!("Build request {}", nar.store_hash),
         hash: vec![0; 20],
         author: Some(user.id),
         author_name: user.name.clone(),
@@ -163,17 +186,35 @@ pub async fn post_dispatch(
     .insert(&tx)
     .await?;
 
+    let cache = resolve_org_cache_name(&tx, organization).await?;
+
     tx.commit().await?;
 
-    let mut active: AUploadSession = session.into();
-    active.dispatched_at = Set(Some(now()));
-    active.update(&state.web_db).await?;
-
-    Ok(ok_json(DispatchResponse {
+    Ok(DispatchResponse {
         evaluation: evaluation.id,
         project: project.id,
         commit: commit.id,
-    }))
+        cache,
+    })
+}
+
+async fn resolve_org_cache_name<C: ConnectionTrait>(
+    tx: &C,
+    org: gradient_types::ids::OrganizationId,
+) -> WebResult<Option<String>> {
+    let Some(link) = EOrganizationCache::find()
+        .filter(COrganizationCache::Organization.eq(org))
+        .one(tx)
+        .await?
+    else {
+        return Ok(None);
+    };
+
+    Ok(ECache::find_by_id(link.cache)
+        .one(tx)
+        .await?
+        .filter(|c| c.active)
+        .map(|c| c.name))
 }
 
 async fn materialise_staging(

--- a/backend/gradient-web/src/endpoints/build_requests/mod.rs
+++ b/backend/gradient-web/src/endpoints/build_requests/mod.rs
@@ -13,5 +13,6 @@
 pub mod blobs;
 pub mod dispatch;
 pub mod manifest;
+pub mod source;
 pub mod types;
 mod validation;

--- a/backend/gradient-web/src/endpoints/build_requests/source.rs
+++ b/backend/gradient-web/src/endpoints/build_requests/source.rs
@@ -10,7 +10,7 @@
 //! CLI uses this to skip the per-file blob manifest.
 
 use super::dispatch::{DispatchResponse, finalize_build_request};
-use crate::access::has_permission;
+use crate::access::{Caller, OrgAccess, load_org};
 use crate::authorization::MaybeApiKey;
 use crate::error::{WebError, WebResult};
 use crate::helpers::ok_json;
@@ -20,14 +20,13 @@ use axum::Json;
 use axum::extract::{Multipart, Query, State};
 use gradient_core::ServerState;
 use gradient_storage::source_nar::source_nar_from_bytes;
-use gradient_types::ids::OrganizationId;
 use gradient_types::{BaseResponse, MUser};
 use serde::Deserialize;
 use std::sync::Arc;
 
 #[derive(Deserialize)]
 pub struct SourceQuery {
-    pub organization: OrganizationId,
+    pub organization: String,
 }
 
 pub async fn post_source(
@@ -37,17 +36,17 @@ pub async fn post_source(
     Query(query): Query<SourceQuery>,
     mut multipart: Multipart,
 ) -> WebResult<Json<BaseResponse<DispatchResponse>>> {
-    if !has_permission(
-        &state,
-        user.id,
-        query.organization,
-        Permission::TriggerEvaluation,
+    let org = load_org(
+        &state.0,
+        Caller::User(&user),
         api_key.as_ref(),
+        query.organization,
+        OrgAccess::Require {
+            permission: Permission::TriggerEvaluation,
+            reject_managed: false,
+        },
     )
-    .await?
-    {
-        return Err(WebError::not_found("Organization"));
-    }
+    .await?;
 
     let mut nar_bytes: Option<Vec<u8>> = None;
     let mut target: Option<String> = None;
@@ -82,7 +81,7 @@ pub async fn post_source(
         .map_err(|e| WebError::internal(format!("Failed to read source NAR: {}", e)))?;
 
     let response =
-        finalize_build_request(&state, query.organization, &user, &nar, target, system).await?;
+        finalize_build_request(&state, org.id, &user, &nar, target, system).await?;
 
     Ok(ok_json(response))
 }

--- a/backend/gradient-web/src/endpoints/build_requests/source.rs
+++ b/backend/gradient-web/src/endpoints/build_requests/source.rs
@@ -1,0 +1,88 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! `POST /build-requests/source` - accepts a pre-packed source NAR (multipart
+//! fields `nar`, `target`, `system`), computes the `/nix/store/<hash>-source`
+//! path server-side, and finalises a build-request evaluation. The `nix`-feature
+//! CLI uses this to skip the per-file blob manifest.
+
+use super::dispatch::{DispatchResponse, finalize_build_request};
+use crate::access::has_permission;
+use crate::authorization::MaybeApiKey;
+use crate::error::{WebError, WebResult};
+use crate::helpers::ok_json;
+use crate::permissions::Permission;
+use axum::Extension;
+use axum::Json;
+use axum::extract::{Multipart, Query, State};
+use gradient_core::ServerState;
+use gradient_storage::source_nar::source_nar_from_bytes;
+use gradient_types::ids::OrganizationId;
+use gradient_types::{BaseResponse, MUser};
+use serde::Deserialize;
+use std::sync::Arc;
+
+#[derive(Deserialize)]
+pub struct SourceQuery {
+    pub organization: OrganizationId,
+}
+
+pub async fn post_source(
+    state: State<Arc<ServerState>>,
+    Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
+    Query(query): Query<SourceQuery>,
+    mut multipart: Multipart,
+) -> WebResult<Json<BaseResponse<DispatchResponse>>> {
+    if !has_permission(
+        &state,
+        user.id,
+        query.organization,
+        Permission::TriggerEvaluation,
+        api_key.as_ref(),
+    )
+    .await?
+    {
+        return Err(WebError::not_found("Organization"));
+    }
+
+    let mut nar_bytes: Option<Vec<u8>> = None;
+    let mut target: Option<String> = None;
+    let mut system: Option<String> = None;
+
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|e| WebError::bad_request(format!("Invalid multipart payload: {}", e)))?
+    {
+        match field.name() {
+            Some("nar") => {
+                let data = field
+                    .bytes()
+                    .await
+                    .map_err(|e| WebError::bad_request(format!("Failed to read nar: {}", e)))?;
+                nar_bytes = Some(data.to_vec());
+            }
+            Some("target") => target = field.text().await.ok(),
+            Some("system") => system = field.text().await.ok(),
+            _ => {}
+        }
+    }
+
+    let nar_bytes = nar_bytes.ok_or_else(|| WebError::bad_request("missing `nar` field"))?;
+    if nar_bytes.is_empty() {
+        return Err(WebError::bad_request("empty `nar` field"));
+    }
+
+    let nar = source_nar_from_bytes(nar_bytes)
+        .await
+        .map_err(|e| WebError::internal(format!("Failed to read source NAR: {}", e)))?;
+
+    let response =
+        finalize_build_request(&state, query.organization, &user, &nar, target, system).await?;
+
+    Ok(ok_json(response))
+}

--- a/backend/gradient-web/src/lib.rs
+++ b/backend/gradient-web/src/lib.rs
@@ -348,6 +348,12 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
             "/build-requests/{session}/dispatch",
             post(build_requests::dispatch::post_dispatch),
         )
+        .route(
+            "/build-requests/source",
+            post(build_requests::source::post_source).layer(DefaultBodyLimit::max(
+                gradient_types::constants::MAX_BUILD_REQUEST_SIZE,
+            )),
+        )
         .route("/caches", get(caches::get).put(caches::put))
         .route("/caches/available", get(caches::get_cache_name_available))
         .route(

--- a/backend/gradient-web/tests/build_requests_dispatch.rs
+++ b/backend/gradient-web/tests/build_requests_dispatch.rs
@@ -290,6 +290,8 @@ fn happy_path_creates_project_commit_and_evaluation() {
                 last_insert_id: 0,
                 rows_affected: 1,
             }])
+            // resolve_org_cache_name → org-cache link lookup (none → cache=null)
+            .append_query_results([Vec::<gradient_entity::organization_cache::Model>::new()])
             // After tx commit: UPDATE upload_session
             .append_query_results([vec![updated]])
             .append_exec_results([MockExecResult {
@@ -319,6 +321,11 @@ fn happy_path_creates_project_commit_and_evaluation() {
             body["message"]["evaluation"].as_str().unwrap(),
             eval_model.id.to_string()
         );
+        assert!(
+            body["message"].as_object().unwrap().contains_key("cache"),
+            "DispatchResponse must carry a `cache` field"
+        );
+        assert!(body["message"]["cache"].is_null());
     });
 }
 
@@ -360,6 +367,8 @@ fn happy_path_reuses_existing_build_request_project() {
                 last_insert_id: 0,
                 rows_affected: 1,
             }])
+            // resolve_org_cache_name → org-cache link lookup (none → cache=null)
+            .append_query_results([Vec::<gradient_entity::organization_cache::Model>::new()])
             .append_query_results([vec![updated]])
             .append_exec_results([MockExecResult {
                 last_insert_id: 0,

--- a/backend/gradient-web/tests/build_requests_source.rs
+++ b/backend/gradient-web/tests/build_requests_source.rs
@@ -1,0 +1,218 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Integration tests for `POST /api/v1/build-requests/source` (#422). The
+//! `nix`-feature CLI uploads a pre-packed source NAR; the server computes the
+//! store path and queues a build-request evaluation.
+
+use axum::http::StatusCode;
+use axum_test::multipart::{MultipartForm, Part};
+use chrono::Utc;
+use gradient_entity::ids::*;
+use gradient_entity::role;
+use gradient_db::permissions::PermissionMask;
+use gradient_types::SessionId;
+use gradient_types::consts::BASE_ROLE_WRITE_ID;
+use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
+use serde_json::Value;
+use gradient_test_support::fixtures::{org_id, user, user_id};
+use gradient_test_support::web::{live_session, make_test_server, make_token};
+use uuid::Uuid;
+
+fn write_role_row() -> role::Model {
+    role::Model {
+        id: BASE_ROLE_WRITE_ID,
+        name: "write".into(),
+        permission: gradient_db::permissions::write_mask() as PermissionMask,
+        ..Default::default()
+    }
+}
+
+fn membership() -> gradient_entity::organization_user::Model {
+    gradient_entity::organization_user::Model {
+        id: OrganizationUserId::new(
+            Uuid::parse_str("00000000-0000-0000-0000-0000000000bb").unwrap(),
+        ),
+        organization: org_id(),
+        user: user_id(),
+        role: BASE_ROLE_WRITE_ID,
+    }
+}
+
+fn with_auth(db: MockDatabase, session_id: SessionId) -> MockDatabase {
+    let session = live_session(session_id);
+    db.append_query_results([vec![session.clone()]])
+        .append_query_results([vec![session]])
+        .append_query_results([vec![user()]])
+}
+
+fn project_row(id: ProjectId) -> gradient_entity::project::Model {
+    gradient_entity::project::Model {
+        id,
+        organization: org_id(),
+        name: "build-request".into(),
+        active: true,
+        display_name: "Build Requests".into(),
+        description: "Server-managed project for `gradient build` submissions.".into(),
+        repository: "build-request".into(),
+        wildcard: "*".into(),
+        last_check_at: chrono::NaiveDateTime::default(),
+        created_by: user_id(),
+        created_at: Utc::now().naive_utc(),
+        managed: true,
+        keep_evaluations: 30,
+        concurrency: 1,
+        sign_cache: true,
+        ..Default::default()
+    }
+}
+
+fn cached_path_row(hash: &str) -> gradient_entity::cached_path::Model {
+    gradient_entity::cached_path::Model {
+        id: CachedPathId::now_v7(),
+        store_path: format!("/nix/store/{}-source", hash),
+        hash: hash.into(),
+        package: "source".into(),
+        file_hash: Some(format!("sha256:{}", hash)),
+        file_size: Some(0),
+        nar_size: Some(0),
+        nar_hash: Some(format!("sha256:{}", hash)),
+        created_at: Utc::now().naive_utc(),
+        ..Default::default()
+    }
+}
+
+fn commit_row() -> gradient_entity::commit::Model {
+    gradient_entity::commit::Model {
+        id: CommitId::now_v7(),
+        message: "Build request".into(),
+        hash: vec![0; 20],
+        author: Some(user_id()),
+        author_name: "Test User".into(),
+    }
+}
+
+fn eval_row(project: ProjectId, commit: CommitId) -> gradient_entity::evaluation::Model {
+    let now = Utc::now().naive_utc();
+    gradient_entity::evaluation::Model {
+        id: EvaluationId::now_v7(),
+        project: Some(project),
+        repository: "/nix/store/abc-source".into(),
+        commit,
+        wildcard: "*".into(),
+        status: gradient_entity::evaluation::EvaluationStatus::Queued,
+        created_at: now,
+        updated_at: now,
+        ..Default::default()
+    }
+}
+
+fn source_url() -> String {
+    format!("/api/v1/build-requests/source?organization={}", org_id())
+}
+
+fn run<F: std::future::Future>(fut: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(fut)
+}
+
+#[test]
+fn source_upload_creates_queued_eval() {
+    run(async {
+        let session_id = SessionId::now_v7();
+        let token = make_token(session_id);
+
+        let project_id = ProjectId::now_v7();
+        let project_model = project_row(project_id);
+        let commit_model = commit_row();
+        let eval_model = eval_row(project_id, commit_model.id);
+        let cp_row = cached_path_row("00000000000000000000000000000000");
+
+        let db = with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id)
+            // has_permission → membership + role
+            .append_query_results([vec![membership()]])
+            .append_query_results([vec![write_role_row()]])
+            // ensure_cached_path → SELECT (None) then INSERT
+            .append_query_results([Vec::<gradient_entity::cached_path::Model>::new()])
+            .append_query_results([vec![cp_row]])
+            .append_exec_results([MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }])
+            // queue_signature_placeholders → org caches (empty)
+            .append_query_results([Vec::<gradient_entity::organization_cache::Model>::new()])
+            // ensure_build_request_project → SELECT (None) then INSERT
+            .append_query_results([Vec::<gradient_entity::project::Model>::new()])
+            .append_query_results([vec![project_model.clone()]])
+            .append_exec_results([MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }])
+            // INSERT commit
+            .append_query_results([vec![commit_model.clone()]])
+            .append_exec_results([MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }])
+            // INSERT evaluation
+            .append_query_results([vec![eval_model.clone()]])
+            .append_exec_results([MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }])
+            // resolve_org_cache_name → org-cache link lookup (none → cache=null)
+            .append_query_results([Vec::<gradient_entity::organization_cache::Model>::new()]);
+
+        let server = make_test_server(db.into_connection());
+
+        let form = MultipartForm::new()
+            .add_part("nar", Part::bytes(b"a pretend source nar".to_vec()))
+            .add_text("target", "packages.x86_64-linux.hello")
+            .add_text("system", "x86_64-linux");
+
+        let res = server
+            .post(&source_url())
+            .add_header("authorization", format!("Bearer {}", token))
+            .multipart(form)
+            .await;
+
+        res.assert_status_ok();
+        let body: Value = res.json();
+        assert_eq!(body["error"], false);
+        assert_eq!(
+            body["message"]["evaluation"].as_str().unwrap(),
+            eval_model.id.to_string()
+        );
+        assert!(body["message"]["cache"].is_null());
+    });
+}
+
+#[test]
+fn source_upload_missing_nar_is_400() {
+    run(async {
+        let session_id = SessionId::now_v7();
+        let token = make_token(session_id);
+
+        let db = with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id)
+            .append_query_results([vec![membership()]])
+            .append_query_results([vec![write_role_row()]]);
+
+        let server = make_test_server(db.into_connection());
+
+        let form = MultipartForm::new().add_text("target", "x");
+
+        let res = server
+            .post(&source_url())
+            .add_header("authorization", format!("Bearer {}", token))
+            .multipart(form)
+            .await;
+
+        res.assert_status(StatusCode::BAD_REQUEST);
+    });
+}

--- a/backend/gradient-web/tests/build_requests_source.rs
+++ b/backend/gradient-web/tests/build_requests_source.rs
@@ -49,6 +49,12 @@ fn with_auth(db: MockDatabase, session_id: SessionId) -> MockDatabase {
         .append_query_results([vec![user()]])
 }
 
+fn with_org_access(db: MockDatabase) -> MockDatabase {
+    db.append_query_results([vec![gradient_test_support::fixtures::org()]])
+        .append_query_results([vec![membership()]])
+        .append_query_results([vec![write_role_row()]])
+}
+
 fn project_row(id: ProjectId) -> gradient_entity::project::Model {
     gradient_entity::project::Model {
         id,
@@ -111,7 +117,7 @@ fn eval_row(project: ProjectId, commit: CommitId) -> gradient_entity::evaluation
 }
 
 fn source_url() -> String {
-    format!("/api/v1/build-requests/source?organization={}", org_id())
+    "/api/v1/build-requests/source?organization=test-org".to_string()
 }
 
 fn run<F: std::future::Future>(fut: F) -> F::Output {
@@ -134,10 +140,10 @@ fn source_upload_creates_queued_eval() {
         let eval_model = eval_row(project_id, commit_model.id);
         let cp_row = cached_path_row("00000000000000000000000000000000");
 
-        let db = with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id)
-            // has_permission → membership + role
-            .append_query_results([vec![membership()]])
-            .append_query_results([vec![write_role_row()]])
+        let db = with_org_access(with_auth(
+            MockDatabase::new(DatabaseBackend::Postgres),
+            session_id,
+        ))
             // ensure_cached_path → SELECT (None) then INSERT
             .append_query_results([Vec::<gradient_entity::cached_path::Model>::new()])
             .append_query_results([vec![cp_row]])
@@ -199,9 +205,10 @@ fn source_upload_missing_nar_is_400() {
         let session_id = SessionId::now_v7();
         let token = make_token(session_id);
 
-        let db = with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id)
-            .append_query_results([vec![membership()]])
-            .append_query_results([vec![write_role_row()]]);
+        let db = with_org_access(with_auth(
+            MockDatabase::new(DatabaseBackend::Postgres),
+            session_id,
+        ));
 
         let server = make_test_server(db.into_connection());
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,7 +25,7 @@ strum_macros = "0.28"
 serde = { version = "1.0", features = ["derive"] }
 dirs = "6.0"
 toml = "1.0"
-tokio = { version = "1.50", features = ["macros", "process", "rt-multi-thread"] }
+tokio = { version = "1.50", features = ["macros", "process", "rt-multi-thread", "time"] }
 serde_json = "1.0"
 connector = { path = "connector" }
 rand = { version = "0.10", features = ["std_rng"] }
@@ -38,7 +38,11 @@ ratatui = "0.30"
 
 [features]
 default = []
-nix = ["dep:harmonia-file-nar", "dep:harmonia-store-path", "dep:harmonia-store-remote", "dep:harmonia-utils-hash"]
+nix = ["dep:harmonia-file-nar", "dep:harmonia-store-path", "dep:harmonia-store-remote", "dep:harmonia-utils-hash", "dep:tempfile"]
+
+[dependencies.tempfile]
+version = "3"
+optional = true
 
 [dependencies.harmonia-file-nar]
 git = "https://github.com/nix-community/harmonia.git"

--- a/cli/connector/src/build_requests.rs
+++ b/cli/connector/src/build_requests.rs
@@ -21,6 +21,12 @@ pub struct BuildSession {
     pub missing: Vec<String>,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct BlobsResponse {
+    pub uploaded: usize,
+    pub remaining: usize,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct DispatchRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -34,6 +40,7 @@ pub struct DispatchResponse {
     pub evaluation: String,
     pub project: String,
     pub commit: String,
+    pub cache: Option<String>,
 }
 
 pub struct BuildRequestsApi<'a>(pub(crate) &'a Client);
@@ -59,13 +66,44 @@ impl BuildRequestsApi<'_> {
         &self,
         session: &str,
         form: reqwest::multipart::Form,
-    ) -> Result<String, ConnectorError> {
+    ) -> Result<BlobsResponse, ConnectorError> {
         let req = http::request(
             self.0.http(),
             self.0.base_url(),
             self.0.token(),
             Method::POST,
             &format!("build-requests/{session}/blobs"),
+            true,
+        )?
+        .multipart(form);
+        http::decode(req.send().await?).await
+    }
+
+    pub async fn upload_source_nar(
+        &self,
+        organization: &str,
+        target: Option<&str>,
+        system: Option<&str>,
+        nar_bytes: Vec<u8>,
+    ) -> Result<DispatchResponse, ConnectorError> {
+        let mut form = reqwest::multipart::Form::new().part(
+            "nar",
+            reqwest::multipart::Part::bytes(nar_bytes).file_name("source.nar"),
+        );
+        if let Some(t) = target {
+            form = form.text("target", t.to_owned());
+        }
+
+        if let Some(s) = system {
+            form = form.text("system", s.to_owned());
+        }
+
+        let req = http::request(
+            self.0.http(),
+            self.0.base_url(),
+            self.0.token(),
+            Method::POST,
+            &format!("build-requests/source?organization={organization}"),
             true,
         )?
         .multipart(form);

--- a/cli/connector/tests/build_requests_api.rs
+++ b/cli/connector/tests/build_requests_api.rs
@@ -7,6 +7,57 @@ fn ok<T: serde::Serialize>(m: T) -> serde_json::Value {
 }
 
 #[tokio::test]
+async fn upload_blobs_decodes_counts() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v1/build-requests/sess-1/blobs"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(ok(serde_json::json!({ "uploaded": 118, "remaining": 0 }))),
+        )
+        .mount(&server)
+        .await;
+
+    let client = Client::builder()
+        .base_url(server.uri())
+        .token("t")
+        .build()
+        .unwrap();
+    let resp = client
+        .build_requests()
+        .upload_blobs("sess-1", reqwest::multipart::Form::new())
+        .await
+        .unwrap();
+    assert_eq!(resp.uploaded, 118);
+    assert_eq!(resp.remaining, 0);
+}
+
+#[tokio::test]
+async fn upload_source_nar_returns_dispatch() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v1/build-requests/source"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(ok(serde_json::json!({
+            "evaluation": "eval-1", "project": "proj-1", "commit": "commit-1", "cache": "my-cache"
+        }))))
+        .mount(&server)
+        .await;
+
+    let client = Client::builder()
+        .base_url(server.uri())
+        .token("t")
+        .build()
+        .unwrap();
+    let resp = client
+        .build_requests()
+        .upload_source_nar("my-org", Some("pkg"), Some("x86_64-linux"), b"nar".to_vec())
+        .await
+        .unwrap();
+    assert_eq!(resp.evaluation, "eval-1");
+    assert_eq!(resp.cache.as_deref(), Some("my-cache"));
+}
+
+#[tokio::test]
 async fn submit_manifest_returns_session() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))

--- a/cli/src/commands/base.rs
+++ b/cli/src/commands/base.rs
@@ -100,6 +100,9 @@ enum MainCommands {
         background: bool,
         #[arg(short, long)]
         quiet: bool,
+        /// Do not produce a `result` symlink/folder after the build
+        #[arg(long)]
+        no_link: bool,
     },
     /// Watch a running evaluation's live build logs and status
     Watch {
@@ -298,7 +301,10 @@ pub async fn run_cli() -> std::io::Result<()> {
             organization,
             background,
             quiet,
-        } => build::handle_build(target, system, organization, background, quiet, out).await,
+            no_link,
+        } => {
+            build::handle_build(target, system, organization, background, quiet, no_link, out).await
+        }
         MainCommands::Watch { evaluation } => watch::handle_watch(&evaluation, out).await,
         MainCommands::Download {
             flake_ref,

--- a/cli/src/commands/build.rs
+++ b/cli/src/commands/build.rs
@@ -7,9 +7,11 @@
 use crate::config::*;
 use crate::input::client_from_config;
 use crate::output::{Output, to_exit_kind};
-use connector::build_requests::{BuildManifestRequest, DispatchRequest, ManifestFile};
+use connector::build_requests::DispatchResponse;
+use connector::evals::{ArtefactTree, EntryPointArtefacts};
 use futures::StreamExt;
 use futures::pin_mut;
+#[cfg(not(feature = "nix"))]
 use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::process::exit;
@@ -20,6 +22,7 @@ pub async fn handle_build(
     organization: Option<String>,
     background: bool,
     quiet: bool,
+    no_link: bool,
     out: Output,
 ) {
     let organization = organization
@@ -73,20 +76,7 @@ pub async fn handle_build(
         if !abs.is_file() {
             continue;
         }
-        match hash_file(&abs) {
-            Ok((hash, size)) => entries.push(TrackedFile {
-                path,
-                hash,
-                size,
-                abs,
-            }),
-            Err(e) => {
-                if !quiet {
-                    out.progress(format!("Failed to hash {}: {}", abs.display(), e));
-                }
-                exit(1);
-            }
-        }
+        entries.push(TrackedFile { path, abs });
     }
 
     if entries.is_empty() {
@@ -96,90 +86,16 @@ pub async fn handle_build(
         exit(1);
     }
 
-    if !quiet {
-        out.human(format!(
-            "Sending manifest for {} tracked files...",
-            entries.len()
-        ));
-    }
-
-    let manifest_req = BuildManifestRequest {
-        organization,
-        files: entries
-            .iter()
-            .map(|e| ManifestFile {
-                path: e.path.clone(),
-                hash: e.hash.clone(),
-                size: e.size,
-            })
-            .collect(),
-    };
-
-    let manifest = match client.build_requests().submit_manifest(manifest_req).await {
-        Ok(m) => m,
-        Err(e) => {
-            if !quiet {
-                out.progress(format!("Manifest rejected: {}", e));
-            }
-            exit(1);
-        }
-    };
-
-    if !manifest.missing.is_empty() {
-        if !quiet {
-            out.human(format!(
-                "Uploading {} missing blob(s) to session {}...",
-                manifest.missing.len(),
-                manifest.session
-            ));
-        }
-
-        let missing: std::collections::HashSet<&str> =
-            manifest.missing.iter().map(String::as_str).collect();
-        let mut form = reqwest::multipart::Form::new();
-        for entry in &entries {
-            if !missing.contains(entry.hash.as_str()) {
-                continue;
-            }
-            match std::fs::read(&entry.abs) {
-                Ok(bytes) => {
-                    let part = reqwest::multipart::Part::bytes(bytes).file_name(entry.hash.clone());
-                    form = form.part(entry.hash.clone(), part);
-                }
-                Err(e) => {
-                    if !quiet {
-                        out.progress(format!("Failed to read {}: {}", entry.abs.display(), e));
-                    }
-                    exit(1);
-                }
-            }
-        }
-
-        if let Err(e) = client
-            .build_requests()
-            .upload_blobs(&manifest.session, form)
-            .await
-        {
-            if !quiet {
-                out.progress(format!("Failed to upload blobs: {}", e));
-            }
-            exit(1);
-        }
-    }
-
-    let dispatch = match client
-        .build_requests()
-        .dispatch(&manifest.session, DispatchRequest { target, system })
-        .await
-    {
-        Ok(d) => d,
-        Err(e) => {
-            if !quiet {
-                out.progress(format!("Failed to dispatch build request: {}", e));
-            }
-            exit(1);
-        }
-    };
+    let dispatch = upload_and_dispatch(
+        &client,
+        &organization,
+        &entries,
+        target.clone(),
+        system.clone(),
+        quiet,
+        out,
+    )
+    .await;
 
     if background {
         out.ok(&dispatch);
@@ -225,15 +141,273 @@ pub async fn handle_build(
             Err(e) => out.err(to_exit_kind(&e), e),
         }
     }
+
+    if no_link {
+        return;
+    }
+
+    let status = wait_for_terminal(&client, &dispatch.evaluation, out).await;
+    if status != "Completed" {
+        if !quiet {
+            out.human(format!(
+                "Build did not complete (status: {status}); skipping result."
+            ));
+        }
+        return;
+    }
+
+    let tree = match client.evals().artefacts(&dispatch.evaluation).await {
+        Ok(t) => t,
+        Err(e) => {
+            if !quiet {
+                out.progress(format!("Could not fetch artefacts: {}", e));
+            }
+            return;
+        }
+    };
+
+    #[cfg(feature = "nix")]
+    crate::commands::build_nix::link_result(&dispatch, &tree, target.as_deref(), out).await;
+    #[cfg(not(feature = "nix"))]
+    download_result_dir(&client, &tree, target.as_deref(), out).await;
 }
 
-struct TrackedFile {
-    path: String,
-    hash: String,
-    size: i64,
-    abs: PathBuf,
+async fn upload_and_dispatch(
+    client: &connector::Client,
+    organization: &str,
+    entries: &[TrackedFile],
+    target: Option<String>,
+    system: Option<String>,
+    quiet: bool,
+    out: Output,
+) -> DispatchResponse {
+    #[cfg(feature = "nix")]
+    {
+        crate::commands::build_nix::dispatch_via_nar(
+            client,
+            organization,
+            target,
+            system,
+            entries,
+            quiet,
+            out,
+        )
+        .await
+    }
+    #[cfg(not(feature = "nix"))]
+    {
+        dispatch_via_manifest(client, organization, entries, target, system, quiet, out).await
+    }
 }
 
+#[cfg(not(feature = "nix"))]
+async fn dispatch_via_manifest(
+    client: &connector::Client,
+    organization: &str,
+    entries: &[TrackedFile],
+    target: Option<String>,
+    system: Option<String>,
+    quiet: bool,
+    out: Output,
+) -> DispatchResponse {
+    use connector::build_requests::{BuildManifestRequest, DispatchRequest, ManifestFile};
+
+    if !quiet {
+        out.human(format!(
+            "Sending manifest for {} tracked files...",
+            entries.len()
+        ));
+    }
+
+    let hashed: Vec<(String, String, i64)> = entries
+        .iter()
+        .map(|e| match hash_file(&e.abs) {
+            Ok((hash, size)) => (e.path.clone(), hash, size),
+            Err(err) => {
+                if !quiet {
+                    out.progress(format!("Failed to hash {}: {}", e.abs.display(), err));
+                }
+                exit(1);
+            }
+        })
+        .collect();
+
+    let manifest_req = BuildManifestRequest {
+        organization: organization.to_owned(),
+        files: hashed
+            .iter()
+            .map(|(path, hash, size)| ManifestFile {
+                path: path.clone(),
+                hash: hash.clone(),
+                size: *size,
+            })
+            .collect(),
+    };
+
+    let manifest = match client.build_requests().submit_manifest(manifest_req).await {
+        Ok(m) => m,
+        Err(e) => {
+            if !quiet {
+                out.progress(format!("Manifest rejected: {}", e));
+            }
+            exit(1);
+        }
+    };
+
+    if !manifest.missing.is_empty() {
+        if !quiet {
+            out.human(format!(
+                "Uploading {} missing blob(s) to session {}...",
+                manifest.missing.len(),
+                manifest.session
+            ));
+        }
+
+        let missing: std::collections::HashSet<&str> =
+            manifest.missing.iter().map(String::as_str).collect();
+        let abs_by_path: std::collections::HashMap<&str, &PathBuf> =
+            entries.iter().map(|e| (e.path.as_str(), &e.abs)).collect();
+        let mut form = reqwest::multipart::Form::new();
+        for (path, hash, _) in &hashed {
+            if !missing.contains(hash.as_str()) {
+                continue;
+            }
+            let abs = abs_by_path[path.as_str()];
+            match std::fs::read(abs) {
+                Ok(bytes) => {
+                    let part = reqwest::multipart::Part::bytes(bytes).file_name(hash.clone());
+                    form = form.part(hash.clone(), part);
+                }
+                Err(e) => {
+                    if !quiet {
+                        out.progress(format!("Failed to read {}: {}", abs.display(), e));
+                    }
+                    exit(1);
+                }
+            }
+        }
+
+        match client
+            .build_requests()
+            .upload_blobs(&manifest.session, form)
+            .await
+        {
+            Ok(resp) => {
+                if !quiet {
+                    out.human(format!("Uploaded {} blob(s).", resp.uploaded));
+                }
+            }
+            Err(e) => {
+                if !quiet {
+                    out.progress(format!("Failed to upload blobs: {}", e));
+                }
+                exit(1);
+            }
+        }
+    }
+
+    match client
+        .build_requests()
+        .dispatch(&manifest.session, DispatchRequest { target, system })
+        .await
+    {
+        Ok(d) => d,
+        Err(e) => {
+            if !quiet {
+                out.progress(format!("Failed to dispatch build request: {}", e));
+            }
+            exit(1);
+        }
+    }
+}
+
+/// Poll the evaluation until it reaches a terminal status, returning it.
+async fn wait_for_terminal(client: &connector::Client, eval_id: &str, out: Output) -> String {
+    loop {
+        match client.evals().get(eval_id).await {
+            Ok(e) => {
+                if matches!(e.status.as_str(), "Completed" | "Failed" | "Aborted") {
+                    return e.status;
+                }
+            }
+            Err(e) => {
+                out.progress(format!("Status poll failed: {}", e));
+                return String::new();
+            }
+        }
+
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    }
+}
+
+/// Pick the entry point matching `target` (exact or suffix), else the first.
+pub(crate) fn select_primary_entry_point<'a>(
+    tree: &'a ArtefactTree,
+    target: Option<&str>,
+) -> Option<&'a EntryPointArtefacts> {
+    if let Some(t) = target.filter(|t| *t != "*")
+        && let Some(ep) = tree
+            .entry_points
+            .iter()
+            .find(|e| e.attr == t || e.attr.ends_with(t))
+    {
+        return Some(ep);
+    }
+
+    tree.entry_points.first()
+}
+
+#[cfg(not(feature = "nix"))]
+async fn download_result_dir(
+    client: &connector::Client,
+    tree: &ArtefactTree,
+    target: Option<&str>,
+    out: Output,
+) {
+    use crate::commands::download::{product_filename, safe_relative_name};
+
+    let Some(ep) = select_primary_entry_point(tree, target) else {
+        out.human("No outputs to download.");
+        return;
+    };
+
+    let dir = PathBuf::from("result");
+    let mut wrote = 0usize;
+    for output in &ep.outputs {
+        for product in &output.products {
+            let name = product_filename(product);
+            let bytes = match client.builds().download_file(&ep.build_id, &name).await {
+                Ok(b) => b,
+                Err(e) => {
+                    out.progress(format!("Failed to download {}: {}", name, e));
+                    continue;
+                }
+            };
+            let dest = dir.join(safe_relative_name(&name));
+            if let Some(parent) = dest.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            if let Err(e) = std::fs::write(&dest, bytes) {
+                out.progress(format!("Failed to write {}: {}", dest.display(), e));
+                continue;
+            }
+            wrote += 1;
+        }
+    }
+
+    if wrote == 0 {
+        out.human("No build products to place in result/.");
+    } else {
+        out.human(format!("Wrote {} product(s) to result/", wrote));
+    }
+}
+
+pub(crate) struct TrackedFile {
+    pub(crate) path: String,
+    pub(crate) abs: PathBuf,
+}
+
+#[cfg(not(feature = "nix"))]
 fn hash_file(path: &Path) -> std::io::Result<(String, i64)> {
     let mut hasher = blake3::Hasher::new();
     let mut reader = BufReader::new(std::fs::File::open(path)?);

--- a/cli/src/commands/build_nix.rs
+++ b/cli/src/commands/build_nix.rs
@@ -1,0 +1,121 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! `nix`-feature fast paths for `gradient build`: pack the source NAR locally
+//! (skipping the per-file blob manifest) and substitute the built output back
+//! into the local store as a `result` symlink (instead of downloading products).
+
+use crate::commands::build::{TrackedFile, select_primary_entry_point};
+use crate::input::server_base;
+use crate::output::{ExitKind, Output};
+use connector::build_requests::DispatchResponse;
+use connector::evals::ArtefactTree;
+use futures::StreamExt as _;
+use harmonia_file_nar::NarByteStream;
+
+/// Stage the git-tracked files into a temp dir, NAR-pack them with the same
+/// serialiser the server uses (so the store path matches), and upload the NAR.
+pub async fn dispatch_via_nar(
+    client: &connector::Client,
+    organization: &str,
+    target: Option<String>,
+    system: Option<String>,
+    entries: &[TrackedFile],
+    quiet: bool,
+    out: Output,
+) -> DispatchResponse {
+    let staging = tempfile::tempdir()
+        .unwrap_or_else(|e| out.err(ExitKind::Api, format!("Failed to create temp dir: {}", e)));
+
+    for entry in entries {
+        let dest = staging.path().join(&entry.path);
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent).unwrap_or_else(|e| {
+                out.err(ExitKind::Api, format!("Failed to stage {}: {}", entry.path, e))
+            });
+        }
+        std::fs::copy(&entry.abs, &dest).unwrap_or_else(|e| {
+            out.err(ExitKind::Api, format!("Failed to stage {}: {}", entry.path, e))
+        });
+    }
+
+    let mut stream = NarByteStream::new(staging.path().to_path_buf());
+    let mut nar = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk =
+            chunk.unwrap_or_else(|e| out.err(ExitKind::Api, format!("Failed to pack NAR: {}", e)));
+        nar.extend_from_slice(&chunk);
+    }
+
+    if !quiet {
+        out.human(format!(
+            "Packed source NAR ({} bytes) from {} tracked files, uploading...",
+            nar.len(),
+            entries.len()
+        ));
+    }
+
+    match client
+        .build_requests()
+        .upload_source_nar(organization, target.as_deref(), system.as_deref(), nar)
+        .await
+    {
+        Ok(d) => d,
+        Err(e) => out.err(ExitKind::Api, format!("Failed to upload source NAR: {}", e)),
+    }
+}
+
+/// Substitute every built output from the gradient cache and create a single
+/// GC-rooted `result` symlink to the primary output.
+pub async fn link_result(
+    dispatch: &DispatchResponse,
+    tree: &ArtefactTree,
+    target: Option<&str>,
+    out: Output,
+) {
+    let Some(cache) = dispatch.cache.as_deref() else {
+        out.human("Organization has no cache; skipping output substitution.");
+        return;
+    };
+
+    let base = server_base(out);
+    let cache_url = format!("{}/cache/{}", base.trim_end_matches('/'), cache);
+
+    for ep in &tree.entry_points {
+        for output in &ep.outputs {
+            let status = tokio::process::Command::new("nix")
+                .args(["copy", "--from", &cache_url, "--no-check-sigs", &output.store_path])
+                .status()
+                .await;
+            if !matches!(status, Ok(s) if s.success()) {
+                out.progress(format!("warning: nix copy failed for {}", output.store_path));
+            }
+        }
+    }
+
+    let Some(primary) = select_primary_entry_point(tree, target) else {
+        out.human("No outputs to link.");
+        return;
+    };
+
+    let Some(out_path) = primary
+        .outputs
+        .iter()
+        .find(|o| o.name == "out")
+        .or_else(|| primary.outputs.first())
+    else {
+        return;
+    };
+
+    let status = tokio::process::Command::new("nix-store")
+        .args(["--realise", &out_path.store_path, "--add-root", "result", "--indirect"])
+        .status()
+        .await;
+    match status {
+        Ok(s) if s.success() => out.human(format!("result -> {}", out_path.store_path)),
+        _ => out.progress("warning: could not create result symlink"),
+    }
+}

--- a/cli/src/commands/download.rs
+++ b/cli/src/commands/download.rs
@@ -143,7 +143,7 @@ fn flatten_products(tree: &ArtefactTree) -> Vec<FlatProduct<'_>> {
     out
 }
 
-fn product_filename(p: &ProductArtefact) -> String {
+pub(crate) fn product_filename(p: &ProductArtefact) -> String {
     Path::new(&p.path)
         .file_name()
         .and_then(|n| n.to_str())
@@ -151,7 +151,7 @@ fn product_filename(p: &ProductArtefact) -> String {
         .unwrap_or_else(|| p.name.clone())
 }
 
-fn safe_relative_name(name: &str) -> PathBuf {
+pub(crate) fn safe_relative_name(name: &str) -> PathBuf {
     let stripped = name.trim_start_matches('/');
     let mut buf = PathBuf::new();
     for comp in Path::new(stripped).components() {

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -11,6 +11,8 @@ pub mod builds_log;
 pub mod cache_upload_nix;
 pub mod base;
 pub mod build;
+#[cfg(feature = "nix")]
+pub mod build_nix;
 pub mod cache;
 pub mod cache_nar;
 pub mod cache_upload;

--- a/cli/src/input.rs
+++ b/cli/src/input.rs
@@ -37,6 +37,19 @@ pub fn client_from_config(out: Output) -> Client {
         .unwrap_or_else(|e| out.err(ExitKind::Api, format!("client init failed: {}", e)))
 }
 
+#[cfg(feature = "nix")]
+pub fn server_base(out: Output) -> String {
+    load_config()
+        .get(&ConfigKey::Server)
+        .and_then(|v| v.clone())
+        .unwrap_or_else(|| {
+            out.err(
+                ExitKind::Usage,
+                "Server URL not set. Use `gradient config server <url>`.",
+            );
+        })
+}
+
 pub fn handle_input(values: Vec<(String, Option<String>)>, skip: bool) -> HashMap<String, String> {
     if values.is_empty() {
         println!("No input fields");

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -3267,6 +3267,64 @@ paths:
         '410':
           description: Session expired.
 
+  /build-requests/source:
+    post:
+      tags: [build-requests]
+      summary: Upload a pre-packed source NAR and queue an evaluation
+      description: |-
+        One-shot alternative to the manifest/blob flow for clients built with
+        the `nix` feature. The client NAR-packs the git-tracked source itself
+        and uploads it here; the server computes the `/nix/store/<hash>-source`
+        path, signs it, lazily creates the per-org `build-request` project, and
+        queues an evaluation. Bounded by the same per-request size limit as blob
+        upload.
+      operationId: postBuildRequestSource
+      parameters:
+        - name: organization
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Organization name.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [nar]
+              properties:
+                nar:
+                  type: string
+                  format: binary
+                  description: The packed source NAR.
+                target:
+                  type: string
+                  description: Eval target attribute path (defaults to the project wildcard).
+                system:
+                  type: string
+                  description: Target system.
+      responses:
+        '200':
+          description: Evaluation queued
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BaseResponse'
+                  - type: object
+                    properties:
+                      message:
+                        $ref: '#/components/schemas/DispatchResponse'
+        '400':
+          description: Missing or empty `nar` field.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   # ── Builds ───────────────────────────────────────────────────────────────────
 
   /builds/{build}:
@@ -8591,6 +8649,13 @@ components:
           description: |-
             Synthetic commit row pointing at the materialised
             `/nix/store/<hash>-source` path. `hash` is a 20-byte zero placeholder.
+        cache:
+          type: string
+          nullable: true
+          description: |-
+            Name of the org cache the build output is signed into, for the
+            client to substitute from (`<server>/cache/<cache>`). `null` when
+            the organization has no cache.
 
     # ── Builds ────────────────────────────────────────────────────────────────
 

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -4319,3 +4319,30 @@ NixOS VM (`nix/tests/gradient/open-pr`):
   and one tracked input, the worker bumps the input and verifies the candidate
   lock, and a PR is opened on the (test) forge; a re-run with no upstream change
   produces an empty patch and opens no second PR.
+
+## Gradient build end-to-end + nix fast paths (#422)
+
+Fixes two blocking bugs in `gradient build` (the CLI decoded a successful blob
+upload as an error; the scheduler git-cloned the materialised
+`/nix/store/<hash>-source`) and adds the `nix`-feature source NAR upload and
+post-build `result`.
+
+- `backend/gradient-storage/src/source_nar.rs::tests::from_bytes_matches_dir` -
+  `source_nar_from_bytes` computes the same store path/hashes as
+  `materialise_source_nar` for the same NAR, so the CLI and server agree on the
+  source store path.
+- `backend/gradient-scheduler/src/dispatch.rs::eval_source_tests` -
+  `cached_source_dispatches_without_fetch` dispatches a `/nix/store/...`
+  repository as `FlakeSource::Cached` with `[EvaluateFlake, EvaluateDerivations]`
+  and the source in `required_paths`; `repository_source_keeps_fetch` leaves a
+  git URL on the `FlakeSource::Repository` + `FetchFlake` path.
+- `backend/gradient-web/tests/build_requests_source.rs` -
+  `source_upload_creates_queued_eval` (multipart NAR → Queued eval, `cache` null)
+  and `source_upload_missing_nar_is_400`.
+- `backend/gradient-web/tests/build_requests_dispatch.rs` - the happy paths now
+  assert the `DispatchResponse.cache` field.
+- `cli/connector/tests/build_requests_api.rs` - `upload_blobs_decodes_counts`
+  (decodes `{uploaded,remaining}` instead of erroring on a 200) and
+  `upload_source_nar_returns_dispatch`.
+- The `nix copy`/`result` substitution and the staged NAR pack are daemon/`nix`
+  dependent and covered end-to-end by CI.

--- a/docs/src/usage/cli.md
+++ b/docs/src/usage/cli.md
@@ -152,6 +152,7 @@ gradient build                          # eval the project's wildcard target
 gradient build checks.x86_64-linux.foo  # eval a specific attribute path
 gradient build --system x86_64-linux    # override target system (default: org preference)
 gradient build -b                       # dispatch and print the evaluation UUID, then exit
+gradient build --no-link                # skip producing a result symlink/folder
 ```
 
 Requirements and limits:
@@ -163,6 +164,18 @@ Requirements and limits:
   pass `-b`/`--background` to print only the evaluation UUID and return
   immediately. Pair it with [`gradient watch`](#watching-an-evaluation) to
   follow the build later: `eval=$(gradient build -b); gradient watch "$eval"`.
+
+After a foreground build completes, the CLI produces a `result` for the primary
+output (use `--no-link` to skip it):
+
+- A CLI built with the `nix` feature substitutes every output from the org cache
+  into the local Nix store via `nix copy` and creates a single GC-rooted `result`
+  symlink to the primary output (like `nix build`). It also packs the source NAR
+  locally and uploads it in one shot (`POST /build-requests/source`), skipping the
+  per-file blob manifest.
+- A CLI without the `nix` feature downloads the primary entry point's build
+  products into a `result/` folder (only declared `hydra-build-products` are
+  included).
 
 ### Watching an evaluation
 


### PR DESCRIPTION
Fixes #422: decode the typed blob-upload response, dispatch `/nix/store` build-request sources as `FlakeSource::Cached` (no git clone), and add the `nix`-feature source NAR upload (`POST /build-requests/source`) plus post-build `result` (nix copy + symlink, or `result/` product download without the feature).