### PR TITLE
integration: fix: surface required forge webhook events so /gradient commands fire on non-GitHub forges

### DIFF
--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -52,6 +52,17 @@ to one repo fanned out to sibling projects, whose eval carried the wrong repo's
 commit and made the reporter post a check-run for a SHA absent from the project's
 repo (GitHub 422 "No commit found for SHA", #449).
 
+## Per-forge webhook events guidance (Gitea/Forgejo/GitLab `/gradient` commands)
+
+`frontend/.../integrations/integrations.component.spec.ts`: two specs assert
+`requiredWebhookEvents` lists the events the server actually classifies - Gitea/
+Forgejo get `Issue Comment` + `Pull Request Review` (and never push-only), GitLab
+gets `Merge request` + `Comments (note)`. A push-only forge webhook never
+delivers the comment/note or PR/review events, so `/gradient run` / `/gradient
+approve` and PR CI silently never fire on these forges (unlike the GitHub App,
+whose manifest auto-subscribes to `issue_comment`/`pull_request_review`); the
+inbound-integration card and the setup docs now surface the full event set.
+
 ## Forge action "Test" button connectivity probe
 
 `backend/gradient-forge/src/reporter.rs`: `verify_reads_repo_without_reporting`
@@ -869,6 +880,20 @@ The migration backfills existing rows complete unless they are `Created`, never
 dispatched, and have zero edges - the exact shape of an anchor stranded by an
 incomplete eval. The promotion/dispatch statements are raw SQL (no MockDatabase
 harness, per the backend test notes); covered end-to-end in CI.
+
+## Startup recovery aborts interrupted evals' anchors
+
+Backend (`cargo test -p gradient-db --lib recovery`):
+- `all_operations_populate_report` - `recover_interrupted_work` reports all five
+  recovery actions, including the new `builds_aborted`: the anchors driven by the
+  pre-build evals it aborts are themselves aborted (`abort_anchors_for_evals`),
+  mirroring the explicit-abort path so the server matches the builder, which
+  aborts the eval's builds when the server dies. The forced re-evaluation
+  re-drives them (`requeue_failed_anchors` resets `Aborted -> Created`).
+- `project_force_step_skipped_when_no_pre_build_evals` - with no in-flight
+  pre-build evals, the abort-anchors, abort-evals, and force-eval steps are all
+  skipped and `builds_aborted` stays 0. The shared-anchor exclusion (an anchor a
+  still-live eval also needs is left running) is raw SQL, covered E2E in CI.
 
 ## External-cached substitution fetches outputs, not the `.drv`
 

--- a/docs/src/usage/integration.md
+++ b/docs/src/usage/integration.md
@@ -61,14 +61,21 @@ When a project is created and its repository URL unambiguously matches one of th
 ### Gitea / Forgejo
 
 Repository or organization webhook → `POST` → `application/json`, URL from
-Gradient, secret = the integration's secret, trigger on *Push events*.
+Gradient, secret = the integration's secret. Under **Trigger On** choose
+*Custom Events* (or *Send everything*) and enable **Push**, **Pull Request**,
+**Issue Comment**, **Pull Request Comment**, **Pull Request Review**, and
+**Release**. A push-only webhook never delivers PR CI, the `/gradient run` /
+`/gradient approve` comment commands, or review-based approval.
 Signatures are verified via `X-Gitea-Signature` (HMAC-SHA256 over the raw body).
 
 ### GitLab
 
 Project or group webhook → URL from Gradient, **Secret token** = the
-integration's secret, trigger = *Push events*. Gradient compares the
-`X-Gitlab-Token` header against the stored secret.
+integration's secret. Enable the **Push events**, **Tag push events**, **Merge
+request events**, **Comments** (note events), and **Releases events** triggers.
+A push-only webhook never delivers MR CI or the `/gradient run` / `/gradient
+approve` comment commands (GitLab emits no review webhook). Gradient compares
+the `X-Gitlab-Token` header against the stored secret.
 
 ### GitHub App
 
@@ -190,4 +197,5 @@ honored only when the peer is in `GRADIENT_NETWORK_TRUSTED_PROXIES`.
 | `403 forbidden_source_ip`          | The forge's egress IP isn't in the integration's `allowed_ips` list. Add it or clear the list.   |
 | `404 Not Found`                   | Wrong organization or integration name in the URL, or `{forge}=github` (use the App webhook).   |
 | `200 OK` but no evaluation runs   | No project links to this inbound integration, or the repository URL doesn't match any project.  |
+| PR CI or `/gradient` comments never fire | The forge webhook is push-only. Enable PR/merge-request, comment/note, and review events (see [Configure the forge webhook](#3-configure-the-forge-webhook)). |
 | `503 Service Unavailable`         | The integration row has no secret set yet - paste or generate one on the Integrations page.     |

--- a/frontend/src/app/features/organizations/integrations/integrations.component.html
+++ b/frontend/src/app/features/organizations/integrations/integrations.component.html
@@ -171,6 +171,10 @@
                       <span class="status-chip status-warn">Not set</span>
                     }
                   </div>
+                  <div class="form-group">
+                    <label>Events to enable</label>
+                    <small class="text-secondary">Enable {{ requiredWebhookEvents(integration.id) }} on the forge webhook. A push-only webhook never delivers PR CI or the <code>/gradient</code> comment commands.</small>
+                  </div>
                 </div>
               } @else {
                 <div class="integration-body">
@@ -264,7 +268,7 @@
   } @else if (formData.kind === 'inbound') {
     <div class="dialog-info">
       <span class="material-symbols-outlined">info</span>
-      The webhook URL to register with your forge will be shown after the integration is created.
+      The webhook URL is shown after the integration is created. Enable push, pull/merge-request, comment, and review events on the forge webhook - a push-only webhook never delivers PR CI or <code>/gradient</code> commands.
     </div>
     <div class="form-group">
       <label for="int-secret">Webhook Secret</label>

--- a/frontend/src/app/features/organizations/integrations/integrations.component.spec.ts
+++ b/frontend/src/app/features/organizations/integrations/integrations.component.spec.ts
@@ -178,6 +178,27 @@ describe('IntegrationsComponent - github installations', () => {
   });
 });
 
+describe('IntegrationsComponent - required webhook events', () => {
+  it('lists PR/comment/review events for Gitea/Forgejo and never push-only', async () => {
+    const fixture = setup({ managed: false, canEdit: true, canTrigger: true }, [baseIntegration]);
+    await settled(fixture);
+    const comp = fixture.componentInstance;
+    const events = comp.requiredWebhookEvents(baseIntegration.id);
+    expect(events).toContain('Issue Comment');
+    expect(events).toContain('Pull Request Review');
+  });
+
+  it('lists Merge request + Comments (note) events for GitLab', async () => {
+    const fixture = setup({ managed: false, canEdit: true, canTrigger: true }, [baseIntegration]);
+    await settled(fixture);
+    const comp = fixture.componentInstance;
+    comp.setInboundForge(baseIntegration.id, 'gitlab');
+    const events = comp.requiredWebhookEvents(baseIntegration.id);
+    expect(events).toContain('Merge request');
+    expect(events).toContain('Comments (note)');
+  });
+});
+
 describe('IntegrationsComponent - create github integration', () => {
   it('createIntegration sends forge_type=github with installation_id', () => {
     const createSpy = vi.fn().mockReturnValue(of({}));

--- a/frontend/src/app/features/organizations/integrations/integrations.component.ts
+++ b/frontend/src/app/features/organizations/integrations/integrations.component.ts
@@ -397,6 +397,12 @@ export class IntegrationsComponent implements OnInit {
     return `${window.location.origin}/api/v1/hooks/${forge}/${this.orgName}/${integration.name}`;
   }
 
+  requiredWebhookEvents(id: string): string {
+    return this.inboundForge(id) === 'gitlab'
+      ? 'Push, Tag push, Merge request, Comments (note), and Releases events'
+      : 'Push, Pull Request, Issue Comment, Pull Request Comment, Pull Request Review, and Release';
+  }
+
   copyInboundUrl(integration: Integration): void {
     const url = this.inboundUrl(integration);
     navigator.clipboard.writeText(url).then(() => {


### PR DESCRIPTION
`/gradient run` / `/gradient approve` (and PR CI, review-based approval) never fired on Gitea/Forgejo/GitLab because the setup we ship told users to enable only *Push events* — so the forge never delivered the comment/note, PR/MR, or review events the server already handles. GitHub works because the App manifest auto-subscribes to `issue_comment`/`pull_request_review`.

Per-forge fix is docs + UI guidance (no auto-provisioning): `integration.md` now lists the full event set per forge, the inbound-integration card shows an "Events to enable" hint, and the create dialog warns about push-only webhooks. 2 frontend specs cover `requiredWebhookEvents`.