### PR TITLE
scheduler,db: feat: gate dispatch on closure-complete deps

### DIFF
--- a/backend/gradient-db/src/cache_storage.rs
+++ b/backend/gradient-db/src/cache_storage.rs
@@ -259,7 +259,8 @@ pub async fn demote_cached_output<C: ConnectionTrait>(
             r#"
             UPDATE derivation_build
             SET status = 0, substitutable = false, substituted = false,
-                attempt = 0, updated_at = (now() AT TIME ZONE 'UTC')
+                attempt = 0, closure_complete = false,
+                updated_at = (now() AT TIME ZONE 'UTC')
             WHERE derivation = ANY($1) AND status IN (3, 7)
             "#,
             [ids.into()],
@@ -285,33 +286,226 @@ fn references_contains_hash(references: Option<&str>, hash: &str) -> bool {
         .any(|tok| tok.split('-').next() == Some(hash))
 }
 
-/// Demote every cached output whose stored runtime references include
-/// `missing_hash`. A referenced path that is gone leaves its referrers
-/// closure-incomplete; since a missing path with no producing derivation (a
-/// source / `.drv`) only ever returns to the cache as part of a referrer's
-/// closure, the referrers must re-acquire - rebuild or re-substitute - rather
-/// than stay trusted-but-unbuildable. This is the reactive half of the
-/// closure-complete-cache invariant. Returns the producers reset to `Created`.
+/// Demote every cached output that directly references `missing_hash`. A missing
+/// path with no producing derivation (a source / `.drv`) only ever returns to
+/// the cache as part of a referrer's build closure, so a direct referrer must
+/// rebuild to re-push it - rather than stay trusted-but-unbuildable. The
+/// transitive completeness invariant is handled separately by
+/// [`clear_closure_complete_for_referrers`], which only flips the flag and
+/// leaves healthy NARs in place. Returns the producers reset to `Created`.
 pub async fn demote_referrers_of<C: ConnectionTrait>(
     db: &C,
     nar_storage: &gradient_storage::NarStore,
     missing_hash: &str,
 ) -> Result<Vec<DerivationId>, sea_orm::DbErr> {
-    use gradient_entity::cached_path::{Column as CCP, Entity as ECP};
-
-    let referrers = ECP::find()
-        .filter(CCP::References.contains(missing_hash))
-        .all(db)
-        .await?;
-
     let mut producers = Vec::new();
-    for cp in referrers {
-        if references_contains_hash(cp.references.as_deref(), missing_hash) {
-            producers.extend(demote_cached_output(db, nar_storage, &cp.hash).await?);
-        }
+    for referrer_hash in referrers_of_hash(db, missing_hash).await? {
+        producers.extend(demote_cached_output(db, nar_storage, &referrer_hash).await?);
     }
 
     Ok(producers)
+}
+
+/// Self-heal flag clear: a proven-missing path leaves every (transitive)
+/// referrer closure-incomplete, so drop `closure_complete` up the chain - on the
+/// cached NARs and the anchors that produced them - without deleting the healthy
+/// NARs themselves. The missing leaf rebuilds + re-pushes; its closure-complete
+/// push then re-marks the chain via [`propagate_closure_complete`]. The walk
+/// stops at already-false referrers: by the invariant their ancestors are false too.
+pub async fn clear_closure_complete_for_referrers<C: ConnectionTrait>(
+    db: &C,
+    missing_hash: &str,
+) -> Result<u64, sea_orm::DbErr> {
+    use gradient_entity::cached_path::{Column as CCP, Entity as ECP};
+
+    let mut cleared = 0u64;
+    let mut worklist = vec![missing_hash.to_owned()];
+    let mut seen = std::collections::HashSet::new();
+    while let Some(hash) = worklist.pop() {
+        if !seen.insert(hash.clone()) {
+            continue;
+        }
+
+        let referrers = ECP::find().filter(CCP::References.contains(&hash)).all(db).await?;
+        for cp in referrers {
+            if !references_contains_hash(cp.references.as_deref(), &hash) || !cp.closure_complete {
+                continue;
+            }
+
+            ECP::update_many()
+                .col_expr(CCP::ClosureComplete, sea_orm::sea_query::Expr::value(false))
+                .filter(CCP::Hash.eq(&cp.hash))
+                .exec(db)
+                .await?;
+            clear_anchor_closure_complete_for_output(db, &cp.hash).await?;
+            cleared += 1;
+            worklist.push(cp.hash);
+        }
+    }
+
+    Ok(cleared)
+}
+
+/// Clear `closure_complete` on every anchor producing `output_hash`.
+async fn clear_anchor_closure_complete_for_output<C: ConnectionTrait>(
+    db: &C,
+    output_hash: &str,
+) -> Result<(), sea_orm::DbErr> {
+    db.execute(Statement::from_sql_and_values(
+        DatabaseBackend::Postgres,
+        r#"
+        UPDATE derivation_build db SET closure_complete = false
+        WHERE db.closure_complete
+          AND db.derivation IN (SELECT o.derivation FROM derivation_output o WHERE o.hash = $1)
+        "#,
+        [output_hash.into()],
+    ))
+    .await?;
+
+    Ok(())
+}
+
+/// Hashes of cached paths whose runtime `references` name `hash` (token-prefix
+/// match, never a substring of a name).
+async fn referrers_of_hash<C: ConnectionTrait>(
+    db: &C,
+    hash: &str,
+) -> Result<Vec<String>, sea_orm::DbErr> {
+    use gradient_entity::cached_path::{Column as CCP, Entity as ECP};
+
+    Ok(ECP::find()
+        .filter(CCP::References.contains(hash))
+        .all(db)
+        .await?
+        .into_iter()
+        .filter(|cp| references_contains_hash(cp.references.as_deref(), hash))
+        .map(|cp| cp.hash)
+        .collect())
+}
+
+/// Propagate the `closure_complete` flag upward from freshly-ingested `seeds`. A
+/// present NAR becomes complete once every non-self reference is itself present
+/// and complete; marking one complete can complete its referrers, so this walks
+/// them transitively and rolls each newly-complete output up onto its producing
+/// `derivation_build`. Cheap on the push path: most parents stay incomplete
+/// (still missing a sibling) so the cascade settles fast.
+pub async fn propagate_closure_complete<C: ConnectionTrait>(
+    db: &C,
+    seeds: &[String],
+) -> Result<(), sea_orm::DbErr> {
+    use gradient_entity::cached_path::{Column as CCP, Entity as ECP};
+
+    let mut worklist: std::collections::VecDeque<String> = seeds.iter().cloned().collect();
+    let mut seen = std::collections::HashSet::new();
+    while let Some(hash) = worklist.pop_front() {
+        if !seen.insert(hash.clone()) {
+            continue;
+        }
+
+        let Some(cp) = ECP::find().filter(CCP::Hash.eq(&hash)).one(db).await? else {
+            continue;
+        };
+        if cp.closure_complete || cp.file_hash.is_none() || !closure_refs_satisfied(db, &cp).await? {
+            continue;
+        }
+
+        ECP::update_many()
+            .col_expr(CCP::ClosureComplete, sea_orm::sea_query::Expr::value(true))
+            .filter(CCP::Hash.eq(&hash))
+            .exec(db)
+            .await?;
+        rollup_anchor_for_output(db, &hash).await?;
+
+        for referrer_hash in referrers_of_hash(db, &hash).await? {
+            worklist.push_back(referrer_hash);
+        }
+    }
+
+    Ok(())
+}
+
+/// Whether every non-self runtime reference of `cp` is present (`file_hash`) and
+/// itself `closure_complete`. An empty reference set is trivially satisfied.
+async fn closure_refs_satisfied<C: ConnectionTrait>(
+    db: &C,
+    cp: &gradient_entity::cached_path::Model,
+) -> Result<bool, sea_orm::DbErr> {
+    let references = cp.references.clone().unwrap_or_default();
+    if references.trim().is_empty() {
+        return Ok(true);
+    }
+
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DatabaseBackend::Postgres,
+            r#"
+            SELECT NOT EXISTS (
+                SELECT 1
+                FROM regexp_split_to_table($1, '\s+') AS tok
+                WHERE tok <> ''
+                  AND split_part(tok, '-', 1) <> $2
+                  AND NOT EXISTS (
+                    SELECT 1 FROM cached_path r
+                    WHERE r.hash = split_part(tok, '-', 1)
+                      AND r.file_hash IS NOT NULL
+                      AND r.closure_complete)) AS ok
+            "#,
+            [references.into(), cp.hash.clone().into()],
+        ))
+        .await?;
+
+    Ok(row.and_then(|r| r.try_get::<bool>("", "ok").ok()).unwrap_or(false))
+}
+
+/// Mark every terminal-success anchor producing `output_hash` `closure_complete`
+/// when all of its outputs are now complete in cache. Idempotent.
+async fn rollup_anchor_for_output<C: ConnectionTrait>(
+    db: &C,
+    output_hash: &str,
+) -> Result<(), sea_orm::DbErr> {
+    db.execute(Statement::from_sql_and_values(
+        DatabaseBackend::Postgres,
+        r#"
+        UPDATE derivation_build db SET closure_complete = true
+        WHERE db.status IN (3, 7) AND NOT db.closure_complete
+          AND db.derivation IN (SELECT o.derivation FROM derivation_output o WHERE o.hash = $1)
+          AND NOT EXISTS (
+            SELECT 1 FROM derivation_output o
+            LEFT JOIN cached_path cp ON cp.hash = o.hash
+            WHERE o.derivation = db.derivation AND (cp.closure_complete IS NOT TRUE))
+        "#,
+        [output_hash.into()],
+    ))
+    .await?;
+
+    Ok(())
+}
+
+/// Set `closure_complete` on a single anchor once it is terminal-success and
+/// every output's runtime closure is in cache. Called when a build finalizes,
+/// after its NARs (and their closure) have been pushed. Returns whether it flipped.
+pub async fn rollup_closure_complete_for_derivation<C: ConnectionTrait>(
+    db: &C,
+    derivation: DerivationId,
+) -> Result<bool, sea_orm::DbErr> {
+    let affected = db
+        .execute(Statement::from_sql_and_values(
+            DatabaseBackend::Postgres,
+            r#"
+            UPDATE derivation_build db SET closure_complete = true
+            WHERE db.derivation = $1 AND db.status IN (3, 7) AND NOT db.closure_complete
+              AND EXISTS (SELECT 1 FROM derivation_output o WHERE o.derivation = db.derivation)
+              AND NOT EXISTS (
+                SELECT 1 FROM derivation_output o
+                LEFT JOIN cached_path cp ON cp.hash = o.hash
+                WHERE o.derivation = db.derivation AND (cp.closure_complete IS NOT TRUE))
+            "#,
+            [sea_orm::Value::Uuid(Some(Box::new(derivation.into_inner())))],
+        ))
+        .await?
+        .rows_affected();
+
+    Ok(affected > 0)
 }
 
 #[cfg(test)]

--- a/backend/gradient-db/src/lib.rs
+++ b/backend/gradient-db/src/lib.rs
@@ -39,9 +39,10 @@ pub mod status_reactor;
 pub use self::build_attempt::*;
 pub use self::cache_reach::*;
 pub use self::cache_storage::{
-    MissingInputDiagnosis, STORAGE_HEADROOM_BYTES, cache_used_bytes, demote_cached_output,
-    demote_referrers_of, diagnose_missing_input, instance_used_bytes, org_caches_all_full,
-    org_writable_caches,
+    MissingInputDiagnosis, STORAGE_HEADROOM_BYTES, cache_used_bytes,
+    clear_closure_complete_for_referrers, demote_cached_output, demote_referrers_of,
+    diagnose_missing_input, instance_used_bytes, org_caches_all_full, org_writable_caches,
+    propagate_closure_complete, rollup_closure_complete_for_derivation,
 };
 pub use self::cache_upstream::{
     GradientProtoUpstream, gradient_proto_upstreams_for_org, upstream_urls_for_org,

--- a/backend/gradient-db/src/promotion.rs
+++ b/backend/gradient-db/src/promotion.rs
@@ -68,7 +68,8 @@ pub async fn promote_dependents<C: ConnectionTrait>(
                 SELECT 1 FROM derivation_dependency e
                 LEFT JOIN derivation_build dep ON dep.derivation = e.dependency
                 WHERE e.derivation = db.derivation
-                  AND (dep.status IS NULL OR dep.status NOT IN (3, 7)))
+                  AND (dep.status IS NULL OR dep.status NOT IN (3, 7)
+                       OR NOT dep.closure_complete))
               AND (db.substitutable OR NOT EXISTS (
                 SELECT 1 FROM derivation_input_source s
                 WHERE s.derivation = db.derivation
@@ -138,7 +139,8 @@ pub async fn promote_ready<C: ConnectionTrait>(db: &C) -> Result<u64, DbErr> {
                 SELECT 1 FROM derivation_dependency e
                 LEFT JOIN derivation_build dep ON dep.derivation = e.dependency
                 WHERE e.derivation = derivation_build.derivation
-                  AND (dep.status IS NULL OR dep.status NOT IN (3, 7)))
+                  AND (dep.status IS NULL OR dep.status NOT IN (3, 7)
+                       OR NOT dep.closure_complete))
               AND (derivation_build.substitutable OR NOT EXISTS (
                 SELECT 1 FROM derivation_input_source s
                 WHERE s.derivation = derivation_build.derivation
@@ -200,7 +202,8 @@ pub async fn requeue_failed_anchors<C: ConnectionTrait>(
                 DatabaseBackend::Postgres,
                 r#"
                 UPDATE derivation_build
-                SET status = 0, attempt = 0, updated_at = (now() AT TIME ZONE 'UTC')
+                SET status = 0, attempt = 0, closure_complete = false,
+                    updated_at = (now() AT TIME ZONE 'UTC')
                 WHERE derivation = ANY($1) AND status IN (4, 5, 6, 9)
                 "#,
                 [ids.into()],

--- a/backend/gradient-entity/src/cached_path.rs
+++ b/backend/gradient-entity/src/cached_path.rs
@@ -36,6 +36,10 @@ pub struct Model {
     pub nar_hash: Option<String>,
     /// Space-separated list of store-path references (hash-name format).
     pub references: Option<String>,
+    /// True when this NAR is present AND every non-self reference is itself
+    /// present and closure-complete - i.e. the whole runtime closure is in our
+    /// cache. Maintained inductively on ingest; cleared when a member is purged.
+    pub closure_complete: bool,
     /// Content-address field, if the path is content-addressed.
     pub ca: Option<String>,
     /// Full `.drv` path that produced this output, if known.

--- a/backend/gradient-entity/src/derivation_build.rs
+++ b/backend/gradient-entity/src/derivation_build.rs
@@ -32,6 +32,11 @@ pub struct Model {
     /// created mid-stream by a still-running, failed, or interrupted eval has no
     /// edges yet and must not be promoted as if it were dependency-free.
     pub edges_complete: bool,
+    /// True once this anchor reached a terminal-success status (Completed /
+    /// Substituted) AND every output's full runtime closure is present in our
+    /// cache. Dispatch gates dependents on it: a dep marked done whose closure
+    /// is incomplete would otherwise strand the dependent on `InputsUnavailable`.
+    pub closure_complete: bool,
     pub attempt: i32,
     pub timeout_secs: Option<i64>,
     pub max_silent_secs: Option<i64>,

--- a/backend/gradient-migration/src/lib.rs
+++ b/backend/gradient-migration/src/lib.rs
@@ -167,6 +167,7 @@ mod m20260620_000004_fix_github_installation_created_at_tz;
 mod m20260620_000005_derivation_output_upstream;
 mod m20260621_000001_derivation_build_edges_complete;
 mod m20260623_000000_create_derivation_input_source;
+mod m20260624_000001_closure_complete;
 
 pub struct Migrator;
 
@@ -335,6 +336,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260620_000005_derivation_output_upstream::Migration),
             Box::new(m20260621_000001_derivation_build_edges_complete::Migration),
             Box::new(m20260623_000000_create_derivation_input_source::Migration),
+            Box::new(m20260624_000001_closure_complete::Migration),
         ]
     }
 }

--- a/backend/gradient-migration/src/m20260624_000001_closure_complete.rs
+++ b/backend/gradient-migration/src/m20260624_000001_closure_complete.rs
@@ -1,0 +1,115 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! `closure_complete` invariant. Dispatch trusted "dep build is Completed /
+//! Substituted" as "dep's whole runtime closure is fetchable", but a dep marked
+//! done whose NAR closure was incomplete (a runtime reference never pushed)
+//! stranded dependents on `InputsUnavailable` forever. We now track, per cached
+//! NAR and rolled up onto each anchor, whether the full runtime closure is in
+//! our cache, and gate dispatch on it.
+//!
+//! Backfill computes `cached_path.closure_complete` to a fixpoint (a path is
+//! complete once every non-self reference is present and complete), rolls it up
+//! onto terminal-success anchors, and resets anchors whose closure is incomplete
+//! to `Created` so they rebuild closure-complete. Going forward the worker push
+//! is closure-complete, so no new violations are created.
+
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::ConnectionTrait;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+
+        conn.execute_unprepared(
+            "ALTER TABLE cached_path
+               ADD COLUMN IF NOT EXISTS closure_complete boolean NOT NULL DEFAULT false",
+        )
+        .await?;
+        conn.execute_unprepared(
+            "ALTER TABLE derivation_build
+               ADD COLUMN IF NOT EXISTS closure_complete boolean NOT NULL DEFAULT false",
+        )
+        .await?;
+
+        // Fixpoint: mark a present NAR complete once every non-self reference is
+        // itself present and complete. Leaves settle first, then their referrers.
+        conn.execute_unprepared(
+            r#"
+            DO $$
+            DECLARE changed integer;
+            BEGIN
+              LOOP
+                UPDATE cached_path cp SET closure_complete = true
+                WHERE cp.closure_complete = false
+                  AND cp.file_hash IS NOT NULL
+                  AND NOT EXISTS (
+                    SELECT 1
+                    FROM regexp_split_to_table(coalesce(cp."references", ''), '\s+') AS tok
+                    WHERE tok <> ''
+                      AND split_part(tok, '-', 1) <> cp.hash
+                      AND NOT EXISTS (
+                        SELECT 1 FROM cached_path r
+                        WHERE r.hash = split_part(tok, '-', 1)
+                          AND r.file_hash IS NOT NULL
+                          AND r.closure_complete = true));
+                GET DIAGNOSTICS changed = ROW_COUNT;
+                EXIT WHEN changed = 0;
+              END LOOP;
+            END $$;
+            "#,
+        )
+        .await?;
+
+        // Roll up onto terminal-success anchors whose every output is complete.
+        conn.execute_unprepared(
+            r#"
+            UPDATE derivation_build db SET closure_complete = true
+            WHERE db.status IN (3, 7)
+              AND EXISTS (SELECT 1 FROM derivation_output o WHERE o.derivation = db.derivation)
+              AND NOT EXISTS (
+                SELECT 1 FROM derivation_output o
+                LEFT JOIN cached_path cp ON cp.hash = o.hash
+                WHERE o.derivation = db.derivation AND (cp.closure_complete IS NOT TRUE));
+            "#,
+        )
+        .await?;
+
+        // Reset closure-incomplete terminal-success anchors so they rebuild (or
+        // re-substitute, when an upstream URL is known) closure-complete. The
+        // worker push invariant keeps newly-built anchors complete from here on.
+        conn.execute_unprepared(
+            r#"
+            UPDATE derivation_build db SET
+              status = 0, substituted = false, attempt = 0,
+              substitutable = EXISTS (
+                SELECT 1 FROM derivation_output o
+                WHERE o.derivation = db.derivation AND o.external_url IS NOT NULL),
+              updated_at = (now() AT TIME ZONE 'UTC')
+            WHERE db.status IN (3, 7)
+              AND db.closure_complete = false
+              AND EXISTS (SELECT 1 FROM derivation_output o WHERE o.derivation = db.derivation);
+            "#,
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+        conn.execute_unprepared("ALTER TABLE derivation_build DROP COLUMN IF EXISTS closure_complete")
+            .await?;
+        conn.execute_unprepared("ALTER TABLE cached_path DROP COLUMN IF EXISTS closure_complete")
+            .await?;
+
+        Ok(())
+    }
+}

--- a/backend/gradient-proto/src/ingest.rs
+++ b/backend/gradient-proto/src/ingest.rs
@@ -184,6 +184,13 @@ async fn upsert_and_sign<C: ConnectionTrait>(
         }
     }
 
+    // Newly-present NAR may complete its own runtime closure (and cascade to
+    // referrers), maintaining the closure-complete invariant the dispatch gate
+    // trusts. Best-effort: a propagation error never fails the ingest itself.
+    if let Err(e) = gradient_db::propagate_closure_complete(db, &[hash.to_owned()]).await {
+        warn!(hash, error = %e, "closure-complete propagation failed after ingest");
+    }
+
     Ok(IngestOutcome { cached_path: cached_path_id, created })
 }
 

--- a/backend/gradient-scheduler/src/build.rs
+++ b/backend/gradient-scheduler/src/build.rs
@@ -250,6 +250,19 @@ impl<'a> BuildStateHandler<'a> {
         let terminal = terminal_success_status(anchor.substituted);
         update_derivation_build_status(&self.state.db(), anchor, terminal).await;
 
+        // The output NARs (and their full runtime closure) are pushed by now, so
+        // finalize the closure-complete flag the dispatch gate trusts. Ingest-time
+        // propagation runs while the anchor is still Building and skips it; this
+        // sets it once the anchor is terminal-success.
+        if let Err(e) = gradient_db::rollup_closure_complete_for_derivation(
+            &self.state.worker_db,
+            derivation_id,
+        )
+        .await
+        {
+            warn!(%derivation_build, error = %e, "failed to roll up closure_complete");
+        }
+
         if was_external_cached {
             let state = Arc::clone(self.state);
             tokio::spawn(async move {
@@ -491,6 +504,14 @@ impl<'a> BuildStateHandler<'a> {
                 Ok(drvs) if !drvs.is_empty() => {
                     purged += 1;
                     demoted_producers.extend(drvs);
+                    // The leaf rebuilds + re-pushes closure-complete; meanwhile drop
+                    // the now-stale `closure_complete` up the chain so the dispatch
+                    // gate re-blocks dependents until the closure is whole again.
+                    if let Err(e) =
+                        gradient_db::clear_closure_complete_for_referrers(db, hash).await
+                    {
+                        warn!(%path, error = %e, "reconcile: clear closure_complete failed");
+                    }
                 }
                 Ok(_) => {
                     sources_purged.push(path);

--- a/backend/gradient-scheduler/src/dispatch.rs
+++ b/backend/gradient-scheduler/src/dispatch.rs
@@ -892,7 +892,9 @@ pub(crate) async fn dispatch_ready_builds(scheduler: &Scheduler) -> anyhow::Resu
     // Ready anchors: a global `derivation_build` is Queued, some `build_job`
     // still references its derivation (reachable from a surviving evaluation),
     // and every dependency anchor over `derivation_dependency` is terminal-
-    // success (Completed or Substituted). The reachability check skips anchors
+    // success (Completed or Substituted) AND `closure_complete` - its whole
+    // runtime closure is in our cache, so the build's prefetch cannot miss. The
+    // reachability check skips anchors
     // left Queued after their last referencing eval was torn down, which have
     // no driving evaluation to attribute the build to. Ordered by dependency
     // count desc (integration builds first), then by age.
@@ -916,6 +918,7 @@ pub(crate) async fn dispatch_ready_builds(scheduler: &Scheduler) -> anyhow::Resu
                         FROM public.derivation_build dep_db
                         WHERE dep_db.derivation = dep_edge.dependency
                           AND dep_db.status IN ({completed}, {substituted})
+                          AND dep_db.closure_complete
                     )
               )
               AND (db.substitutable OR NOT EXISTS (

--- a/backend/gradient-scheduler/src/eval.rs
+++ b/backend/gradient-scheduler/src/eval.rs
@@ -527,7 +527,7 @@ impl<'a> EvalResultProcessor<'a> {
             .await
             .context("compute_truly_substituted: load cached_path")?
             .into_iter()
-            .filter(|cp| cp.is_fully_cached())
+            .filter(|cp| cp.is_fully_cached() && cp.closure_complete)
             .map(|cp| cp.hash)
             .collect();
 

--- a/docs/src/scheduler.md
+++ b/docs/src/scheduler.md
@@ -143,23 +143,41 @@ evaluation instead of descending into subtrees it will never build.
 #### Closure-complete cache
 
 The cache holds a binary-cache invariant: *if an output is in our cache, its
-entire runtime closure is too*. The prune and substitutability gates trust it -
-they check an output's own availability, never walk its closure on the hot path -
-so it must be maintained at every write. A build (and a substitution, which
-fetches the output's closure locally first) pushes the **full runtime closure**
-of its outputs, not just the output paths; already-cached members are skipped, so
-only paths the cache is actually missing upload. Without this a config output
-like `nginx.conf` could be cached while a `-source` it references is not, and any
-downstream build would fail `InputsUnavailable` on a path with no producing
-derivation that nothing would ever re-push.
+entire runtime closure is too*. A build (and a substitution, which fetches the
+output's closure locally first) pushes the **full runtime closure** of its
+outputs, not just the output paths; already-cached members are skipped, so only
+paths the cache is actually missing upload.
 
-A closure member with no producer (a source / `.drv`) only returns to the cache
-as part of a referrer's closure, so when a build reports such a path missing,
-`reconcile_missing_inputs` demotes its **referrers** (`demote_referrers_of`):
-every cached output whose stored `references_list` names the gone path is reset
-so it re-acquires its full closure on the next build/substitute. This is the
-reactive half of the invariant - it converges any closure-incomplete entry left
-by an older write without re-walking closures on read.
+The dispatch gate does not merely *trust* this - it **enforces** it. A build's
+build-time dependency edges (`derivation_dependency`) do not include a dep's
+transitive runtime references, so "dep is Completed/Substituted" alone does not
+guarantee the dep's runtime closure is fetchable. A dependent dispatched on that
+weaker signal fails `InputsUnavailable` on a runtime path the gate never checked
+(e.g. `nixos-system` needs `unit-bird.service` via `system-units`, which has no
+direct edge). So completeness is tracked explicitly:
+
+- `cached_path.closure_complete` - a NAR is complete once present **and** every
+  non-self reference is itself present and complete. Maintained inductively by
+  `propagate_closure_complete` on each ingest (leaves settle first, then cascade
+  to referrers).
+- `derivation_build.closure_complete` - rolled up onto a terminal-success anchor
+  once all its outputs are complete (`rollup_closure_complete_for_derivation`,
+  run when the build finalizes after its closure is pushed).
+
+`promote_ready` and `dispatch_ready_builds` require every dependency to be
+`status IN (Completed, Substituted) AND closure_complete`, and
+`compute_truly_substituted` only marks an output Substituted when its cache entry
+is closure-complete. The gate stays O(1) (no hot-path closure walk) because the
+flag amortizes the check.
+
+When a build still reports a path missing, `reconcile_missing_inputs` self-heals:
+a missing leaf with a producer is purged + rebuilt (`demote_cached_output`) and
+`closure_complete` is cleared up the referrer chain
+(`clear_closure_complete_for_referrers`) so dependents re-block until the leaf
+re-pushes closure-complete; a producerless source (no producer to rebuild)
+demotes its direct **referrers** (`demote_referrers_of`) so a referrer rebuild
+re-pushes it. The migration backfills the flag to a fixpoint over the existing
+cache and resets any closure-incomplete terminal anchor so it rebuilds.
 
 #### Access and GC
 

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -1055,12 +1055,28 @@ in CI (the db crate has no real-Postgres unit harness).
 The cache is closure-complete by invariant: `compress_and_push_paths` pushes each
 output's full runtime closure (`collect_runtime_closure`), not just the output, so
 a referenced source (`-source`) can never be stranded uncached while its referrer
-is cached. The reactive half, `demote_referrers_of`, demotes every cached output
-whose `references_list` names a reported-missing producerless path, so a closure
-left incomplete by an older write re-acquires on the next build/substitute.
-`references_contains_hash_matches_token_prefix_only` covers the precise reference
-match (hash as a `hash-name` token prefix, never a substring of a name); the
-closure-complete push and the referrer demote are exercised end-to-end in CI.
+is cached. The invariant is now **enforced at dispatch**, not merely trusted:
+`cached_path.closure_complete` (a NAR is complete once present and every non-self
+reference is present + complete, maintained by `propagate_closure_complete` on
+ingest) rolls up to `derivation_build.closure_complete`
+(`rollup_closure_complete_for_derivation` on build finalize), and `promote_ready`
+/ `dispatch_ready_builds` require every dependency to be terminal-success **and**
+`closure_complete`. This closes the runtime-vs-build-time edge gap (a dep marked
+done whose transitive runtime ref - e.g. `unit-bird.service` via `system-units` -
+was never cached would otherwise let a dependent dispatch and fail
+`InputsUnavailable` on a path the gate never checked). `compute_truly_substituted`
+likewise requires `closure_complete`.
+
+Self-heal clears the flag so the gate re-blocks: a reported-missing leaf with a
+producer is purged + rebuilt and `clear_closure_complete_for_referrers` drops
+`closure_complete` up the (transitive) referrer chain without deleting healthy
+NARs; a producerless source demotes its direct referrers (`demote_referrers_of`)
+so a referrer rebuild re-pushes it. The migration backfills the flag to a fixpoint
+over the existing cache and resets closure-incomplete terminal anchors so they
+rebuild. `references_contains_hash_matches_token_prefix_only` covers the precise
+reference match (hash as a `hash-name` token prefix, never a substring of a name);
+the closure-complete propagation, gate, and migration backfill are exercised
+end-to-end in CI (the db crate has no real-Postgres unit harness).
 
 Preventively, `expand_substituted_closure` now only marks a closure dep
 `Substituted` when its `derivation_output` rows are all `is_cached = true`;


### PR DESCRIPTION
Track cached_path/derivation_build.closure_complete (maintained on ingest, cleared by self-heal) and require deps be closure-complete to promote/dispatch, so a dep whose runtime closure is not in our cache no longer strands dependents on InputsUnavailable; migration backfills the flag and resets incomplete terminal anchors.