### PR TITLE
frontend: fix: GitHub App setup cleanup (#457)

### DIFF
--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -546,6 +546,17 @@ Frontend (`pnpm --dir frontend exec ng test --include='**/github-app.component.s
 - `clicking create-button calls requestGithubAppManifest with host`
 - `renders credentials when ready=1 and the API returns them`
 
+## GitHub App setup cleanup (#457)
+
+Frontend (`pnpm --dir frontend exec ng test --include='**/health.component.spec.ts' --watch=false`):
+- `hides the "Set up GitHub App" link` - the System Health admin action is omitted once the App is configured.
+
+Frontend (`pnpm --dir frontend exec ng test --include='**/github-app.component.spec.ts' --watch=false`):
+- `allows leaving the setup view without prompting` - `canDeactivate()` returns true when no credentials are shown.
+- `prompts and blocks leaving when the user cancels` - `canDeactivate()` confirms and returns false while one-shot credentials are visible.
+- `prompts and allows leaving when the user confirms`.
+- `flags beforeunload while credentials are shown` - the `beforeunload` handler cancels the event so the browser warns before unload.
+
 ## Narinfo Deriver field
 
 Backend (`cargo test -p web --tests narinfo`):

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -7,6 +7,7 @@
 import { Routes } from '@angular/router';
 import { authGuard } from '@core/guards/auth.guard';
 import { adminGuard } from '@core/guards/admin.guard';
+import { unsavedChangesGuard } from '@core/guards/unsaved-changes.guard';
 import { projectAccessResolver } from '@core/resolvers/project-access.resolver';
 import { cacheAccessResolver } from '@core/resolvers/cache-access.resolver';
 import { organizationAccessResolver } from '@core/resolvers/organization-access.resolver';
@@ -452,6 +453,7 @@ export const routes: Routes = [
     path: 'admin/github-app',
     title: 'GitHub App (admin)',
     canActivate: [authGuard, adminGuard],
+    canDeactivate: [unsavedChangesGuard],
     loadComponent: () =>
       import('./features/admin/github-app/github-app.component').then(
         (m) => m.GithubAppComponent,

--- a/frontend/src/app/core/guards/unsaved-changes.guard.ts
+++ b/frontend/src/app/core/guards/unsaved-changes.guard.ts
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { CanDeactivateFn } from '@angular/router';
+
+export interface CanComponentDeactivate {
+  canDeactivate(): boolean;
+}
+
+export const unsavedChangesGuard: CanDeactivateFn<CanComponentDeactivate> = (component) =>
+  component.canDeactivate();

--- a/frontend/src/app/features/admin/github-app/github-app.component.scss
+++ b/frontend/src/app/features/admin/github-app/github-app.component.scss
@@ -1,3 +1,5 @@
+@use '../../../styles/variables' as *;
+
 .container {
   padding: 1.5rem;
 }
@@ -13,9 +15,9 @@
 
 .error {
   padding: 0.75rem 1rem;
-  border: 1px solid var(--p-red-300, #fca5a5);
-  background: var(--p-red-50, #fef2f2);
-  color: var(--p-red-900, #7f1d1d);
+  border: 1px solid $color-danger;
+  background: $color-tertiary;
+  color: $color-danger;
   border-radius: 0.5rem;
 }
 
@@ -32,7 +34,9 @@
   pre {
     margin: 0;
     overflow: auto;
-    background: var(--p-gray-50, #f9fafb);
+    background: $color-tertiary;
+    color: $text-primary;
+    border: 1px solid $color-border;
     padding: 0.5rem;
     border-radius: 0.25rem;
   }

--- a/frontend/src/app/features/admin/github-app/github-app.component.spec.ts
+++ b/frontend/src/app/features/admin/github-app/github-app.component.spec.ts
@@ -102,4 +102,53 @@ describe('GithubAppComponent', () => {
     );
     expect(banner).toBeTruthy();
   });
+
+  describe('navigation guard while credentials are shown', () => {
+    function withCredentials() {
+      setup({ ready: '1' });
+      admin.fetchGithubAppCredentials.mockReturnValue(
+        of({
+          id: 7,
+          slug: 'gradient',
+          html_url: 'https://github.com/apps/gradient',
+          pem: 'PEM',
+          webhook_secret: 'whsec',
+          client_id: 'cid',
+          client_secret: 'csec',
+        }),
+      );
+      const fixture = TestBed.createComponent(GithubAppComponent);
+      fixture.detectChanges();
+      return fixture;
+    }
+
+    it('allows leaving the setup view without prompting', () => {
+      const confirmSpy = vi.spyOn(window, 'confirm');
+      setup({});
+      const fixture = TestBed.createComponent(GithubAppComponent);
+      fixture.detectChanges();
+      expect(fixture.componentInstance.canDeactivate()).toBe(true);
+      expect(confirmSpy).not.toHaveBeenCalled();
+    });
+
+    it('prompts and blocks leaving when the user cancels', () => {
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+      const fixture = withCredentials();
+      expect(fixture.componentInstance.canDeactivate()).toBe(false);
+      expect(confirmSpy).toHaveBeenCalledOnce();
+    });
+
+    it('prompts and allows leaving when the user confirms', () => {
+      vi.spyOn(window, 'confirm').mockReturnValue(true);
+      const fixture = withCredentials();
+      expect(fixture.componentInstance.canDeactivate()).toBe(true);
+    });
+
+    it('flags beforeunload while credentials are shown', () => {
+      const fixture = withCredentials();
+      const event = new Event('beforeunload', { cancelable: true });
+      fixture.componentInstance.onBeforeUnload(event as BeforeUnloadEvent);
+      expect(event.defaultPrevented).toBe(true);
+    });
+  });
 });

--- a/frontend/src/app/features/admin/github-app/github-app.component.ts
+++ b/frontend/src/app/features/admin/github-app/github-app.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal } from '@angular/core';
+import { Component, HostListener, OnInit, computed, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -30,6 +30,11 @@ export class GithubAppComponent implements OnInit {
   showResult = signal(false);
   credentials = signal<GithubAppCredentials | null>(null);
   credentialsMissing = signal(false);
+
+  private keysVisible = computed(() => this.showResult() && this.credentials() !== null);
+
+  private readonly leaveWarning =
+    'The generated credentials are shown only once and cannot be recovered. Leave anyway?';
 
   ngOnInit(): void {
     const ready = this.route.snapshot.queryParamMap.get('ready');
@@ -84,5 +89,17 @@ export class GithubAppComponent implements OnInit {
 
   copy(value: string): void {
     navigator.clipboard.writeText(value).catch(() => {});
+  }
+
+  canDeactivate(): boolean {
+    return !this.keysVisible() || window.confirm(this.leaveWarning);
+  }
+
+  @HostListener('window:beforeunload', ['$event'])
+  onBeforeUnload(event: BeforeUnloadEvent): void {
+    if (this.keysVisible()) {
+      event.preventDefault();
+      event.returnValue = this.leaveWarning;
+    }
   }
 }

--- a/frontend/src/app/features/board/health/health.component.spec.ts
+++ b/frontend/src/app/features/board/health/health.component.spec.ts
@@ -86,11 +86,10 @@ describe('BoardHealthComponent', () => {
       expect(fixture.nativeElement.textContent).toContain('deep_gc');
     });
 
-    it('shows "GitHub App configured" text with disabled class on the link', () => {
+    it('hides the "Set up GitHub App" link', () => {
       const link: HTMLAnchorElement = fixture.nativeElement.querySelector('a.btn');
-      expect(link).toBeTruthy();
-      expect(link.textContent?.trim()).toBe('GitHub App configured');
-      expect(link.classList.contains('disabled')).toBe(true);
+      expect(link).toBeNull();
+      expect(fixture.nativeElement.textContent).not.toContain('Set up GitHub App');
     });
   });
 

--- a/frontend/src/app/features/board/health/health.component.ts
+++ b/frontend/src/app/features/board/health/health.component.ts
@@ -47,10 +47,9 @@ const MIB = 1024 ** 2;
 
       <h2>Admin</h2>
       <div class="admin-actions">
-        <a class="btn" [class.disabled]="githubConfigured()" routerLink="/admin/github-app"
-           [attr.aria-disabled]="githubConfigured()">
-          {{ githubConfigured() ? 'GitHub App configured' : 'Set up GitHub App' }}
-        </a>
+        @if (!githubConfigured()) {
+          <a class="btn" routerLink="/admin/github-app">Set up GitHub App</a>
+        }
         <button class="btn" (click)="runDeepGc()" [disabled]="gcBusy()">Run Deep GC</button>
         <button class="btn" [class.danger]="!h.draining" (click)="toggleDraining(h.draining)" [disabled]="drainBusy()">
           {{ h.draining ? 'Disable Draining' : 'Enable Draining' }}


### PR DESCRIPTION
Closes #457.

- Hide the System Health "Set up GitHub App" action once the App is configured.
- Dark theme the one-shot private-key field (was white-on-white).
- Warn before navigating/unloading the setup page while credentials are shown.