### PR TITLE
forge,frontend: fix: Forgejo webhook + project state + Settings breadcrumb (#441, #452, #460)

### DIFF
--- a/backend/gradient-forge/src/provider.rs
+++ b/backend/gradient-forge/src/provider.rs
@@ -44,8 +44,9 @@ pub trait ForgeProvider: Send + Sync + std::fmt::Debug {
         true
     }
 
-    /// Header carrying the webhook signature/token to pass to [`verify_signature`](Self::verify_signature).
-    fn signature_header(&self) -> &'static str;
+    /// Header(s) carrying the webhook signature/token, tried in order (first
+    /// present wins), passed to [`verify_signature`](Self::verify_signature).
+    fn signature_headers(&self) -> &'static [&'static str];
 
     /// Verify a webhook signature/token (HMAC for Gitea/GitHub, constant-time
     /// token equality for GitLab) against the integration secret.

--- a/backend/gradient-forge/src/providers/gitea.rs
+++ b/backend/gradient-forge/src/providers/gitea.rs
@@ -48,8 +48,8 @@ impl ForgeProvider for GiteaProvider {
         Ok(Arc::new(GiteaReporter::new(http, base_url, token)?))
     }
 
-    fn signature_header(&self) -> &'static str {
-        "X-Gitea-Signature"
+    fn signature_headers(&self) -> &'static [&'static str] {
+        &["X-Forgejo-Signature", "X-Gitea-Signature"]
     }
 
     fn verify_signature(&self, secret: &str, signature: &str, body: &[u8]) -> bool {
@@ -57,7 +57,7 @@ impl ForgeProvider for GiteaProvider {
     }
 
     fn event_headers(&self) -> &'static [&'static str] {
-        &["X-Gitea-Event", "X-Gogs-Event"]
+        &["X-Forgejo-Event", "X-Gitea-Event", "X-Gogs-Event"]
     }
 
     fn classify_event(&self, event: &str) -> WebhookEventKind {
@@ -92,5 +92,21 @@ mod tests {
     fn rejects_missing_signature() {
         let p = GiteaProvider::new(ForgeType::Gitea);
         assert!(!p.verify_signature("s3cret", "", b"body"));
+    }
+
+    #[test]
+    fn accepts_forgejo_and_gitea_headers() {
+        let p = GiteaProvider::new(ForgeType::Forgejo);
+        assert!(p.event_headers().contains(&"X-Forgejo-Event"));
+        assert!(p.event_headers().contains(&"X-Gitea-Event"));
+        assert!(p.signature_headers().contains(&"X-Forgejo-Signature"));
+        assert!(p.signature_headers().contains(&"X-Gitea-Signature"));
+    }
+
+    #[test]
+    fn classifies_pr_comment_as_comment() {
+        let p = GiteaProvider::new(ForgeType::Forgejo);
+        assert!(matches!(p.classify_event("issue_comment"), WebhookEventKind::Comment));
+        assert!(matches!(p.classify_event("pull_request_comment"), WebhookEventKind::Comment));
     }
 }

--- a/backend/gradient-forge/src/providers/github.rs
+++ b/backend/gradient-forge/src/providers/github.rs
@@ -53,8 +53,8 @@ impl ForgeProvider for GithubProvider {
         false
     }
 
-    fn signature_header(&self) -> &'static str {
-        "X-Hub-Signature-256"
+    fn signature_headers(&self) -> &'static [&'static str] {
+        &["X-Hub-Signature-256"]
     }
 
     fn verify_signature(&self, secret: &str, signature: &str, body: &[u8]) -> bool {

--- a/backend/gradient-forge/src/providers/gitlab.rs
+++ b/backend/gradient-forge/src/providers/gitlab.rs
@@ -41,8 +41,8 @@ impl ForgeProvider for GitlabProvider {
         Ok(Arc::new(GitlabReporter::new(http, base_url, token)?))
     }
 
-    fn signature_header(&self) -> &'static str {
-        "X-Gitlab-Token"
+    fn signature_headers(&self) -> &'static [&'static str] {
+        &["X-Gitlab-Token"]
     }
 
     fn verify_signature(&self, secret: &str, signature: &str, _body: &[u8]) -> bool {

--- a/backend/gradient-web/src/endpoints/forge_hooks/mod.rs
+++ b/backend/gradient-web/src/endpoints/forge_hooks/mod.rs
@@ -410,7 +410,7 @@ pub async fn forge_webhook(
         WebError::internal("internal error")
     })?;
 
-    let signature = first_header(&headers, &[provider.signature_header()]);
+    let signature = first_header(&headers, provider.signature_headers());
     if !provider.verify_signature(plaintext_secret.expose(), signature, &body) {
         warn!(org = %org_name, forge = %forge, integration = %integration_name, "Forge webhook: invalid signature");
         return Err(WebError::unauthorized("invalid webhook signature"));

--- a/backend/gradient-web/src/endpoints/forge_hooks/trigger.rs
+++ b/backend/gradient-web/src/endpoints/forge_hooks/trigger.rs
@@ -1454,6 +1454,12 @@ pub(super) async fn handle_issue_comment(
         // answer is the same. This also lets us fire the eyes/confused
         // reaction exactly once per integration.
         let Some(probe_project) = first_project_with_reporter(state, &project_ids).await else {
+            warn!(
+                %integration_id,
+                pr_number,
+                projects = project_ids.len(),
+                "/gradient comment ignored: integration has no project with a usable forge reporter (needs an API token)"
+            );
             continue;
         };
         let is_maintainer = sender_is_trusted(state, probe_project, owner, repo, &sender).await;

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -63,6 +63,42 @@ approve` and PR CI silently never fire on these forges (unlike the GitHub App,
 whose manifest auto-subscribes to `issue_comment`/`pull_request_review`); the
 inbound-integration card and the setup docs now surface the full event set.
 
+## Forgejo webhook header support (#460)
+
+`backend/gradient-forge/src/providers/gitea.rs`:
+- `accepts_forgejo_and_gitea_headers` - the Gitea/Forgejo provider lists both
+  `X-Forgejo-Event`/`X-Forgejo-Signature` and the Gitea-prefixed equivalents, so
+  a Forgejo host (e.g. Codeberg) that sends only its own header family is still
+  classified and signature-verified instead of falling through to a silent
+  `Unknown`-event 200. The signature check runs before event classification, so
+  a missing header family previously dropped every webhook.
+- `classifies_pr_comment_as_comment` - `issue_comment` / `pull_request_comment`
+  map to `WebhookEventKind::Comment`.
+
+When a `/gradient` comment is delivered but the integration has no project with a
+usable forge reporter (no API token), `handle_issue_comment` now logs a `warn`
+instead of silently returning, making the "nothing happened" case diagnosable.
+
+## GitHub App setup cleanup + state surfacing + breadcrumbs (#441, #452)
+
+Frontend (`pnpm --dir frontend exec ng test --include='**/eval-status-badge.component.spec.ts' --watch=false`):
+- shared `EvalStatusBadgeComponent` collapses `Evaluating*` to `Evaluating`,
+  applies the success class for `Completed`, spins a running icon, and pulses a
+  queued icon. Reused by the organization detail list and the project detail
+  title (one source of truth for the eval status tag).
+
+Frontend (`**/project-detail.component.spec.ts`):
+- `disables Start Evaluation while an evaluation is in progress` and `enables
+  Start Evaluation once the latest evaluation finished` - the button is gated on
+  `evaluationInProgress()` so it no longer surfaces "evaluation already in
+  progress".
+- `shows the eval status badge in the title while in progress` / `hides the title
+  badge when the latest evaluation is terminal`.
+
+Frontend (`**/project-actions.component.spec.ts`):
+- `includes a Settings link in the breadcrumb` - Actions breadcrumb is now
+  `[Org] / [Project] / Settings / Actions`.
+
 ## Forge action "Test" button connectivity probe
 
 `backend/gradient-forge/src/reporter.rs`: `verify_reads_repo_without_reporting`

--- a/docs/src/usage/integration.md
+++ b/docs/src/usage/integration.md
@@ -66,7 +66,9 @@ Gradient, secret = the integration's secret. Under **Trigger On** choose
 **Issue Comment**, **Pull Request Comment**, **Pull Request Review**, and
 **Release**. A push-only webhook never delivers PR CI, the `/gradient run` /
 `/gradient approve` comment commands, or review-based approval.
-Signatures are verified via `X-Gitea-Signature` (HMAC-SHA256 over the raw body).
+Both the Forgejo (`X-Forgejo-Event` / `X-Forgejo-Signature`) and Gitea
+(`X-Gitea-Event` / `X-Gitea-Signature`) header families are accepted; signatures
+are HMAC-SHA256 over the raw body.
 
 ### GitLab
 

--- a/frontend/src/app/features/organizations/organization-detail/organization-detail.component.html
+++ b/frontend/src/app/features/organizations/organization-detail/organization-detail.component.html
@@ -36,12 +36,7 @@
                 <p class="text-secondary">{{ project.description || 'No description' }}</p>
                 <div class="project-meta">
                   @if (project.last_evaluation_status) {
-                    <span class="eval-status-badge" [class]="getEvalStatusClass(project.last_evaluation_status)">
-                      <span class="material-symbols-outlined" [class.pulsing]="project.last_evaluation_status === 'Queued' || project.last_evaluation_status === 'Waiting'" [class.spinning]="isRunningStatus(project.last_evaluation_status) && project.last_evaluation_status !== 'Waiting' && project.last_evaluation_status !== 'Queued'">
-                        {{ getEvalStatusIcon(project.last_evaluation_status) }}
-                      </span>
-                      {{ getEvalStatusLabel(project.last_evaluation_status) }}
-                    </span>
+                    <app-eval-status-badge [status]="project.last_evaluation_status" />
                   }
                 </div>
               </div>

--- a/frontend/src/app/features/organizations/organization-detail/organization-detail.component.scss
+++ b/frontend/src/app/features/organizations/organization-detail/organization-detail.component.scss
@@ -151,33 +151,6 @@
   }
 }
 
-.eval-status-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: $spacing-xs;
-  padding: 2px $spacing-sm;
-  border-radius: $border-radius-sm;
-  font-size: $font-size-xs;
-  font-weight: 500;
-
-  .material-symbols-outlined { font-size: 13px; }
-
-  &.status-success   { background: rgba($color-success, 0.15); color: $color-success; }
-  &.status-danger    { background: rgba($color-danger, 0.15);  color: $color-danger; }
-  &.status-secondary { background: rgba($text-secondary, 0.15); color: $text-secondary; }
-  &.status-warning   { background: rgba($color-warning, 0.15); color: $color-warning; }
-  &.status-running   { background: rgba($color-info, 0.15); color: $color-info; }
-}
-
-@keyframes spin { to { transform: rotate(-360deg); } }
-.spinning { display: inline-block; animation: spin 1.2s linear infinite; }
-
-@keyframes pulsing-kf {
-  0%, 100% { opacity: 1; }
-  50%      { opacity: 0.4; }
-}
-.pulsing { display: inline-block; animation: pulsing-kf 1.6s ease-in-out infinite; }
-
 .dialog-error {
   display: flex;
   align-items: center;

--- a/frontend/src/app/features/organizations/organization-detail/organization-detail.component.ts
+++ b/frontend/src/app/features/organizations/organization-detail/organization-detail.component.ts
@@ -20,8 +20,9 @@ import { ProjectsService } from '@core/services/projects.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { EmptyStateComponent } from '@shared/components/empty-state/empty-state.component';
 import { LabelHelpComponent } from '@shared/components/form';
+import { EvalStatusBadgeComponent } from '@shared/components/eval-status-badge/eval-status-badge.component';
 import { slugify } from '@shared/text';
-import { Organization, Project, EvaluationStatus } from '@core/models';
+import { Organization, Project } from '@core/models';
 
 const RESERVED_PROJECT_NAMES = ['build-request'];
 
@@ -39,6 +40,7 @@ const RESERVED_PROJECT_NAMES = ['build-request'];
     LoadingSpinnerComponent,
     EmptyStateComponent,
     LabelHelpComponent,
+    EvalStatusBadgeComponent,
   ],
   templateUrl: './organization-detail.component.html',
   styleUrl: './organization-detail.component.scss',
@@ -142,37 +144,6 @@ export class OrganizationDetailComponent implements OnInit, OnDestroy {
     }
     this.nameCheckState.set('checking');
     this.nameCheck$.next(name);
-  }
-
-  isRunningStatus(status: EvaluationStatus): boolean {
-    return status === 'Queued' || status === 'Fetching' || status === 'EvaluatingFlake' || status === 'EvaluatingDerivation' || status === 'Building' || status === 'Waiting';
-  }
-
-  getEvalStatusClass(status: EvaluationStatus): string {
-    switch (status) {
-      case 'Completed': return 'status-success';
-      case 'Failed': return 'status-danger';
-      case 'Aborted': return 'status-secondary';
-      case 'Waiting': return 'status-warning';
-      default: return 'status-running';
-    }
-  }
-
-  getEvalStatusIcon(status: EvaluationStatus): string {
-    switch (status) {
-      case 'Completed': return 'check_circle';
-      case 'Failed': return 'error';
-      case 'Aborted': return 'cancel';
-      case 'Queued': return 'hourglass_empty';
-      case 'Waiting': return 'pause_circle';
-      default: return 'sync';
-    }
-  }
-
-  getEvalStatusLabel(status: EvaluationStatus): string {
-    if (status === 'Fetching') return 'Fetching';
-    if (status === 'EvaluatingFlake' || status === 'EvaluatingDerivation') return 'Evaluating';
-    return status;
   }
 
   get wildcardInvalid(): boolean {

--- a/frontend/src/app/features/projects/project-actions/project-actions.component.html
+++ b/frontend/src/app/features/projects/project-actions/project-actions.component.html
@@ -12,6 +12,8 @@
         <span class="breadcrumb-separator">/</span>
         <a [routerLink]="['/organization', orgName, 'project', projectName]" class="breadcrumb-link">{{ projectName }}</a>
         <span class="breadcrumb-separator">/</span>
+        <a [routerLink]="['/organization', orgName, 'project', projectName, 'settings']" class="breadcrumb-link">Settings</a>
+        <span class="breadcrumb-separator">/</span>
         <span class="breadcrumb-current">Actions</span>
       </div>
       <h1>Actions</h1>

--- a/frontend/src/app/features/projects/project-actions/project-actions.component.spec.ts
+++ b/frontend/src/app/features/projects/project-actions/project-actions.component.spec.ts
@@ -102,6 +102,15 @@ describe('ProjectActionsComponent', () => {
     expect(testBtn!.disabled).toBe(false);
   });
 
+  it('includes a Settings link in the breadcrumb', () => {
+    const fixture = setup({ managed: false, canEdit: true, canTrigger: true });
+    const link = Array.from(
+      fixture.nativeElement.querySelectorAll('.breadcrumb a.breadcrumb-link'),
+    ).find((a) => (a as HTMLElement).textContent?.trim() === 'Settings') as HTMLAnchorElement | undefined;
+    expect(link).toBeTruthy();
+    expect(link!.getAttribute('href')).toContain('/settings');
+  });
+
   it('renders action name and event chips', () => {
     const fixture = setup({ managed: false, canEdit: true, canTrigger: true });
     const text = fixture.nativeElement.textContent ?? '';

--- a/frontend/src/app/features/projects/project-detail/project-detail.component.html
+++ b/frontend/src/app/features/projects/project-detail/project-detail.component.html
@@ -12,12 +12,19 @@
       <div class="breadcrumb">
         <a [routerLink]="['/organization', orgName]">{{ orgDisplayName() || orgName }}</a>
       </div>
-      <h1>{{ proj.display_name }}</h1>
+      <div class="title-row">
+        <h1>{{ proj.display_name }}</h1>
+        @if (evaluationInProgress() && latestEvaluation(); as ev) {
+          <app-eval-status-badge [status]="ev.status" />
+        }
+      </div>
     </div>
     <div class="head-actions">
       @if (authService.isAuthenticated()) {
         <button *appWritable="triggerAccess()" pButton label="Start Evaluation" icon="pi pi-play"
-                (click)="startEvaluation()" [loading]="starting()" [disabled]="starting()"></button>
+                (click)="startEvaluation()" [loading]="starting()"
+                [disabled]="starting() || evaluationInProgress()"
+                [pTooltip]="evaluationInProgress() ? 'An evaluation is already in progress' : ''"></button>
         <button *appWritable="triggerAccess()" pButton label="Restart Failed Builds" icon="pi pi-refresh"
                 severity="secondary" (click)="restartFailedBuilds()" [disabled]="starting()"></button>
         @if (proj.name !== 'build-request') {

--- a/frontend/src/app/features/projects/project-detail/project-detail.component.scss
+++ b/frontend/src/app/features/projects/project-detail/project-detail.component.scss
@@ -6,6 +6,13 @@
 
 @use '../../../styles/variables' as *;
 
+.title-row {
+  display: flex;
+  align-items: center;
+  gap: $spacing-md;
+  flex-wrap: wrap;
+}
+
 .evaluation-error {
   display: flex;
   align-items: center;

--- a/frontend/src/app/features/projects/project-detail/project-detail.component.spec.ts
+++ b/frontend/src/app/features/projects/project-detail/project-detail.component.spec.ts
@@ -50,7 +50,11 @@ function activatedRouteStub(access: AccessState): ActivatedRoute {
   } as unknown as ActivatedRoute;
 }
 
-function projectFor(access: AccessState, extraEvals: EvaluationSummary[] = []) {
+function projectFor(
+  access: AccessState,
+  extraEvals: EvaluationSummary[] = [],
+  primaryStatus: EvaluationSummary['status'] = 'Building',
+) {
   return {
     id: 'p',
     name: 'demo',
@@ -63,7 +67,7 @@ function projectFor(access: AccessState, extraEvals: EvaluationSummary[] = []) {
     keep_evaluations: 5,
     last_check_at: '2026-01-01T00:00:00',
     queue: { building: 0, queued: 0 },
-    last_evaluations: [evalSummary('e1'), ...extraEvals],
+    last_evaluations: [evalSummary('e1', primaryStatus), ...extraEvals],
     can_edit: access.canEdit,
     can_trigger: access.canTrigger,
     managed: access.managed,
@@ -83,10 +87,11 @@ function makeProjectsService(access: AccessState, overrides: Partial<{
   abortEvaluation: (org: string, proj: string, id: string) => ReturnType<ProjectsService['abortEvaluation']>;
   getEntryPoints: () => ReturnType<ProjectsService['getEntryPoints']>;
   extraEvals: EvaluationSummary[];
+  primaryStatus: EvaluationSummary['status'];
 }> = {}): ProjectsService {
   const extraEvals = overrides.extraEvals ?? [];
   return {
-    getProject: () => of(projectFor(access, extraEvals)),
+    getProject: () => of(projectFor(access, extraEvals, overrides.primaryStatus)),
     getEntryPoints: overrides.getEntryPoints ?? (() => of([])),
     startEvaluation: overrides.startEvaluation ?? (() => of('ok')),
     restartFailedBuilds: overrides.restartFailedBuilds ?? (() => of('ok')),
@@ -125,7 +130,7 @@ describe('ProjectDetailComponent - access gating', () => {
   });
 
   it('keeps Start Evaluation / Restart / Abort enabled on state-managed projects', () => {
-    const { fixture } = setup({ managed: true, canEdit: true, canTrigger: true });
+    const { fixture } = setup({ managed: true, canEdit: true, canTrigger: true }, { primaryStatus: 'Completed' });
     const startBtn = findByText(fixture.nativeElement, 'start evaluation') as HTMLButtonElement | null;
     const restartBtn = findByText(fixture.nativeElement, 'restart failed') as HTMLButtonElement | null;
     expect(startBtn).not.toBeNull();
@@ -135,13 +140,41 @@ describe('ProjectDetailComponent - access gating', () => {
   });
 
   it('shows Start / Restart to a caller with TriggerEvaluation but not EditProject', () => {
-    const { fixture } = setup({ managed: false, canEdit: false, canTrigger: true });
+    const { fixture } = setup({ managed: false, canEdit: false, canTrigger: true }, { primaryStatus: 'Completed' });
     const startBtn = findByText(fixture.nativeElement, 'start evaluation') as HTMLButtonElement | null;
     const restartBtn = findByText(fixture.nativeElement, 'restart failed') as HTMLButtonElement | null;
     expect(startBtn).not.toBeNull();
     expect(startBtn!.disabled).toBe(false);
     expect(restartBtn).not.toBeNull();
     expect(restartBtn!.disabled).toBe(false);
+  });
+});
+
+describe('ProjectDetailComponent - in-progress state (#452)', () => {
+  it('disables Start Evaluation while an evaluation is in progress', () => {
+    const { fixture } = setup({ managed: false, canEdit: true, canTrigger: true }, { primaryStatus: 'Fetching' });
+    const startBtn = findByText(fixture.nativeElement, 'start evaluation') as HTMLButtonElement | null;
+    expect(startBtn).not.toBeNull();
+    expect(startBtn!.disabled).toBe(true);
+    expect(fixture.componentInstance.evaluationInProgress()).toBe(true);
+  });
+
+  it('enables Start Evaluation once the latest evaluation finished', () => {
+    const { fixture } = setup({ managed: false, canEdit: true, canTrigger: true }, { primaryStatus: 'Completed' });
+    const startBtn = findByText(fixture.nativeElement, 'start evaluation') as HTMLButtonElement | null;
+    expect(startBtn!.disabled).toBe(false);
+    expect(fixture.componentInstance.evaluationInProgress()).toBe(false);
+  });
+
+  it('shows the eval status badge in the title while in progress', () => {
+    const { fixture } = setup({ managed: false, canEdit: true, canTrigger: true }, { primaryStatus: 'Building' });
+    const badge = fixture.nativeElement.querySelector('.title-row app-eval-status-badge');
+    expect(badge).toBeTruthy();
+  });
+
+  it('hides the title badge when the latest evaluation is terminal', () => {
+    const { fixture } = setup({ managed: false, canEdit: true, canTrigger: true }, { primaryStatus: 'Completed' });
+    expect(fixture.nativeElement.querySelector('.title-row app-eval-status-badge')).toBeNull();
   });
 });
 

--- a/frontend/src/app/features/projects/project-detail/project-detail.component.ts
+++ b/frontend/src/app/features/projects/project-detail/project-detail.component.ts
@@ -12,6 +12,7 @@ import { auditTime } from 'rxjs/operators';
 import { ButtonModule } from 'primeng/button';
 import { DialogModule } from 'primeng/dialog';
 import { MenuModule } from 'primeng/menu';
+import { TooltipModule } from 'primeng/tooltip';
 import { MenuItem } from 'primeng/api';
 import { LiveService } from '@core/services/live.service';
 import { AuthService } from '@core/services/auth.service';
@@ -19,6 +20,7 @@ import { OrganizationsService } from '@core/services/organizations.service';
 import { ProjectsService } from '@core/services/projects.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { EmptyStateComponent } from '@shared/components/empty-state/empty-state.component';
+import { EvalStatusBadgeComponent } from '@shared/components/eval-status-badge/eval-status-badge.component';
 import { AccessService, WritableDirective } from '@shared/access';
 import { injectProjectAccess } from '@core/resolvers/inject-access';
 import { ProjectDetail, EvaluationSummary, EvaluationStatus, EntryPointSummary, BuildStatus, BuildStatusCounts } from '@core/models';
@@ -29,9 +31,9 @@ import { SegmentedBarComponent } from './segmented-bar/segmented-bar.component';
   selector: 'app-project-detail',
   standalone: true,
   imports: [
-    CommonModule, RouterModule, ButtonModule, DialogModule, MenuModule,
+    CommonModule, RouterModule, ButtonModule, DialogModule, MenuModule, TooltipModule,
     LoadingSpinnerComponent, EmptyStateComponent, WritableDirective,
-    SegmentedBarComponent,
+    SegmentedBarComponent, EvalStatusBadgeComponent,
   ],
   templateUrl: './project-detail.component.html',
   styleUrls: [
@@ -89,6 +91,12 @@ export class ProjectDetailComponent implements OnInit, OnDestroy {
   selectedList = computed<EvaluationSummary[]>(() => {
     const s = this.selected();
     return s ? [s] : [];
+  });
+
+  latestEvaluation = computed<EvaluationSummary | null>(() => this.evaluations()[0] ?? null);
+  evaluationInProgress = computed(() => {
+    const e = this.latestEvaluation();
+    return !!e && isRunningEvaluationStatus(e.status);
   });
 
   ngOnInit(): void {

--- a/frontend/src/app/shared/components/eval-status-badge/eval-status-badge.component.scss
+++ b/frontend/src/app/shared/components/eval-status-badge/eval-status-badge.component.scss
@@ -1,0 +1,28 @@
+@use '../../../styles/variables' as *;
+
+.eval-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-xs;
+  padding: 2px $spacing-sm;
+  border-radius: $border-radius-sm;
+  font-size: $font-size-xs;
+  font-weight: 500;
+
+  .material-symbols-outlined { font-size: 13px; }
+
+  &.status-success   { background: rgba($color-success, 0.15); color: $color-success; }
+  &.status-danger    { background: rgba($color-danger, 0.15);  color: $color-danger; }
+  &.status-secondary { background: rgba($text-secondary, 0.15); color: $text-secondary; }
+  &.status-warning   { background: rgba($color-warning, 0.15); color: $color-warning; }
+  &.status-running   { background: rgba($color-info, 0.15); color: $color-info; }
+}
+
+@keyframes spin { to { transform: rotate(-360deg); } }
+.spinning { display: inline-block; animation: spin 1.2s linear infinite; }
+
+@keyframes pulsing-kf {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.4; }
+}
+.pulsing { display: inline-block; animation: pulsing-kf 1.6s ease-in-out infinite; }

--- a/frontend/src/app/shared/components/eval-status-badge/eval-status-badge.component.spec.ts
+++ b/frontend/src/app/shared/components/eval-status-badge/eval-status-badge.component.spec.ts
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { EvalStatusBadgeComponent } from './eval-status-badge.component';
+
+function render(status: string): ComponentFixture<EvalStatusBadgeComponent> {
+  const fixture = TestBed.createComponent(EvalStatusBadgeComponent);
+  fixture.componentRef.setInput('status', status);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('EvalStatusBadgeComponent', () => {
+  it('collapses Evaluating* statuses to a single "Evaluating" label', () => {
+    const fixture = render('EvaluatingDerivation');
+    expect(fixture.nativeElement.textContent.trim()).toContain('Evaluating');
+  });
+
+  it('marks completed evaluations with the success class', () => {
+    const fixture = render('Completed');
+    expect(fixture.nativeElement.querySelector('.eval-status-badge.status-success')).toBeTruthy();
+  });
+
+  it('spins the icon for an actively running status', () => {
+    const fixture = render('Building');
+    expect(fixture.nativeElement.querySelector('.material-symbols-outlined.spinning')).toBeTruthy();
+  });
+
+  it('pulses (not spins) the icon while queued', () => {
+    const fixture = render('Queued');
+    expect(fixture.nativeElement.querySelector('.material-symbols-outlined.pulsing')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('.material-symbols-outlined.spinning')).toBeNull();
+  });
+});

--- a/frontend/src/app/shared/components/eval-status-badge/eval-status-badge.component.ts
+++ b/frontend/src/app/shared/components/eval-status-badge/eval-status-badge.component.ts
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Component, computed, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { EvaluationStatus } from '@core/models/project.model';
+import { isRunningEvaluationStatus } from '@shared/evaluation';
+
+@Component({
+  selector: 'app-eval-status-badge',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <span class="eval-status-badge" [class]="statusClass()">
+      <span class="material-symbols-outlined" [class.spinning]="spinning()" [class.pulsing]="pulsing()">
+        {{ icon() }}
+      </span>
+      {{ label() }}
+    </span>
+  `,
+  styleUrl: './eval-status-badge.component.scss',
+})
+export class EvalStatusBadgeComponent {
+  status = input.required<EvaluationStatus>();
+
+  statusClass = computed(() => {
+    switch (this.status()) {
+      case 'Completed': return 'status-success';
+      case 'Failed': return 'status-danger';
+      case 'Aborted': return 'status-secondary';
+      case 'Waiting': return 'status-warning';
+      default: return 'status-running';
+    }
+  });
+
+  icon = computed(() => {
+    switch (this.status()) {
+      case 'Completed': return 'check_circle';
+      case 'Failed': return 'error';
+      case 'Aborted': return 'cancel';
+      case 'Queued': return 'hourglass_empty';
+      case 'Waiting': return 'pause_circle';
+      default: return 'sync';
+    }
+  });
+
+  label = computed(() => {
+    const s = this.status();
+    if (s === 'EvaluatingFlake' || s === 'EvaluatingDerivation') return 'Evaluating';
+    return s;
+  });
+
+  pulsing = computed(() => this.status() === 'Queued' || this.status() === 'Waiting');
+  spinning = computed(() => isRunningEvaluationStatus(this.status()) && !this.pulsing());
+}


### PR DESCRIPTION
Closes #441, closes #452, closes #460.

- **#460** Gitea/Forgejo provider now accepts Forgejo's native `X-Forgejo-Event` / `X-Forgejo-Signature` headers (Codeberg/Forgejo deliveries that lead with the Forgejo family were dropped at the signature gate before classification), and `handle_issue_comment` now warns instead of silently returning when the integration has no project with a usable forge reporter.
- **#452** Project detail shows the in-progress eval state as a tag on the title and disables Start Evaluation while one is running (no more "evaluation already in progress"); the status tag is extracted into a shared `EvalStatusBadgeComponent` reused by the org detail list.
- **#441** Actions breadcrumb is now `[Org] / [Project] / Settings / Actions` (Integrations already had Settings).