### PR TITLE
fix: wildcard drvPath tolerance, fair-share idle gate, all-scores Live Jobs (#419)

### DIFF
--- a/backend/gradient-forge/src/lib.rs
+++ b/backend/gradient-forge/src/lib.rs
@@ -24,5 +24,5 @@ pub use registry::ForgeRegistry;
 pub use reporter::*;
 pub use webhook::{
     ParsedPullRequestEvent, ParsedPullRequestReviewEvent, ParsedPushEvent, ParsedReleaseEvent,
-    PushCommit, WebhookEventKind,
+    PushCommit, PushOutcome, WebhookEventKind,
 };

--- a/backend/gradient-forge/src/provider.rs
+++ b/backend/gradient-forge/src/provider.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use gradient_types::ForgeType;
 use crate::reporter::CiReporter;
 use crate::webhook::{
-    ParsedPullRequestEvent, ParsedPushEvent, ParsedReleaseEvent, WebhookEventKind,
+    ParsedPullRequestEvent, ParsedReleaseEvent, PushOutcome, WebhookEventKind,
 };
 
 pub trait ForgeProvider: Send + Sync + std::fmt::Debug {
@@ -57,7 +57,7 @@ pub trait ForgeProvider: Send + Sync + std::fmt::Debug {
     /// Map a raw forge event string onto the shared [`WebhookEventKind`].
     fn classify_event(&self, event: &str) -> WebhookEventKind;
 
-    fn parse_push_event(&self, body: &[u8]) -> Option<ParsedPushEvent>;
+    fn parse_push_event(&self, body: &[u8]) -> Option<PushOutcome>;
     fn parse_pull_request_event(&self, body: &[u8]) -> Option<ParsedPullRequestEvent>;
     fn parse_release_event(&self, body: &[u8]) -> Option<ParsedReleaseEvent>;
 }

--- a/backend/gradient-forge/src/providers/gitea.rs
+++ b/backend/gradient-forge/src/providers/gitea.rs
@@ -15,7 +15,7 @@ use crate::github_app::verify_gitea_signature;
 use crate::provider::ForgeProvider;
 use crate::reporter::{CiReporter, GiteaReporter};
 use crate::webhook::{
-    ParsedPullRequestEvent, ParsedPushEvent, ParsedReleaseEvent, WebhookEventKind,
+    ParsedPullRequestEvent, ParsedPushEvent, ParsedReleaseEvent, PushOutcome, WebhookEventKind,
 };
 
 #[derive(Debug)]
@@ -71,7 +71,7 @@ impl ForgeProvider for GiteaProvider {
         }
     }
 
-    fn parse_push_event(&self, body: &[u8]) -> Option<ParsedPushEvent> {
+    fn parse_push_event(&self, body: &[u8]) -> Option<PushOutcome> {
         ParsedPushEvent::from_gitea(body)
     }
 

--- a/backend/gradient-forge/src/providers/github.rs
+++ b/backend/gradient-forge/src/providers/github.rs
@@ -19,7 +19,7 @@ use crate::github_app::verify_github_signature;
 use crate::provider::ForgeProvider;
 use crate::reporter::{CiReporter, GithubReporter};
 use crate::webhook::{
-    ParsedPullRequestEvent, ParsedPushEvent, ParsedReleaseEvent, WebhookEventKind,
+    ParsedPullRequestEvent, ParsedPushEvent, ParsedReleaseEvent, PushOutcome, WebhookEventKind,
 };
 
 #[derive(Debug)]
@@ -69,7 +69,7 @@ impl ForgeProvider for GithubProvider {
         WebhookEventKind::Unknown("github".into())
     }
 
-    fn parse_push_event(&self, body: &[u8]) -> Option<ParsedPushEvent> {
+    fn parse_push_event(&self, body: &[u8]) -> Option<PushOutcome> {
         ParsedPushEvent::from_github(body)
     }
 

--- a/backend/gradient-forge/src/providers/gitlab.rs
+++ b/backend/gradient-forge/src/providers/gitlab.rs
@@ -16,7 +16,7 @@ use gradient_types::ForgeType;
 use crate::provider::ForgeProvider;
 use crate::reporter::{CiReporter, GitlabReporter};
 use crate::webhook::{
-    ParsedPullRequestEvent, ParsedPushEvent, ParsedReleaseEvent, WebhookEventKind,
+    ParsedPullRequestEvent, ParsedPushEvent, ParsedReleaseEvent, PushOutcome, WebhookEventKind,
 };
 
 #[derive(Debug)]
@@ -63,7 +63,7 @@ impl ForgeProvider for GitlabProvider {
         }
     }
 
-    fn parse_push_event(&self, body: &[u8]) -> Option<ParsedPushEvent> {
+    fn parse_push_event(&self, body: &[u8]) -> Option<PushOutcome> {
         ParsedPushEvent::from_gitlab(body)
     }
 

--- a/backend/gradient-forge/src/webhook.rs
+++ b/backend/gradient-forge/src/webhook.rs
@@ -358,6 +358,15 @@ pub struct ParsedPushEvent {
     pub is_tag: bool,
 }
 
+/// Outcome of parsing a push webhook payload. Separates a buildable push from a
+/// well-formed delivery with nothing to build - a branch/tag deletion or a forge
+/// "test" webhook, both of which carry an all-zero `after` SHA - so the endpoint
+/// answers the latter with a 200 no-op rather than rejecting it as malformed.
+pub enum PushOutcome {
+    Build(ParsedPushEvent),
+    Ignored,
+}
+
 /// Pull-request event normalised across forges. `commit_hash` is the PR head SHA.
 pub struct ParsedPullRequestEvent {
     pub commit_hash: Vec<u8>,
@@ -497,7 +506,7 @@ fn gitlab_project_urls(project: &GitLabProject) -> Vec<String> {
 // ── ParsedPushEvent impl ───────────────────────────────────────────────────
 
 impl ParsedPushEvent {
-    pub fn from_github(body: &[u8]) -> Option<Self> {
+    pub fn from_github(body: &[u8]) -> Option<PushOutcome> {
         let payload: GitHubPushPayload = match serde_json::from_slice(body) {
             Ok(p) => p,
             Err(e) => {
@@ -505,19 +514,21 @@ impl ParsedPushEvent {
                 return None;
             }
         };
-        let pc = decode_push_commit(&payload.git_ref, &payload.after, "github")?;
+        let Some(pc) = decode_push_commit(&payload.git_ref, &payload.after, "github") else {
+            return Some(PushOutcome::Ignored);
+        };
         let head = payload.head_commit.as_ref();
-        Some(Self {
+        Some(PushOutcome::Build(Self {
             commit_hash: pc.hash,
             repository_urls: vec![payload.repository.clone_url, payload.repository.ssh_url],
             commit_message: head.and_then(commit_subject),
             author_name: head.and_then(|c| c.author.as_ref()).and_then(|a| a.name.clone()),
             ref_name: pc.ref_name,
             is_tag: pc.is_tag,
-        })
+        }))
     }
 
-    pub fn from_gitea(body: &[u8]) -> Option<Self> {
+    pub fn from_gitea(body: &[u8]) -> Option<PushOutcome> {
         let payload: GiteaPushPayload = match serde_json::from_slice(body) {
             Ok(p) => p,
             Err(e) => {
@@ -525,24 +536,26 @@ impl ParsedPushEvent {
                 return None;
             }
         };
-        let pc = decode_push_commit(&payload.git_ref, &payload.after, "gitea")?;
+        let Some(pc) = decode_push_commit(&payload.git_ref, &payload.after, "gitea") else {
+            return Some(PushOutcome::Ignored);
+        };
         let mut urls = vec![payload.repository.clone_url];
         if let Some(ssh) = payload.repository.ssh_url {
             urls.push(ssh);
         }
 
         let head = payload.head_commit.as_ref();
-        Some(Self {
+        Some(PushOutcome::Build(Self {
             commit_hash: pc.hash,
             repository_urls: urls,
             commit_message: head.and_then(commit_subject),
             author_name: head.and_then(|c| c.author.as_ref()).and_then(|a| a.name.clone()),
             ref_name: pc.ref_name,
             is_tag: pc.is_tag,
-        })
+        }))
     }
 
-    pub fn from_gitlab(body: &[u8]) -> Option<Self> {
+    pub fn from_gitlab(body: &[u8]) -> Option<PushOutcome> {
         let payload: GitLabPushPayload = match serde_json::from_slice(body) {
             Ok(p) => p,
             Err(e) => {
@@ -550,7 +563,9 @@ impl ParsedPushEvent {
                 return None;
             }
         };
-        let pc = decode_push_commit(&payload.git_ref, &payload.after, "gitlab")?;
+        let Some(pc) = decode_push_commit(&payload.git_ref, &payload.after, "gitlab") else {
+            return Some(PushOutcome::Ignored);
+        };
         let mut urls = vec![payload.project.http_url];
         if let Some(ssh) = payload.project.ssh_url {
             urls.push(ssh);
@@ -561,14 +576,14 @@ impl ParsedPushEvent {
             .iter()
             .find(|c| c.id.as_deref() == Some(payload.after.as_str()))
             .or_else(|| payload.commits.last());
-        Some(Self {
+        Some(PushOutcome::Build(Self {
             commit_hash: pc.hash,
             repository_urls: urls,
             commit_message: head.and_then(commit_subject),
             author_name: head.and_then(|c| c.author.as_ref()).and_then(|a| a.name.clone()),
             ref_name: pc.ref_name,
             is_tag: pc.is_tag,
-        })
+        }))
     }
 }
 
@@ -878,6 +893,14 @@ mod tests {
 
     const VALID_SHA: &str = "abcdef0123456789abcdef0123456789abcdef01";
     const ZERO_SHA: &str = "0000000000000000000000000000000000000000";
+
+    #[track_caller]
+    fn build(outcome: Option<PushOutcome>) -> ParsedPushEvent {
+        match outcome {
+            Some(PushOutcome::Build(ev)) => ev,
+            _ => panic!("expected a buildable push"),
+        }
+    }
 
     // ── push helpers ──────────────────────────────────────────────────────
 
@@ -1395,7 +1418,7 @@ mod tests {
                 "head_commit": {{ "id": "{VALID_SHA}", "message": "feat: add thing\n\nlong body", "author": {{ "name": "Octo Cat" }} }}
             }}"#
         );
-        let ev = ParsedPushEvent::from_github(body.as_bytes()).unwrap();
+        let ev = build(ParsedPushEvent::from_github(body.as_bytes()));
         assert_eq!(ev.commit_message.as_deref(), Some("feat: add thing"));
         assert_eq!(ev.author_name.as_deref(), Some("Octo Cat"));
     }
@@ -1409,7 +1432,7 @@ mod tests {
                 "repository": {{ "clone_url": "https://github.com/org/repo.git", "ssh_url": "git@github.com:org/repo.git" }}
             }}"#
         );
-        let ev = ParsedPushEvent::from_github(body.as_bytes()).unwrap();
+        let ev = build(ParsedPushEvent::from_github(body.as_bytes()));
         assert_eq!(ev.commit_message, None);
         assert_eq!(ev.author_name, None);
     }
@@ -1427,8 +1450,49 @@ mod tests {
                 ]
             }}"#
         );
-        let ev = ParsedPushEvent::from_gitlab(body.as_bytes()).unwrap();
+        let ev = build(ParsedPushEvent::from_gitlab(body.as_bytes()));
         assert_eq!(ev.commit_message.as_deref(), Some("fix: the bug"));
         assert_eq!(ev.author_name.as_deref(), Some("Dev"));
+    }
+
+    #[test]
+    fn gitea_test_webhook_zero_sha_is_ignored_not_malformed() {
+        let body = format!(
+            r#"{{
+                "ref": "refs/heads/master",
+                "before": "{ZERO_SHA}",
+                "after": "{ZERO_SHA}",
+                "commits": [
+                    {{ "id": "{ZERO_SHA}", "message": "This is a fake commit", "verification": null, "added": null, "removed": null, "modified": null }}
+                ],
+                "head_commit": {{ "id": "{ZERO_SHA}", "message": "This is a fake commit", "verification": null }},
+                "repository": {{ "clone_url": "https://gitea.example.com/user/repo.git", "ssh_url": "git@gitea.example.com:user/repo.git" }}
+            }}"#
+        );
+        assert!(matches!(
+            ParsedPushEvent::from_gitea(body.as_bytes()),
+            Some(PushOutcome::Ignored)
+        ));
+    }
+
+    #[test]
+    fn push_with_unparseable_json_is_malformed() {
+        assert!(ParsedPushEvent::from_gitea(b"not json").is_none());
+        assert!(ParsedPushEvent::from_github(b"{}").is_none());
+    }
+
+    #[test]
+    fn github_branch_deletion_zero_sha_is_ignored() {
+        let body = format!(
+            r#"{{
+                "ref": "refs/heads/feature",
+                "after": "{ZERO_SHA}",
+                "repository": {{ "clone_url": "https://github.com/org/repo.git", "ssh_url": "git@github.com:org/repo.git" }}
+            }}"#
+        );
+        assert!(matches!(
+            ParsedPushEvent::from_github(body.as_bytes()),
+            Some(PushOutcome::Ignored)
+        ));
     }
 }

--- a/backend/gradient-scheduler/src/jobs.rs
+++ b/backend/gradient-scheduler/src/jobs.rs
@@ -6,7 +6,7 @@
 
 //! Pending and active job tracking.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use gradient_types::ids::{BuildId, CommitId, EvaluationId, OrganizationId, ProjectId};
 use gradient_types::proto::{
@@ -172,6 +172,28 @@ impl PendingJob {
         }
     }
 
+    /// Wire discriminator matching `dispatched_job.kind`: eval `0`, build `1`.
+    pub fn kind_disc(&self) -> i16 {
+        match self {
+            PendingJob::Eval(_) => 0,
+            PendingJob::Build(_) => 1,
+        }
+    }
+
+    pub fn build_id(&self) -> Option<BuildId> {
+        match self {
+            PendingJob::Build(j) => Some(j.build_id),
+            PendingJob::Eval(_) => None,
+        }
+    }
+
+    pub fn pname(&self) -> Option<String> {
+        match self {
+            PendingJob::Build(j) => j.pname.clone(),
+            PendingJob::Eval(_) => None,
+        }
+    }
+
     pub fn dependency_count(&self) -> u32 {
         match self {
             PendingJob::Build(j) => j.dependency_count,
@@ -278,12 +300,46 @@ pub struct PendingJobInfo {
     pub pname: Option<String>,
 }
 
+/// One scored candidate weighed in a dispatch decision. Captured for every
+/// candidate, including those that scored below the dispatch floor, so the Live
+/// Jobs "all scores" view can surface negative scores for rule tuning (#419).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DecisionCandidate {
+    pub job_id: String,
+    pub kind: i16,
+    pub organization: OrganizationId,
+    pub build_id: Option<BuildId>,
+    pub evaluation_id: EvaluationId,
+    pub pname: Option<String>,
+    pub score: f64,
+}
+
+/// A recorded dispatch decision: the candidates a worker was scored against and
+/// which (if any) won. Kept in a bounded ring on the tracker.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DispatchDecision {
+    pub at: chrono::NaiveDateTime,
+    pub worker_id: String,
+    pub kind: i16,
+    pub winner: Option<String>,
+    pub candidates: Vec<DecisionCandidate>,
+}
+
+/// How many dispatch decisions to retain, and how many candidates per decision.
+/// Both bounded so a large queue can't grow the ring without limit; candidates
+/// are kept highest-score first, so the dispatch boundary and the lowest-scoring
+/// jobs stay visible.
+const DECISION_RING_CAP: usize = 200;
+const CANDIDATES_PER_DECISION: usize = 64;
+
 #[derive(Debug, Default)]
 pub struct JobTracker {
     pending: HashMap<String, PendingJob>,
     /// Per-worker, per-job scores: `worker_id → job_id → score`.
     scores: HashMap<String, HashMap<String, WorkerJobScore>>,
     active: HashMap<String, (String, PendingJob)>,
+    /// Bounded ring of recent dispatch decisions for the Live Jobs view.
+    decisions: VecDeque<DispatchDecision>,
 }
 
 impl JobTracker {
@@ -341,6 +397,20 @@ impl JobTracker {
         }
     }
 
+    /// Append a dispatch decision to the bounded ring, evicting the oldest.
+    fn push_decision(&mut self, decision: DispatchDecision) {
+        if self.decisions.len() >= DECISION_RING_CAP {
+            self.decisions.pop_front();
+        }
+
+        self.decisions.push_back(decision);
+    }
+
+    /// Recent dispatch decisions, most recent first (cloned snapshot for the API).
+    pub fn recent_decisions(&self) -> Vec<DispatchDecision> {
+        self.decisions.iter().rev().cloned().collect()
+    }
+
     /// Assign the best pending job matching `kind` for `peer_id`.
     ///
     /// Each eligible candidate is scored by `policy`.  The job with the
@@ -358,7 +428,9 @@ impl JobTracker {
         policy: &dyn ScoringPolicy,
         instance: &gradient_score::InstanceContext,
     ) -> Option<Assignment> {
-        let worker_scores = self.scores.get(peer_id);
+        // Owned snapshot so recording the decision (a `&mut self` push below)
+        // doesn't collide with this borrow of `self.scores`.
+        let worker_scores = self.scores.get(peer_id).cloned();
 
         let worker_ctx = caps.map(|c| WorkerContext {
             architectures: &c.architectures,
@@ -395,7 +467,7 @@ impl JobTracker {
         };
 
         let score_of = |id: &str, job: &PendingJob| -> f64 {
-            let s = worker_scores.and_then(|ws| ws.get(id));
+            let s = worker_scores.as_ref().and_then(|ws| ws.get(id));
             let closure_size = match job {
                 PendingJob::Build(b) => b.closure_size,
                 PendingJob::Eval(_) => None,
@@ -436,7 +508,7 @@ impl JobTracker {
             policy.score(&ctx, worker_ctx, instance)
         };
 
-        let best = self
+        let mut scored: Vec<(&String, f64)> = self
             .pending
             .iter()
             .filter(|(_, j)| {
@@ -449,25 +521,57 @@ impl JobTracker {
                     && job_eligible_for_caps(j, caps)
             })
             .map(|(id, job)| (id, score_of(id, job)))
-            .max_by(|(id_a, sa), (id_b, sb)| {
-                sa.partial_cmp(sb)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-                    // Tie-break by job_id for determinism.
-                    .then_with(|| id_b.cmp(id_a))
-            });
+            .collect();
+        // Highest score first; tie-break on the smaller job_id for determinism.
+        scored.sort_by(|(id_a, sa), (id_b, sb)| {
+            sb.partial_cmp(sa)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| id_a.cmp(id_b))
+        });
 
         // A negative best total means dispatching now is worse than idling this
         // round (e.g. a build still awaiting candidate scores); the worker waits.
-        let job_id = match best {
-            Some((id, s)) if s >= 0.0 => id.clone(),
-            _ => return None,
-        };
+        let winner = scored.first().filter(|(_, s)| *s >= 0.0).map(|(id, _)| (*id).clone());
+
+        // Snapshot the decision (incl. rejected/negative candidates) for the Live
+        // Jobs "all scores" view before the immutable borrow of `pending` ends.
+        let candidates: Vec<DecisionCandidate> = scored
+            .iter()
+            .take(CANDIDATES_PER_DECISION)
+            .filter_map(|(id, s)| {
+                self.pending.get(*id).map(|job| DecisionCandidate {
+                    job_id: (*id).clone(),
+                    kind: job.kind_disc(),
+                    organization: job.peer_id(),
+                    build_id: job.build_id(),
+                    evaluation_id: job.evaluation_id(),
+                    pname: job.pname(),
+                    score: *s,
+                })
+            })
+            .collect();
+        drop(scored);
+
+        if !candidates.is_empty() {
+            self.push_decision(DispatchDecision {
+                at: gradient_types::now(),
+                worker_id: peer_id.to_owned(),
+                kind: match kind {
+                    JobKind::Flake => 0,
+                    JobKind::Build => 1,
+                },
+                winner: winner.clone(),
+                candidates,
+            });
+        }
+
+        let job_id = winner?;
 
         // Recompute the winner's score with the per-rule breakdown, captured for
         // the dispatched_job row. Owned snapshots so the borrow ends before the
         // mutable assign_pending below.
         let dispatch_record = self.pending.get(&job_id).map(|job| {
-            let s = worker_scores.and_then(|ws| ws.get(job_id.as_str()));
+            let s = worker_scores.as_ref().and_then(|ws| ws.get(job_id.as_str()));
             let closure_size = match job {
                 PendingJob::Build(b) => b.closure_size,
                 PendingJob::Eval(_) => None,
@@ -1080,6 +1184,46 @@ mod tests {
         assert_eq!(assignment.unwrap().job_id, "j1");
         assert_eq!(tracker.pending_count(), 0);
         assert_eq!(tracker.active_count(), 1);
+    }
+
+    #[test]
+    fn records_dispatch_decisions_including_rejected_candidates() {
+        let mut tracker = JobTracker::new();
+        let peer = OrganizationId::now_v7();
+        tracker.add_pending("j1".into(), build_job(peer, vec![]));
+        let p = gradient_score::policy_by_name("simple");
+        let inst = gradient_score::InstanceContext::default();
+
+        // No cached score → negative total → the worker idles, but the rejected
+        // candidate and its negative score are still recorded (#419).
+        assert!(
+            tracker
+                .take_best_of_kind("w1", None, None, &JobKind::Build, &*p, &inst)
+                .is_none()
+        );
+        let decisions = tracker.recent_decisions();
+        assert_eq!(decisions.len(), 1);
+        assert!(decisions[0].winner.is_none());
+        assert_eq!(decisions[0].candidates.len(), 1);
+        assert_eq!(decisions[0].candidates[0].job_id, "j1");
+        assert!(
+            decisions[0].candidates[0].score < 0.0,
+            "a rejected candidate's negative score must be visible"
+        );
+
+        // Caching a score lets it dispatch; the newer decision records the winner.
+        tracker.record_scores(
+            "w1",
+            vec![CandidateScore { job_id: "j1".into(), missing_count: 0, missing_nar_size: 0 }],
+        );
+        assert!(
+            tracker
+                .take_best_of_kind("w1", None, None, &JobKind::Build, &*p, &inst)
+                .is_some()
+        );
+        let decisions = tracker.recent_decisions();
+        assert_eq!(decisions.len(), 2, "most recent first");
+        assert_eq!(decisions[0].winner.as_deref(), Some("j1"));
     }
 
     #[test]

--- a/backend/gradient-scheduler/src/lib.rs
+++ b/backend/gradient-scheduler/src/lib.rs
@@ -49,7 +49,7 @@ use worker_pool::WorkerPool;
 type EdgeReadinessMap = Arc<RwLock<HashMap<EvaluationId, EdgeReadiness>>>;
 
 pub use gradient_types::BoardEvent;
-pub use jobs::PendingJobInfo;
+pub use jobs::{DecisionCandidate, DispatchDecision, PendingJobInfo};
 pub use worker_pool::WorkerInfo;
 
 #[cfg(test)]
@@ -151,5 +151,9 @@ impl Scheduler {
 
     pub async fn pending_jobs_snapshot(&self) -> Vec<jobs::PendingJobInfo> {
         self.job_tracker.read().await.pending_snapshot()
+    }
+
+    pub async fn recent_decisions(&self) -> Vec<jobs::DispatchDecision> {
+        self.job_tracker.read().await.recent_decisions()
     }
 }

--- a/backend/gradient-score/src/rules/fair_share.rs
+++ b/backend/gradient-score/src/rules/fair_share.rs
@@ -9,7 +9,8 @@ use crate::rule::{JobContext, ScoreRule, WorkerContext};
 
 /// Penalizes a job proportional to its owning org's share of currently-active
 /// builds, so a quiet org's job is picked promptly even when a busy org floods
-/// the queue (#111).
+/// the queue (#111). Only bites under contention - when every worker is busy -
+/// so a single busy org is never penalized into leaving the cluster idle (#419).
 #[derive(Debug)]
 pub struct FairShareRule {
     pub weight: f64,
@@ -26,8 +27,15 @@ impl ScoreRule for FairShareRule {
         &self,
         job: &JobContext<'_>,
         _worker: &WorkerContext<'_>,
-        _instance: &InstanceContext,
+        instance: &InstanceContext,
     ) -> f64 {
+        // Spare capacity means no org is starving another: dispatch freely.
+        // Penalizing here would only push a lone busy org's jobs below the
+        // dispatcher's zero floor and leave workers idle.
+        if instance.idle_workers > 0 {
+            return 0.0;
+        }
+
         match job.org_work_share {
             Some(share) => -self.weight * share as f64,
             None => 0.0,
@@ -35,7 +43,7 @@ impl ScoreRule for FairShareRule {
     }
 
     fn description(&self) -> &'static str {
-        "Penalizes a job by how large a share of currently-active builds its organization already holds, so a busy org cannot starve a quiet one."
+        "Penalizes a job by how large a share of currently-active builds its organization already holds, so a busy org cannot starve a quiet one; only applied when every worker is busy so it never idles the cluster."
     }
 }
 
@@ -84,6 +92,27 @@ mod tests {
         let busy = rule.score(&ctx(&job, Some(0.99)), &w, &InstanceContext::default());
         let quiet = rule.score(&ctx(&job, Some(0.01)), &w, &InstanceContext::default());
         assert!(busy < quiet, "busy org must score lower: {busy} vs {quiet}");
+    }
+
+    #[test]
+    fn idle_capacity_lifts_penalty() {
+        let rule = FairShareRule::default();
+        let job = build_job();
+        let w = worker();
+        let busy = ctx(&job, Some(1.0));
+
+        let saturated = InstanceContext { idle_workers: 0, total_workers: 4, ..Default::default() };
+        assert!(
+            rule.score(&busy, &w, &saturated) < 0.0,
+            "a saturated cluster still rations a busy org"
+        );
+
+        let spare = InstanceContext { idle_workers: 1, total_workers: 4, ..Default::default() };
+        assert_eq!(
+            rule.score(&busy, &w, &spare),
+            0.0,
+            "idle workers must not be left empty by the fair-share penalty"
+        );
     }
 
     #[test]

--- a/backend/gradient-sources/src/git/commit_info.rs
+++ b/backend/gradient-sources/src/git/commit_info.rs
@@ -6,6 +6,7 @@
 
 use super::context::ProjectGitContext;
 use super::remote::accept_cert;
+use super::url::git_transport_url;
 use crate::SourceError;
 use gradient_types::input::vec_to_hex;
 use git2::RemoteCallbacks;
@@ -23,7 +24,7 @@ impl ProjectGitContext<'_> {
         debug!("Fetching commit info");
 
         let hash_str = vec_to_hex(commit_hash);
-        let url = self.project.repository.clone();
+        let url = git_transport_url(&self.project.repository).to_string();
         let ssh_creds = self.ssh_creds.clone();
 
         let temp_dir = tempfile::TempDir::new().map_err(|e| SourceError::FileRead {

--- a/backend/gradient-sources/src/git/remote/mod.rs
+++ b/backend/gradient-sources/src/git/remote/mod.rs
@@ -11,6 +11,7 @@ mod git_protocol;
 mod https;
 mod ssh;
 
+use super::url::git_transport_url;
 use crate::SourceError;
 use git_protocol::ls_remote_head_git_protocol;
 use https::ls_remote_head_no_creds;
@@ -34,6 +35,7 @@ pub(super) fn ls_remote_head(
     public_key: Option<&str>,
     branch: Option<&str>,
 ) -> Result<Vec<u8>, SourceError> {
+    let url = git_transport_url(url);
     match (private_key, public_key) {
         (Some(priv_key), Some(pub_key)) => ls_remote_head_ssh(url, priv_key, pub_key, branch),
         _ if url.starts_with("git://") => ls_remote_head_git_protocol(url, branch),

--- a/backend/gradient-sources/src/git/tests/mod.rs
+++ b/backend/gradient-sources/src/git/tests/mod.rs
@@ -7,9 +7,32 @@
 mod fixtures;
 
 use super::pktline::read_ref_from_pktlines;
-use super::url::{parse_git_protocol_url, parse_nix_git_url};
+use super::url::{git_transport_url, parse_git_protocol_url, parse_nix_git_url};
 use crate::SourceError;
 use fixtures::{FAKE_SHA, FLUSH, ref_line, ref_line_with_caps};
+
+// ── git_transport_url ────────────────────────────────────────────────────
+
+#[test]
+fn git_transport_url_strips_git_plus_https() {
+    assert_eq!(
+        git_transport_url("git+https://git.example.com/org/repo..git"),
+        "https://git.example.com/org/repo..git"
+    );
+}
+
+#[test]
+fn git_transport_url_strips_git_plus_http_and_ssh() {
+    assert_eq!(git_transport_url("git+http://h/r"), "http://h/r");
+    assert_eq!(git_transport_url("git+ssh://git@h/r"), "ssh://git@h/r");
+}
+
+#[test]
+fn git_transport_url_passes_through_bare_schemes_and_scp() {
+    assert_eq!(git_transport_url("https://h/r"), "https://h/r");
+    assert_eq!(git_transport_url("git://h/r"), "git://h/r");
+    assert_eq!(git_transport_url("git@github.com:u/r.git"), "git@github.com:u/r.git");
+}
 
 // ── parse_nix_git_url ────────────────────────────────────────────────────
 

--- a/backend/gradient-sources/src/git/url.rs
+++ b/backend/gradient-sources/src/git/url.rs
@@ -19,11 +19,20 @@ pub(super) fn parse_git_protocol_url(url: &str) -> Result<(&str, u16, &str), Sou
     Ok((host, port, repo_path))
 }
 
+/// Translates a nix flake URL into a transport URL libgit2 understands by
+/// stripping the `git+` scheme prefix (`git+https://h/r` → `https://h/r`).
+/// libgit2 registers no `git+https`/`git+http` transport: it misroutes such a
+/// URL to SSH, whose scheme has no default port, and the connect then fails with
+/// "invalid argument port". Bare schemes and SCP-style remotes pass through.
+pub(super) fn git_transport_url(url: &str) -> &str {
+    url.strip_prefix("git+").unwrap_or(url)
+}
+
 /// Parses a nix flake URL of the form `git+<scheme>://host/repo?rev=<hash>` into
 /// `(git_url, rev)`.  The `git+` prefix is stripped so the returned URL is
 /// suitable for direct use with libgit2.
 pub(super) fn parse_nix_git_url(nix_url: &str) -> Result<(String, String), SourceError> {
-    let url = nix_url.strip_prefix("git+").unwrap_or(nix_url);
+    let url = git_transport_url(nix_url);
     let (base_url, query) = url.split_once('?').ok_or(SourceError::UrlParsing)?;
     let rev = query
         .split('&')

--- a/backend/gradient-web/src/endpoints/board.rs
+++ b/backend/gradient-web/src/endpoints/board.rs
@@ -163,6 +163,63 @@ pub async fn get_dispatched_jobs(
 }
 
 #[derive(Serialize)]
+pub struct DecisionCandidateView {
+    pub job_id: String,
+    pub kind: i16,
+    pub organization: Uuid,
+    pub build_id: Option<Uuid>,
+    pub evaluation_id: Uuid,
+    pub pname: Option<String>,
+    pub score: f64,
+}
+
+#[derive(Serialize)]
+pub struct DispatchDecisionView {
+    pub at: String,
+    pub worker_id: String,
+    pub kind: i16,
+    pub winner: Option<String>,
+    pub candidates: Vec<DecisionCandidateView>,
+}
+
+/// Recent dispatch decisions with every scored candidate, including rejected and
+/// negative ones the dispatcher passed over. Superuser-only: candidates span all
+/// orgs, and the view exists to tune cross-org scoring rules (#419).
+pub async fn get_dispatch_decisions(
+    Extension(user): Extension<MUser>,
+    Extension(scheduler): Extension<Arc<Scheduler>>,
+) -> WebResult<Json<BaseResponse<Vec<DispatchDecisionView>>>> {
+    require_superuser(&user)?;
+
+    let views = scheduler
+        .recent_decisions()
+        .await
+        .into_iter()
+        .map(|d| DispatchDecisionView {
+            at: d.at.and_utc().to_rfc3339(),
+            worker_id: d.worker_id,
+            kind: d.kind,
+            winner: d.winner,
+            candidates: d
+                .candidates
+                .into_iter()
+                .map(|c| DecisionCandidateView {
+                    job_id: c.job_id,
+                    kind: c.kind,
+                    organization: c.organization.into(),
+                    build_id: c.build_id.map(Into::into),
+                    evaluation_id: c.evaluation_id.into(),
+                    pname: c.pname,
+                    score: c.score,
+                })
+                .collect(),
+        })
+        .collect();
+
+    Ok(ok_json(views))
+}
+
+#[derive(Serialize)]
 pub struct AttemptSummary {
     pub dispatched_job_id: Uuid,
     pub substitute: bool,

--- a/backend/gradient-web/src/endpoints/forge_hooks/mod.rs
+++ b/backend/gradient-web/src/endpoints/forge_hooks/mod.rs
@@ -42,7 +42,7 @@ use crate::client_ip::{OptionalPeer, resolve_client_ip};
 use crate::error::{ErrorCode, WebError, WebResult};
 use crate::helpers::ok_json;
 
-use gradient_forge::{ParsedPullRequestEvent, ParsedPushEvent, ParsedReleaseEvent};
+use gradient_forge::{ParsedPullRequestEvent, ParsedPushEvent, ParsedReleaseEvent, PushOutcome};
 use trigger::{
     PushRefKind, handle_github_installation, resolve_github_app_targets,
     trigger_pr_for_integration, trigger_push_for_integration, trigger_release_for_integration,
@@ -100,21 +100,22 @@ pub async fn github_app_webhook(
     debug!(event = %event, "GitHub App webhook received");
 
     let response = match event.as_str() {
-        "push" => {
-            let Some(parsed) = ParsedPushEvent::from_github(&body) else {
-                return Err(WebError::bad_request("malformed webhook payload"));
-            };
-            let urls = parsed.repository_urls.clone();
-            let outcome =
-                dispatch_github_app_push(&state, &scheduler, parsed, &body, client_ip).await;
-            WebhookResponse {
-                event: "push".to_string(),
-                repository_urls: urls,
-                projects_scanned: outcome.projects_scanned,
-                queued: outcome.queued,
-                skipped: outcome.skipped,
+        "push" => match ParsedPushEvent::from_github(&body) {
+            None => return Err(WebError::bad_request("malformed webhook payload")),
+            Some(PushOutcome::Ignored) => WebhookResponse::empty("push"),
+            Some(PushOutcome::Build(parsed)) => {
+                let urls = parsed.repository_urls.clone();
+                let outcome =
+                    dispatch_github_app_push(&state, &scheduler, parsed, &body, client_ip).await;
+                WebhookResponse {
+                    event: "push".to_string(),
+                    repository_urls: urls,
+                    projects_scanned: outcome.projects_scanned,
+                    queued: outcome.queued,
+                    skipped: outcome.skipped,
+                }
             }
-        }
+        },
         "pull_request" => {
             let Some(parsed) = ParsedPullRequestEvent::from_github(&body) else {
                 return Err(WebError::bad_request("malformed webhook payload"));
@@ -439,36 +440,36 @@ pub async fn forge_webhook(
     let event_type = provider.classify_event(raw_event);
 
     let response = match event_type {
-        WebhookEventKind::Push => {
-            let Some(parsed) = provider.parse_push_event(&body) else {
-                return Err(WebError::bad_request("malformed webhook payload"));
-            };
-            let urls = parsed.repository_urls.clone();
-            let ref_name = parsed.ref_name.clone();
-            let is_tag = parsed.is_tag;
-            let ref_kind = if is_tag {
-                PushRefKind::Tag(&ref_name)
-            } else {
-                PushRefKind::Branch(&ref_name)
-            };
-            let outcome = trigger_push_for_integration(
-                &state,
-                &scheduler,
-                integration_id,
-                ref_kind,
-                parsed.commit_hash,
-                parsed.commit_message,
-                parsed.author_name,
-            )
-            .await;
-            WebhookResponse {
-                event: "push".to_string(),
-                repository_urls: urls,
-                projects_scanned: outcome.projects_scanned,
-                queued: outcome.queued,
-                skipped: outcome.skipped,
+        WebhookEventKind::Push => match provider.parse_push_event(&body) {
+            None => return Err(WebError::bad_request("malformed webhook payload")),
+            Some(PushOutcome::Ignored) => WebhookResponse::empty("push"),
+            Some(PushOutcome::Build(parsed)) => {
+                let urls = parsed.repository_urls.clone();
+                let ref_name = parsed.ref_name.clone();
+                let ref_kind = if parsed.is_tag {
+                    PushRefKind::Tag(&ref_name)
+                } else {
+                    PushRefKind::Branch(&ref_name)
+                };
+                let outcome = trigger_push_for_integration(
+                    &state,
+                    &scheduler,
+                    integration_id,
+                    ref_kind,
+                    parsed.commit_hash,
+                    parsed.commit_message,
+                    parsed.author_name,
+                )
+                .await;
+                WebhookResponse {
+                    event: "push".to_string(),
+                    repository_urls: urls,
+                    projects_scanned: outcome.projects_scanned,
+                    queued: outcome.queued,
+                    skipped: outcome.skipped,
+                }
             }
-        }
+        },
         WebhookEventKind::PullRequest => {
             let Some(parsed) = provider.parse_pull_request_event(&body) else {
                 return Err(WebError::bad_request("malformed webhook payload"));

--- a/backend/gradient-web/src/lib.rs
+++ b/backend/gradient-web/src/lib.rs
@@ -558,6 +558,7 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
             get(projects::get_entry_point_metrics),
         )
         .route("/board/jobs/dispatched", get(board::get_dispatched_jobs))
+        .route("/board/jobs/decisions", get(board::get_dispatch_decisions))
         .route("/board/jobs/pending", get(board::get_pending_jobs))
         .route("/board/jobs/expensive", get(board::get_expensive_jobs))
         .route(

--- a/backend/gradient-web/tests/forge_hooks.rs
+++ b/backend/gradient-web/tests/forge_hooks.rs
@@ -142,6 +142,22 @@ const GITEA_PUSH_BRANCH_BODY: &str = r#"{
     }
 }"#;
 
+// Gitea's "Test Delivery" button (and real branch deletions) send a push with
+// an all-zero `after` SHA; see issue #428.
+const GITEA_TEST_WEBHOOK_BODY: &str = r#"{
+    "ref": "refs/heads/master",
+    "before": "0000000000000000000000000000000000000000",
+    "after": "0000000000000000000000000000000000000000",
+    "commits": [
+        { "id": "0000000000000000000000000000000000000000", "message": "This is a fake commit", "verification": null, "added": null, "removed": null, "modified": null }
+    ],
+    "head_commit": { "id": "0000000000000000000000000000000000000000", "message": "This is a fake commit", "verification": null },
+    "repository": {
+        "clone_url": "https://gitea.example.com/test-org/repo",
+        "ssh_url": "git@gitea.example.com:test-org/repo.git"
+    }
+}"#;
+
 const GITHUB_PUSH_BODY: &str = r#"{
     "ref": "refs/heads/main",
     "after": "abcdef0123456789abcdef0123456789abcdef01",
@@ -476,6 +492,53 @@ async fn forge_webhook_push_fires_trigger_inner() {
     assert_eq!(queued.len(), 1);
     assert_eq!(queued[0]["project_name"], "test-project");
     assert_eq!(queued[0]["organization"], "test-org");
+    assert!(msg["skipped"].as_array().unwrap().is_empty());
+}
+
+// ── Gitea test webhook / branch deletion (all-zero SHA) → 200 no-op (#428) ────
+
+#[test]
+fn forge_webhook_test_ping_zero_sha_is_ok_noop() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async { forge_webhook_test_ping_zero_sha_is_ok_noop_inner().await });
+}
+
+async fn forge_webhook_test_ping_zero_sha_is_ok_noop_inner() {
+    let plaintext_secret = "test-secret-plaintext";
+    let crypt_path = temp_secret_file("this-is-a-32-byte-crypt-key!!!!"); // 32 bytes
+    let ciphertext = encrypt_webhook_secret(&crypt_path, plaintext_secret).expect("encrypt");
+
+    // Signature verification needs the org + integration rows; the all-zero push
+    // short-circuits before any trigger/project lookup, so no further rows.
+    let db = MockDatabase::new(DatabaseBackend::Postgres)
+        .append_query_results([vec![org_row("test-org")]])
+        .append_query_results([vec![integration_row(&ciphertext)]])
+        .into_connection();
+
+    let state = make_state(db, Some(crypt_path), None);
+    let router = create_router(state);
+    let server = TestServer::new(router);
+
+    let body = GITEA_TEST_WEBHOOK_BODY.as_bytes();
+    let sig = gitea_signature(plaintext_secret, body);
+
+    let response = server
+        .post("/api/v1/hooks/gitea/test-org/my-hook")
+        .add_header("X-Gitea-Event", "push")
+        .add_header("X-Gitea-Signature", &sig)
+        .bytes(body.into())
+        .await;
+
+    response.assert_status_ok();
+    let json: Value = response.json();
+    assert_eq!(json["error"], false);
+    let msg = &json["message"];
+    assert_eq!(msg["event"], "push");
+    assert_eq!(msg["projects_scanned"], 0);
+    assert!(msg["queued"].as_array().unwrap().is_empty());
     assert!(msg["skipped"].as_array().unwrap().is_empty());
 }
 

--- a/backend/gradient-worker/src/executor/eval.rs
+++ b/backend/gradient-worker/src/executor/eval.rs
@@ -41,6 +41,20 @@ fn is_aborted(abort: &mut watch::Receiver<bool>) -> bool {
     *abort.borrow_and_update()
 }
 
+/// The set of attr paths the user requested explicitly: patterns with no
+/// `*`/`#` wildcard segment (and not an exclusion). A drvPath-resolution
+/// failure on one of these is a genuine error; failures on wildcard-expanded
+/// attrs are skipped, since a wildcard spans attrs that aren't derivations.
+fn explicit_attr_set(wildcards: &[String]) -> HashSet<String> {
+    wildcards
+        .iter()
+        .filter_map(|w| {
+            let (exclude, segs) = crate::nix::wildcard_walk::parse_pattern(w);
+            (!exclude && !segs.iter().any(|s| s == "*" || s == "#")).then(|| segs.join("."))
+        })
+        .collect()
+}
+
 /// How many `.drv` files to read+parse concurrently inside a single BFS wave.
 /// Reading a `.drv` is async filesystem IO, so the sequential walk would only
 /// keep one in-flight read at a time and bottleneck on round-trip latency.
@@ -754,14 +768,22 @@ pub async fn evaluate_derivations_with(
         };
     warnings.extend(resolve_warnings);
 
+    // An attr the user pinpointed exactly (no `*`/`#`) must surface a resolution
+    // failure; one that only matched a wildcard is silently skipped - a wildcard
+    // legitimately spans attrs that aren't buildable derivations (#419).
+    let explicit = explicit_attr_set(&job.wildcards);
+
     let mut root_drvs: Vec<(String, String)> = Vec::new();
     let mut errors: Vec<String> = Vec::new();
     for (attr, result) in resolved {
         match result {
             Ok((drv_path, _refs)) => root_drvs.push((attr, drv_path)),
-            Err(e) => {
-                warn!(attr, error = %e, "failed to resolve attr; skipping");
+            Err(e) if explicit.contains(&attr) => {
+                warn!(attr, error = %e, "failed to resolve explicitly requested attr");
                 errors.push(format!("failed to resolve {attr}: {e}"));
+            }
+            Err(e) => {
+                debug!(attr, error = %e, "skipping wildcard attr with no resolvable derivation");
             }
         }
     }
@@ -839,6 +861,22 @@ mod tests {
     fn never_abort() -> watch::Receiver<bool> {
         let (_tx, rx) = watch::channel(false);
         rx
+    }
+
+    #[test]
+    fn explicit_attr_set_keeps_only_wildcard_free_includes() {
+        let set = explicit_attr_set(&[
+            "packages.x86_64-linux.hello".into(),
+            "packages.x86_64-linux.#".into(),
+            "packages.x86_64-linux.*".into(),
+            "!packages.x86_64-linux.broken".into(),
+            "checks.\"py.3\".unit".into(),
+        ]);
+
+        assert!(set.contains("packages.x86_64-linux.hello"));
+        assert!(set.contains("checks.py.3.unit"), "quoted dots collapse to the discovered path form");
+        assert!(!set.contains("packages.x86_64-linux.broken"), "exclusions are not explicit requests");
+        assert_eq!(set.len(), 2, "wildcard patterns contribute nothing");
     }
 
     fn setup_from_fixture(

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -6062,6 +6062,28 @@ paths:
                   other_running:
                     type: integer
 
+  /board/jobs/decisions:
+    get:
+      tags: [board]
+      summary: Recent dispatch decisions (all candidate scores)
+      description: >
+        Bounded ring of the most recent dispatch decisions, each with every
+        scored candidate including the rejected/negative ones the dispatcher
+        passed over. For tuning scoring rules. Superuser-only, as candidates
+        span all organizations.
+      operationId: getBoardDispatchDecisions
+      responses:
+        '200':
+          description: Recent dispatch decisions, most recent first
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DispatchDecision'
+        '403':
+          description: Caller is not a superuser
+
   /board/jobs/pending:
     get:
       tags: [board]
@@ -10218,6 +10240,31 @@ components:
         queued_at: { type: string, format: date-time }
         dependency_count: { type: integer }
         pname: { type: string, nullable: true }
+
+    DispatchDecisionCandidate:
+      type: object
+      description: One scored candidate weighed in a dispatch decision.
+      properties:
+        job_id: { type: string }
+        kind: { type: integer }
+        organization: { type: string, format: uuid }
+        build_id: { type: string, format: uuid, nullable: true }
+        evaluation_id: { type: string, format: uuid }
+        pname: { type: string, nullable: true }
+        score: { type: number }
+
+    DispatchDecision:
+      type: object
+      description: A recorded dispatch decision - the candidates a worker was scored against and which (if any) won.
+      properties:
+        at: { type: string, format: date-time }
+        worker_id: { type: string }
+        kind: { type: integer }
+        winner: { type: string, nullable: true }
+        candidates:
+          type: array
+          items:
+            $ref: '#/components/schemas/DispatchDecisionCandidate'
 
     # ── SCIM 2.0 ──────────────────────────────────────────────────────────────
 

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -5826,7 +5826,9 @@ paths:
 
         **Handled events:**
         - `push` / `pull_request` / `release` - trigger an evaluation on any project whose
-          repository URL matches the matching trigger.
+          repository URL matches the matching trigger. A `push` carrying an
+          all-zero `after` SHA (a branch/tag deletion or a forge "test" delivery)
+          is accepted as a `200` no-op rather than rejected.
         - `check_run` - the "Approve and Run" action clears a fork-PR approval gate.
         - `issue_comment` - `/gradient run` / `/gradient approve` maintainer commands.
         - `pull_request_review` - a maintainer's approving review clears a fork-PR approval gate.
@@ -5869,7 +5871,7 @@ paths:
                       message:
                         $ref: '#/components/schemas/WebhookResponse'
         '400':
-          description: Malformed payload or unsupported forge
+          description: Unparseable JSON payload or unsupported forge
         '401':
           description: Invalid webhook signature
         '404':
@@ -5919,6 +5921,9 @@ paths:
         `project_integration.inbound_integration` points at this row and whose
         repository URL matches the webhook payload's clone URL.
 
+        A push carrying an all-zero `after` SHA (a branch/tag deletion or a
+        forge "test" delivery) is accepted as a `200` no-op rather than rejected.
+
         This endpoint is unauthenticated (verified via forge-specific signature).
       operationId: forgeWebhook
       requestBody:
@@ -5941,7 +5946,7 @@ paths:
                       message:
                         $ref: '#/components/schemas/WebhookResponse'
         '400':
-          description: Malformed payload or unsupported forge
+          description: Unparseable JSON payload or unsupported forge
         '401':
           description: Invalid webhook signature
         '404':

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -73,6 +73,11 @@ A wildcard (`*`/`#`) legitimately spans attrs that aren't buildable derivations,
 - `backend/gradient-worker/src/executor/eval.rs`: `explicit_attr_set_keeps_only_wildcard_free_includes` asserts only wildcard-free, non-exclusion patterns count as explicit (quoted dots collapse to the discovered path form).
 - `backend/gradient-score/src/rules/fair_share.rs`: `idle_capacity_lifts_penalty` asserts a busy org is rationed when `idle_workers == 0` but not penalized when a worker is idle.
 
+The scheduler also keeps a bounded ring of recent dispatch decisions - every scored candidate, including the rejected/negative ones the dispatcher passed over - exposed at `GET /board/jobs/decisions` (superuser-only) and surfaced by a Live Jobs "incl. rejected" dropdown so operators can see all scores while tuning rules.
+
+- `backend/gradient-scheduler/src/jobs.rs`: `records_dispatch_decisions_including_rejected_candidates` asserts a worker that idles on a negative best score still records the decision with the rejected candidate and its negative score, and a later dispatch records a decision naming the winner.
+- `frontend/src/app/features/board/live-jobs/live-jobs.component.spec.ts`: the decision-scores spec asserts the "incl. rejected" scope flattens decisions to candidate rows, marking the winner and showing negative-scored, passed-over candidates.
+
 ## Bulk evaluation abort + dispatch race
 
 Aborting an evaluation now parks it as `Waiting` with `WaitingReason::Aborting` before touching its builds, then aborts all in-flight builds in a handful of set-based statements instead of one round-trip per build. The dispatcher's queue finder skips `Waiting` evaluations, so it stops handing out the aborting eval's builds; any build that already escaped to a worker is aborted when it reports started.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -3364,6 +3364,26 @@ Run with: `pnpm --dir frontend exec ng test --watch=false`
   retries'` - calling `dismissError()` resets `errorMessage()` to `null` and the
   banner disappears.
 
+## Flake `git+` scheme breaks repository polling (#427)
+
+A repository URL stored in its nix flake form (`git+https://host/org/repo.git`)
+passes validation but failed evaluation with `Git command failed: invalid
+argument port`. libgit2 registers no `git+https`/`git+http` transport, so it
+misroutes such URLs to SSH, whose scheme has no default port, and the connect
+aborts. The libgit2 polling paths (`ls_remote_head`, `commit_info`) now strip the
+`git+` prefix via `git::url::git_transport_url` before handing the URL to
+libgit2, mirroring what `parse_nix_git_url` already does for the SSH prefetch
+path. Bare schemes and SCP-style remotes pass through unchanged.
+
+Run with: `cargo test -p gradient-sources --lib git::tests::git_transport_url`
+
+- `git_transport_url_strips_git_plus_https` - `git+https://…/repo..git` →
+  `https://…/repo..git` (the exact URL from the issue).
+- `git_transport_url_strips_git_plus_http_and_ssh` - `git+http://` and
+  `git+ssh://` lose the prefix too.
+- `git_transport_url_passes_through_bare_schemes_and_scp` - `https://`, `git://`,
+  and `git@host:path` are returned verbatim.
+
 ## Source-IP allowlist (#282)
 
 ### Backend

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -3389,6 +3389,40 @@ Run with: `cargo test -p gradient-sources --lib git::tests::git_transport_url`
 - `git_transport_url_passes_through_bare_schemes_and_scp` - `https://`, `git://`,
   and `git@host:path` are returned verbatim.
 
+## Gitea test webhook rejected as malformed (#428)
+
+Gitea's "Test Delivery" button sends a push event with an all-zero `after` SHA
+(the same shape a real branch/tag deletion has). `decode_push_commit` returns
+`None` for that, and the endpoint conflated it with a genuinely unparseable
+payload, answering `400 malformed webhook payload` - which makes the forge mark
+the webhook as failing. Push parsing now returns a `PushOutcome`: `None` only for
+unparseable JSON (still `400`), `Ignored` for a well-formed but non-buildable
+delivery (all-zero SHA), and `Build` for a real push. The endpoint maps `Ignored`
+to a `200` empty `WebhookResponse` (`event: "push"`, no queued/skipped).
+
+### gradient-forge
+
+Run with: `cargo test -p gradient-forge --lib webhook`
+
+- `gitea_test_webhook_zero_sha_is_ignored_not_malformed` - the exact issue
+  payload parses to `Some(PushOutcome::Ignored)`, not `None`.
+- `github_branch_deletion_zero_sha_is_ignored` - a real branch deletion is also
+  a no-op, not an error.
+- `push_with_unparseable_json_is_malformed` - non-JSON and `{}` still yield
+  `None` (the `400` path).
+- `github_push_extracts_commit_subject_and_author`,
+  `github_push_without_head_commit_has_no_message`,
+  `gitlab_push_picks_commit_matching_after` - real pushes still parse to
+  `PushOutcome::Build` (updated for the new return type).
+
+### gradient-web
+
+Run with: `cargo test -p gradient-web --test forge_hooks`
+
+- `forge_webhook_test_ping_zero_sha_is_ok_noop` - posting the all-zero Gitea
+  push to `/hooks/gitea/{org}/{name}` (valid signature) returns `200` with an
+  empty `push` response and touches no trigger/project rows.
+
 ## Source-IP allowlist (#282)
 
 ### Backend

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -66,6 +66,13 @@ a banner when draining, and the button click calls `AdminService.setDraining(tru
 - `saturation_is_lenient_for_builtin_and_exempts_evals_and_no_metrics` - at `85%` CPU (between the two thresholds) a `builtin` fetch scores `0` while a real build scores `-1000`; eval jobs and workers reporting no metrics score `0` regardless of saturation.
 - `ram_prediction_exceeding_free_penalizes_and_stacks_with_saturation` - a build whose predicted peak RAM x1.1 exceeds free RAM scores `-1000`, `0` when it fits, and `-2000` when the worker is also saturated.
 
+## Wildcard attr tolerance + fair-share idle gate (#419)
+
+A wildcard (`*`/`#`) legitimately spans attrs that aren't buildable derivations, so a drvPath-resolution failure on a wildcard-matched attr is skipped silently; only an attr the user pinpointed exactly still surfaces the error. The `FairShareRule` penalty now applies only when every worker is busy, so a lone busy org is never penalized below the dispatcher's zero floor into leaving the cluster idle.
+
+- `backend/gradient-worker/src/executor/eval.rs`: `explicit_attr_set_keeps_only_wildcard_free_includes` asserts only wildcard-free, non-exclusion patterns count as explicit (quoted dots collapse to the discovered path form).
+- `backend/gradient-score/src/rules/fair_share.rs`: `idle_capacity_lifts_penalty` asserts a busy org is rationed when `idle_workers == 0` but not penalized when a worker is idle.
+
 ## Bulk evaluation abort + dispatch race
 
 Aborting an evaluation now parks it as `Waiting` with `WaitingReason::Aborting` before touching its builds, then aborts all in-flight builds in a handful of set-based statements instead of one round-trip per build. The dispatcher's queue finder skips `Waiting` evaluations, so it stops handing out the aborting eval's builds; any build that already escaped to a worker is aborted when it reports started.

--- a/frontend/src/app/core/services/board.service.ts
+++ b/frontend/src/app/core/services/board.service.ts
@@ -40,6 +40,24 @@ export interface PendingJobsResponse {
   other_pending: number;
 }
 
+export interface DecisionCandidateView {
+  job_id: string;
+  kind: number;
+  organization: string;
+  build_id: string | null;
+  evaluation_id: string;
+  pname: string | null;
+  score: number;
+}
+
+export interface DispatchDecisionView {
+  at: string;
+  worker_id: string;
+  kind: number;
+  winner: string | null;
+  candidates: DecisionCandidateView[];
+}
+
 export interface GradientCapabilities {
   core: boolean; federate: boolean; fetch: boolean; eval: boolean; build: boolean; cache: boolean;
 }
@@ -309,6 +327,12 @@ export class BoardService {
 
   getPendingJobs(): Observable<PendingJobsResponse> {
     return this.api.get<PendingJobsResponse>('board/jobs/pending');
+  }
+
+  /// Recent dispatch decisions with every candidate's score, including the
+  /// rejected/negative ones the dispatcher passed over (superuser-only).
+  getDispatchDecisions(): Observable<DispatchDecisionView[]> {
+    return this.api.get<DispatchDecisionView[]>('board/jobs/decisions');
   }
 
   getJob(id: string): Observable<DispatchedJobDetail> {

--- a/frontend/src/app/features/board/live-jobs/live-jobs.component.spec.ts
+++ b/frontend/src/app/features/board/live-jobs/live-jobs.component.spec.ts
@@ -98,6 +98,59 @@ describe('BoardLiveJobsComponent - dispatched pname column', () => {
   });
 });
 
+describe('BoardLiveJobsComponent - decision scores (#419)', () => {
+  beforeEach(() => sessionStorage.clear());
+
+  function setupDecisions(): ComponentFixture<BoardLiveJobsComponent> {
+    TestBed.configureTestingModule({
+      imports: [BoardLiveJobsComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: BoardService,
+          useValue: {
+            getDispatchedJobs: () => of({ jobs: [], other_running: 0 }),
+            getPendingJobs: () => of({ jobs: [], other_pending: 0 }),
+            getDispatchDecisions: () =>
+              of([
+                {
+                  at: '2026-06-08T00:00:00Z',
+                  worker_id: 'w1',
+                  kind: 1,
+                  winner: 'j1',
+                  candidates: [
+                    { job_id: 'j1', kind: 1, organization: 'o1', build_id: 'b1', evaluation_id: 'e1', pname: 'win', score: 12 },
+                    { job_id: 'j2', kind: 1, organization: 'o2', build_id: 'b2', evaluation_id: 'e2', pname: 'loser', score: -8 },
+                  ],
+                },
+              ]),
+          },
+        },
+        { provide: BoardLiveService, useValue: { connect: () => EMPTY } },
+      ],
+    });
+    const fixture = TestBed.createComponent(BoardLiveJobsComponent);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('surfaces rejected/negative candidate scores when scope is "incl. rejected"', () => {
+    const fixture = setupDecisions();
+    const cmp = fixture.componentInstance;
+    cmp.setScoreScope('all');
+    fixture.detectChanges();
+
+    const rows = cmp.decisionRows();
+    expect(rows.length).toBe(2);
+    expect(rows.some((r) => r.score < 0 && r.pname === 'loser' && !r.won)).toBe(true);
+    expect(rows.some((r) => r.pname === 'win' && r.won)).toBe(true);
+
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text).toContain('passed over');
+    expect(text).toContain('-8');
+  });
+});
+
 describe('BoardLiveJobsComponent - pending view toggle', () => {
   beforeEach(() => sessionStorage.clear());
 

--- a/frontend/src/app/features/board/live-jobs/live-jobs.component.ts
+++ b/frontend/src/app/features/board/live-jobs/live-jobs.component.ts
@@ -9,11 +9,21 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
 import { Subscription } from 'rxjs';
-import { BoardService, DispatchedJobSummary, PendingJobSummary } from '@core/services/board.service';
+import { BoardService, DispatchedJobSummary, DispatchDecisionView, PendingJobSummary } from '@core/services/board.service';
 import { BoardLiveService } from '@core/services/board-live.service';
 
 type KindFilter = 'all' | 'eval' | 'build';
 type StatusFilter = 'all' | 'pending' | 'dispatched';
+type ScoreScope = 'current' | 'all';
+
+interface DecisionRow {
+  at: string;
+  worker_id: string;
+  kind: number;
+  pname: string | null;
+  score: number;
+  won: boolean;
+}
 
 @Component({
   selector: 'app-board-live-jobs',
@@ -34,6 +44,12 @@ type StatusFilter = 'all' | 'pending' | 'dispatched';
       </div>
 
       <div class="filters">
+        <label>Scores
+          <select [ngModel]="scoreScope()" (ngModelChange)="setScoreScope($event)">
+            <option value="current">dispatched</option>
+            <option value="all">incl. rejected</option>
+          </select>
+        </label>
         <label>Type
           <select [ngModel]="kindFilter()" (ngModelChange)="kindFilter.set($event)">
             <option value="all">all</option>
@@ -56,25 +72,47 @@ type StatusFilter = 'all' | 'pending' | 'dispatched';
         </label>
       </div>
 
-      <table class="jobs">
-        <thead>
-          <tr><th>Kind</th><th>Worker</th><th>Derivation</th><th>Score</th><th>Dispatched</th><th></th></tr>
-        </thead>
-        <tbody>
-          @for (j of filteredJobs(); track j.id) {
-            <tr [class.live]="isLive(j)" [class.clickable]="canInspect(j)" (click)="inspect(j)">
-              <td>{{ j.kind === 1 ? 'build' : 'eval' }}</td>
-              <td class="mono">{{ j.worker_id }}</td>
-              <td class="mono">{{ j.pname ?? '-' }}</td>
-              <td>{{ j.score | number: '1.1-1' }}</td>
-              <td>{{ j.dispatched_at | date: 'HH:mm:ss' }}</td>
-              <td>{{ canInspect(j) ? '›' : '' }}</td>
-            </tr>
-          } @empty {
-            <tr><td colspan="6" class="muted">No matching dispatched jobs.</td></tr>
-          }
-        </tbody>
-      </table>
+      @if (scoreScope() === 'current') {
+        <table class="jobs">
+          <thead>
+            <tr><th>Kind</th><th>Worker</th><th>Derivation</th><th>Score</th><th>Dispatched</th><th></th></tr>
+          </thead>
+          <tbody>
+            @for (j of filteredJobs(); track j.id) {
+              <tr [class.live]="isLive(j)" [class.clickable]="canInspect(j)" (click)="inspect(j)">
+                <td>{{ j.kind === 1 ? 'build' : 'eval' }}</td>
+                <td class="mono">{{ j.worker_id }}</td>
+                <td class="mono">{{ j.pname ?? '-' }}</td>
+                <td>{{ j.score | number: '1.1-1' }}</td>
+                <td>{{ j.dispatched_at | date: 'HH:mm:ss' }}</td>
+                <td>{{ canInspect(j) ? '›' : '' }}</td>
+              </tr>
+            } @empty {
+              <tr><td colspan="6" class="muted">No matching dispatched jobs.</td></tr>
+            }
+          </tbody>
+        </table>
+      } @else {
+        <table class="jobs">
+          <thead>
+            <tr><th>Outcome</th><th>Kind</th><th>Worker</th><th>Derivation</th><th>Score</th><th>When</th></tr>
+          </thead>
+          <tbody>
+            @for (r of decisionRows(); track $index) {
+              <tr [class.negative]="r.score < 0">
+                <td>{{ r.won ? 'dispatched' : 'passed over' }}</td>
+                <td>{{ r.kind === 1 ? 'build' : 'eval' }}</td>
+                <td class="mono">{{ r.worker_id }}</td>
+                <td class="mono">{{ r.pname ?? '-' }}</td>
+                <td>{{ r.score | number: '1.1-1' }}</td>
+                <td>{{ r.at | date: 'HH:mm:ss' }}</td>
+              </tr>
+            } @empty {
+              <tr><td colspan="6" class="muted">No recent decisions (superuser-only).</td></tr>
+            }
+          </tbody>
+        </table>
+      }
     }
 
     @if (view() === 'pending') {
@@ -113,6 +151,7 @@ type StatusFilter = 'all' | 'pending' | 'dispatched';
       tbody tr.clickable { cursor: pointer; }
       tbody tr.clickable:hover { background: #2d333b; }
       tbody tr.live { opacity: 0.7; font-style: italic; }
+      tbody tr.negative td { color: #f0883e; }
       .mono { font-family: monospace; }
       .view-toggle { display: flex; gap: 0.5rem; margin-bottom: 1rem; }
       .view-toggle button { background: #21262d; color: #abb0b4; border: 1px solid #2d333b; border-radius: 6px; padding: 0.3rem 0.8rem; cursor: pointer; }
@@ -144,6 +183,9 @@ export class BoardLiveJobsComponent implements OnInit, OnDestroy {
   scoreMin = signal<number | null>(null);
   scoreMax = signal<number | null>(null);
 
+  scoreScope = signal<ScoreScope>('current');
+  decisions = signal<DispatchDecisionView[]>([]);
+
   constructor() {
     this.restoreState();
     effect(() => {
@@ -153,6 +195,7 @@ export class BoardLiveJobsComponent implements OnInit, OnDestroy {
         statusFilter: this.statusFilter(),
         scoreMin: this.scoreMin(),
         scoreMax: this.scoreMax(),
+        scoreScope: this.scoreScope(),
       };
       try {
         sessionStorage.setItem(BoardLiveJobsComponent.STATE_KEY, JSON.stringify(state));
@@ -179,9 +222,37 @@ export class BoardLiveJobsComponent implements OnInit, OnDestroy {
     });
   });
 
+  /// Recent decisions flattened to one row per candidate (incl. rejected and
+  /// negative scores), honoring the type/score filters above.
+  decisionRows = computed<DecisionRow[]>(() => {
+    const kind = this.kindFilter();
+    const min = this.scoreMin();
+    const max = this.scoreMax();
+    const rows: DecisionRow[] = [];
+    for (const d of this.decisions()) {
+      for (const c of d.candidates) {
+        if (kind === 'eval' && c.kind !== 0) continue;
+        if (kind === 'build' && c.kind !== 1) continue;
+        if (min !== null && c.score < min) continue;
+        if (max !== null && c.score > max) continue;
+        rows.push({
+          at: d.at,
+          worker_id: d.worker_id,
+          kind: c.kind,
+          pname: c.pname,
+          score: c.score,
+          won: d.winner === c.job_id,
+        });
+      }
+    }
+
+    return rows;
+  });
+
   ngOnInit(): void {
     this.loadDispatched();
     if (this.view() === 'pending') this.loadPending();
+    if (this.scoreScope() === 'all') this.loadDecisions();
     this.sub = this.live.connect().subscribe({
       next: (ev) => {
         if (ev.type === 'job_dispatched' && ev.organization) {
@@ -218,6 +289,18 @@ export class BoardLiveJobsComponent implements OnInit, OnDestroy {
     if (v === 'pending') this.loadPending();
   }
 
+  setScoreScope(scope: ScoreScope): void {
+    this.scoreScope.set(scope);
+    if (scope === 'all') this.loadDecisions();
+  }
+
+  private loadDecisions(): void {
+    this.board.getDispatchDecisions().subscribe({
+      next: (d) => this.decisions.set(d),
+      error: () => this.decisions.set([]),
+    });
+  }
+
   private loadDispatched(): void {
     this.board.getDispatchedJobs().subscribe((r) => {
       this.jobs.set(r.jobs);
@@ -246,6 +329,7 @@ export class BoardLiveJobsComponent implements OnInit, OnDestroy {
       if (s.statusFilter) this.statusFilter.set(s.statusFilter);
       this.scoreMin.set(s.scoreMin ?? null);
       this.scoreMax.set(s.scoreMax ?? null);
+      if (s.scoreScope) this.scoreScope.set(s.scoreScope);
     } catch {
       /* ignore malformed state */
     }


### PR DESCRIPTION
Fixes #419 (three parts), and bundles two local fixes (#427, #428).
Fixes #427
Fixes #428

**#419**
- **Wildcard drvPath**: an attr matched only by a `*`/`#` wildcard that has no `.drvPath` is skipped silently; only an attr the user pinpointed exactly still surfaces the resolution error.
- **FairShareRule**: the penalty now applies only when every worker is busy, so a lone busy org is never pushed below the dispatcher's zero floor into leaving the cluster idle.
- **Live Jobs all scores**: the scheduler keeps a bounded ring of recent dispatch decisions with every candidate's score (incl. rejected/negative), exposed at `GET /board/jobs/decisions` (superuser) and shown via a new "dispatched / incl. rejected" dropdown.

**Bundled**
- #427: strip the flake `git+` scheme before libgit2 repo polling.
- #428: accept all-zero-SHA push webhooks (deletion / test ping) as a 200 no-op.