### PR TITLE
fix: umlaut slugs, build-request source NAR zstd + eval surfacing, fetch-by-SHA (#431, #435, #430)

### DIFF
--- a/backend/gradient-proto/src/handler/dispatch.rs
+++ b/backend/gradient-proto/src/handler/dispatch.rs
@@ -1089,7 +1089,6 @@ impl<'a> DispatchContext<'a> {
             .collect();
         let known = match self.scheduler.peer_id_for_job(&job_id).await {
             Some(org_id) => {
-                use gradient_entity::build::BuildStatus;
                 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 
                 // First: find derivations that exist for this org.
@@ -1103,28 +1102,31 @@ impl<'a> DispatchContext<'a> {
                 if candidates.is_empty() {
                     vec![]
                 } else {
-                    // Second: keep only those that have a Completed or Substituted build.
-                    // A derivation exists in the DB but has only Failed builds should
-                    // NOT be pruned - the worker must retry it.
+                    // Second: prune only derivations whose full output set is
+                    // recorded AND every output is in our cache. Pruning on build
+                    // status alone (a `Substituted` build is a belief, not a
+                    // stored NAR) stranded output-less / not-yet-cached
+                    // derivations as permanent `InputsUnavailable` dead-ends: the
+                    // BFS re-records the pruned node with no outputs every eval,
+                    // so its output path is never buildable or fetchable.
                     let drv_ids: Vec<DerivationId> = candidates.iter().map(|d| d.id).collect();
-                    let built: std::collections::HashSet<DerivationId> = EBuild::find()
-                        .filter(CBuild::Derivation.is_in(drv_ids))
-                        .filter(
-                            CBuild::Status
-                                .is_in(vec![BuildStatus::Completed, BuildStatus::Substituted]),
-                        )
+                    let mut output_counts: HashMap<DerivationId, (usize, usize)> = HashMap::new();
+                    for o in EDerivationOutput::find()
+                        .filter(CDerivationOutput::Derivation.is_in(drv_ids))
                         .all(&self.state.worker_db)
                         .await
                         .unwrap_or_default()
-                        .into_iter()
-                        .map(|b| b.derivation)
-                        .collect();
+                    {
+                        let entry = output_counts.entry(o.derivation).or_insert((0, 0));
+                        entry.0 += 1;
+                        if !o.is_cached {
+                            entry.1 += 1;
+                        }
+                    }
 
-                    candidates
-                        .into_iter()
-                        .filter(|d| built.contains(&d.id))
-                        .map(|d| d.store_path())
-                        .collect()
+                    let candidates: Vec<(DerivationId, String)> =
+                        candidates.into_iter().map(|d| (d.id, d.store_path())).collect();
+                    prunable_known_derivations(candidates, &output_counts)
                 }
             }
             None => {
@@ -1139,6 +1141,58 @@ impl<'a> DispatchContext<'a> {
         )
         .await
         .is_ok()
+    }
+}
+
+/// Decide which `(derivation_id, store_path)` candidates the eval BFS may prune.
+///
+/// A derivation is safe to prune (skip subtree traversal) only when the server
+/// holds its complete output set AND every output is in our cache, per
+/// `output_counts: id -> (total_outputs, uncached_outputs)`. An output-less or
+/// not-yet-cached derivation must keep being walked so its outputs get recorded
+/// and a build is scheduled - otherwise it is stranded as a permanent
+/// `InputsUnavailable` dead-end.
+fn prunable_known_derivations(
+    candidates: Vec<(DerivationId, String)>,
+    output_counts: &HashMap<DerivationId, (usize, usize)>,
+) -> Vec<String> {
+    candidates
+        .into_iter()
+        .filter(|(id, _)| {
+            let (total, uncached) = output_counts.get(id).copied().unwrap_or((0, 0));
+            total > 0 && uncached == 0
+        })
+        .map(|(_, store_path)| store_path)
+        .collect()
+}
+
+#[cfg(test)]
+mod prunable_known_derivations_tests {
+    use super::prunable_known_derivations;
+    use gradient_types::ids::DerivationId;
+    use std::collections::HashMap;
+
+    #[test]
+    fn prunes_only_fully_recorded_and_cached_derivations() {
+        let cached = DerivationId::now_v7();
+        let uncached = DerivationId::now_v7();
+        let output_less = DerivationId::now_v7();
+        let unknown = DerivationId::now_v7();
+
+        let candidates = vec![
+            (cached, "/nix/store/aaa-cached".to_string()),
+            (uncached, "/nix/store/bbb-uncached".to_string()),
+            (output_less, "/nix/store/ccc-output-less".to_string()),
+            (unknown, "/nix/store/ddd-unknown".to_string()),
+        ];
+        let mut counts = HashMap::new();
+        counts.insert(cached, (2usize, 0usize)); // 2 outputs, all cached
+        counts.insert(uncached, (1usize, 1usize)); // 1 output, not cached
+        counts.insert(output_less, (0usize, 0usize)); // recorded drv, no outputs
+        // `unknown` absent from the map entirely.
+
+        let prunable = prunable_known_derivations(candidates, &counts);
+        assert_eq!(prunable, vec!["/nix/store/aaa-cached".to_string()]);
     }
 }
 

--- a/backend/gradient-scheduler/src/jobs.rs
+++ b/backend/gradient-scheduler/src/jobs.rs
@@ -8,7 +8,9 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 
-use gradient_types::ids::{BuildId, CommitId, EvaluationId, OrganizationId, ProjectId};
+use gradient_types::ids::{
+    BuildId, CommitId, DispatchedJobId, EvaluationId, OrganizationId, ProjectId,
+};
 use gradient_types::proto::{
     BuildJob, CandidateScore, FlakeJob, FlakeSource, FlakeTask, Job, JobCandidate, JobKind,
     RequiredPath,
@@ -258,6 +260,14 @@ pub struct DispatchRecord {
     pub build_context: serde_json::Value,
 }
 
+/// Per-candidate scoring result computed once and reused for both the decision
+/// ring and (for the winner) the persisted `dispatched_job` record.
+struct ScoredCandidate {
+    total: f64,
+    score_breakdown: serde_json::Value,
+    job_context: serde_json::Value,
+}
+
 /// Returns true when the worker can execute `job`: a flake job that fetches
 /// from a repository (carries `FetchFlake`) needs the `fetch` capability; a
 /// build job needs matching architecture/features. If `caps` is `None`,
@@ -305,6 +315,10 @@ pub struct PendingJobInfo {
 /// Jobs "all scores" view can surface negative scores for rule tuning (#419).
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct DecisionCandidate {
+    /// Ephemeral id used to serve this candidate's detail from the in-memory ring
+    /// via `GET /board/jobs/{id}` - never persisted, so it co-exists with the
+    /// `dispatched_job` UUID namespace without collision.
+    pub id: DispatchedJobId,
     pub job_id: String,
     pub kind: i16,
     pub organization: OrganizationId,
@@ -312,6 +326,13 @@ pub struct DecisionCandidate {
     pub evaluation_id: EvaluationId,
     pub pname: Option<String>,
     pub score: f64,
+    pub won: bool,
+    pub queued_at: chrono::NaiveDateTime,
+    /// Per-rule contributions and the per-candidate job context captured at
+    /// decision time, so the detail page renders a score breakdown even for a
+    /// candidate that was passed over and never reached `dispatched_job`.
+    pub score_breakdown: serde_json::Value,
+    pub job_context: serde_json::Value,
 }
 
 /// A recorded dispatch decision: the candidates a worker was scored against and
@@ -322,7 +343,32 @@ pub struct DispatchDecision {
     pub worker_id: String,
     pub kind: i16,
     pub winner: Option<String>,
+    /// Worker and instance context are identical for every candidate in one
+    /// decision, so they are stored once here rather than per candidate.
+    pub worker_context: serde_json::Value,
+    pub instance_context: serde_json::Value,
     pub candidates: Vec<DecisionCandidate>,
+}
+
+/// Owned snapshot reconstructing one candidate's job detail from the decision
+/// ring, served by `GET /board/jobs/{id}` when the id is an ephemeral candidate.
+#[derive(Debug, Clone)]
+pub struct CandidateDetail {
+    pub id: DispatchedJobId,
+    pub kind: i16,
+    pub organization: OrganizationId,
+    pub build_id: Option<BuildId>,
+    pub evaluation_id: EvaluationId,
+    pub pname: Option<String>,
+    pub score: f64,
+    pub won: bool,
+    pub worker_id: String,
+    pub scored_at: chrono::NaiveDateTime,
+    pub queued_at: chrono::NaiveDateTime,
+    pub score_breakdown: serde_json::Value,
+    pub worker_context: serde_json::Value,
+    pub job_context: serde_json::Value,
+    pub instance_context: serde_json::Value,
 }
 
 /// How many dispatch decisions to retain, and how many candidates per decision.
@@ -411,6 +457,34 @@ impl JobTracker {
         self.decisions.iter().rev().cloned().collect()
     }
 
+    /// Reconstruct a candidate's job detail from the ring by its ephemeral id,
+    /// most-recent decision first. `None` once the decision has been evicted.
+    pub fn candidate_detail(&self, id: DispatchedJobId) -> Option<CandidateDetail> {
+        for d in self.decisions.iter().rev() {
+            if let Some(c) = d.candidates.iter().find(|c| c.id == id) {
+                return Some(CandidateDetail {
+                    id: c.id,
+                    kind: c.kind,
+                    organization: c.organization,
+                    build_id: c.build_id,
+                    evaluation_id: c.evaluation_id,
+                    pname: c.pname.clone(),
+                    score: c.score,
+                    won: c.won,
+                    worker_id: d.worker_id.clone(),
+                    scored_at: d.at,
+                    queued_at: c.queued_at,
+                    score_breakdown: c.score_breakdown.clone(),
+                    worker_context: d.worker_context.clone(),
+                    job_context: c.job_context.clone(),
+                    instance_context: d.instance_context.clone(),
+                });
+            }
+        }
+
+        None
+    }
+
     /// Assign the best pending job matching `kind` for `peer_id`.
     ///
     /// Each eligible candidate is scored by `policy`.  The job with the
@@ -466,7 +540,11 @@ impl JobTracker {
             (total_work > 0.0).then(|| (org_work.get(&peer).copied().unwrap_or(0.0) / total_work) as f32)
         };
 
-        let score_of = |id: &str, job: &PendingJob| -> f64 {
+        // Per-candidate detailed score, computed once and reused for both the
+        // decision ring and the winner's persisted record. `score_detailed` is
+        // the same rule loop as `score` plus a small per-rule map, so capturing
+        // every candidate's breakdown is essentially free.
+        let score_of = |id: &str, job: &PendingJob| -> ScoredCandidate {
             let s = worker_scores.as_ref().and_then(|ws| ws.get(id));
             let closure_size = match job {
                 PendingJob::Build(b) => b.closure_size,
@@ -505,10 +583,17 @@ impl JobTracker {
                 org_work_share: org_work_share(job.peer_id()),
                 rescore_count: job.rescore_count(),
             };
-            policy.score(&ctx, worker_ctx, instance)
+            let breakdown = policy.score_detailed(&ctx, worker_ctx, instance);
+            ScoredCandidate {
+                total: breakdown.total,
+                score_breakdown: serde_json::to_value(&breakdown)
+                    .unwrap_or(serde_json::Value::Null),
+                job_context: serde_json::to_value(crate::views::JobContextView::new(&ctx, job))
+                    .unwrap_or(serde_json::Value::Null),
+            }
         };
 
-        let mut scored: Vec<(&String, f64)> = self
+        let mut scored: Vec<(&String, ScoredCandidate)> = self
             .pending
             .iter()
             .filter(|(_, j)| {
@@ -523,33 +608,56 @@ impl JobTracker {
             .map(|(id, job)| (id, score_of(id, job)))
             .collect();
         // Highest score first; tie-break on the smaller job_id for determinism.
-        scored.sort_by(|(id_a, sa), (id_b, sb)| {
-            sb.partial_cmp(sa)
+        scored.sort_by(|(id_a, a), (id_b, b)| {
+            b.total
+                .partial_cmp(&a.total)
                 .unwrap_or(std::cmp::Ordering::Equal)
                 .then_with(|| id_a.cmp(id_b))
         });
 
         // A negative best total means dispatching now is worse than idling this
         // round (e.g. a build still awaiting candidate scores); the worker waits.
-        let winner = scored.first().filter(|(_, s)| *s >= 0.0).map(|(id, _)| (*id).clone());
+        let winner = scored.first().filter(|(_, sc)| sc.total >= 0.0).map(|(id, _)| (*id).clone());
+
+        // Worker and instance context are identical for every candidate, so they
+        // are computed once and shared across the decision and the winner record.
+        let worker_context = serde_json::to_value(crate::views::WorkerContextView::new(
+            worker_ctx,
+            caps.map(|c| c.capabilities.clone()).unwrap_or_default(),
+        ))
+        .unwrap_or(serde_json::Value::Null);
+        let instance_context =
+            serde_json::to_value(instance).unwrap_or(serde_json::Value::Null);
 
         // Snapshot the decision (incl. rejected/negative candidates) for the Live
         // Jobs "all scores" view before the immutable borrow of `pending` ends.
         let candidates: Vec<DecisionCandidate> = scored
             .iter()
             .take(CANDIDATES_PER_DECISION)
-            .filter_map(|(id, s)| {
+            .filter_map(|(id, sc)| {
                 self.pending.get(*id).map(|job| DecisionCandidate {
+                    id: DispatchedJobId::now_v7(),
                     job_id: (*id).clone(),
                     kind: job.kind_disc(),
                     organization: job.peer_id(),
                     build_id: job.build_id(),
                     evaluation_id: job.evaluation_id(),
                     pname: job.pname(),
-                    score: *s,
+                    score: sc.total,
+                    won: winner.as_deref() == Some(id.as_str()),
+                    queued_at: job.queued_at(),
+                    score_breakdown: sc.score_breakdown.clone(),
+                    job_context: sc.job_context.clone(),
                 })
             })
             .collect();
+
+        // The winner's detailed snapshot, cloned out before the `scored`/`pending`
+        // borrows end so the owned record can outlive them.
+        let winner_detail = scored
+            .first()
+            .filter(|(_, sc)| sc.total >= 0.0)
+            .map(|(_, sc)| (sc.total, sc.score_breakdown.clone(), sc.job_context.clone()));
         drop(scored);
 
         if !candidates.is_empty() {
@@ -561,55 +669,19 @@ impl JobTracker {
                     JobKind::Build => 1,
                 },
                 winner: winner.clone(),
+                worker_context: worker_context.clone(),
+                instance_context: instance_context.clone(),
                 candidates,
             });
         }
 
         let job_id = winner?;
+        let (winner_score, winner_breakdown, winner_job_context) =
+            winner_detail.expect("a winner implies its scored detail exists");
 
-        // Recompute the winner's score with the per-rule breakdown, captured for
-        // the dispatched_job row. Owned snapshots so the borrow ends before the
-        // mutable assign_pending below.
+        // Reuse the winner's already-computed breakdown/context for the
+        // `dispatched_job` record; only build-specific fields are derived here.
         let dispatch_record = self.pending.get(&job_id).map(|job| {
-            let s = worker_scores.as_ref().and_then(|ws| ws.get(job_id.as_str()));
-            let closure_size = match job {
-                PendingJob::Build(b) => b.closure_size,
-                PendingJob::Eval(_) => None,
-            };
-            let history = match job {
-                PendingJob::Build(b) => b.history,
-                PendingJob::Eval(_) => gradient_score::HistoryPrediction::default(),
-            };
-            let closure = move || closure_size;
-            let history_provider = move || history;
-            let scored = match job {
-                PendingJob::Eval(e) => ScoredJob::new_eval(
-                    job_id.as_str(),
-                    job.peer_id(),
-                    e.job.tasks.contains(&FlakeTask::FetchFlake),
-                    e.history,
-                ),
-                PendingJob::Build(b) => ScoredJob::new_build(
-                    job_id.as_str(),
-                    job.peer_id(),
-                    b.architecture.as_str(),
-                    b.prefer_local_build,
-                    b.is_fixed_output,
-                    None,
-                    LazyProviders { closure_size: &closure, history: &history_provider },
-                ),
-            };
-            let ctx = JobContext {
-                job: &scored,
-                missing_count: s.map(|s| s.missing_count),
-                missing_nar_size: s.map(|s| s.missing_nar_size),
-                dependency_count: job.dependency_count(),
-                queued_at: job.queued_at(),
-                ready_at: job.ready_at(),
-                org_work_share: org_work_share(job.peer_id()),
-                rescore_count: job.rescore_count(),
-            };
-            let breakdown = policy.score_detailed(&ctx, worker_ctx, instance);
             let (kind_disc, build_id, project) = match job {
                 PendingJob::Build(b) => (1i16, Some(b.build_id), None),
                 PendingJob::Eval(e) => (0i16, None, e.project_id),
@@ -620,20 +692,13 @@ impl JobTracker {
                 evaluation_id: job.evaluation_id(),
                 organization: job.peer_id(),
                 project,
-                score: breakdown.total,
+                score: winner_score,
                 queued_at: job.queued_at(),
-                ready_at: ctx.ready_at,
-                score_breakdown: serde_json::to_value(&breakdown)
-                    .unwrap_or(serde_json::Value::Null),
-                worker_context: serde_json::to_value(crate::views::WorkerContextView::new(
-                    worker_ctx,
-                    caps.map(|c| c.capabilities.clone()).unwrap_or_default(),
-                ))
-                .unwrap_or(serde_json::Value::Null),
-                job_context: serde_json::to_value(crate::views::JobContextView::new(&ctx, job))
-                    .unwrap_or(serde_json::Value::Null),
-                instance_context: serde_json::to_value(instance)
-                    .unwrap_or(serde_json::Value::Null),
+                ready_at: job.ready_at(),
+                score_breakdown: winner_breakdown,
+                worker_context,
+                job_context: winner_job_context,
+                instance_context,
                 substitute: matches!(job, PendingJob::Build(b) if b.substitute),
                 build_context: match job {
                     PendingJob::Build(b) => serde_json::json!({
@@ -1224,6 +1289,37 @@ mod tests {
         let decisions = tracker.recent_decisions();
         assert_eq!(decisions.len(), 2, "most recent first");
         assert_eq!(decisions[0].winner.as_deref(), Some("j1"));
+    }
+
+    #[test]
+    fn candidates_carry_ephemeral_id_and_breakdown_for_detail_lookup() {
+        let mut tracker = JobTracker::new();
+        let peer = OrganizationId::now_v7();
+        tracker.add_pending("j1".into(), build_job(peer, vec![]));
+        let p = gradient_score::policy_by_name("simple");
+        let inst = gradient_score::InstanceContext::default();
+
+        tracker.take_best_of_kind("w1", None, None, &JobKind::Build, &*p, &inst);
+
+        let decisions = tracker.recent_decisions();
+        let cand = &decisions[0].candidates[0];
+        assert!(!cand.won, "an uncached candidate is passed over, not dispatched");
+        assert!(
+            cand.score_breakdown.get("rules").is_some(),
+            "candidate must carry its per-rule breakdown for the detail page"
+        );
+
+        // The ephemeral id resolves to a reconstructed detail served from RAM.
+        let detail = tracker
+            .candidate_detail(cand.id)
+            .expect("ephemeral id resolves to a candidate detail");
+        assert_eq!(detail.id, cand.id);
+        assert_eq!(detail.worker_id, "w1");
+        assert!(!detail.won);
+        assert!(detail.worker_context.is_object());
+
+        // An unknown id resolves to nothing rather than erroring.
+        assert!(tracker.candidate_detail(DispatchedJobId::now_v7()).is_none());
     }
 
     #[test]

--- a/backend/gradient-scheduler/src/lib.rs
+++ b/backend/gradient-scheduler/src/lib.rs
@@ -156,4 +156,11 @@ impl Scheduler {
     pub async fn recent_decisions(&self) -> Vec<jobs::DispatchDecision> {
         self.job_tracker.read().await.recent_decisions()
     }
+
+    pub async fn candidate_detail(
+        &self,
+        id: gradient_types::ids::DispatchedJobId,
+    ) -> Option<jobs::CandidateDetail> {
+        self.job_tracker.read().await.candidate_detail(id)
+    }
 }

--- a/backend/gradient-storage/src/log.rs
+++ b/backend/gradient-storage/src/log.rs
@@ -156,6 +156,10 @@ impl LogStorage for FileLogStorage {
                 .open(&path)
                 .await?;
             file.write_all(text.as_bytes()).await?;
+            // tokio buffers writes and submits the syscall to a blocking task;
+            // without flushing, the in-flight write is detached on drop and a
+            // read-after-write races it, observing an empty file.
+            file.flush().await?;
             Ok(())
         })
     }

--- a/backend/gradient-storage/src/source_nar.rs
+++ b/backend/gradient-storage/src/source_nar.rs
@@ -20,6 +20,10 @@ use harmonia_store_path::{StoreDir, StorePathName};
 use harmonia_utils_hash::{Algorithm, Hash, HashFormat as _, Sha256};
 use std::path::Path;
 
+/// zstd level for the stored source NAR; matches the worker's `NarPush`
+/// compression so every object under `nars/` is encoded the same way.
+const SOURCE_NAR_ZSTD_LEVEL: i32 = 6;
+
 pub struct SourceNar {
     pub store_path: String,
     pub store_hash: String,
@@ -27,6 +31,11 @@ pub struct SourceNar {
     pub nar_size: u64,
     pub nar_hash_sri: String,
     pub nar_hash_nix32: String,
+    /// zstd-compressed NAR as persisted in `NarStore` (which stores `.nar.zst`).
+    pub compressed_bytes: Vec<u8>,
+    /// Size and SHA-256 of `compressed_bytes`, i.e. the narinfo `FileSize`/`FileHash`.
+    pub file_size: u64,
+    pub file_hash_sri: String,
 }
 
 async fn nar_bytes_from_dir(staging_dir: &Path) -> Result<Vec<u8>> {
@@ -66,6 +75,11 @@ pub async fn source_nar_from_bytes(nar_bytes: Vec<u8>) -> Result<SourceNar> {
     let store_hash = store_path_obj.hash().to_string();
     let store_path = format!("/nix/store/{store_hash}-source");
 
+    let compressed_bytes = zstd::encode_all(std::io::Cursor::new(&nar_bytes), SOURCE_NAR_ZSTD_LEVEL)
+        .context("failed to zstd-compress source NAR")?;
+    let file_size = compressed_bytes.len() as u64;
+    let file_hash_sri = Sha256::digest(&compressed_bytes).as_sri().to_string();
+
     Ok(SourceNar {
         store_path,
         store_hash,
@@ -73,6 +87,9 @@ pub async fn source_nar_from_bytes(nar_bytes: Vec<u8>) -> Result<SourceNar> {
         nar_size,
         nar_hash_sri,
         nar_hash_nix32,
+        compressed_bytes,
+        file_size,
+        file_hash_sri,
     })
 }
 
@@ -115,6 +132,23 @@ mod tests {
         assert_eq!(from_dir.nar_hash_nix32, from_bytes.nar_hash_nix32);
         assert_eq!(from_dir.nar_hash_sri, from_bytes.nar_hash_sri);
         assert_eq!(from_dir.nar_size, from_bytes.nar_size);
+    }
+
+    #[tokio::test]
+    async fn compressed_bytes_round_trip_to_nar() {
+        let dir = make_staging_dir();
+        let nar = materialise_source_nar(dir.path()).await.unwrap();
+
+        assert_ne!(
+            nar.compressed_bytes, nar.nar_bytes,
+            "stored bytes must be compressed, not the raw NAR"
+        );
+        let decompressed = zstd::decode_all(std::io::Cursor::new(&nar.compressed_bytes)).unwrap();
+        assert_eq!(decompressed, nar.nar_bytes);
+
+        assert_eq!(nar.file_size, nar.compressed_bytes.len() as u64);
+        let expected_file_hash = Sha256::digest(&nar.compressed_bytes).as_sri().to_string();
+        assert_eq!(nar.file_hash_sri, expected_file_hash);
     }
 
     #[tokio::test]

--- a/backend/gradient-web/src/endpoints/board.rs
+++ b/backend/gradient-web/src/endpoints/board.rs
@@ -164,6 +164,9 @@ pub async fn get_dispatched_jobs(
 
 #[derive(Serialize)]
 pub struct DecisionCandidateView {
+    /// Ephemeral id navigable via `GET /board/jobs/{id}` to this candidate's
+    /// score-breakdown detail, served from the in-memory decision ring.
+    pub id: Uuid,
     pub job_id: String,
     pub kind: i16,
     pub organization: Uuid,
@@ -171,6 +174,7 @@ pub struct DecisionCandidateView {
     pub evaluation_id: Uuid,
     pub pname: Option<String>,
     pub score: f64,
+    pub won: bool,
 }
 
 #[derive(Serialize)]
@@ -204,6 +208,7 @@ pub async fn get_dispatch_decisions(
                 .candidates
                 .into_iter()
                 .map(|c| DecisionCandidateView {
+                    id: c.id.into(),
                     job_id: c.job_id,
                     kind: c.kind,
                     organization: c.organization.into(),
@@ -211,6 +216,7 @@ pub async fn get_dispatch_decisions(
                     evaluation_id: c.evaluation_id.into(),
                     pname: c.pname,
                     score: c.score,
+                    won: c.won,
                 })
                 .collect(),
         })
@@ -248,14 +254,55 @@ pub struct DispatchedJobDetail {
     pub instance_context: serde_json::Value,
     pub candidates: Option<serde_json::Value>,
     pub previous_attempts: Vec<AttemptSummary>,
+    /// True when this detail is an in-memory candidate the dispatcher scored but
+    /// passed over (never written to `dispatched_job`). The UI labels it as such.
+    pub passed_over: bool,
 }
 
 pub async fn get_dispatched_job(
     State(state): State<Arc<ServerState>>,
     Extension(MaybeUser(maybe_user)): Extension<MaybeUser>,
+    Extension(scheduler): Extension<Arc<Scheduler>>,
     Path(id): Path<Uuid>,
 ) -> WebResult<Json<BaseResponse<DispatchedJobDetail>>> {
     let scope = MetricsScope::resolve(&state.web_db, &maybe_user).await?;
+
+    // In-memory candidates (rejected and winning alike) carry an ephemeral id;
+    // look there first, then fall back to the persisted `dispatched_job` row.
+    if let Some(c) = scheduler.candidate_detail(DispatchedJobId::from(id)).await {
+        if !scope.allows(&Uuid::from(c.organization)) {
+            return Err(WebError::not_found("Job"));
+        }
+
+        let organization_name = gradient_entity::organization::Entity::find_by_id(c.organization)
+            .one(&state.web_db)
+            .await?
+            .map(|o| o.name)
+            .unwrap_or_default();
+
+        return Ok(ok_json(DispatchedJobDetail {
+            id: c.id.into(),
+            kind: c.kind,
+            organization: c.organization.into(),
+            organization_name,
+            worker_id: c.worker_id,
+            score: c.score,
+            queued_at: c.queued_at.and_utc().to_rfc3339(),
+            dispatched_at: c.scored_at.and_utc().to_rfc3339(),
+            finished_at: None,
+            build_id: c.build_id.map(Into::into),
+            evaluation_id: c.evaluation_id.into(),
+            pname: c.pname,
+            score_breakdown: c.score_breakdown,
+            worker_context: c.worker_context,
+            job_context: c.job_context,
+            instance_context: c.instance_context,
+            candidates: None,
+            previous_attempts: Vec::new(),
+            passed_over: !c.won,
+        }));
+    }
+
     let j = gradient_entity::dispatched_job::Entity::find_by_id(DispatchedJobId::from(id))
         .one(&state.web_db)
         .await?
@@ -331,6 +378,7 @@ pub async fn get_dispatched_job(
         instance_context: j.instance_context.unwrap_or(serde_json::Value::Null),
         candidates: if scope.is_all() { j.candidates } else { None },
         previous_attempts,
+        passed_over: false,
     }))
 }
 

--- a/backend/gradient-web/src/endpoints/build_requests/dispatch.rs
+++ b/backend/gradient-web/src/endpoints/build_requests/dispatch.rs
@@ -144,7 +144,7 @@ pub(super) async fn finalize_build_request(
 
     state
         .nar_storage
-        .put(&nar.store_hash, nar.nar_bytes.clone())
+        .put(&nar.store_hash, nar.compressed_bytes.clone())
         .await
         .map_err(|e| WebError::internal(format!("Failed to store source NAR: {}", e)))?;
 
@@ -263,16 +263,17 @@ async fn ensure_cached_path<C: ConnectionTrait>(
         return Ok(existing);
     }
 
-    let normalised_hash = normalize_nar_hash(&nar.nar_hash_sri);
+    let nar_hash = normalize_nar_hash(&nar.nar_hash_sri);
+    let file_hash = normalize_nar_hash(&nar.file_hash_sri);
     let row = MCachedPath {
         id: CachedPathId::now_v7(),
         store_path: nar.store_path.clone(),
         hash: nar.store_hash.clone(),
         package: "source".to_string(),
-        file_hash: Some(normalised_hash.clone()),
-        file_size: Some(nar.nar_size as i64),
+        file_hash: Some(file_hash),
+        file_size: Some(nar.file_size as i64),
         nar_size: Some(nar.nar_size as i64),
-        nar_hash: Some(normalised_hash),
+        nar_hash: Some(nar_hash),
         created_at: now(),
         ..Default::default()
     }

--- a/backend/gradient-web/src/endpoints/evals/query.rs
+++ b/backend/gradient-web/src/endpoints/evals/query.rs
@@ -50,6 +50,19 @@ pub async fn get_evaluation(
         .iter()
         .filter(|m| m.level == gradient_entity::evaluation_message::MessageLevel::Warning)
         .count() as u64;
+    let mut error_messages: Vec<&gradient_entity::evaluation_message::Model> = all_messages
+        .iter()
+        .filter(|m| m.level == gradient_entity::evaluation_message::MessageLevel::Error)
+        .collect();
+    error_messages.sort_by_key(|m| m.created_at);
+
+    let error = (!error_messages.is_empty()).then(|| {
+        error_messages
+            .iter()
+            .map(|m| m.message.as_str())
+            .collect::<Vec<_>>()
+            .join("\n")
+    });
 
     // Load entry points with their build statuses.
     let ep_rows = EEntryPoint::find()
@@ -134,8 +147,10 @@ pub async fn get_evaluation(
             previous: evaluation.previous,
             next: evaluation.next,
             created_at: evaluation.created_at,
+            updated_at: evaluation.updated_at,
             error_count,
             warning_count,
+            error,
             entry_points,
             trigger,
             triggered_by,

--- a/backend/gradient-web/src/endpoints/evals/types.rs
+++ b/backend/gradient-web/src/endpoints/evals/types.rs
@@ -53,8 +53,13 @@ pub struct EvaluationResponse {
     pub previous: Option<EvaluationId>,
     pub next: Option<EvaluationId>,
     pub created_at: chrono::NaiveDateTime,
+    pub updated_at: chrono::NaiveDateTime,
     pub error_count: u64,
     pub warning_count: u64,
+    /// Concatenated text of the evaluation's error-level messages, or `null`
+    /// when there are none. Lets clients surface the failure reason without a
+    /// second round-trip to the messages endpoint.
+    pub error: Option<String>,
     pub entry_points: Vec<EntryPointBrief>,
     /// `null` for manually-triggered evaluations (Web UI / API), populated for
     /// evaluations that fired from a project trigger (polling, schedule,

--- a/backend/gradient-worker/src/executor/fetch.rs
+++ b/backend/gradient-worker/src/executor/fetch.rs
@@ -411,9 +411,10 @@ async fn query_path_info(
     Ok(Vec::new())
 }
 
-fn clone_and_checkout(url: &str, commit: &str, ssh_key: Option<&str>) -> Result<String> {
-    let temp_dir = std::env::temp_dir().join(format!("gradient-fetch-{}", uuid::Uuid::now_v7()));
-
+/// `FetchOptions` that accept the remote certificate and authenticate with the
+/// SSH key when one is given. Returned by value so the same auth can serve both
+/// the initial clone and a fallback fetch-by-SHA.
+fn fetch_options_with_auth(ssh_key: Option<&str>) -> git2::FetchOptions<'static> {
     let mut callbacks = RemoteCallbacks::new();
     callbacks.certificate_check(|cert, _valid| Ok(gradient_sources::accept_cert(cert)));
 
@@ -426,18 +427,41 @@ fn clone_and_checkout(url: &str, commit: &str, ssh_key: Option<&str>) -> Result<
 
     let mut fo = git2::FetchOptions::new();
     fo.remote_callbacks(callbacks);
+    fo
+}
+
+fn clone_and_checkout(url: &str, commit: &str, ssh_key: Option<&str>) -> Result<String> {
+    let temp_dir = std::env::temp_dir().join(format!("gradient-fetch-{}", uuid::Uuid::now_v7()));
 
     let repo = git2::build::RepoBuilder::new()
-        .fetch_options(fo)
+        .fetch_options(fetch_options_with_auth(ssh_key))
         .clone(url, &temp_dir)
         .with_context(|| format!("failed to clone {url}"))?;
 
     let oid =
         git2::Oid::from_str(commit).with_context(|| format!("invalid commit SHA: {commit}"))?;
 
-    let git_commit = repo
-        .find_commit(oid)
-        .with_context(|| format!("commit {commit} not found in {url}"))?;
+    let git_commit = match repo.find_commit(oid) {
+        Ok(c) => c,
+        Err(_) => {
+            // A default clone only brings down commits reachable from the
+            // remote's advertised branch refs; a fork-PR head or a
+            // force-pushed commit can be absent. Fetch it directly by SHA and
+            // retry before giving up.
+            repo.find_remote("origin")
+                .context("failed to find origin remote")?
+                .fetch(&[commit], Some(&mut fetch_options_with_auth(ssh_key)), None)
+                .with_context(|| {
+                    format!(
+                        "commit {commit} not reachable in {url} (force-pushed, GC'd, or a fork PR ref)"
+                    )
+                })?;
+
+            repo.find_commit(oid).with_context(|| {
+                format!("commit {commit} still not found in {url} after fetching it directly")
+            })?
+        }
+    };
 
     let tree = git_commit.tree().context("failed to get commit tree")?;
 

--- a/cli/connector/src/evals.rs
+++ b/cli/connector/src/evals.rs
@@ -12,10 +12,14 @@ pub struct EvaluationResponse {
     pub commit: String,
     pub wildcard: String,
     pub status: String,
+    #[serde(default)]
     pub previous: Option<String>,
+    #[serde(default)]
     pub next: Option<String>,
     pub created_at: String,
+    #[serde(default)]
     pub updated_at: String,
+    #[serde(default)]
     pub error: Option<String>,
 }
 
@@ -166,5 +170,54 @@ impl EvalsApi<'_> {
             true,
         )?;
         http::decode(req.send().await?).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EvaluationResponse;
+
+    // Regression for #435: a build-request eval omits `updated_at`/`error`,
+    // which used to make `gradient watch`/`build` report "Unknown evaluation".
+    #[test]
+    fn deserializes_eval_without_updated_at_or_error() {
+        let body = r#"{
+            "id":"019ed787-8325-7441-9343-118e6285488e",
+            "project":"019ed787-8321-7703-ab8d-e79cc2da3d88",
+            "project_name":"build-request",
+            "repository":"/nix/store/abc-source",
+            "commit":"0000000000000000000000000000000000000000",
+            "wildcard":".#dig",
+            "status":"Queued",
+            "previous":null,
+            "next":null,
+            "created_at":"2026-06-17T21:40:42.917745",
+            "error_count":0,
+            "warning_count":0,
+            "entry_points":[]
+        }"#;
+        let eval: EvaluationResponse = serde_json::from_str(body).expect("decode");
+        assert_eq!(eval.status, "Queued");
+        assert!(eval.updated_at.is_empty());
+        assert!(eval.error.is_none());
+    }
+
+    #[test]
+    fn deserializes_eval_with_error_message() {
+        let body = r#"{
+            "id":"019ed787-8325-7441-9343-118e6285488e",
+            "repository":"/nix/store/abc-source",
+            "commit":"0000",
+            "wildcard":".#dig",
+            "status":"Failed",
+            "created_at":"2026-06-17T21:40:42.917745",
+            "updated_at":"2026-06-17T21:42:42.917745",
+            "error_count":1,
+            "warning_count":0,
+            "error":"prefetch import failed",
+            "entry_points":[]
+        }"#;
+        let eval: EvaluationResponse = serde_json::from_str(body).expect("decode");
+        assert_eq!(eval.error.as_deref(), Some("prefetch import failed"));
     }
 }

--- a/cli/src/commands/build.rs
+++ b/cli/src/commands/build.rs
@@ -8,7 +8,7 @@ use crate::config::*;
 use crate::input::client_from_config;
 use crate::output::{Output, to_exit_kind};
 use connector::build_requests::DispatchResponse;
-use connector::evals::{ArtefactTree, EntryPointArtefacts};
+use connector::evals::{ArtefactTree, EntryPointArtefacts, EvaluationResponse};
 use futures::StreamExt;
 use futures::pin_mut;
 #[cfg(not(feature = "nix"))]
@@ -146,9 +146,18 @@ pub async fn handle_build(
         return;
     }
 
-    let status = wait_for_terminal(&client, &dispatch.evaluation, out).await;
+    let eval = wait_for_terminal(&client, &dispatch.evaluation, out).await;
+    let status = eval.as_ref().map(|e| e.status.clone()).unwrap_or_default();
     if status != "Completed" {
         if !quiet {
+            if let Some(err) = eval
+                .as_ref()
+                .and_then(|e| e.error.as_deref())
+                .filter(|s| !s.is_empty())
+            {
+                out.human(format!("Evaluation error: {err}"));
+            }
+
             out.human(format!(
                 "Build did not complete (status: {status}); skipping result."
             ));
@@ -322,17 +331,22 @@ async fn dispatch_via_manifest(
 }
 
 /// Poll the evaluation until it reaches a terminal status, returning it.
-async fn wait_for_terminal(client: &connector::Client, eval_id: &str, out: Output) -> String {
+/// `None` means the poll failed (already reported to `out`).
+async fn wait_for_terminal(
+    client: &connector::Client,
+    eval_id: &str,
+    out: Output,
+) -> Option<EvaluationResponse> {
     loop {
         match client.evals().get(eval_id).await {
             Ok(e) => {
                 if matches!(e.status.as_str(), "Completed" | "Failed" | "Aborted") {
-                    return e.status;
+                    return Some(e);
                 }
             }
             Err(e) => {
                 out.progress(format!("Status poll failed: {}", e));
-                return String::new();
+                return None;
             }
         }
 

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -10215,6 +10215,9 @@ components:
           type: array
           description: All build attempts for the same build, ordered by creation time ascending.
           items: { $ref: '#/components/schemas/AttemptSummary' }
+        passed_over:
+          type: boolean
+          description: True when this detail is an in-memory candidate the dispatcher scored but passed over (never persisted); the UI labels it "Passed over".
 
     AttemptSummary:
       type: object
@@ -10256,6 +10259,10 @@ components:
       type: object
       description: One scored candidate weighed in a dispatch decision.
       properties:
+        id:
+          type: string
+          format: uuid
+          description: Ephemeral id navigable via GET /board/jobs/{id} to this candidate's score-breakdown detail, served from the in-memory decision ring.
         job_id: { type: string }
         kind: { type: integer }
         organization: { type: string, format: uuid }
@@ -10263,6 +10270,7 @@ components:
         evaluation_id: { type: string, format: uuid }
         pname: { type: string, nullable: true }
         score: { type: number }
+        won: { type: boolean, description: Whether this candidate won the decision and was dispatched. }
 
     DispatchDecision:
       type: object

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -8293,6 +8293,10 @@ components:
         warning_count:
           type: integer
           description: Number of warning-level messages recorded during evaluation
+        error:
+          type: string
+          nullable: true
+          description: Concatenated text of the evaluation's error-level messages, or null when there are none.
         created_at:
           type: string
           format: date-time

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -4504,3 +4504,16 @@ post-build `result`.
   needs a live git transport, so it is covered by CI/manual rather than a unit
   test; the worker now fetches the commit by SHA before failing with a clearer
   "not reachable (force-pushed, GC'd, or a fork PR ref)" message.
+
+## Clickable rejected jobs on the Live Jobs board
+
+Lets a passed-over candidate in the "incl. rejected" view open the job detail
+page with its score breakdown, served from the in-memory decision ring.
+
+- `backend/gradient-scheduler/src/jobs.rs::tests::candidates_carry_ephemeral_id_and_breakdown_for_detail_lookup`
+  - every scored candidate gets an ephemeral id and per-rule `score_breakdown`;
+  `JobTracker::candidate_detail(id)` reconstructs the detail (worker/instance
+  context shared per decision) and returns `None` for an unknown id.
+- The memory-first `GET /board/jobs/{id}` resolution (ring before DB) and the
+  frontend's clickable rows + "Passed over"/"Scored" labelling are exercised
+  end-to-end by the board E2E rather than a unit test.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -4484,3 +4484,23 @@ post-build `result`.
   `upload_source_nar_returns_dispatch`.
 - The `nix copy`/`result` substitution and the staged NAR pack are daemon/`nix`
   dependent and covered end-to-end by CI.
+
+## Slug umlauts, source NAR compression, CLI eval surfacing & fetch-by-SHA (#431, #435, #430)
+
+- `frontend/src/app/shared/text/slug.spec.ts` - `slugify` transliterates umlauts
+  (`NüschtOS` → `nuschtos`), expands `ß`→`ss`, strips other Latin diacritics, and
+  keeps the lowercase/hyphen/trim behaviour. Fixes #431 (`NüschtOS` → `n-schtos`).
+- `backend/gradient-storage/src/source_nar.rs::tests::compressed_bytes_round_trip_to_nar`
+  - the stored `compressed_bytes` zstd-decompress back to the raw NAR, and
+  `file_size`/`file_hash_sri` describe the compressed object. Fixes #435 "Zstd
+  decompress failed: Unknown frame descriptor" (source NAR was stored
+  uncompressed while the worker import expects `.nar.zst`).
+- `cli/connector/src/evals.rs::tests` - `deserializes_eval_without_updated_at_or_error`
+  and `deserializes_eval_with_error_message`: the CLI tolerates a server eval
+  payload that omits `updated_at`/`error` (the decode failure behind `gradient
+  watch` "Unknown evaluation" / `build` "api error (200)") and surfaces the
+  populated `error`.
+- #430 (fetch-by-SHA fallback for a commit not reachable from the cloned refs)
+  needs a live git transport, so it is covered by CI/manual rather than a unit
+  test; the worker now fetches the commit by SHA before failing with a clearer
+  "not reachable (force-pushed, GC'd, or a fork PR ref)" message.

--- a/frontend/src/app/core/services/board.service.ts
+++ b/frontend/src/app/core/services/board.service.ts
@@ -41,6 +41,7 @@ export interface PendingJobsResponse {
 }
 
 export interface DecisionCandidateView {
+  id: string;
   job_id: string;
   kind: number;
   organization: string;
@@ -48,6 +49,7 @@ export interface DecisionCandidateView {
   evaluation_id: string;
   pname: string | null;
   score: number;
+  won: boolean;
 }
 
 export interface DispatchDecisionView {
@@ -139,6 +141,7 @@ export interface DispatchedJobDetail extends DispatchedJobSummary {
     reason: number | null;
     created_at: string;
   }[];
+  passed_over: boolean;
 }
 
 export interface BoardWorker {

--- a/frontend/src/app/features/board/job-detail/job-detail.component.ts
+++ b/frontend/src/app/features/board/job-detail/job-detail.component.ts
@@ -41,7 +41,7 @@ interface RuleRow {
       <header class="head">
         <div>
           <span class="kind" [class.build]="j.kind === 1">{{ j.kind === 1 ? 'build' : 'eval' }}</span>
-          <h1>Dispatched job</h1>
+          <h1>{{ j.passed_over ? 'Passed over' : 'Dispatched job' }}</h1>
         </div>
         <div class="total">
           <span class="label">Total score</span>
@@ -60,7 +60,7 @@ interface RuleRow {
       <section class="timeline">
         <div class="step"><span class="label">Queued</span><span>{{ j.queued_at | date: 'medium' }}</span></div>
         <div class="step"><span class="label">Wait</span><span class="hl">{{ waitLabel() }}</span></div>
-        <div class="step"><span class="label">Dispatched</span><span>{{ j.dispatched_at | date: 'medium' }}</span></div>
+        <div class="step"><span class="label">{{ j.passed_over ? 'Scored' : 'Dispatched' }}</span><span>{{ j.dispatched_at | date: 'medium' }}</span></div>
         <div class="step"><span class="label">Current State</span><span class="hl">{{ currentState() }}</span></div>
       </section>
 

--- a/frontend/src/app/features/board/live-jobs/live-jobs.component.ts
+++ b/frontend/src/app/features/board/live-jobs/live-jobs.component.ts
@@ -17,6 +17,7 @@ type StatusFilter = 'all' | 'pending' | 'dispatched';
 type ScoreScope = 'current' | 'all';
 
 interface DecisionRow {
+  id: string;
   at: string;
   worker_id: string;
   kind: number;
@@ -95,20 +96,21 @@ interface DecisionRow {
       } @else {
         <table class="jobs">
           <thead>
-            <tr><th>Outcome</th><th>Kind</th><th>Worker</th><th>Derivation</th><th>Score</th><th>When</th></tr>
+            <tr><th>Outcome</th><th>Kind</th><th>Worker</th><th>Derivation</th><th>Score</th><th>When</th><th></th></tr>
           </thead>
           <tbody>
-            @for (r of decisionRows(); track $index) {
-              <tr [class.negative]="r.score < 0">
+            @for (r of decisionRows(); track r.id) {
+              <tr [class.negative]="r.score < 0" class="clickable" (click)="inspectDecision(r)">
                 <td>{{ r.won ? 'dispatched' : 'passed over' }}</td>
                 <td>{{ r.kind === 1 ? 'build' : 'eval' }}</td>
                 <td class="mono">{{ r.worker_id }}</td>
                 <td class="mono">{{ r.pname ?? '-' }}</td>
                 <td>{{ r.score | number: '1.1-1' }}</td>
                 <td>{{ r.at | date: 'HH:mm:ss' }}</td>
+                <td>›</td>
               </tr>
             } @empty {
-              <tr><td colspan="6" class="muted">No recent decisions (superuser-only).</td></tr>
+              <tr><td colspan="7" class="muted">No recent decisions (superuser-only).</td></tr>
             }
           </tbody>
         </table>
@@ -236,12 +238,13 @@ export class BoardLiveJobsComponent implements OnInit, OnDestroy {
         if (min !== null && c.score < min) continue;
         if (max !== null && c.score > max) continue;
         rows.push({
+          id: c.id,
           at: d.at,
           worker_id: d.worker_id,
           kind: c.kind,
           pname: c.pname,
           score: c.score,
-          won: d.winner === c.job_id,
+          won: c.won,
         });
       }
     }
@@ -353,5 +356,9 @@ export class BoardLiveJobsComponent implements OnInit, OnDestroy {
   inspect(j: DispatchedJobSummary): void {
     if (this.isLive(j)) return;
     this.router.navigate(['/board/jobs', j.id]);
+  }
+
+  inspectDecision(r: DecisionRow): void {
+    this.router.navigate(['/board/jobs', r.id]);
   }
 }

--- a/frontend/src/app/features/caches/cache-list/cache-list.component.ts
+++ b/frontend/src/app/features/caches/cache-list/cache-list.component.ts
@@ -18,6 +18,7 @@ import { CachesService } from '@core/services/caches.service';
 import { AuthService } from '@core/services/auth.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { EmptyStateComponent } from '@shared/components/empty-state/empty-state.component';
+import { slugify } from '@shared/text';
 import { Cache } from '@core/models';
 
 @Component({
@@ -124,7 +125,7 @@ export class CacheListComponent implements OnInit, OnDestroy {
 
   onCacheDisplayNameChange(value: string): void {
     if (!this.cacheNameEditedByUser) {
-      const slug = this.toSlug(value);
+      const slug = slugify(value);
       this.newCache.name = slug;
       this.onCacheNameChange(slug);
     }
@@ -132,13 +133,6 @@ export class CacheListComponent implements OnInit, OnDestroy {
 
   onCacheNameUserInput(): void {
     this.cacheNameEditedByUser = true;
-  }
-
-  private toSlug(text: string): string {
-    return text
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-+|-+$/g, '');
   }
 
   onCacheNameChange(name: string): void {

--- a/frontend/src/app/features/organizations/organization-detail/organization-detail.component.ts
+++ b/frontend/src/app/features/organizations/organization-detail/organization-detail.component.ts
@@ -20,6 +20,7 @@ import { ProjectsService } from '@core/services/projects.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { EmptyStateComponent } from '@shared/components/empty-state/empty-state.component';
 import { LabelHelpComponent } from '@shared/components/form';
+import { slugify } from '@shared/text';
 import { Organization, Project, EvaluationStatus } from '@core/models';
 
 const RESERVED_PROJECT_NAMES = ['build-request'];
@@ -117,7 +118,7 @@ export class OrganizationDetailComponent implements OnInit, OnDestroy {
 
   onProjectDisplayNameChange(value: string): void {
     if (!this.projectNameEditedByUser) {
-      const slug = this.toSlug(value);
+      const slug = slugify(value);
       this.newProject.name = slug;
       this.onProjectNameChange(slug);
     }
@@ -125,13 +126,6 @@ export class OrganizationDetailComponent implements OnInit, OnDestroy {
 
   onProjectNameUserInput(): void {
     this.projectNameEditedByUser = true;
-  }
-
-  private toSlug(text: string): string {
-    return text
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-+|-+$/g, '');
   }
 
   onProjectNameChange(name: string): void {

--- a/frontend/src/app/features/organizations/organization-list/organization-list.component.ts
+++ b/frontend/src/app/features/organizations/organization-list/organization-list.component.ts
@@ -18,6 +18,7 @@ import { OrganizationsService } from '@core/services/organizations.service';
 import { AuthService } from '@core/services/auth.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { EmptyStateComponent } from '@shared/components/empty-state/empty-state.component';
+import { slugify } from '@shared/text';
 import { Organization } from '@core/models';
 
 @Component({
@@ -123,7 +124,7 @@ export class OrganizationListComponent implements OnInit, OnDestroy {
 
   onOrgDisplayNameChange(value: string): void {
     if (!this.orgNameEditedByUser) {
-      const slug = this.toSlug(value);
+      const slug = slugify(value);
       this.newOrg.name = slug;
       this.onOrgNameChange(slug);
     }
@@ -131,13 +132,6 @@ export class OrganizationListComponent implements OnInit, OnDestroy {
 
   onOrgNameUserInput(): void {
     this.orgNameEditedByUser = true;
-  }
-
-  private toSlug(text: string): string {
-    return text
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-+|-+$/g, '');
   }
 
   onOrgNameChange(name: string): void {

--- a/frontend/src/app/shared/text/index.ts
+++ b/frontend/src/app/shared/text/index.ts
@@ -1,0 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export * from './slug';

--- a/frontend/src/app/shared/text/slug.spec.ts
+++ b/frontend/src/app/shared/text/slug.spec.ts
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { slugify } from './slug';
+
+describe('slugify', () => {
+  it('transliterates German umlauts instead of dropping them', () => {
+    expect(slugify('NüschtOS')).toBe('nuschtos');
+    expect(slugify('Übersicht')).toBe('ubersicht');
+    expect(slugify('Öl Ärger')).toBe('ol-arger');
+  });
+
+  it('expands the sharp s to ss', () => {
+    expect(slugify('Straße')).toBe('strasse');
+    expect(slugify('GROẞ')).toBe('gross');
+  });
+
+  it('strips diacritics from other Latin scripts', () => {
+    expect(slugify('Café Crème')).toBe('cafe-creme');
+    expect(slugify('Señor')).toBe('senor');
+  });
+
+  it('lowercases, collapses separators to single hyphens and trims them', () => {
+    expect(slugify('My  Cool__Project!!')).toBe('my-cool-project');
+    expect(slugify('  spaced  ')).toBe('spaced');
+  });
+
+  it('returns an empty string when nothing slug-worthy remains', () => {
+    expect(slugify('')).toBe('');
+    expect(slugify('—')).toBe('');
+  });
+});

--- a/frontend/src/app/shared/text/slug.ts
+++ b/frontend/src/app/shared/text/slug.ts
@@ -1,0 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+// Transliterate accented Latin characters to ASCII before slugifying so names
+// like "NüschtOS" become "nuschtos" rather than collapsing umlauts to hyphens.
+export function slugify(text: string): string {
+  return text
+    .normalize('NFKD')
+    .replace(/\p{M}/gu, '')
+    .toLowerCase()
+    .replace(/ß/g, 'ss')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}


### PR DESCRIPTION
- **#431** umlauts in names (`NüschtOS` → `n-schtos`): shared `slugify()` transliterates diacritics (`ß`→`ss`) instead of dropping them to hyphens.
- **#435** `Zstd decompress failed: Unknown frame descriptor`: the `gradient build` source NAR is now zstd-compressed before storage (the worker import expects `.nar.zst`); the eval response gains `updated_at`/`error` so `gradient watch`/`build` stop reporting "Unknown evaluation"/"api error (200)" and surface the failure.
- **#430** `commit … not found … object not found`: the worker fetches the commit by SHA before failing when it isn't reachable from the clone (fork PR / force-push).
- **#419 board**: rejected candidates in Live Jobs "incl. rejected" are now clickable to the job detail page with score breakdown, served from an ephemeral in-memory id (memory-first, DB fallback) and labelled "Passed over".

Fixes #431
Fixes #435
Fixes #430
