### PR TITLE
web: fix: forge action Test button probes connectivity instead of posting a synthetic status

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2216,6 +2216,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "subtle",
+ "tokio",
  "tracing",
  "url",
 ]

--- a/backend/gradient-ci/src/actions/mod.rs
+++ b/backend/gradient-ci/src/actions/mod.rs
@@ -27,7 +27,7 @@ pub use crypto::{
 pub use executor::execute_action;
 pub use matchers::{FORGE_STATUS_EVENTS, forge_status_for_event, matches_event};
 pub use payload::forge_status_payload;
-pub use send::reporter_for_project;
+pub use send::{reporter_for_project, verify_forge_action};
 
 pub const MAX_BODY_BYTES: usize = 64 * 1024;
 

--- a/backend/gradient-ci/src/actions/send/forge_status.rs
+++ b/backend/gradient-ci/src/actions/send/forge_status.rs
@@ -59,6 +59,35 @@ pub(crate) async fn execute_forge_status_report(
     })
 }
 
+/// Non-mutating "Test" probe for the forge-integration actions
+/// (`ForgeStatusReport`, `OpenPr`): builds the reporter from the action's
+/// integration and confirms it can reach the project's repository. The regular
+/// synthetic test-fire posts a status/PR against placeholder owner/repo/sha,
+/// which every forge rejects, so connectivity-verify is the only test these
+/// actions can meaningfully pass.
+pub async fn verify_forge_action(
+    ctx: &CiContext,
+    action: &gradient_types::MProjectAction,
+    repository: &str,
+) -> Result<()> {
+    let integration_id = match serde_json::from_value::<ActionConfig>(action.config.clone())
+        .context("decoding action config")?
+    {
+        ActionConfig::ForgeStatusReport { integration_id }
+        | ActionConfig::OpenPr { integration_id, .. } => integration_id,
+        _ => anyhow::bail!("action does not use a forge integration"),
+    };
+
+    let (owner, repo) = crate::parse_owner_repo(repository)
+        .ok_or_else(|| anyhow!("could not parse owner/repo from {}", repository))?;
+    let reporter = build_reporter_for_integration(ctx, integration_id).await?;
+
+    reporter
+        .verify(&owner, &repo)
+        .await
+        .context("forge connectivity check failed")
+}
+
 /// Find the project's first active `ForgeStatusReport` action and build a
 /// `CiReporter` from its integration. Used by the PR-approval trust probe to
 /// reuse the same forge credentials Actions already use for status reporting.

--- a/backend/gradient-ci/src/actions/send/mod.rs
+++ b/backend/gradient-ci/src/actions/send/mod.rs
@@ -16,4 +16,4 @@ pub(crate) use forge_status::execute_forge_status_report;
 pub(crate) use mail::execute_send_mail;
 pub(crate) use open_pr::execute_open_pr;
 pub(crate) use web_request::execute_send_web_request;
-pub use forge_status::reporter_for_project;
+pub use forge_status::{reporter_for_project, verify_forge_action};

--- a/backend/gradient-forge/Cargo.toml
+++ b/backend/gradient-forge/Cargo.toml
@@ -35,3 +35,6 @@ sha2        = { workspace = true }
 subtle      = { workspace = true }
 tracing     = { workspace = true }
 url         = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/backend/gradient-forge/src/reporter.rs
+++ b/backend/gradient-forge/src/reporter.rs
@@ -283,6 +283,15 @@ pub trait CiReporter: Send + Sync + std::fmt::Debug + 'static {
     ) -> Result<()> {
         Ok(())
     }
+
+    /// Non-mutating credential + connectivity probe behind the Actions "Test"
+    /// button. Confirms this reporter's token / App installation can reach
+    /// `owner/repo` without writing any status or check run. The default impl
+    /// reads the repository's default branch - an authenticated GET every real
+    /// reporter implements and that any status/PR token can perform.
+    async fn verify(&self, owner: &str, repo: &str) -> Result<()> {
+        self.default_branch(owner, repo).await.map(|_| ())
+    }
 }
 
 // ── NoopCiReporter ────────────────────────────────────────────────────────────
@@ -2360,6 +2369,56 @@ mod tests {
             url,
             "https://gitea.example.com/api/v1/repos/octo/demo/issues/42/comments"
         );
+    }
+
+    // ── verify (Test button) probe ───────────────────────────────────────────
+
+    #[derive(Debug, Default)]
+    struct ProbeReporter {
+        reported: std::sync::atomic::AtomicBool,
+        branch_reads: std::sync::atomic::AtomicUsize,
+        unreachable: bool,
+    }
+
+    #[async_trait]
+    impl CiReporter for ProbeReporter {
+        async fn report(&self, _report: &CiReport) -> Result<Option<i64>> {
+            self.reported
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok(None)
+        }
+
+        async fn default_branch(&self, _owner: &str, _repo: &str) -> Result<String> {
+            self.branch_reads
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if self.unreachable {
+                anyhow::bail!("forge unreachable");
+            }
+
+            Ok("main".into())
+        }
+    }
+
+    #[tokio::test]
+    async fn verify_reads_repo_without_reporting() {
+        use std::sync::atomic::Ordering::SeqCst;
+
+        let ok = ProbeReporter::default();
+        ok.verify("acme", "widgets")
+            .await
+            .expect("verify passes when the repo is reachable");
+        assert_eq!(ok.branch_reads.load(SeqCst), 1);
+        assert!(
+            !ok.reported.load(SeqCst),
+            "verify must never post a status to the forge"
+        );
+
+        let down = ProbeReporter {
+            unreachable: true,
+            ..Default::default()
+        };
+        let err = down.verify("acme", "widgets").await.unwrap_err();
+        assert!(err.to_string().contains("forge unreachable"));
     }
 
     #[test]

--- a/backend/gradient-web/src/endpoints/projects/actions.rs
+++ b/backend/gradient-web/src/endpoints/projects/actions.rs
@@ -537,16 +537,25 @@ pub async fn test_action(
         .or_not_found("Action")?;
 
     let action_type = ActionType::from_i16(action.action_type).unwrap_or(ActionType::SendMail);
-    let event = match action_type {
-        ActionType::ForgeStatusReport | ActionType::OpenPr => "build.completed".to_string(),
-        _ => action
-            .events
-            .as_array()
-            .and_then(|a| a.first())
-            .and_then(|v| v.as_str())
-            .unwrap_or("evaluation.completed")
-            .to_string(),
-    };
+
+    // Forge-integration actions can't be test-fired against a synthetic commit
+    // (the forge rejects the placeholder owner/repo/sha); probe the
+    // integration's connectivity to the project repo instead.
+    if matches!(action_type, ActionType::ForgeStatusReport | ActionType::OpenPr) {
+        gradient_ci::actions::verify_forge_action(&state.ci(), &action, &proj.repository)
+            .await
+            .map_err(|e| WebError::internal(format!("test fire failed: {}", e)))?;
+
+        return Ok(ok_json(serde_json::Value::Null));
+    }
+
+    let event = action
+        .events
+        .as_array()
+        .and_then(|a| a.first())
+        .and_then(|v| v.as_str())
+        .unwrap_or("evaluation.completed")
+        .to_string();
 
     let now = chrono::Utc::now();
     let payload = serde_json::json!({
@@ -555,11 +564,7 @@ pub async fn test_action(
         "org": organization,
         "project": project,
         "id": "00000000-0000-0000-0000-000000000000",
-        "status": match action_type {
-            ActionType::ForgeStatusReport => "success",
-            ActionType::OpenPr => "opened",
-            _ => "ok",
-        },
+        "status": "ok",
         "time": now.to_rfc3339(),
         "link": format!("https://gradient.example/projects/{}/{}", organization, project),
         "owner": "gradient-test",

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -2144,7 +2144,11 @@ paths:
       tags: [actions]
       summary: Fire action now (synthetic test)
       operationId: testProjectAction
-      description: Fires the action immediately with a synthetic test event, bypassing event matching.
+      description: >-
+        Fires the action immediately with a synthetic test event, bypassing event matching.
+        Forge-integration actions (`forge_status_report`, `open_pr`) instead run a non-mutating
+        connectivity check against the project's repository, since a synthetic status/PR posted
+        against a placeholder commit is always rejected by the forge.
       responses:
         '200':
           description: Action fired

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -33,6 +33,15 @@ matcher keyed off a literal `github.com` substring and an org-name equals login
 fallback, so a `github:`-form project (and any org not named after the account)
 left `github_installation_id` unset.
 
+## Forge action "Test" button connectivity probe
+
+`backend/gradient-forge/src/reporter.rs`: `verify_reads_repo_without_reporting`
+asserts `CiReporter::verify` performs a non-mutating repo read (the default
+branch) and never calls `report`, and propagates a forge error when the repo is
+unreachable. This backs the Actions Test button, which now probes connectivity
+for `forge_status_report` / `open_pr` instead of posting a status against a
+placeholder commit (which the forge always rejects).
+
 ## Minor frontend issues (#401)
 
 `backend/gradient-web/src/endpoints/projects/auto_attach.rs`: `host_parsing_covers_url_shapes`,

--- a/docs/src/usage/actions.md
+++ b/docs/src/usage/actions.md
@@ -97,6 +97,8 @@ A run that targets a wildcard other than the project default - e.g. `/gradient r
 
 The integration must be `kind: outbound`. The forge type determines the API call format (Gitea, GitLab, GitHub App).
 
+The **Test** button does not post a synthetic status (a forge rejects a status against a placeholder commit); it runs a non-mutating connectivity check that confirms the integration's credentials can reach the project repository. The same applies to **Open PR**.
+
 ## Open PR
 
 Opens (or updates) a pull request that bumps the project's flake inputs, driven by a native `flake.lock` updater. Unlike the other actions it does not react to a project's ordinary runs: it fires on a verify-gate event (default `build.completed`) but only for `input_update` evaluations.


### PR DESCRIPTION
The Actions Test button fired a synthetic status against a placeholder repo/commit (`gradient-test/<project>` @ all-zeros SHA), which every forge rejects, so `forge_status_report` (and `open_pr`) always showed "Test failed". Forge-integration actions now run a non-mutating connectivity probe (`CiReporter::verify`, an authenticated repo read) against the project's real repository instead.