### PR TITLE
db: feat: log start of database migrations (#446)

### DIFF
--- a/backend/gradient-db/src/connection.rs
+++ b/backend/gradient-db/src/connection.rs
@@ -103,11 +103,30 @@ pub async fn connect_db(cli: &Cli) -> Result<DatabaseConnection> {
     prune_removed_migrations(&db)
         .await
         .context("Failed to prune removed-migration entries from seaql_migrations")?;
-    Migrator::up(&db, None)
-        .await
-        .context("Failed to run database migrations")?;
+    run_migrations(&db).await?;
     update_db(&db).await.context("Failed to update database")?;
     Ok(db)
+}
+
+/// Run pending migrations, logging the start so a slow migration is not
+/// mistaken for a hung process.
+async fn run_migrations(db: &DatabaseConnection) -> Result<()> {
+    let pending = Migrator::get_pending_migrations(db)
+        .await
+        .context("Failed to determine pending database migrations")?;
+    if pending.is_empty() {
+        tracing::info!("database schema up to date; no migrations to run");
+        return Ok(());
+    }
+
+    let names: Vec<&str> = pending.iter().map(|m| m.name()).collect();
+    tracing::info!(count = pending.len(), migrations = ?names, "running database migrations; this may take a while");
+    Migrator::up(db, None)
+        .await
+        .context("Failed to run database migrations")?;
+    tracing::info!(count = pending.len(), "database migrations complete");
+
+    Ok(())
 }
 
 /// Purge `seaql_migrations` rows whose `version` is no longer in the

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -208,6 +208,15 @@ rollups require (`uuidv7()`). `backend/gradient-db/src/connection.rs::pg_version
 covers the pure decision: `170_004`/`179_999` are rejected (with a `17.4`-style
 detected-version message) and `180_000`+ are accepted.
 
+## Migration start logging (#446)
+
+`run_migrations` in `backend/gradient-db/src/connection.rs` logs the pending
+migration count and names at `info` before calling `Migrator::up`, then logs
+completion, so a slow schema change is not mistaken for a hung process. No
+applied migrations logs `database schema up to date`. The behaviour depends on
+the live `seaql_migrations` table (after `install`/prune) so it is exercised at
+server startup, not via the MockDatabase unit harness.
+
 ## OIDC - CSRF cookie, ID-token verification, identity binding
 
 Tests in `backend/web/src/authorization/oidc.rs` cover the security


### PR DESCRIPTION
Closes #446.

Log pending migration count and names before running `Migrator::up` (plus a completion line), so a slow migration is not mistaken for a hung server.