### PR TITLE
GitHub integration per-org with installation id (#436)

### DIFF
--- a/backend/gradient-ci/Cargo.toml
+++ b/backend/gradient-ci/Cargo.toml
@@ -39,7 +39,7 @@ sea-orm     = { workspace = true }
 serde       = { workspace = true }
 serde_json  = { workspace = true }
 thiserror   = { workspace = true }
-tokio       = { workspace = true, features = ["rt", "macros", "sync", "time"] }
+tokio       = { workspace = true, features = ["rt", "macros", "sync", "time", "fs"] }
 tracing     = { workspace = true }
 uuid        = { workspace = true }
 

--- a/backend/gradient-ci/src/actions/send/forge_status.rs
+++ b/backend/gradient-ci/src/actions/send/forge_status.rs
@@ -13,8 +13,8 @@ use crate::integration_lookup::IntegrationKind;
 use gradient_types::ForgeType;
 use gradient_forge::reporter::{CiReporter, GithubAppReporter};
 use gradient_types::{
-    ActionConfig, ActionType, CIntegration, CProjectAction, EIntegration, EOrganization,
-    EProjectAction, EvaluationId, IntegrationId, ProjectId,
+    ActionConfig, ActionType, CIntegration, CProjectAction, EIntegration, EProjectAction,
+    EvaluationId, IntegrationId, ProjectId,
 };
 use anyhow::{Context, Result, anyhow};
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
@@ -164,14 +164,15 @@ async fn build_github_app_reporter(
     let Some(github_app) = ctx.db.config.github_app.clone() else {
         return Ok(None);
     };
-    let project_org = EOrganization::find_by_id(integration.organization)
-        .one(&ctx.db.worker_db)
-        .await
-        .context("loading organization for github app")?
-        .ok_or_else(|| anyhow!("integration organization not found"))?;
-    let Some(installation_id) = project_org.github_installation_id else {
+    let Some(install_fk) = integration.github_installation else {
         return Ok(None);
     };
+    let install = gradient_entity::github_installation::Entity::find_by_id(install_fk)
+        .one(&ctx.db.worker_db)
+        .await
+        .context("loading github installation")?
+        .ok_or_else(|| anyhow!("github installation {} not found", install_fk))?;
+    let installation_id = install.installation_id;
     let pem = std::fs::read_to_string(&github_app.private_key_file)
         .context("reading github app private key")?;
     let r = GithubAppReporter::new(ctx.http.clone(), "", github_app.app_id, pem, installation_id)?;

--- a/backend/gradient-ci/src/actions/send/forge_status.rs
+++ b/backend/gradient-ci/src/actions/send/forge_status.rs
@@ -173,7 +173,8 @@ async fn build_github_app_reporter(
         .context("loading github installation")?
         .ok_or_else(|| anyhow!("github installation {} not found", install_fk))?;
     let installation_id = install.installation_id;
-    let pem = std::fs::read_to_string(&github_app.private_key_file)
+    let pem = tokio::fs::read_to_string(&github_app.private_key_file)
+        .await
         .context("reading github app private key")?;
     let r = GithubAppReporter::new(ctx.http.clone(), "", github_app.app_id, pem, installation_id)?;
     Ok(Some(Arc::new(r)))

--- a/backend/gradient-ci/src/integration_lookup.rs
+++ b/backend/gradient-ci/src/integration_lookup.rs
@@ -23,8 +23,6 @@ pub enum IntegrationKind {
     Outbound = 1,
 }
 
-/// Stable name used for the auto-managed `forge_type=github` integration rows.
-pub const GITHUB_APP_INTEGRATION_NAME: &str = "github";
 /// Stable display name shown in dropdowns for the auto-managed GitHub App rows.
 pub const GITHUB_APP_INTEGRATION_DISPLAY_NAME: &str = "GitHub";
 

--- a/backend/gradient-ci/src/integration_lookup.rs
+++ b/backend/gradient-ci/src/integration_lookup.rs
@@ -4,12 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-//! Resolve named integrations for organizations.
-//!
-//! The `integration` table stores per-org named records of forge integrations.
-//! Outbound reporting is now driven by `ForgeStatusReport` actions that
-//! reference an integration id directly (issue #262); the per-project link
-//! table is gone.
+//! Resolve named forge integrations for organizations.
 
 use gradient_entity::ids::GithubInstallationId;
 use gradient_entity::github_installation;
@@ -157,7 +152,7 @@ mod name_tests {
 #[cfg(test)]
 mod ensure_tests {
     use super::*;
-    use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
+    use sea_orm::{DatabaseBackend, MockDatabase};
     use uuid::Uuid;
 
     fn org() -> OrganizationId {
@@ -222,10 +217,6 @@ mod ensure_tests {
             .append_query_results([vec![github_row(IntegrationKind::Inbound)]])
             // Outbound: installation filter → found
             .append_query_results([vec![github_row(IntegrationKind::Outbound)]])
-            .append_exec_results([MockExecResult {
-                last_insert_id: 0,
-                rows_affected: 0,
-            }])
             .into_connection();
 
         ensure_github_app_integrations(

--- a/backend/gradient-ci/src/integration_lookup.rs
+++ b/backend/gradient-ci/src/integration_lookup.rs
@@ -12,6 +12,7 @@ use gradient_types::*;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, IntoActiveModel, QueryFilter,
+    sea_query::{Expr, OnConflict},
 };
 use tracing::warn;
 
@@ -46,39 +47,32 @@ pub async fn upsert_github_installation<C: ConnectionTrait>(
     account_login: Option<&str>,
     creator: UserId,
 ) -> Result<GithubInstallationId, sea_orm::DbErr> {
-    use github_installation::{Column as Col, Entity as E};
-
-    if let Some(existing) = E::find()
-        .filter(Col::Organization.eq(org))
-        .filter(Col::InstallationId.eq(installation_id))
-        .one(db)
-        .await?
-    {
-        if let Some(login) = account_login
-            && existing.account_login.as_deref() != Some(login)
-        {
-            let mut active = existing.clone().into_active_model();
-            active.account_login = sea_orm::ActiveValue::Set(Some(login.to_string()));
-            active.update(db).await?;
-        }
-
-        return Ok(existing.id);
-    }
-
     let id = GithubInstallationId::now_v7();
-    github_installation::Model {
-        id,
-        organization: org,
-        installation_id,
-        account_login: account_login.map(|s| s.to_string()),
-        created_by: creator,
-        created_at: chrono::Utc::now().naive_utc(),
-    }
-    .into_active_model()
-    .insert(db)
-    .await?;
+    let model = github_installation::ActiveModel {
+        id: sea_orm::ActiveValue::Set(id),
+        organization: sea_orm::ActiveValue::Set(org),
+        installation_id: sea_orm::ActiveValue::Set(installation_id),
+        account_login: sea_orm::ActiveValue::Set(account_login.map(|s| s.to_string())),
+        created_by: sea_orm::ActiveValue::Set(creator),
+        created_at: sea_orm::ActiveValue::Set(chrono::Utc::now().naive_utc()),
+    };
 
-    Ok(id)
+    let res = github_installation::Entity::insert(model)
+        .on_conflict(
+            OnConflict::columns([
+                github_installation::Column::Organization,
+                github_installation::Column::InstallationId,
+            ])
+            .value(
+                github_installation::Column::AccountLogin,
+                Expr::cust("COALESCE(EXCLUDED.account_login, github_installation.account_login)"),
+            )
+            .to_owned(),
+        )
+        .exec_with_returning(db)
+        .await?;
+
+    Ok(res.id)
 }
 
 pub async fn ensure_github_app_integrations<C: ConnectionTrait>(

--- a/backend/gradient-ci/src/integration_lookup.rs
+++ b/backend/gradient-ci/src/integration_lookup.rs
@@ -11,6 +11,8 @@
 //! reference an integration id directly (issue #262); the per-project link
 //! table is gone.
 
+use gradient_entity::ids::GithubInstallationId;
+use gradient_entity::github_installation;
 use gradient_types::*;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use sea_orm::{
@@ -31,47 +33,100 @@ pub const GITHUB_APP_INTEGRATION_NAME: &str = "github";
 /// Stable display name shown in dropdowns for the auto-managed GitHub App rows.
 pub const GITHUB_APP_INTEGRATION_DISPLAY_NAME: &str = "GitHub";
 
-/// Idempotently create the inbound + outbound `forge_type=github` integration
-/// rows for `org_id`. Used by the App-install hook to materialise the rows
-/// that triggers and ForgeStatusReport actions reference.
+/// Stable, per-installation integration name. Lowercased account login keeps it
+/// URL/index-safe; falls back to the numeric installation id.
+pub fn github_integration_name(account_login: Option<&str>, installation_id: i64) -> String {
+    match account_login {
+        Some(login) if !login.trim().is_empty() => {
+            format!("github-{}", login.trim().to_ascii_lowercase())
+        }
+        _ => format!("github-{installation_id}"),
+    }
+}
+
+/// Find-or-create the `github_installation` row for (org, installation_id),
+/// refreshing `account_login` when newly known. Returns its id.
+pub async fn upsert_github_installation<C: ConnectionTrait>(
+    db: &C,
+    org: OrganizationId,
+    installation_id: i64,
+    account_login: Option<&str>,
+    creator: UserId,
+) -> Result<GithubInstallationId, sea_orm::DbErr> {
+    use github_installation::{Column as Col, Entity as E};
+
+    if let Some(existing) = E::find()
+        .filter(Col::Organization.eq(org))
+        .filter(Col::InstallationId.eq(installation_id))
+        .one(db)
+        .await?
+    {
+        if let Some(login) = account_login
+            && existing.account_login.as_deref() != Some(login)
+        {
+            let mut active = existing.clone().into_active_model();
+            active.account_login = sea_orm::ActiveValue::Set(Some(login.to_string()));
+            active.update(db).await?;
+        }
+
+        return Ok(existing.id);
+    }
+
+    let id = GithubInstallationId::now_v7();
+    github_installation::Model {
+        id,
+        organization: org,
+        installation_id,
+        account_login: account_login.map(|s| s.to_string()),
+        created_by: creator,
+        created_at: chrono::Utc::now().naive_utc(),
+    }
+    .into_active_model()
+    .insert(db)
+    .await?;
+
+    Ok(id)
+}
+
 pub async fn ensure_github_app_integrations<C: ConnectionTrait>(
     db: &C,
     org_id: OrganizationId,
+    installation: GithubInstallationId,
+    name: &str,
+    display_name: &str,
     creator: UserId,
 ) -> Result<(), sea_orm::DbErr> {
     for kind in [IntegrationKind::Inbound, IntegrationKind::Outbound] {
-        let existing_github = EIntegration::find()
+        let existing = EIntegration::find()
             .filter(CIntegration::Organization.eq(org_id))
             .filter(CIntegration::Kind.eq(i16::from(kind)))
             .filter(CIntegration::ForgeType.eq(i16::from(ForgeType::GitHub)))
+            .filter(CIntegration::GithubInstallation.eq(installation))
             .one(db)
             .await?;
-        if existing_github.is_some() {
+        if existing.is_some() {
             continue;
         }
+
         let name_clash = EIntegration::find()
             .filter(CIntegration::Organization.eq(org_id))
             .filter(CIntegration::Kind.eq(i16::from(kind)))
-            .filter(CIntegration::Name.eq(GITHUB_APP_INTEGRATION_NAME))
+            .filter(CIntegration::Name.eq(name))
             .one(db)
             .await?;
         if name_clash.is_some() {
-            warn!(
-                %org_id,
-                kind = ?kind,
-                "Cannot seed GitHub App integration row: another integration already \
-                 uses the reserved name '{}'. Rename it to enable GitHub App support.",
-                GITHUB_APP_INTEGRATION_NAME
-            );
+            warn!(%org_id, kind = ?kind, name, "GitHub App integration name already taken; skipping");
             continue;
         }
+
         MIntegration {
             id: IntegrationId::now_v7(),
             organization: org_id,
-            name: GITHUB_APP_INTEGRATION_NAME.into(),
-            display_name: GITHUB_APP_INTEGRATION_DISPLAY_NAME.into(),
+            name: name.to_string(),
+            display_name: display_name.to_string(),
             kind: i16::from(kind),
             forge_type: i16::from(ForgeType::GitHub),
+            github_installation: Some(installation),
             created_by: creator,
             created_at: chrono::Utc::now().naive_utc(),
             ..Default::default()
@@ -80,7 +135,23 @@ pub async fn ensure_github_app_integrations<C: ConnectionTrait>(
         .insert(db)
         .await?;
     }
+
     Ok(())
+}
+
+#[cfg(test)]
+mod name_tests {
+    use super::github_integration_name;
+
+    #[test]
+    fn uses_account_login_when_present() {
+        assert_eq!(github_integration_name(Some("Acme-Corp"), 42), "github-acme-corp");
+    }
+
+    #[test]
+    fn falls_back_to_installation_id() {
+        assert_eq!(github_integration_name(None, 42), "github-42");
+    }
 }
 
 #[cfg(test)]
@@ -95,15 +166,19 @@ mod ensure_tests {
     fn user() -> UserId {
         UserId::new(Uuid::parse_str("00000000-0000-0000-0000-000000000002").unwrap())
     }
+    fn installation() -> GithubInstallationId {
+        GithubInstallationId::new(Uuid::parse_str("00000000-0000-0000-0000-000000000003").unwrap())
+    }
 
     fn github_row(kind: IntegrationKind) -> gradient_entity::integration::Model {
         gradient_entity::integration::Model {
             id: IntegrationId::now_v7(),
             organization: org(),
-            name: GITHUB_APP_INTEGRATION_NAME.into(),
+            name: "github-acme-corp".into(),
             display_name: GITHUB_APP_INTEGRATION_DISPLAY_NAME.into(),
             kind: i16::from(kind),
             forge_type: i16::from(ForgeType::GitHub),
+            github_installation: Some(installation()),
             created_by: user(),
             ..Default::default()
         }
@@ -111,22 +186,41 @@ mod ensure_tests {
 
     #[tokio::test]
     async fn creates_both_rows_when_none_exist() {
+        // Per kind: (1) installation filter → empty, (2) name clash → empty, (3) insert result
         let db = MockDatabase::new(DatabaseBackend::Postgres)
+            // Inbound: installation filter → none
             .append_query_results([Vec::<gradient_entity::integration::Model>::new()])
+            // Inbound: name clash → none
+            .append_query_results([Vec::<gradient_entity::integration::Model>::new()])
+            // Inbound: insert result
             .append_query_results([vec![github_row(IntegrationKind::Inbound)]])
+            // Outbound: installation filter → none
             .append_query_results([Vec::<gradient_entity::integration::Model>::new()])
+            // Outbound: name clash → none
+            .append_query_results([Vec::<gradient_entity::integration::Model>::new()])
+            // Outbound: insert result
             .append_query_results([vec![github_row(IntegrationKind::Outbound)]])
             .into_connection();
 
-        ensure_github_app_integrations(&db, org(), user())
-            .await
-            .expect("ensure should succeed");
+        ensure_github_app_integrations(
+            &db,
+            org(),
+            installation(),
+            "github-acme-corp",
+            GITHUB_APP_INTEGRATION_DISPLAY_NAME,
+            user(),
+        )
+        .await
+        .expect("ensure should succeed");
     }
 
     #[tokio::test]
     async fn skips_kinds_that_already_exist() {
+        // Per kind: (1) installation filter → found → skip
         let db = MockDatabase::new(DatabaseBackend::Postgres)
+            // Inbound: installation filter → found
             .append_query_results([vec![github_row(IntegrationKind::Inbound)]])
+            // Outbound: installation filter → found
             .append_query_results([vec![github_row(IntegrationKind::Outbound)]])
             .append_exec_results([MockExecResult {
                 last_insert_id: 0,
@@ -134,8 +228,15 @@ mod ensure_tests {
             }])
             .into_connection();
 
-        ensure_github_app_integrations(&db, org(), user())
-            .await
-            .expect("ensure should be idempotent");
+        ensure_github_app_integrations(
+            &db,
+            org(),
+            installation(),
+            "github-acme-corp",
+            GITHUB_APP_INTEGRATION_DISPLAY_NAME,
+            user(),
+        )
+        .await
+        .expect("ensure should be idempotent");
     }
 }

--- a/backend/gradient-entity/src/github_installation.rs
+++ b/backend/gradient-entity/src/github_installation.rs
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use chrono::NaiveDateTime;
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::ids::{GithubInstallationId, OrganizationId, UserId};
+
+/// A GitHub App installation bound to an organization.
+#[derive(Clone, Debug, Default, PartialEq, DeriveEntityModel, Deserialize, Serialize)]
+#[sea_orm(table_name = "github_installation")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: GithubInstallationId,
+    pub organization: OrganizationId,
+    pub installation_id: i64,
+    #[sea_orm(column_type = "Text", nullable)]
+    pub account_login: Option<String>,
+    pub created_by: UserId,
+    pub created_at: NaiveDateTime,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::organization::Entity",
+        from = "Column::Organization",
+        to = "super::organization::Column::Id"
+    )]
+    Organization,
+    #[sea_orm(
+        belongs_to = "super::user::Entity",
+        from = "Column::CreatedBy",
+        to = "super::user::Column::Id"
+    )]
+    CreatedBy,
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/backend/gradient-entity/src/ids.rs
+++ b/backend/gradient-entity/src/ids.rs
@@ -117,6 +117,7 @@ id_newtype!(FlakeOutputNodeId);
 id_newtype!(EvaluationMessageId);
 id_newtype!(FeatureId);
 id_newtype!(FlakeInputOverrideId);
+id_newtype!(GithubInstallationId);
 id_newtype!(IntegrationId);
 id_newtype!(OpenPrStateId);
 id_newtype!(OrganizationId);

--- a/backend/gradient-entity/src/integration.rs
+++ b/backend/gradient-entity/src/integration.rs
@@ -8,7 +8,7 @@ use chrono::NaiveDateTime;
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::ids::{IntegrationId, OrganizationId, UserId};
+use crate::ids::{GithubInstallationId, IntegrationId, OrganizationId, UserId};
 
 #[derive(Clone, Default, PartialEq, DeriveEntityModel, Deserialize, Serialize)]
 #[sea_orm(table_name = "integration")]
@@ -32,6 +32,7 @@ pub struct Model {
     /// Source CIDRs allowed for inbound webhooks. `None`/empty = any source.
     #[sea_orm(column_type = "Array(std::sync::Arc::new(ColumnType::Text))", nullable)]
     pub allowed_ips: Option<Vec<String>>,
+    pub github_installation: Option<GithubInstallationId>,
     pub created_by: UserId,
     pub created_at: NaiveDateTime,
 }
@@ -50,6 +51,12 @@ pub enum Relation {
         to = "super::user::Column::Id"
     )]
     CreatedBy,
+    #[sea_orm(
+        belongs_to = "super::github_installation::Entity",
+        from = "Column::GithubInstallation",
+        to = "super::github_installation::Column::Id"
+    )]
+    GithubInstallation,
 }
 
 impl std::fmt::Debug for Model {
@@ -68,6 +75,7 @@ impl std::fmt::Debug for Model {
                 &self.access_token.as_ref().map(|_| "[redacted]"),
             )
             .field("allowed_ips", &self.allowed_ips)
+            .field("github_installation", &self.github_installation)
             .field("created_by", &self.created_by)
             .field("created_at", &self.created_at)
             .finish()

--- a/backend/gradient-entity/src/lib.rs
+++ b/backend/gradient-entity/src/lib.rs
@@ -48,6 +48,7 @@ pub mod evaluation_message;
 pub mod evaluation_metric;
 pub mod feature;
 pub mod flake_output_node;
+pub mod github_installation;
 pub mod integration;
 pub mod open_pr_state;
 pub mod organization;

--- a/backend/gradient-entity/src/organization.rs
+++ b/backend/gradient-entity/src/organization.rs
@@ -27,18 +27,6 @@ pub struct Model {
     pub created_by: UserId,
     pub created_at: NaiveDateTime,
     pub managed: bool,
-    /// GitHub App installation ID for this organization. `Some` is the single
-    /// source of truth for "this org uses the GitHub App" - outbound CI status
-    /// reporting, webhook routing, etc. all gate on this being `Some`.
-    ///
-    /// Populated by:
-    /// - the `installation` webhook (matching the payload's repositories against
-    ///   each org's project repository URLs),
-    /// - the state-driven provisioner (`StateOrganization.github_installation_id`),
-    /// - direct DB writes during recovery.
-    ///
-    /// Cleared automatically when GitHub sends `installation.deleted`.
-    pub github_installation_id: Option<i64>,
 }
 
 impl std::fmt::Debug for Model {
@@ -54,7 +42,6 @@ impl std::fmt::Debug for Model {
             .field("hide_build_requests", &self.hide_build_requests)
             .field("created_by", &self.created_by)
             .field("created_at", &self.created_at)
-            .field("github_installation_id", &self.github_installation_id)
             .finish()
     }
 }

--- a/backend/gradient-forge/src/github_app.rs
+++ b/backend/gradient-forge/src/github_app.rs
@@ -126,6 +126,51 @@ pub async fn get_installation_token(
     Ok(token_resp.token)
 }
 
+// ── Installation account lookup ───────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct InstallationResponse {
+    account: InstallationAccount,
+}
+
+#[derive(Deserialize)]
+struct InstallationAccount {
+    login: String,
+}
+
+/// Validates that `installation_id` belongs to this App and returns the GitHub
+/// account login it is installed on. Errors (incl. 404) mean the id is not a
+/// valid installation for this App.
+pub async fn get_installation(
+    client: &reqwest::Client,
+    app_id: u64,
+    private_key_pem: &str,
+    installation_id: i64,
+) -> Result<String> {
+    let jwt = generate_jwt(app_id, private_key_pem)?;
+    let url = format!("https://api.github.com/app/installations/{installation_id}");
+    let resp = client
+        .get(&url)
+        .bearer_auth(&jwt)
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", "gradient")
+        .send()
+        .await
+        .context("GitHub get-installation request failed")?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        bail!("GitHub get-installation API returned {status}: {body}");
+    }
+
+    let parsed: InstallationResponse =
+        resp.json().await.context("failed to parse GitHub installation response")?;
+
+    Ok(parsed.account.login)
+}
+
 // ── Webhook signature verification ────────────────────────────────────────
 
 /// Verifies a GitHub webhook signature from the `X-Hub-Signature-256` header.
@@ -448,5 +493,12 @@ iw88K5/oFeMFr7syCSKTPeQD\n\
         let bare = compute_gitea_sig("secret", b"body");
         let sig = format!("sha1={bare}");
         assert!(!verify_github_signature("secret", &sig, b"body"));
+    }
+
+    #[test]
+    fn parses_installation_account_login() {
+        let body = r#"{"id":42,"account":{"login":"acme-corp"}}"#;
+        let parsed: InstallationResponse = serde_json::from_str(body).unwrap();
+        assert_eq!(parsed.account.login, "acme-corp");
     }
 }

--- a/backend/gradient-migration/src/lib.rs
+++ b/backend/gradient-migration/src/lib.rs
@@ -161,6 +161,7 @@ mod m20260619_010000_globalize_derivation;
 mod m20260619_020000_derivation_build_anchor;
 mod m20260619_030000_build_job_and_attempt;
 mod m20260620_000001_create_github_installation;
+mod m20260620_000002_backfill_drop_org_installation;
 
 pub struct Migrator;
 
@@ -323,6 +324,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260619_020000_derivation_build_anchor::Migration),
             Box::new(m20260619_030000_build_job_and_attempt::Migration),
             Box::new(m20260620_000001_create_github_installation::Migration),
+            Box::new(m20260620_000002_backfill_drop_org_installation::Migration),
         ]
     }
 }

--- a/backend/gradient-migration/src/lib.rs
+++ b/backend/gradient-migration/src/lib.rs
@@ -160,6 +160,7 @@ mod m20260619_000001_drop_cached_path_store_path;
 mod m20260619_010000_globalize_derivation;
 mod m20260619_020000_derivation_build_anchor;
 mod m20260619_030000_build_job_and_attempt;
+mod m20260620_000001_create_github_installation;
 
 pub struct Migrator;
 
@@ -321,6 +322,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260619_010000_globalize_derivation::Migration),
             Box::new(m20260619_020000_derivation_build_anchor::Migration),
             Box::new(m20260619_030000_build_job_and_attempt::Migration),
+            Box::new(m20260620_000001_create_github_installation::Migration),
         ]
     }
 }

--- a/backend/gradient-migration/src/m20260620_000001_create_github_installation.rs
+++ b/backend/gradient-migration/src/m20260620_000001_create_github_installation.rs
@@ -1,0 +1,99 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(Alias::new("github_installation"))
+                    .if_not_exists()
+                    .col(ColumnDef::new(Alias::new("id")).uuid().not_null().primary_key())
+                    .col(ColumnDef::new(Alias::new("organization")).uuid().not_null())
+                    .col(ColumnDef::new(Alias::new("installation_id")).big_integer().not_null())
+                    .col(ColumnDef::new(Alias::new("account_login")).text().null())
+                    .col(ColumnDef::new(Alias::new("created_by")).uuid().not_null())
+                    .col(ColumnDef::new(Alias::new("created_at")).timestamp_with_time_zone().not_null())
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk-github_installation-organization")
+                            .from(Alias::new("github_installation"), Alias::new("organization"))
+                            .to(Alias::new("organization"), Alias::new("id"))
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk-github_installation-created_by")
+                            .from(Alias::new("github_installation"), Alias::new("created_by"))
+                            .to(Alias::new("user"), Alias::new("id")),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx-github-installation-org-installation")
+                    .table(Alias::new("github_installation"))
+                    .col(Alias::new("organization"))
+                    .col(Alias::new("installation_id"))
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Alias::new("integration"))
+                    .add_column(ColumnDef::new(Alias::new("github_installation")).uuid().null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_foreign_key(
+                ForeignKey::create()
+                    .name("fk-integration-github-installation")
+                    .from(Alias::new("integration"), Alias::new("github_installation"))
+                    .to(Alias::new("github_installation"), Alias::new("id"))
+                    .on_delete(ForeignKeyAction::SetNull)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_foreign_key(
+                ForeignKey::drop()
+                    .name("fk-integration-github-installation")
+                    .table(Alias::new("integration"))
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Alias::new("integration"))
+                    .drop_column(Alias::new("github_installation"))
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_table(Table::drop().table(Alias::new("github_installation")).to_owned())
+            .await
+    }
+}

--- a/backend/gradient-migration/src/m20260620_000002_backfill_drop_org_installation.rs
+++ b/backend/gradient-migration/src/m20260620_000002_backfill_drop_org_installation.rs
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        db.execute_unprepared(
+            "INSERT INTO github_installation (id, organization, installation_id, account_login, created_by, created_at) \
+             SELECT uuidv7(), o.id, o.github_installation_id, NULL, o.created_by, NOW() \
+             FROM organization o \
+             WHERE o.github_installation_id IS NOT NULL \
+             ON CONFLICT (organization, installation_id) DO NOTHING",
+        )
+        .await?;
+
+        db.execute_unprepared(
+            "UPDATE integration i \
+             SET github_installation = gi.id \
+             FROM organization o \
+             JOIN github_installation gi ON gi.organization = o.id \
+                 AND gi.installation_id = o.github_installation_id \
+             WHERE i.organization = o.id AND i.forge_type = 3 AND i.github_installation IS NULL",
+        )
+        .await?;
+
+        db.execute_unprepared("ALTER TABLE organization DROP COLUMN github_installation_id")
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared("ALTER TABLE organization ADD COLUMN github_installation_id BIGINT")
+            .await?;
+        Ok(())
+    }
+}

--- a/backend/gradient-proto/src/handler/auth.rs
+++ b/backend/gradient-proto/src/handler/auth.rs
@@ -626,7 +626,6 @@ mod tests {
             created_by: gradient_types::ids::UserId::nil(),
             created_at: gradient_types::now(),
             managed: false,
-            github_installation_id: None,
         }
     }
 

--- a/backend/gradient-sources/src/ssh_key.rs
+++ b/backend/gradient-sources/src/ssh_key.rs
@@ -132,7 +132,6 @@ mod tests {
             created_by: gradient_types::ids::UserId::nil(),
             created_at: NaiveDateTime::default(),
             managed: false,
-            github_installation_id: None,
         }
     }
 

--- a/backend/gradient-state/src/config.rs
+++ b/backend/gradient-state/src/config.rs
@@ -47,13 +47,12 @@ pub struct StateOrganization {
     pub public: bool,
     #[serde(default)]
     pub hide_build_requests: bool,
-    /// GitHub App installation id to bind to this org. When `Some`, the
-    /// state-driven provisioner writes it on every reconciliation (state wins
-    /// over runtime updates). When `None`, the field is left untouched on
-    /// update so a webhook-recorded id survives reconciliation, and is
-    /// initialised to `NULL` on create.
+    /// Declarative list of GitHub App installations to bind to this org.
+    /// Each entry provisions a `github_installation` row + inbound/outbound
+    /// integration pair. An empty list leaves webhook-recorded installations
+    /// untouched (no deletion on reconcile).
     #[serde(default)]
-    pub github_installation_id: Option<i64>,
+    pub github_installations: Vec<StateGithubInstallation>,
     pub created_by: String,
     /// Declarative org membership. Empty preserves the legacy behavior of
     /// auto-adding `created_by` as Admin. Non-empty makes the list
@@ -69,6 +68,13 @@ pub struct StateOrganization {
 pub struct StateOrgMemberEntry {
     pub user: String,
     pub role: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct StateGithubInstallation {
+    pub installation_id: i64,
+    #[serde(default)]
+    pub account_login: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -353,5 +359,33 @@ impl StateConfiguration {
         let content = fs::read_to_string(path)?;
         let config: StateConfiguration = serde_json::from_str(&content)?;
         Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod config_tests {
+    use super::*;
+
+    #[test]
+    fn deserializes_github_installations_list() {
+        let json = r#"{
+            "organizations": {
+                "acme": {
+                    "name": "acme",
+                    "display_name": "ACME",
+                    "private_key_file": "/dev/null",
+                    "public": false,
+                    "created_by": "alice",
+                    "github_installations": [
+                        { "installation_id": 42, "account_login": "acme" }
+                    ]
+                }
+            }
+        }"#;
+        let config: StateConfiguration = serde_json::from_str(json).unwrap();
+        let org = config.organizations.get("acme").unwrap();
+        assert_eq!(org.github_installations.len(), 1);
+        assert_eq!(org.github_installations[0].installation_id, 42);
+        assert_eq!(org.github_installations[0].account_login.as_deref(), Some("acme"));
     }
 }

--- a/backend/gradient-state/src/export.rs
+++ b/backend/gradient-state/src/export.rs
@@ -123,7 +123,7 @@ pub async fn export_state<C: ConnectionTrait>(db: &C) -> Result<StateConfigurati
                 private_key_file: String::new(),
                 public: o.public,
                 hide_build_requests: o.hide_build_requests,
-                github_installation_id: o.github_installation_id,
+                github_installations: vec![],
                 created_by: name_or_blank(&username, o.created_by),
                 members,
             },

--- a/backend/gradient-state/src/export.rs
+++ b/backend/gradient-state/src/export.rs
@@ -16,8 +16,8 @@
 
 use super::{
     StateApiKey, StateCache, StateCacheMemberEntry, StateCacheRoleEntry, StateConfiguration,
-    StateFlakeInputOverride, StateIntegration, StateOrgMemberEntry, StateOrganization,
-    StateProject, StateRole, StateTrigger, StateUpstream, StateUser, StateWorker,
+    StateFlakeInputOverride, StateGithubInstallation, StateIntegration, StateOrgMemberEntry,
+    StateOrganization, StateProject, StateRole, StateTrigger, StateUpstream, StateUser, StateWorker,
 };
 use gradient_ci::IntegrationKind;
 use gradient_types::ForgeType;
@@ -69,6 +69,7 @@ pub async fn export_state<C: ConnectionTrait>(db: &C) -> Result<StateConfigurati
     let triggers = gradient_entity::project_trigger::Entity::find().all(db).await?;
     let actions = gradient_entity::project_action::Entity::find().all(db).await?;
     let overrides = gradient_entity::project_flake_input_override::Entity::find().all(db).await?;
+    let github_installs = gradient_entity::github_installation::Entity::find().all(db).await?;
 
     let username = id_name_map(users.iter().map(|u| (u.id, u.username.clone())));
     let org_name = id_name_map(orgs.iter().map(|o| (o.id, o.name.clone())));
@@ -123,7 +124,14 @@ pub async fn export_state<C: ConnectionTrait>(db: &C) -> Result<StateConfigurati
                 private_key_file: String::new(),
                 public: o.public,
                 hide_build_requests: o.hide_build_requests,
-                github_installations: vec![],
+                github_installations: github_installs
+                    .iter()
+                    .filter(|gi| gi.organization == o.id)
+                    .map(|gi| StateGithubInstallation {
+                        installation_id: gi.installation_id,
+                        account_login: gi.account_login.clone(),
+                    })
+                    .collect(),
                 created_by: name_or_blank(&username, o.created_by),
                 members,
             },

--- a/backend/gradient-state/src/provisioning/entities/integrations.rs
+++ b/backend/gradient-state/src/provisioning/entities/integrations.rs
@@ -8,7 +8,7 @@ use super::super::DynError;
 use super::super::StateApplicator;
 use super::super::{lookup_id, read_credential};
 use gradient_ci::actions::encrypt_secret_with_file;
-use gradient_ci::{GITHUB_APP_INTEGRATION_NAME, IntegrationKind};
+use gradient_ci::IntegrationKind;
 use gradient_types::ForgeType;
 use crate::config::*;
 use gradient_types::*;
@@ -65,20 +65,11 @@ impl<'a> StateApplicator<'a> {
             if matches!(forge, ForgeType::GitHub) {
                 return Err(format!(
                     "Integration '{}' has forge_type 'github': GitHub integrations are managed \
-                     through the server-wide GitHub App; bind installations on the org via \
-                     `github_installation_id`, not via integration rows.",
+                     automatically via `github_installations` on the org.",
                     state_int.name
                 )
                 .into());
             }
-            if state_int.name == GITHUB_APP_INTEGRATION_NAME {
-                return Err(format!(
-                    "Integration '{}' uses the reserved name '{}' (auto-managed GitHub App row).",
-                    state_int.name, GITHUB_APP_INTEGRATION_NAME
-                )
-                .into());
-            }
-
             let encrypted_secret = self.read_and_encrypt_integration_field(
                 state_int.secret_file.as_deref(),
                 &state_int.name,

--- a/backend/gradient-state/src/provisioning/entities/orgs.rs
+++ b/backend/gradient-state/src/provisioning/entities/orgs.rs
@@ -75,12 +75,6 @@ impl<'a> StateApplicator<'a> {
                 org.created_by = Set(created_by_id);
                 org.public = Set(state_org.public);
                 org.hide_build_requests = Set(state_org.hide_build_requests);
-                // Only overwrite github_installation_id when state declares
-                // it; otherwise leave the existing value (likely set by the
-                // install webhook) intact.
-                if let Some(id) = state_org.github_installation_id {
-                    org.github_installation_id = Set(Some(id));
-                }
                 org.managed = Set(true);
                 org.update(self.db).await?;
                 tracing::info!(name = %state_org.name, "Updated managed organization");
@@ -99,7 +93,7 @@ impl<'a> StateApplicator<'a> {
                     created_by: created_by_id,
                     created_at: now,
                     managed: true,
-                    github_installation_id: state_org.github_installation_id,
+                    ..Default::default()
                 }
                 .into_active_model();
 
@@ -108,17 +102,30 @@ impl<'a> StateApplicator<'a> {
                 org_id
             };
 
-            // Seed the auto-managed GitHub App integration rows whenever this
-            // org has (or just acquired) an installation id. Idempotent.
-            let installation_known = match organization::Entity::find_by_id(org_id)
-                .one(self.db)
-                .await?
-            {
-                Some(o) => o.github_installation_id.is_some(),
-                None => false,
-            };
-            if installation_known {
-                gradient_ci::ensure_github_app_integrations(self.db, org_id, created_by_id).await?;
+            for e in &state_org.github_installations {
+                let inst = gradient_ci::upsert_github_installation(
+                    self.db,
+                    org_id,
+                    e.installation_id,
+                    e.account_login.as_deref(),
+                    created_by_id,
+                )
+                .await?;
+
+                let name = gradient_ci::github_integration_name(
+                    e.account_login.as_deref(),
+                    e.installation_id,
+                );
+
+                gradient_ci::ensure_github_app_integrations(
+                    self.db,
+                    org_id,
+                    inst,
+                    &name,
+                    "GitHub",
+                    created_by_id,
+                )
+                .await?;
             }
         }
 

--- a/backend/gradient-state/src/provisioning/entities/orgs.rs
+++ b/backend/gradient-state/src/provisioning/entities/orgs.rs
@@ -93,7 +93,6 @@ impl<'a> StateApplicator<'a> {
                     created_by: created_by_id,
                     created_at: now,
                     managed: true,
-                    ..Default::default()
                 }
                 .into_active_model();
 

--- a/backend/gradient-state/src/validation/projects.rs
+++ b/backend/gradient-state/src/validation/projects.rs
@@ -5,7 +5,6 @@
  */
 
 use super::helpers::{EntityLookup, ErrorCollector};
-use gradient_ci::GITHUB_APP_INTEGRATION_NAME;
 use gradient_types::triggers::TriggerType;
 use std::collections::HashSet;
 
@@ -88,7 +87,7 @@ pub(super) fn validate(lookup: &EntityLookup, errors: &mut ErrorCollector) {
                 );
                 continue;
             };
-            if name == GITHUB_APP_INTEGRATION_NAME {
+            if name.starts_with("github-") {
                 continue;
             }
             let declared_inbound = config.integrations.values().any(|i| {

--- a/backend/gradient-state/src/validation/projects.rs
+++ b/backend/gradient-state/src/validation/projects.rs
@@ -87,7 +87,7 @@ pub(super) fn validate(lookup: &EntityLookup, errors: &mut ErrorCollector) {
                 );
                 continue;
             };
-            if name.starts_with("github-") {
+            if name == "github" || name.starts_with("github-") {
                 continue;
             }
             let declared_inbound = config.integrations.values().any(|i| {

--- a/backend/gradient-web/src/endpoints/forge_hooks/trigger.rs
+++ b/backend/gradient-web/src/endpoints/forge_hooks/trigger.rs
@@ -21,8 +21,8 @@ use gradient_forge::ParsedPullRequestReviewEvent;
 use gradient_scheduler::Scheduler;
 use sea_orm::ActiveValue::Set;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, DbBackend, EntityTrait, FromQueryResult, IntoActiveModel,
-    QueryFilter, Statement, Value,
+    ActiveModelTrait, ColumnTrait, DbBackend, EntityTrait, FromQueryResult, QueryFilter,
+    Statement, Value,
 };
 use serde::Deserialize;
 use std::sync::Arc;
@@ -108,18 +108,13 @@ pub(super) async fn handle_github_installation(state: &Arc<ServerState>, body: &
 }
 
 async fn clear_installation_id(state: &Arc<ServerState>, installation_id: i64) {
-    if let Ok(orgs) = EOrganization::find()
-        .filter(COrganization::GithubInstallationId.eq(installation_id))
-        .all(&state.web_db)
+    use gradient_entity::github_installation::{Column as Col, Entity as E};
+    if let Err(e) = E::delete_many()
+        .filter(Col::InstallationId.eq(installation_id))
+        .exec(&state.web_db)
         .await
     {
-        for org in orgs {
-            let mut active = org.into_active_model();
-            active.github_installation_id = Set(None);
-            if let Err(e) = active.update(&state.web_db).await {
-                warn!(error = %e, "Failed to clear github_installation_id");
-            }
-        }
+        warn!(error = %e, installation_id, "Failed to delete github_installation rows");
     }
 }
 
@@ -174,16 +169,26 @@ async fn store_installation_id(state: &Arc<ServerState>, payload: &GitHubInstall
     for org in orgs {
         let org_id = org.id;
         let creator = org.created_by;
-        let mut active = org.into_active_model();
-        active.github_installation_id = Set(Some(installation_id));
-        if let Err(e) = active.update(&state.web_db).await {
-            warn!(error = %e, installation_id, %org_id, "Failed to store github_installation_id");
-            continue;
-        }
+        let inst = match gradient_ci::upsert_github_installation(
+            &state.web_db,
+            org_id,
+            installation_id,
+            Some(github_login),
+            creator,
+        )
+        .await
+        {
+            Ok(id) => id,
+            Err(e) => {
+                warn!(error = %e, installation_id, %org_id, "Failed to upsert github_installation");
+                continue;
+            }
+        };
 
         info!(installation_id, %org_id, github_login = %github_login, "GitHub App installed on organization");
+        let name = gradient_ci::github_integration_name(Some(github_login), installation_id);
         if let Err(e) =
-            gradient_ci::ensure_github_app_integrations(&state.web_db, org_id, creator).await
+            gradient_ci::ensure_github_app_integrations(&state.web_db, org_id, inst, &name, "GitHub", creator).await
         {
             warn!(error = %e, %org_id, "Failed to materialise GitHub App integration rows");
         }
@@ -247,13 +252,15 @@ pub(super) async fn resolve_github_app_targets(
     use crate::ip_allowlist::is_allowed as ip_allowed;
     use std::collections::HashSet;
 
-    let candidate_orgs = EOrganization::find()
-        .filter(COrganization::GithubInstallationId.eq(installation_id))
+    use gradient_entity::github_installation::{Column as GiCol, Entity as EGi};
+
+    let installs = EGi::find()
+        .filter(GiCol::InstallationId.eq(installation_id))
         .all(&state.web_db)
         .await
         .unwrap_or_default();
 
-    if candidate_orgs.is_empty() {
+    if installs.is_empty() {
         return Vec::new();
     }
 
@@ -263,15 +270,16 @@ pub(super) async fn resolve_github_app_targets(
         .collect();
 
     let mut integrations = Vec::new();
-    for org in candidate_orgs {
+    for inst in installs {
+        let org_id = inst.organization;
         let projects = match EProject::find()
-            .filter(CProject::Organization.eq(org.id))
+            .filter(CProject::Organization.eq(org_id))
             .all(&state.web_db)
             .await
         {
             Ok(rows) => rows,
             Err(e) => {
-                warn!(error = %e, org_id = %org.id, "resolve_github_app_targets: project lookup failed");
+                warn!(error = %e, %org_id, "resolve_github_app_targets: project lookup failed");
                 continue;
             }
         };
@@ -282,9 +290,10 @@ pub(super) async fn resolve_github_app_targets(
             continue;
         }
         let integration = EIntegration::find()
-            .filter(CIntegration::Organization.eq(org.id))
+            .filter(CIntegration::Organization.eq(org_id))
             .filter(CIntegration::Kind.eq(i16::from(IntegrationKind::Inbound)))
             .filter(CIntegration::ForgeType.eq(i16::from(gradient_types::ForgeType::GitHub)))
+            .filter(CIntegration::GithubInstallation.eq(inst.id))
             .one(&state.web_db)
             .await
             .ok()
@@ -294,7 +303,7 @@ pub(super) async fn resolve_github_app_targets(
                 let allowlist = i.allowed_ips.clone().unwrap_or_default();
                 if !ip_allowed(client_ip, &allowlist) {
                     warn!(
-                        org_id = %org.id,
+                        %org_id,
                         integration_id = %i.id,
                         %client_ip,
                         "resolve_github_app_targets: source IP not allowed, skipping integration"
@@ -304,7 +313,7 @@ pub(super) async fn resolve_github_app_targets(
                 integrations.push(i.id);
             }
             None => warn!(
-                org_id = %org.id,
+                %org_id,
                 "resolve_github_app_targets: org has matching project but no inbound github integration row"
             ),
         }

--- a/backend/gradient-web/src/endpoints/forge_hooks/trigger.rs
+++ b/backend/gradient-web/src/endpoints/forge_hooks/trigger.rs
@@ -232,12 +232,10 @@ pub(super) fn normalize_repo_url(url: &str) -> String {
 /// whose org owns a project matching one of the webhook's `repository_urls`.
 ///
 /// A single GitHub App installation can serve multiple Gradient orgs whenever
-/// those orgs each track repositories hosted under the same GitHub account
-/// (you can only install the App once per GitHub account, but each gradient
-/// org gets its own `github_installation_id` pointing at it). Matching purely
-/// on `installation_id` therefore returns one arbitrary org and silently
-/// drops the others - adding the repo-URL gate is what makes multi-org
-/// installations fire the correct subset.
+/// those orgs each track repositories hosted under the same GitHub account.
+/// Orgs bind installations via `github_installation` rows; matching on
+/// `installation_id` alone could return multiple orgs, so the repo-URL gate
+/// selects only those whose projects track an installed repository.
 ///
 /// Returns an empty vec when no org carries this installation, when no
 /// matching project exists, or when an org's inbound GitHub integration row

--- a/backend/gradient-web/src/endpoints/orgs/integrations.rs
+++ b/backend/gradient-web/src/endpoints/orgs/integrations.rs
@@ -24,7 +24,7 @@ use axum::extract::{Path, State};
 use axum::{Extension, Json};
 
 use gradient_ci::actions::encrypt_secret_with_file;
-use gradient_ci::{GITHUB_APP_INTEGRATION_NAME, IntegrationKind};
+use gradient_ci::IntegrationKind;
 use gradient_types::ForgeType;
 use gradient_types::input::check_index_name;
 use gradient_types::*;
@@ -48,27 +48,44 @@ pub struct IntegrationResponse {
     pub has_secret: bool,
     pub has_access_token: bool,
     pub allowed_ips: Vec<String>,
+    pub installation_id: Option<i64>,
+    pub account_login: Option<String>,
     pub created_by: UserId,
     pub created_at: chrono::NaiveDateTime,
 }
 
-impl From<MIntegration> for IntegrationResponse {
-    fn from(m: MIntegration) -> Self {
-        IntegrationResponse {
-            id: m.id,
-            organization: m.organization,
-            name: m.name,
-            display_name: m.display_name,
-            kind: kind_to_str(m.kind).to_string(),
-            forge_type: forge_to_str(m.forge_type).to_string(),
-            endpoint_url: m.endpoint_url,
-            has_secret: m.secret.is_some(),
-            has_access_token: m.access_token.is_some(),
-            allowed_ips: m.allowed_ips.unwrap_or_default(),
-            created_by: m.created_by,
-            created_at: m.created_at,
-        }
+fn base_from(m: MIntegration) -> IntegrationResponse {
+    IntegrationResponse {
+        id: m.id,
+        organization: m.organization,
+        name: m.name,
+        display_name: m.display_name,
+        kind: kind_to_str(m.kind).to_string(),
+        forge_type: forge_to_str(m.forge_type).to_string(),
+        endpoint_url: m.endpoint_url,
+        has_secret: m.secret.is_some(),
+        has_access_token: m.access_token.is_some(),
+        allowed_ips: m.allowed_ips.unwrap_or_default(),
+        installation_id: None,
+        account_login: None,
+        created_by: m.created_by,
+        created_at: m.created_at,
     }
+}
+
+async fn integration_response(
+    db: &impl sea_orm::ConnectionTrait,
+    m: MIntegration,
+) -> Result<IntegrationResponse, WebError> {
+    let install = match m.github_installation {
+        Some(fk) => gradient_entity::github_installation::Entity::find_by_id(fk).one(db).await?,
+        None => None,
+    };
+    Ok(IntegrationResponse {
+        installation_id: install.as_ref().map(|i| i.installation_id),
+        account_login: install.and_then(|i| i.account_login),
+        ..base_from(m)
+    })
 }
 
 fn normalize_allowed_ips(raw: Option<Vec<String>>) -> Result<Option<Vec<String>>, WebError> {
@@ -108,6 +125,8 @@ pub struct CreateIntegrationRequest {
     /// CIDR strings; only inbound webhooks from these sources are accepted.
     #[serde(default)]
     pub allowed_ips: Option<Vec<String>>,
+    /// Required for `forge_type=github`: the App installation id to bind.
+    pub installation_id: Option<i64>,
 }
 
 /// Credential-free integration handle. Returned by the summaries endpoint
@@ -211,9 +230,12 @@ pub async fn get_integrations(
         .all(&state.web_db)
         .await?;
 
-    Ok(ok_json(
-        rows.into_iter().map(IntegrationResponse::from).collect(),
-    ))
+    let mut out = Vec::with_capacity(rows.len());
+    for row in rows {
+        out.push(integration_response(&state.web_db, row).await?);
+    }
+
+    Ok(ok_json(out))
 }
 
 /// `GET /orgs/{organization}/integrations/summary` - list integrations as
@@ -274,21 +296,48 @@ pub async fn put_integration(
     if check_index_name(&body.name).is_err() {
         return Err(WebError::invalid_name("Integration Name"));
     }
-    if body.name == GITHUB_APP_INTEGRATION_NAME {
-        return Err(WebError::bad_request(format!(
-            "Integration name '{}' is reserved for the auto-managed GitHub App row.",
-            GITHUB_APP_INTEGRATION_NAME
-        )));
+
+    let forge = parse_forge(&body.forge_type)?;
+
+    if matches!(forge, ForgeType::GitHub) {
+        let installation_id = body.installation_id.ok_or_else(|| {
+            WebError::bad_request("forge_type 'github' requires an installation_id")
+        })?;
+        let Some(app) = state.config.github_app.clone() else {
+            return Err(WebError::bad_request(
+                "GitHub App is not configured on this server; set GRADIENT_GITHUB_APP_* first",
+            ));
+        };
+        let pem = std::fs::read_to_string(&app.private_key_file)
+            .map_err(|e| WebError::internal(format!("reading github app key: {e}")))?;
+        let account = gradient_forge::github_app::get_installation(
+            &state.http, app.app_id, &pem, installation_id,
+        )
+        .await
+        .map_err(|e| WebError::bad_request(format!("invalid installation_id: {e}")))?;
+
+        let inst = gradient_ci::upsert_github_installation(
+            &state.web_db, org.id, installation_id, Some(&account), user.id,
+        )
+        .await?;
+        let name = gradient_ci::github_integration_name(Some(&account), installation_id);
+        gradient_ci::ensure_github_app_integrations(
+            &state.web_db, org.id, inst, &name, "GitHub", user.id,
+        )
+        .await?;
+
+        let created = EIntegration::find()
+            .filter(CIntegration::Organization.eq(org.id))
+            .filter(CIntegration::Kind.eq(i16::from(IntegrationKind::Outbound)))
+            .filter(CIntegration::GithubInstallation.eq(inst))
+            .one(&state.web_db)
+            .await?
+            .ok_or_else(|| WebError::internal("github integration not created"))?;
+
+        return Ok(ok_json(integration_response(&state.web_db, created).await?));
     }
 
     let kind = parse_kind(&body.kind)?;
-    let forge = parse_forge(&body.forge_type)?;
-    if matches!(forge, ForgeType::GitHub) {
-        return Err(WebError::bad_request(
-            "GitHub integrations are managed through the server-wide GitHub App; \
-             enable the App on the organization instead of creating an integration row.",
-        ));
-    }
 
     // Name must be unique within (organization, kind).
     let existing = EIntegration::find()
@@ -351,7 +400,7 @@ pub async fn put_integration(
 
     let integration = integration.insert(&state.web_db).await?;
 
-    Ok(ok_json(IntegrationResponse::from(integration)))
+    Ok(ok_json(integration_response(&state.web_db, integration).await?))
 }
 
 /// `GET /orgs/{organization}/integrations/{id}` - fetch a single integration.
@@ -373,7 +422,7 @@ pub async fn get_integration(
     )
     .await?;
     let integration = load_integration_in_org(&state, org.id, integration_id).await?;
-    Ok(ok_json(IntegrationResponse::from(integration)))
+    Ok(ok_json(integration_response(&state.web_db, integration).await?))
 }
 
 /// `PATCH /orgs/{organization}/integrations/{id}` - update an integration.
@@ -408,12 +457,6 @@ pub async fn patch_integration(
     if let Some(name) = body.name {
         if check_index_name(&name).is_err() {
             return Err(WebError::invalid_name("Integration Name"));
-        }
-        if name == GITHUB_APP_INTEGRATION_NAME {
-            return Err(WebError::bad_request(format!(
-                "Integration name '{}' is reserved for the auto-managed GitHub App row.",
-                GITHUB_APP_INTEGRATION_NAME
-            )));
         }
         let clash = EIntegration::find()
             .filter(CIntegration::Organization.eq(org.id))
@@ -486,7 +529,7 @@ pub async fn patch_integration(
 
     let updated = active.update(&state.web_db).await?;
 
-    Ok(ok_json(IntegrationResponse::from(updated)))
+    Ok(ok_json(integration_response(&state.web_db, updated).await?))
 }
 
 /// `DELETE /orgs/{organization}/integrations/{id}` - remove an integration.

--- a/backend/gradient-web/src/endpoints/orgs/integrations.rs
+++ b/backend/gradient-web/src/endpoints/orgs/integrations.rs
@@ -30,7 +30,7 @@ use gradient_types::input::check_index_name;
 use gradient_types::*;
 use gradient_core::ServerState;
 use sea_orm::ActiveValue::Set;
-use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, TransactionTrait};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -308,7 +308,8 @@ pub async fn put_integration(
                 "GitHub App is not configured on this server; set GRADIENT_GITHUB_APP_* first",
             ));
         };
-        let pem = std::fs::read_to_string(&app.private_key_file)
+        let pem = tokio::fs::read_to_string(&app.private_key_file)
+            .await
             .map_err(|e| WebError::internal(format!("reading github app key: {e}")))?;
         let account = gradient_forge::github_app::get_installation(
             &state.http, app.app_id, &pem, installation_id,
@@ -316,13 +317,14 @@ pub async fn put_integration(
         .await
         .map_err(|e| WebError::bad_request(format!("invalid installation_id: {e}")))?;
 
+        let txn = state.web_db.inner().begin().await?;
         let inst = gradient_ci::upsert_github_installation(
-            &state.web_db, org.id, installation_id, Some(&account), user.id,
+            &txn, org.id, installation_id, Some(&account), user.id,
         )
         .await?;
         let name = gradient_ci::github_integration_name(Some(&account), installation_id);
         gradient_ci::ensure_github_app_integrations(
-            &state.web_db, org.id, inst, &name, "GitHub", user.id,
+            &txn, org.id, inst, &name, "GitHub", user.id,
         )
         .await?;
 
@@ -330,9 +332,10 @@ pub async fn put_integration(
             .filter(CIntegration::Organization.eq(org.id))
             .filter(CIntegration::Kind.eq(i16::from(IntegrationKind::Outbound)))
             .filter(CIntegration::GithubInstallation.eq(inst))
-            .one(&state.web_db)
+            .one(&txn)
             .await?
             .ok_or_else(|| WebError::internal("github integration not created"))?;
+        txn.commit().await?;
 
         return Ok(ok_json(integration_response(&state.web_db, created).await?));
     }

--- a/backend/gradient-web/src/endpoints/orgs/integrations.rs
+++ b/backend/gradient-web/src/endpoints/orgs/integrations.rs
@@ -343,6 +343,7 @@ pub async fn put_integration(
         endpoint_url,
         access_token: encrypted_token,
         allowed_ips,
+        github_installation: None,
         created_by: user.id,
         created_at: gradient_types::now(),
     }

--- a/backend/gradient-web/src/endpoints/orgs/integrations.rs
+++ b/backend/gradient-web/src/endpoints/orgs/integrations.rs
@@ -334,7 +334,12 @@ pub async fn put_integration(
             .filter(CIntegration::GithubInstallation.eq(inst))
             .one(&txn)
             .await?
-            .ok_or_else(|| WebError::internal("github integration not created"))?;
+            .ok_or_else(|| {
+                WebError::conflict(format!(
+                    "an integration named '{name}' already exists in this organization; \
+                     rename it before binding this installation"
+                ))
+            })?;
         txn.commit().await?;
 
         return Ok(ok_json(integration_response(&state.web_db, created).await?));
@@ -555,9 +560,23 @@ pub async fn delete_integration(
     .await?;
     let integration = load_integration_in_org(&state, org.id, integration_id).await?;
     if integration.forge_type == i16::from(ForgeType::GitHub) {
-        return Err(WebError::bad_request(
-            "GitHub App integrations are managed automatically and cannot be deleted.",
-        ));
+        let txn = state.web_db.inner().begin().await?;
+        match integration.github_installation {
+            Some(fk) => {
+                EIntegration::delete_many()
+                    .filter(CIntegration::GithubInstallation.eq(fk))
+                    .exec(&txn)
+                    .await?;
+                gradient_entity::github_installation::Entity::delete_by_id(fk)
+                    .exec(&txn)
+                    .await?;
+            }
+            None => {
+                integration.into_active_model().delete(&txn).await?;
+            }
+        }
+        txn.commit().await?;
+        return Ok(ok_json(true));
     }
     integration
         .into_active_model()

--- a/backend/gradient-web/src/endpoints/orgs/management.rs
+++ b/backend/gradient-web/src/endpoints/orgs/management.rs
@@ -72,12 +72,7 @@ pub struct OrgResponse {
     pub managed: bool,
     pub created_by: UserId,
     pub created_at: chrono::NaiveDateTime,
-    /// GitHub App installation id for this org. `Some` is the single signal
-    /// that the org uses the GitHub App; outbound CI status reporting and
-    /// install-webhook routing both gate on this being populated.
-    pub github_installation_id: Option<i64>,
-    /// Whether the server has a GitHub App configured at all. The frontend
-    /// hides GitHub-specific UI entirely when this is `false`.
+    /// Whether the server has a GitHub App configured at all.
     pub github_app_available: bool,
     pub role: Option<String>,
 }
@@ -355,7 +350,6 @@ pub async fn get_organization(
         managed: org.managed,
         created_by: org.created_by,
         created_at: org.created_at,
-        github_installation_id: org.github_installation_id,
         github_app_available: state.config.github_app.clone().is_some(),
         role,
     }))

--- a/backend/gradient-web/tests/admin_state.rs
+++ b/backend/gradient-web/tests/admin_state.rs
@@ -41,7 +41,7 @@ fn with_user(db: MockDatabase, session_id: SessionId, caller: gradient_entity::u
         .append_query_results([vec![caller]])
 }
 
-/// Append the eighteen (all-empty) table reads `export_state` issues, in order.
+/// Append the nineteen (all-empty) table reads `export_state` issues, in order.
 fn with_empty_export(db: MockDatabase) -> MockDatabase {
     db.append_query_results([Vec::<gradient_entity::user::Model>::new()])
         .append_query_results([Vec::<gradient_entity::organization::Model>::new()])
@@ -61,6 +61,7 @@ fn with_empty_export(db: MockDatabase) -> MockDatabase {
         .append_query_results([Vec::<gradient_entity::project_trigger::Model>::new()])
         .append_query_results([Vec::<gradient_entity::project_action::Model>::new()])
         .append_query_results([Vec::<gradient_entity::project_flake_input_override::Model>::new()])
+        .append_query_results([Vec::<gradient_entity::github_installation::Model>::new()])
 }
 
 #[test]

--- a/backend/gradient-web/tests/forge_hooks.rs
+++ b/backend/gradient-web/tests/forge_hooks.rs
@@ -181,10 +181,24 @@ fn org_row(name: &str) -> gradient_entity::organization::Model {
     }
 }
 
-fn org_row_with_installation(name: &str, installation_id: i64) -> gradient_entity::organization::Model {
-    let mut row = org_row(name);
-    row.github_installation_id = Some(installation_id);
-    row
+fn github_installation_id() -> gradient_entity::ids::GithubInstallationId {
+    gradient_entity::ids::GithubInstallationId::new(
+        Uuid::parse_str("a0000000-0000-0000-0000-000000000008").unwrap(),
+    )
+}
+
+fn github_installation_row(
+    organization: gradient_types::ids::OrganizationId,
+    installation_id: i64,
+) -> gradient_entity::github_installation::Model {
+    gradient_entity::github_installation::Model {
+        id: github_installation_id(),
+        organization,
+        installation_id,
+        account_login: Some("gh-org".into()),
+        created_by: user_id(),
+        created_at: fixture_date(),
+    }
 }
 
 fn integration_row(secret_ciphertext: &str) -> gradient_entity::integration::Model {
@@ -207,6 +221,7 @@ fn github_integration_row() -> gradient_entity::integration::Model {
         name: "github-app".into(),
         display_name: "GitHub App".into(),
         forge_type: 3, // GitHub
+        github_installation: Some(github_installation_id()),
         created_by: user_id(),
         created_at: fixture_date(),
         ..Default::default()
@@ -944,7 +959,7 @@ async fn github_app_webhook_push_fires_trigger_inner() {
 
     // Mock chain:
     // resolve_github_app_targets:
-    //   1. SELECT orgs by installation_id (.all) → [org row]
+    //   1. SELECT github_installation by installation_id (.all) → [github_installation row]
     //   2. SELECT projects for org (.all) → [project row matching webhook url]
     //   3. SELECT inbound GitHub integration (.one) → integration row
     // fan_out_triggers:
@@ -953,7 +968,7 @@ async fn github_app_webhook_push_fires_trigger_inner() {
     //   6. org_name_for → org row
     //   7+. apply_trigger chain
     let db = MockDatabase::new(DatabaseBackend::Postgres)
-        .append_query_results([vec![org_row_with_installation("gh-org", 9999)]])
+        .append_query_results([vec![github_installation_row(org_id(), 9999)]])
         .append_query_results([vec![github_project_row()]])
         .append_query_results([vec![github_integration_row()]])
         .append_query_results([vec![trigger_row(reporter_push_trigger(vec![]))]])
@@ -1045,9 +1060,8 @@ async fn github_app_webhook_installation_inner() {
     let gh_secret = "github-webhook-secret";
     let gh_secret_path = temp_secret_file(gh_secret);
 
-    let db = MockDatabase::new(DatabaseBackend::Postgres)
-        .append_query_results([Vec::<gradient_entity::organization::Model>::new()])
-        .into_connection();
+    // No repositories in the payload → installed set is empty → early return before any DB query.
+    let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
 
     let state = make_state(db, None, Some(gh_secret_path));
     let router = create_router(state);
@@ -1127,14 +1141,23 @@ async fn github_app_webhook_multi_org_routes_to_matching_org_inner() {
     let gh_secret = "github-webhook-secret";
     let gh_secret_path = temp_secret_file(gh_secret);
 
-    // Two orgs share installation_id=9999. Org A's projects don't match
-    // the webhook's repo URL; org B has the matching project. Only org B's
-    // integration should fire.
+    // Two orgs share installation_id=9999 via separate github_installation rows.
+    // Org A's projects don't match the webhook repo URL; org B has the matching
+    // project. Only org B's integration should fire.
     let org_a_id =
         OrganizationId::new(Uuid::parse_str("a0000000-0000-0000-0000-0000000000aa").unwrap());
-    let mut org_a = org_row_with_installation("org-a", 9999);
-    org_a.id = org_a_id;
-    let org_b = org_row_with_installation("gh-org", 9999);
+    let inst_a_id = gradient_entity::ids::GithubInstallationId::new(
+        Uuid::parse_str("a0000000-0000-0000-0000-0000000000a8").unwrap(),
+    );
+    let inst_a = gradient_entity::github_installation::Model {
+        id: inst_a_id,
+        organization: org_a_id,
+        installation_id: 9999,
+        account_login: Some("org-a".into()),
+        created_by: user_id(),
+        created_at: fixture_date(),
+    };
+    let inst_b = github_installation_row(org_id(), 9999);
 
     let org_a_project = project_row_with(
         ProjectId::new(Uuid::parse_str("a0000000-0000-0000-0000-0000000000ab").unwrap()),
@@ -1146,17 +1169,17 @@ async fn github_app_webhook_multi_org_routes_to_matching_org_inner() {
 
     // Mock chain:
     // resolve_github_app_targets:
-    //   1. orgs.all by installation_id → [org A, org B]
+    //   1. SELECT github_installation by installation_id → [inst_a, inst_b]
     //   2. projects.all for org A → [org_a_project]   (no URL match → skipped)
     //   3. projects.all for org B → [org_b_project]   (URL matches)
-    //   4. integration.one for org B → github_integration_row
+    //   4. integration.one for org B (filtered by inst_b.id) → github_integration_row
     // fan_out_triggers for org B's integration:
     //   5. load_active_triggers → [trigger]
     //   6. EProject::find_by_id → org_b_project
     //   7. org_name_for → org B row
     //   8+. apply_trigger chain
     let db = MockDatabase::new(DatabaseBackend::Postgres)
-        .append_query_results([vec![org_a.clone(), org_b.clone()]])
+        .append_query_results([vec![inst_a, inst_b]])
         .append_query_results([vec![org_a_project]])
         .append_query_results([vec![org_b_project.clone()]])
         .append_query_results([vec![github_integration_row()]])
@@ -1212,7 +1235,7 @@ async fn github_app_webhook_no_matching_repo_returns_zero_inner() {
     );
 
     let db = MockDatabase::new(DatabaseBackend::Postgres)
-        .append_query_results([vec![org_row_with_installation("gh-org", 9999)]])
+        .append_query_results([vec![github_installation_row(org_id(), 9999)]])
         .append_query_results([vec![unrelated]])
         .into_connection();
 

--- a/backend/gradient-web/tests/orgs_integrations.rs
+++ b/backend/gradient-web/tests/orgs_integrations.rs
@@ -15,9 +15,9 @@
 //!   `has_secret`/`has_access_token` booleans so non-admin members cannot
 //!   probe credential state.
 
-use gradient_entity::{ids::*, integration, organization_user, role};
+use gradient_entity::{github_installation, ids::*, integration, organization_user, role};
 use gradient_types::SessionId;
-use sea_orm::{DatabaseBackend, MockDatabase};
+use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
 use serde_json::Value;
 use gradient_test_support::fixtures::{org, org_id, test_date, user, user_id};
 use gradient_test_support::web::{live_session, make_test_server, make_token};
@@ -54,16 +54,36 @@ fn gitea_inbound_row() -> integration::Model {
     }
 }
 
+fn github_installation_id() -> GithubInstallationId {
+    GithubInstallationId::new(Uuid::parse_str("00000000-0000-0000-0000-0000000000cc").unwrap())
+}
+
+fn github_integration_id() -> IntegrationId {
+    IntegrationId::new(Uuid::parse_str("019e16b2-e958-7652-ad97-67cd7b0fea61").unwrap())
+}
+
 fn github_inbound_row() -> integration::Model {
     integration::Model {
-        id: IntegrationId::new(Uuid::parse_str("019e16b2-e958-7652-ad97-67cd7b0fea61").unwrap()),
+        id: github_integration_id(),
         organization: org_id(),
         name: "github".into(),
         display_name: "GitHub".into(),
         forge_type: 3,
+        github_installation: Some(github_installation_id()),
         created_by: user_id(),
         created_at: test_date(),
         ..Default::default()
+    }
+}
+
+fn github_installation_row() -> github_installation::Model {
+    github_installation::Model {
+        id: github_installation_id(),
+        organization: org_id(),
+        installation_id: 999,
+        account_login: Some("acme-corp".into()),
+        created_by: user_id(),
+        created_at: test_date(),
     }
 }
 
@@ -233,6 +253,47 @@ fn summary_endpoint_rejects_non_member() {
             .await;
 
         res.assert_status_not_found();
+    });
+}
+
+#[test]
+fn delete_github_integration_removes_pair_and_installation() {
+    // Sequence: auth (session x2 + user), org+org_user+role (ManageIntegrations),
+    // SELECT integration (load_integration_in_org), DELETE integrations by fk (exec),
+    // DELETE github_installation by id (exec). MockDatabase commit() is a no-op.
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let session_id = SessionId::now_v7();
+        let token = make_token(session_id);
+        let integration_id = github_integration_id();
+
+        let db = with_org_manage(with_auth(
+            MockDatabase::new(DatabaseBackend::Postgres),
+            session_id,
+        ))
+        .append_query_results([vec![github_inbound_row()]])
+        .append_exec_results([
+            MockExecResult { last_insert_id: 0, rows_affected: 2 },
+            MockExecResult { last_insert_id: 0, rows_affected: 1 },
+        ]);
+
+        let _ = github_installation_row();
+        let server = make_test_server(db.into_connection());
+        let res = server
+            .delete(&format!(
+                "/api/v1/orgs/test-org/integrations/{}",
+                integration_id
+            ))
+            .add_header("authorization", format!("Bearer {}", token))
+            .await;
+
+        res.assert_status_ok();
+        let body: Value = res.json();
+        assert_eq!(body["error"], false);
+        assert_eq!(body["message"], true);
     });
 }
 

--- a/backend/gradient-web/tests/orgs_integrations.rs
+++ b/backend/gradient-web/tests/orgs_integrations.rs
@@ -15,7 +15,7 @@
 //!   `has_secret`/`has_access_token` booleans so non-admin members cannot
 //!   probe credential state.
 
-use gradient_entity::{ids::*, integration, organization_user};
+use gradient_entity::{ids::*, integration, organization_user, role};
 use gradient_types::SessionId;
 use sea_orm::{DatabaseBackend, MockDatabase};
 use serde_json::Value;
@@ -93,6 +93,33 @@ fn with_auth(db: MockDatabase, session_id: SessionId) -> MockDatabase {
 fn with_org_member(db: MockDatabase) -> MockDatabase {
     db.append_query_results([vec![org()]])
         .append_query_results([vec![member_only_membership()]])
+}
+
+fn admin_membership() -> organization_user::Model {
+    organization_user::Model {
+        id: OrganizationUserId::new(
+            Uuid::parse_str("00000000-0000-0000-0000-0000000000aa").unwrap(),
+        ),
+        organization: org_id(),
+        user: user_id(),
+        role: gradient_types::consts::BASE_ROLE_ADMIN_ID,
+    }
+}
+
+fn admin_role() -> role::Model {
+    role::Model {
+        id: gradient_types::consts::BASE_ROLE_ADMIN_ID,
+        name: "Admin".into(),
+        permission: gradient_db::permissions::admin_mask(),
+        ..Default::default()
+    }
+}
+
+/// `OrgAccess::Require { ManageIntegrations }` sequence: SELECT org, SELECT org_user, SELECT role.
+fn with_org_manage(db: MockDatabase) -> MockDatabase {
+    db.append_query_results([vec![org()]])
+        .append_query_results([vec![admin_membership()]])
+        .append_query_results([vec![admin_role()]])
 }
 
 const SUMMARY_URL: &str = "/api/v1/orgs/test-org/integrations/summary";
@@ -206,5 +233,43 @@ fn summary_endpoint_rejects_non_member() {
             .await;
 
         res.assert_status_not_found();
+    });
+}
+
+#[test]
+fn github_create_without_app_config_is_rejected() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let session_id = SessionId::now_v7();
+        let token = make_token(session_id);
+
+        let db = with_org_manage(with_auth(
+            MockDatabase::new(DatabaseBackend::Postgres),
+            session_id,
+        ));
+
+        let server = make_test_server(db.into_connection());
+        let res = server
+            .put("/api/v1/orgs/test-org/integrations")
+            .add_header("authorization", format!("Bearer {}", token))
+            .json(&serde_json::json!({
+                "name": "my-gh",
+                "kind": "outbound",
+                "forge_type": "github",
+                "installation_id": 42,
+            }))
+            .await;
+
+        res.assert_status_bad_request();
+        let body: Value = res.json();
+        assert_eq!(body["error"], true);
+        assert!(
+            body["message"].as_str().unwrap().contains("not configured"),
+            "expected 'not configured' in error: {}",
+            body["message"]
+        );
     });
 }

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -4115,9 +4115,9 @@ paths:
         `signing_key_file`, `token_file`, `key_file`, `secret_file`,
         `access_token_file`) is redacted to `null` - the hashed/encrypted
         secrets cannot be recovered and must be filled in by hand. The
-        auto-managed `build-request` project, server-managed GitHub
-        integration rows, and the built-in `Admin`/`Write`/`View` roles are
-        omitted.
+        auto-managed `build-request` project, GitHub integration rows (exported
+        as `github_installations` on the org instead), and the built-in
+        `Admin`/`Write`/`View` roles are omitted.
 
         Requires `superuser`.
       operationId: exportState
@@ -5655,9 +5655,12 @@ paths:
         URL (`/hooks/gitea/...`, `/hooks/forgejo/...`, `/hooks/gitlab/...`).
         The stored `forge_type` is display metadata only for inbound.
 
-        `forge_type: "github"` is rejected with `400`: GitHub integration is
-        provided by the server-wide GitHub App together with the org's
-        `github_installation_id`, not by per-org integration rows.
+        `forge_type: "github"` integrations are creatable by supplying
+        `installation_id`. The server App must be configured (else `400`);
+        the installation id is validated against the App (invalid id returns
+        `400`). An inbound and outbound integration pair is created
+        automatically, named `github-<account>`. Multiple installations per org
+        are supported (one per GitHub account).
       operationId: createOrgIntegration
       requestBody:
         required: true
@@ -5762,9 +5765,8 @@ paths:
         Patch-updates an integration. Omit a field to leave it unchanged.
         Pass an empty string for `secret` or `access_token` to **clear** it.
 
-        `forge_type=github` rows are server-managed (auto-seeded when the
-        GitHub App is installed on the org) and cannot be modified - PATCH
-        rejects them with `400`.
+        `forge_type=github` rows are managed by the App and installation; PATCH
+        rejects them with `400`. Delete the row to remove the integration.
       operationId: patchOrgIntegration
       requestBody:
         required: true
@@ -5798,8 +5800,8 @@ paths:
       description: >-
         Deletes an integration. Any project `project_integration` rows
         referencing it are cleared via `ON DELETE SET NULL`.
-        `forge_type=github` rows are server-managed and cannot be deleted -
-        the endpoint returns `400` for them.
+        `forge_type=github` rows can be deleted; deleting removes the
+        installation binding for that account.
       operationId: deleteOrgIntegration
       responses:
         '200':
@@ -7824,18 +7826,6 @@ components:
         created_at:
           type: string
           format: date-time
-        github_installation_id:
-          type: integer
-          format: int64
-          nullable: true
-          description: >-
-            GitHub App installation ID bound to this org. The presence of this
-            value (non-null) is the single signal that this org uses the GitHub
-            App - outbound CI status reporting and webhook routing both gate on
-            it. Populated automatically by the `installation` webhook (when the
-            GitHub login matches the Gradient org name) and by the state-driven
-            provisioner (`StateOrganization.github_installation_id`); cleared
-            automatically when GitHub sends `installation.deleted`.
         github_app_available:
           type: boolean
           description: >-
@@ -9475,6 +9465,15 @@ components:
             source is allowed. Inbound deliveries from outside the allowlist
             are rejected with `403 forbidden_source_ip` (after signature
             verification succeeds).
+        installation_id:
+          type: integer
+          format: int64
+          nullable: true
+          description: GitHub App installation id. Non-null for `forge_type=github` rows.
+        account_login:
+          type: string
+          nullable: true
+          description: GitHub account login the installation is bound to. Non-null for `forge_type=github` rows.
         created_by:
           type: string
           format: uuid
@@ -9521,11 +9520,17 @@ components:
           enum: [inbound, outbound]
         forge_type:
           type: string
-          enum: [gitea, forgejo, gitlab]
+          enum: [gitea, forgejo, gitlab, github]
           description: >-
-            `github` is intentionally excluded - GitHub integration is
-            provided by the server-wide GitHub App and the org's
-            `github_installation_id`, not by per-integration rows.
+            For `github`: supply `installation_id`; the server App must be
+            configured. An inbound + outbound pair is created automatically.
+        installation_id:
+          type: integer
+          format: int64
+          nullable: true
+          description: >-
+            Required when `forge_type` is `github`. The GitHub App installation
+            id to bind. Validated against the App; invalid ids return `400`.
         secret:
           type: string
           description: >-
@@ -9564,9 +9569,8 @@ components:
           type: string
           enum: [gitea, forgejo, gitlab]
           description: >-
-            `github` is rejected here - GitHub integration is provided by the
-            server-wide GitHub App and the org's `github_installation_id`
-            instead.
+            `github` rows cannot be patched (PATCH returns `400`); delete to
+            remove a GitHub installation integration.
         endpoint_url:
           type: string
           nullable: true

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -9569,8 +9569,10 @@ components:
           type: string
           enum: [gitea, forgejo, gitlab]
           description: >-
-            `github` rows cannot be patched (PATCH returns `400`); delete to
-            remove a GitHub installation integration.
+            `github` is intentionally excluded from this enum: github rows are
+            installation-managed and not editable (PATCH returns `400`). The
+            schema itself prevents supplying `forge_type=github` here; delete
+            the row to remove a GitHub installation integration.
         endpoint_url:
           type: string
           nullable: true

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -241,7 +241,7 @@ services.gradient.githubApp = {
 };
 ```
 
-4. Install the App on each GitHub organization. Gradient auto-stores the `installation_id` from the webhook.
+4. Install the App on each GitHub organization. Gradient auto-creates the `github-<account>` integration pair from the install webhook. Alternatively, org admins can create integrations manually via the UI by entering the installation id (one per GitHub account; multiple per org are supported).
 
 5. Once installed, push events automatically trigger evaluations (no polling) and CI statuses are reported using the installation token instead of a per-project PAT.
 

--- a/docs/src/development/internals.md
+++ b/docs/src/development/internals.md
@@ -11,7 +11,7 @@ Key functions inside each crate.
 **GitHub App** (`POST /api/v1/hooks/github`):
 - Verifies `X-Hub-Signature-256` against `GRADIENT_GITHUB_APP_WEBHOOK_SECRET_FILE`.
 - `push` → calls `core::evaluation_trigger::trigger_evaluation` for each matching project.
-- `installation` / `installation_repositories` → stores or clears `organization.github_installation_id`.
+- `installation` / `installation_repositories` → upserts or clears `github_installation` rows and seeds the `github-<account>` integration pair.
 
 **Generic forges** (`POST /api/v1/hooks/{forge}/{org}/{integration_name}`):
 - `{forge}` ∈ `gitea`, `forgejo`, `gitlab`. GitHub deliveries route to the App webhook above.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -31,7 +31,7 @@ match is purely on the parsed `owner/repo`, so the flake shorthand
 (`github:owner/repo`) binds the same as the https / SSH clone URLs; previously the
 matcher keyed off a literal `github.com` substring and an org-name equals login
 fallback, so a `github:`-form project (and any org not named after the account)
-left `github_installation_id` unset.
+left the org without a `github_installation` row.
 
 ## Forge action "Test" button connectivity probe
 
@@ -4581,3 +4581,35 @@ session on slow object storage).
   in-memory `test_worker_disconnected_requeues` / `test_worker_disconnect_requeues_jobs`;
   the DB reset and the worker-side orphan-task cancellation are covered by CI E2E
   rather than the MockDatabase unit harness.
+
+## Per-org multi-installation GitHub integration (#436)
+
+GitHub is now a first-class creatable forge integration. The App remains
+server-wide; installations are per-org and multiple (one per GitHub account),
+created via `PUT /orgs/{org}/integrations` with `forge_type=github` and
+`installation_id`, or auto-created by the install webhook.
+
+`backend/gradient-ci/src/integration_lookup.rs` - `name_tests`:
+- `uses_account_login_when_present` - `github_integration_name(Some("Acme-Corp"), 42)` yields `"github-acme-corp"` (lowercased, prefixed).
+- `falls_back_to_installation_id` - `github_integration_name(None, 42)` yields `"github-42"` when no login is available.
+
+`backend/gradient-forge/src/github_app.rs` - `parses_installation_account_login`:
+- `InstallationResponse` deserialises `{"id":42,"account":{"login":"acme-corp"}}` and returns `account.login = "acme-corp"`. Guards the `get_installation` API call that validates an installation id on `PUT`.
+
+`backend/gradient-web/tests/orgs_integrations.rs` - `github_create_without_app_config_is_rejected`:
+- `PUT /orgs/{org}/integrations` with `forge_type=github` returns `400` when the server has no GitHub App configured (`GRADIENT_GITHUB_APP_ID` absent). Guards the "App must be configured" prerequisite before any installation lookup.
+
+`backend/gradient-web/tests/forge_hooks.rs` - reworked GitHub App dispatch tests routing by `github_installation` FK:
+- `github_app_webhook_push_fires_trigger` (Test 10) - a push event dispatched via a `github_installation` row fires the matching project trigger and returns one queued evaluation.
+- `github_app_webhook_installation` (Test 12) - an `installation` event for an org not found in the DB warns and returns `200` with `event="installation"` and empty queued arrays (no crash).
+- `github_app_webhook_multi_org_routes_to_matching_org` (Test 15) - a push event routes only to the org whose project URL matches the push payload; the sibling org with a different repo URL is not queued.
+- `github_app_webhook_no_matching_repo_returns_zero` (Test 16) - a push against a repo URL not tracked by any project returns `projects_scanned=0`.
+
+`backend/gradient-state/src/config.rs` - `deserializes_github_installations_list`:
+- `StateOrganization.github_installations` deserialises from a JSON list with `installation_id` + optional `account_login`, covering the new state provisioning path.
+
+`frontend/src/app/features/organizations/integrations/integrations.component.spec.ts` - `IntegrationsComponent - create github integration`:
+- `createIntegration sends forge_type=github with installation_id` - form submit with `forge_type=github` and a numeric `installation_id` string calls `PUT` with the parsed integer.
+- `createIntegration rejects a non-integer installation_id` - a non-numeric installation id string fails client-side validation without sending a request.
+
+Migration backfill (`m20260620_*_github_installation_table`) and the `github_installation` FK wiring are verified by E2E CI against real PostgreSQL.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -2741,45 +2741,6 @@ The metric encoder itself is exercised by a unit test
 that drives `render` with a fixed `Observations` struct and asserts the
 resulting `# HELP` / `# TYPE` lines and value formatting.
 
-## GitHub App as a server-managed integration row
-
-Coverage of the explicit `outbound_integration` opt-in for GitHub status
-reporting and the protections around the auto-managed `forge_type=github`
-integration rows. Run with
-`cargo test -p web --test projects_integration` and
-`cargo test -p core --tests ensure_tests`.
-
-`backend/web/tests/projects_integration.rs`:
-
-- `put_project_integration_accepts_github_outbound_row` - linking a project
-  to the auto-managed GitHub outbound integration via its UUID succeeds.
-- `put_project_integration_accepts_non_github_outbound_row` - Gitea/GitLab
-  outbound rows continue to work the same way (regression).
-- `patch_integration_rejects_github_row` /
-  `delete_integration_rejects_github_row` - server-managed rows can't be
-  edited or deleted via the org integrations API.
-- `delete_integration_accepts_non_github_row` - non-managed rows still
-  delete normally (regression).
-- `put_integration_still_rejects_github_forge_type` - POST with
-  `forge_type=github` continues to be rejected (no manual rows).
-- `put_integration_rejects_reserved_github_name` - name `"github"` is
-  reserved for the auto-managed row; user-created integrations using it
-  are rejected with 400.
-
-`backend/gradient-ci/src/integration_lookup.rs::ensure_tests`:
-
-- `creates_both_rows_when_none_exist` - calling
-  `ensure_github_app_integrations` on an org with no existing rows inserts
-  the inbound and outbound GitHub rows.
-- `skips_kinds_that_already_exist` - repeated calls are idempotent; rows
-  that already exist for that org/kind are not duplicated.
-
-The resolver simplification (URL-based auto-detection removed) is
-indirectly covered by the `put_project_integration_accepts_*` tests:
-linking returns the row id and the resolver now branches purely on
-`project_integration.outbound_integration` plus the integration's
-`forge_type`.
-
 ## Worker: empty `built_outputs` self-heals from the parsed `.drv`
 
 Modern daemons can legitimately return `BuildResult::Success` with an
@@ -4593,11 +4554,17 @@ created via `PUT /orgs/{org}/integrations` with `forge_type=github` and
 - `uses_account_login_when_present` - `github_integration_name(Some("Acme-Corp"), 42)` yields `"github-acme-corp"` (lowercased, prefixed).
 - `falls_back_to_installation_id` - `github_integration_name(None, 42)` yields `"github-42"` when no login is available.
 
+`backend/gradient-ci/src/integration_lookup.rs` - `ensure_tests`:
+- `creates_both_rows_when_none_exist` - `ensure_github_app_integrations` on an org with no existing rows inserts the inbound and outbound pair linked to the specific `github_installation`.
+- `skips_kinds_that_already_exist` - repeated calls are idempotent per installation; rows that already exist for that org/installation/kind are not duplicated.
+
 `backend/gradient-forge/src/github_app.rs` - `parses_installation_account_login`:
 - `InstallationResponse` deserialises `{"id":42,"account":{"login":"acme-corp"}}` and returns `account.login = "acme-corp"`. Guards the `get_installation` API call that validates an installation id on `PUT`.
 
-`backend/gradient-web/tests/orgs_integrations.rs` - `github_create_without_app_config_is_rejected`:
-- `PUT /orgs/{org}/integrations` with `forge_type=github` returns `400` when the server has no GitHub App configured (`GRADIENT_GITHUB_APP_ID` absent). Guards the "App must be configured" prerequisite before any installation lookup.
+`backend/gradient-web/tests/orgs_integrations.rs`:
+- `github_create_without_app_config_is_rejected` - `PUT /orgs/{org}/integrations` with `forge_type=github` returns `400` when the server has no GitHub App configured (`GRADIENT_GITHUB_APP_ID` absent). Guards the "App must be configured" prerequisite before any installation lookup.
+- PATCH on a `forge_type=github` row returns `400`; github rows are installation-managed and not editable via PATCH (delete to remove). The `PatchIntegrationRequest.forge_type` enum excludes `github` at the schema level.
+- github rows CAN be deleted via `DELETE /orgs/{org}/integrations/{id}`; removing the row also removes the `github_installation` binding.
 
 `backend/gradient-web/tests/forge_hooks.rs` - reworked GitHub App dispatch tests routing by `github_installation` FK:
 - `github_app_webhook_push_fires_trigger` (Test 10) - a push event dispatched via a `github_installation` row fires the matching project trigger and returns one queued evaluation.

--- a/docs/src/usage/integration.md
+++ b/docs/src/usage/integration.md
@@ -19,8 +19,8 @@ In the Gradient UI:
       within the organization and kind.
     - **Kind** - *Inbound* (Gradient receives webhooks) or *Outbound*
       (Gradient calls the forge API).
-    - **Forge type** - Gitea / Forgejo / GitLab. (GitHub does not appear here:
-      its inbound + outbound rows are server-managed; see *GitHub App* below.)
+    - **Forge type** - Gitea / Forgejo / GitLab / GitHub. For GitHub, also
+      enter the **Installation ID** (see *GitHub App* below).
 
 Then, depending on the kind:
 
@@ -37,18 +37,18 @@ never returns them again, only a boolean indicating their presence.
 
 ### GitHub App rows
 
-When the GitHub App is installed on an organization, Gradient automatically
-creates two `forge_type=github` integration rows for it: one *inbound* and one
-*outbound*, both named `github`. They appear in the org Integrations list as
-**Server-managed** and cannot be edited or deleted from the UI - their
-credentials come from the server's App config and the org's installation id.
+GitHub integrations are created by entering a GitHub App **Installation ID**
+in the New Integration form (select `forge_type: github`). The server validates
+the id against the configured App and creates an inbound and outbound pair
+automatically, named `github-<account>` (e.g. `github-acme-corp`). Multiple
+installations per org are supported - one per GitHub account.
 
-The integration name `github` is reserved system-wide for these rows; user-created
-integrations cannot use it.
+The install webhook also auto-creates these pairs when the App is installed on
+a GitHub account whose repos match an existing org project.
 
-Reference these rows from project triggers (inbound) and project
-`outbound_integration` (outbound) the same way you'd reference any other
-integration.
+GitHub rows can be **deleted** to remove the binding, but cannot be edited
+(PATCH returns `400`). Reference them from project triggers (inbound) and
+project `outbound_integration` (outbound) like any other integration.
 
 ## 2. Report build status
 
@@ -81,15 +81,16 @@ Gradient server. There are three roles to consider:
 2. **Organization admin** - once the server has the App configured, install the
    App on the organization's GitHub account.
 3. **GitHub repository owner** - installing the App fires the `installation`
-   webhook, which carries the list of granted repositories. Gradient stores the
-   installation id on every organization owning a project whose repository URL
-   resolves to one of those repositories, and seeds the `github-app` inbound +
-   outbound integration rows. Matching is purely on the repository URL: the
-   organization name and the Gradient project name need not match GitHub, and
+   webhook, which carries the list of granted repositories. Gradient writes a
+   `github_installation` row for every org owning a project whose repository URL
+   resolves to one of those repositories, and seeds the `github-<account>`
+   inbound + outbound integration pair. Matching is purely on the repository URL:
+   the organization name and the Gradient project name need not match GitHub, and
    the flake shorthand (`github:owner/repo`) is recognized alongside the https
-   and SSH clone URLs. Subsequent push / pull-request deliveries route to the
-   corresponding Gradient organization, and projects can link to the outbound
-   row to enable status reporting.
+   and SSH clone URLs. Multiple installations per org are supported (one per
+   GitHub account). Subsequent push / pull-request deliveries route to the
+   corresponding integration pair, and projects can link to the outbound row to
+   enable status reporting.
 
 Webhook deliveries are signed with the App's webhook secret and verified
 server-side. Build statuses are reported back via the App's installation token.

--- a/docs/src/usage/state.md
+++ b/docs/src/usage/state.md
@@ -152,9 +152,31 @@ services.gradient.state.organizations.acme = {
 | `description` | `null` | Optional description |
 | `private_key_file` | - | Path to SSH private key (required) |
 | `public` | `false` | Visible to all users |
-| `github_installation_id` | `null` | GitHub App installation id to bind to this org (look it up on the App's "Install App" page on GitHub). Setting this enables outbound CI status reporting and webhook routing. When `null`, the field is left untouched on update so a webhook-recorded id survives reconciliation |
+| `github_installations` | `[]` | List of GitHub App installations to bind to this org. Each entry provisions a `github-<account>` inbound + outbound integration pair. An empty list leaves webhook-recorded installations untouched on reconciliation. |
 | `created_by` | - | Username of creator (required) |
 | `members` | `[]` | Per-org membership list. When non-empty, the list is authoritative (drift removes unlisted memberships, the implicit creator-Admin step is skipped). Empty preserves the legacy behavior. Members referencing not-yet-registered users are skipped silently and backfilled on registration / OIDC first-login |
+
+### GitHub installations
+
+Declare per-org GitHub App installation bindings:
+
+```nix
+services.gradient.state.organizations.acme = {
+  display_name     = "ACME Corp";
+  private_key_file = "/run/secrets/acme-ssh-key";
+  created_by       = "alice";
+  github_installations = [
+    { installation_id = 12345678; account_login = "acme-corp"; }
+  ];
+};
+```
+
+Each entry provisions a `github-<account>` inbound + outbound integration pair for the org. Multiple entries are supported (one per GitHub account). An absent or empty list leaves any webhook-recorded installations untouched on reconciliation.
+
+| Option | Default | Description |
+|---|---|---|
+| `installation_id` | - | GitHub App installation id (required, integer) |
+| `account_login` | `null` | GitHub account login; used to derive the integration name (`github-<login>`). When null, the name falls back to `github-<installation_id>`. |
 
 ### Organization members
 

--- a/docs/src/usage/state.md
+++ b/docs/src/usage/state.md
@@ -152,7 +152,7 @@ services.gradient.state.organizations.acme = {
 | `description` | `null` | Optional description |
 | `private_key_file` | - | Path to SSH private key (required) |
 | `public` | `false` | Visible to all users |
-| `github_installations` | `[]` | List of GitHub App installations to bind to this org. Each entry provisions a `github-<account>` inbound + outbound integration pair. An empty list leaves webhook-recorded installations untouched on reconciliation. |
+| `github_installations` | `[]` | List of GitHub App installations to bind to this org. Each entry provisions a `github-<account>` inbound + outbound integration pair. |
 | `created_by` | - | Username of creator (required) |
 | `members` | `[]` | Per-org membership list. When non-empty, the list is authoritative (drift removes unlisted memberships, the implicit creator-Admin step is skipped). Empty preserves the legacy behavior. Members referencing not-yet-registered users are skipped silently and backfilled on registration / OIDC first-login |
 

--- a/frontend/src/app/core/models/integration.model.ts
+++ b/frontend/src/app/core/models/integration.model.ts
@@ -21,6 +21,8 @@ export interface Integration {
   allowed_ips: string[];
   created_by: string;
   created_at: string;
+  installation_id?: number | null;
+  account_login?: string | null;
 }
 
 /** Credential-free integration handle returned by the org-member summary
@@ -42,6 +44,7 @@ export interface CreateIntegrationRequest {
   endpoint_url?: string;
   access_token?: string;
   allowed_ips?: string[];
+  installation_id?: number;
 }
 
 export interface PatchIntegrationRequest {

--- a/frontend/src/app/core/models/organization.model.ts
+++ b/frontend/src/app/core/models/organization.model.ts
@@ -17,7 +17,6 @@ export interface Organization {
   created_at?: string;
   role?: 'Admin' | 'Write' | 'View';
   running_evaluations?: number;
-  github_installation_id?: number | null;
   github_app_available?: boolean;
 }
 

--- a/frontend/src/app/features/board/job-detail/job-detail.component.spec.ts
+++ b/frontend/src/app/features/board/job-detail/job-detail.component.spec.ts
@@ -82,6 +82,7 @@ const DETAIL: DispatchedJobDetail = {
     idle_workers: 2,
   },
   candidates: null,
+  passed_over: false,
   previous_attempts: [],
 };
 

--- a/frontend/src/app/features/organizations/integrations/integrations.component.html
+++ b/frontend/src/app/features/organizations/integrations/integrations.component.html
@@ -40,7 +40,7 @@
               @if (githubAppInstalled()) {
                 @for (inst of githubInstallations(); track inst.id) {
                   <p class="text-secondary">
-                    <strong>@{{ inst.account_login }}</strong> — installation <code>{{ inst.installation_id }}</code>
+                    <strong>{{ inst.account_login ? '@' + inst.account_login : 'unknown' }}</strong> — installation <code>{{ inst.installation_id ?? 'N/A' }}</code>
                   </p>
                 }
               } @else {
@@ -130,7 +130,7 @@
                   }
                   <div class="form-group">
                     <label>Installation ID</label>
-                    <div class="mono-value">{{ integration.installation_id }}</div>
+                    <div class="mono-value">{{ integration.installation_id ?? 'N/A' }}</div>
                   </div>
                 </div>
               } @else if (integration.kind === 'inbound') {

--- a/frontend/src/app/features/organizations/integrations/integrations.component.html
+++ b/frontend/src/app/features/organizations/integrations/integrations.component.html
@@ -36,18 +36,17 @@
         <div class="settings-card">
           <div class="github-row">
             <div>
-              <h3>GitHub App installation</h3>
+              <h3>GitHub App installations</h3>
               @if (githubAppInstalled()) {
-                <p class="text-secondary">
-                  This organization is bound to GitHub App installation
-                  <code>{{ githubInstallationId() }}</code>. Outbound CI status
-                  reporting and webhook routing are active.
-                </p>
+                @for (inst of githubInstallations(); track inst.id) {
+                  <p class="text-secondary">
+                    <strong>@{{ inst.account_login }}</strong> — installation <code>{{ inst.installation_id }}</code>
+                  </p>
+                }
               } @else {
                 <p class="text-secondary">
-                  No GitHub App installation is bound to this organization yet.
-                  Install the App on your GitHub account, or set
-                  <code>github_installation_id</code> on the org via state config.
+                  No GitHub App installation is linked to this organization yet.
+                  Install the App on your GitHub account, then add an integration here with the installation ID.
                 </p>
               }
             </div>
@@ -94,9 +93,7 @@
                   </div>
                 </div>
                 <div class="integration-actions">
-                  @if (integration.forge_type === 'github') {
-                    <span class="status-chip status-info">Server-managed</span>
-                  } @else {
+                  @if (integration.forge_type !== 'github') {
                     <button
                       *appWritable="access()"
                       pButton
@@ -107,29 +104,34 @@
                       (click)="openEditDialog(integration)"
                       [appManagedDisable]="access()"
                     ></button>
-                    <button
-                      *appWritable="access()"
-                      pButton
-                      label="Delete"
-                      icon="pi pi-trash"
-                      severity="danger"
-                      size="small"
-                      [loading]="deletingId() === integration.id"
-                      [disabled]="deletingId() !== null"
-                      (click)="deleteIntegration(integration)"
-                      [appManagedDisable]="access()"
-                    ></button>
                   }
+                  <button
+                    *appWritable="access()"
+                    pButton
+                    label="Delete"
+                    icon="pi pi-trash"
+                    severity="danger"
+                    size="small"
+                    [loading]="deletingId() === integration.id"
+                    [disabled]="deletingId() !== null"
+                    (click)="deleteIntegration(integration)"
+                    [appManagedDisable]="access()"
+                  ></button>
                 </div>
               </div>
 
               @if (integration.forge_type === 'github') {
                 <div class="integration-body">
-                  <p class="text-secondary">
-                    Credentials and webhook delivery are handled by the server-wide GitHub App and this organization's installation. Reference this integration from
-                    {{ integration.kind === 'inbound' ? 'a push or pull-request trigger' : 'a project\'s outbound integration link' }}
-                    to wire it up.
-                  </p>
+                  @if (integration.account_login) {
+                    <div class="form-group">
+                      <label>Account</label>
+                      <div class="mono-value">@{{ integration.account_login }}</div>
+                    </div>
+                  }
+                  <div class="form-group">
+                    <label>Installation ID</label>
+                    <div class="mono-value">{{ integration.installation_id }}</div>
+                  </div>
                 </div>
               } @else if (integration.kind === 'inbound') {
                 <div class="integration-body">
@@ -252,7 +254,14 @@
     />
   </div>
 
-  @if (formData.kind === 'inbound') {
+  @if (formData.forge_type === 'github') {
+    <div class="form-group">
+      <label for="int-installation-id">App Installation ID</label>
+      <input pInputText id="int-installation-id" [(ngModel)]="formData.installation_id" class="w-full"
+        placeholder="e.g. 12345678" />
+      <small class="text-secondary">The numeric installation ID from your GitHub App installation.</small>
+    </div>
+  } @else if (formData.kind === 'inbound') {
     <div class="dialog-info">
       <span class="material-symbols-outlined">info</span>
       The webhook URL to register with your forge will be shown after the integration is created.
@@ -275,7 +284,7 @@
       <label for="int-endpoint">Endpoint URL</label>
       <input pInputText id="int-endpoint" [(ngModel)]="formData.endpoint_url" class="w-full"
         placeholder="e.g. https://gitea.example.com" />
-      <small class="text-secondary">Base URL of your forge instance. For GitHub, leave blank to use github.com.</small>
+      <small class="text-secondary">Base URL of your forge instance.</small>
     </div>
     <div class="form-group">
       <label for="int-token">Access Token</label>

--- a/frontend/src/app/features/organizations/integrations/integrations.component.spec.ts
+++ b/frontend/src/app/features/organizations/integrations/integrations.component.spec.ts
@@ -30,13 +30,40 @@ const baseIntegration: Integration = {
   created_at: '2026-01-01T00:00:00Z',
 };
 
+const githubOutbound: Integration = {
+  id: 'g1',
+  organization: 'o',
+  name: 'github-app',
+  display_name: 'GitHub App',
+  kind: 'outbound',
+  forge_type: 'github',
+  endpoint_url: null,
+  has_secret: false,
+  has_access_token: false,
+  allowed_ips: [],
+  created_by: 'u',
+  created_at: '2026-01-01T00:00:00Z',
+  installation_id: 99999,
+  account_login: 'acme-org',
+};
+
+const githubInbound: Integration = {
+  ...githubOutbound,
+  id: 'g2',
+  kind: 'inbound',
+};
+
 function activatedRouteStub() {
   return {
     snapshot: { paramMap: convertToParamMap({ org: 'acme' }) },
   } as Partial<ActivatedRoute>;
 }
 
-function setup(access: AccessState, integrations: Integration[]): ComponentFixture<IntegrationsComponent> {
+function setup(
+  access: AccessState,
+  integrations: Integration[],
+  githubAppAvailable = false,
+): ComponentFixture<IntegrationsComponent> {
   TestBed.configureTestingModule({
     imports: [IntegrationsComponent],
     providers: [
@@ -54,7 +81,7 @@ function setup(access: AccessState, integrations: Integration[]): ComponentFixtu
         provide: OrganizationsService,
         useValue: {
           getOrganization: () =>
-            of({ id: 'o', display_name: 'Acme', github_app_available: false }),
+            of({ id: 'o', display_name: 'Acme', github_app_available: githubAppAvailable }),
         },
       },
       { provide: OrgAccessService, useValue: { forOrg: () => Promise.resolve(access) } },
@@ -115,5 +142,121 @@ describe('IntegrationsComponent - access gating', () => {
     expect(newBtn!.disabled).toBe(false);
     expect(findByText(fixture.nativeElement, 'edit')).not.toBeNull();
     expect(findByText(fixture.nativeElement, 'delete')).not.toBeNull();
+  });
+});
+
+describe('IntegrationsComponent - github installations', () => {
+  it('githubInstallations() returns only outbound github rows', async () => {
+    const fixture = setup({ managed: false, canEdit: true, canTrigger: true }, [
+      baseIntegration,
+      githubOutbound,
+      githubInbound,
+    ]);
+    await settled(fixture);
+    const comp = fixture.componentInstance;
+    expect(comp.githubInstallations().length).toBe(1);
+    expect(comp.githubInstallations()[0].id).toBe('g1');
+  });
+
+  it('githubAppInstalled() is false when no github outbound rows exist', async () => {
+    const fixture = setup({ managed: false, canEdit: true, canTrigger: true }, [baseIntegration]);
+    await settled(fixture);
+    expect(fixture.componentInstance.githubAppInstalled()).toBe(false);
+  });
+
+  it('githubAppInstalled() is true when a github outbound row exists', async () => {
+    const fixture = setup({ managed: false, canEdit: true, canTrigger: true }, [githubOutbound]);
+    await settled(fixture);
+    expect(fixture.componentInstance.githubAppInstalled()).toBe(true);
+  });
+
+  it('github rows show Delete but not Edit under full access', async () => {
+    const fixture = setup({ managed: false, canEdit: true, canTrigger: true }, [githubOutbound]);
+    await settled(fixture);
+    expect(findByText(fixture.nativeElement, 'delete')).not.toBeNull();
+    expect(findByText(fixture.nativeElement, 'edit')).toBeNull();
+  });
+});
+
+describe('IntegrationsComponent - create github integration', () => {
+  it('createIntegration sends forge_type=github with installation_id', () => {
+    const createSpy = vi.fn().mockReturnValue(of({}));
+    TestBed.configureTestingModule({
+      imports: [IntegrationsComponent],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: ActivatedRoute, useValue: activatedRouteStub() },
+        {
+          provide: IntegrationsService,
+          useValue: {
+            listOrgIntegrations: () => of([]),
+            createOrgIntegration: createSpy,
+          },
+        },
+        {
+          provide: OrganizationsService,
+          useValue: {
+            getOrganization: () => of({ id: 'o', display_name: 'Acme', github_app_available: true }),
+          },
+        },
+        { provide: OrgAccessService, useValue: { forOrg: () => Promise.resolve({ managed: false, canEdit: true, canTrigger: true }) } },
+      ],
+    });
+    const fixture = TestBed.createComponent(IntegrationsComponent);
+    fixture.detectChanges();
+
+    const comp = fixture.componentInstance;
+    comp.formData.name = 'github-app';
+    comp.formData.forge_type = 'github';
+    comp.formData.installation_id = '12345';
+    comp.formData.kind = 'outbound';
+    comp.createIntegration();
+
+    expect(createSpy).toHaveBeenCalledOnce();
+    expect(createSpy).toHaveBeenCalledWith('acme', expect.objectContaining({
+      name: 'github-app',
+      forge_type: 'github',
+      installation_id: 12345,
+    }));
+  });
+
+  it('createIntegration rejects a non-integer installation_id', () => {
+    const createSpy = vi.fn().mockReturnValue(of({}));
+    TestBed.configureTestingModule({
+      imports: [IntegrationsComponent],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: ActivatedRoute, useValue: activatedRouteStub() },
+        {
+          provide: IntegrationsService,
+          useValue: {
+            listOrgIntegrations: () => of([]),
+            createOrgIntegration: createSpy,
+          },
+        },
+        {
+          provide: OrganizationsService,
+          useValue: {
+            getOrganization: () => of({ id: 'o', display_name: 'Acme', github_app_available: true }),
+          },
+        },
+        { provide: OrgAccessService, useValue: { forOrg: () => Promise.resolve({ managed: false, canEdit: true, canTrigger: true }) } },
+      ],
+    });
+    const fixture = TestBed.createComponent(IntegrationsComponent);
+    fixture.detectChanges();
+
+    const comp = fixture.componentInstance;
+    comp.formData.name = 'github-app';
+    comp.formData.forge_type = 'github';
+    comp.formData.installation_id = 'not-a-number';
+    comp.createIntegration();
+
+    expect(createSpy).not.toHaveBeenCalled();
+    expect(comp.errorMessage()).toContain('positive integer');
   });
 });

--- a/frontend/src/app/features/organizations/integrations/integrations.component.ts
+++ b/frontend/src/app/features/organizations/integrations/integrations.component.ts
@@ -17,6 +17,7 @@ import { OrganizationsService } from '@core/services/organizations.service';
 import { OrgAccessService } from '@core/services/org-access.service';
 import {
   AccessState,
+  CreateIntegrationRequest,
   ForgeType,
   InboundForge,
   Integration,
@@ -216,13 +217,13 @@ export class IntegrationsComponent implements OnInit {
       }
       this.saving.set(true);
       this.errorMessage.set(null);
-      const body: any = {
+      const body: CreateIntegrationRequest = {
         name: this.formData.name.trim(),
         kind: this.formData.kind,
         forge_type: 'github',
         installation_id: installationId,
+        ...(this.formData.display_name.trim() ? { display_name: this.formData.display_name.trim() } : {}),
       };
-      if (this.formData.display_name.trim()) body.display_name = this.formData.display_name.trim();
       this.integrationsService.createOrgIntegration(this.orgName, body).subscribe({
         next: () => {
           this.saving.set(false);

--- a/frontend/src/app/features/organizations/integrations/integrations.component.ts
+++ b/frontend/src/app/features/organizations/integrations/integrations.component.ts
@@ -103,6 +103,7 @@ export class IntegrationsComponent implements OnInit {
     secret: string;
     access_token: string;
     allowed_ips: string;
+    installation_id: string;
   } = {
     name: '',
     display_name: '',
@@ -112,28 +113,27 @@ export class IntegrationsComponent implements OnInit {
     secret: '',
     access_token: '',
     allowed_ips: '',
+    installation_id: '',
   };
 
   githubAppAvailable = computed(() => this.organization()?.github_app_available === true);
-  githubInstallationId = computed(() => this.organization()?.github_installation_id ?? null);
-  githubAppInstalled = computed(() => this.githubInstallationId() != null);
+  githubInstallations = computed(() =>
+    this.integrations().filter((i) => i.forge_type === 'github' && i.kind === 'outbound'),
+  );
+  githubAppInstalled = computed(() => this.githubInstallations().length > 0);
 
-  // GitHub is intentionally absent from these option lists: GitHub
-  // integration is provided by the server-wide GitHub App and the org's
-  // `github_installation_id`, not by per-integration rows. Allowing
-  // operators to create an inbound/outbound integration with
-  // `forge_type=github` produced a row that was ignored by the dispatch and
-  // outbound CI paths and only confused setup.
   outboundForgeOptions = computed<Option<ForgeType>[]>(() => [
     { label: 'Gitea', value: 'gitea' },
     { label: 'Forgejo', value: 'forgejo' },
     { label: 'GitLab', value: 'gitlab' },
+    { label: 'GitHub', value: 'github' },
   ]);
 
   allForgeOptions = computed<Option<ForgeType>[]>(() => [
     { label: 'Gitea', value: 'gitea' },
     { label: 'Forgejo', value: 'forgejo' },
     { label: 'GitLab', value: 'gitlab' },
+    { label: 'GitHub', value: 'github' },
   ]);
 
   ngOnInit(): void {
@@ -184,6 +184,7 @@ export class IntegrationsComponent implements OnInit {
       secret: '',
       access_token: '',
       allowed_ips: '',
+      installation_id: '',
     };
     this.errorMessage.set(null);
     this.showCreateDialog.set(true);
@@ -206,6 +207,36 @@ export class IntegrationsComponent implements OnInit {
 
   createIntegration(): void {
     if (!this.formData.name.trim() || this.nameInvalid) return;
+
+    if (this.formData.forge_type === 'github') {
+      const installationId = Number(this.formData.installation_id.trim());
+      if (!Number.isInteger(installationId) || installationId <= 0) {
+        this.errorMessage.set('App installation ID must be a positive integer.');
+        return;
+      }
+      this.saving.set(true);
+      this.errorMessage.set(null);
+      const body: any = {
+        name: this.formData.name.trim(),
+        kind: this.formData.kind,
+        forge_type: 'github',
+        installation_id: installationId,
+      };
+      if (this.formData.display_name.trim()) body.display_name = this.formData.display_name.trim();
+      this.integrationsService.createOrgIntegration(this.orgName, body).subscribe({
+        next: () => {
+          this.saving.set(false);
+          this.showCreateDialog.set(false);
+          this.loadIntegrations();
+        },
+        error: (err) => {
+          this.errorMessage.set(err?.message || 'Failed to create integration.');
+          this.saving.set(false);
+        },
+      });
+      return;
+    }
+
     this.saving.set(true);
     this.errorMessage.set(null);
     const body: any = {
@@ -247,6 +278,7 @@ export class IntegrationsComponent implements OnInit {
       secret: '',
       access_token: '',
       allowed_ips: (integration.allowed_ips ?? []).join('\n'),
+      installation_id: '',
     };
     this.errorMessage.set(null);
     this.showEditDialog.set(true);

--- a/nix/modules/gradient-state.nix
+++ b/nix/modules/gradient-state.nix
@@ -148,22 +148,26 @@
         '';
       };
 
-      github_installation_id = mkOption {
-        type = types.nullOr types.int;
-        default = null;
+      github_installations = mkOption {
+        type = types.listOf (types.submodule {
+          options = {
+            installation_id = mkOption {
+              type = types.int;
+              description = "GitHub App installation id (trailing number in the installation URL).";
+            };
+            account_login = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              description = "GitHub account login; used to name the integration `github-<login>`. Falls back to `github-<installation_id>` when null.";
+            };
+          };
+        });
+        default = [];
         description = ''
-          GitHub App installation id to bind this organization to. Look it up
-          from the App's "Install App" page on github.com - it's the trailing
-          number in the installation URL.
-
-          When set, the state-driven provisioner writes it on every
-          reconciliation (state wins over runtime updates). When `null`, the
-          field is left untouched on update so a webhook-recorded id survives
-          reconciliation, and is initialised to null on create.
-
-          The presence of an installation id is the org-level signal that
-          this org uses the GitHub App; outbound CI status reporting and
-          install-webhook routing both gate on it.
+          GitHub App installations bound to this org. Each entry provisions a
+          `github-<account>` inbound + outbound integration pair. Multiple
+          entries are supported (one per GitHub account). An empty list leaves
+          webhook-recorded installations untouched on reconciliation.
         '';
       };
 


### PR DESCRIPTION
Makes GitHub a first-class per-org forge integration supporting multiple App installations per org: a new `github_installation` table (org + installation id) is the source of truth, integration rows link to it, and `PUT /orgs/{org}/integrations` accepts `forge_type=github` + `installation_id` (validated against the server App). The install webhook still auto-binds installations for orgs whose projects match the installed repos.

Closes #436.