### PR TITLE
worker: rkyv eval-worker IPC + streaming resolve

### DIFF
--- a/backend/gradient-worker/src/nix/eval_worker.rs
+++ b/backend/gradient-worker/src/nix/eval_worker.rs
@@ -16,90 +16,110 @@
 //! subprocess entry point [`run_eval_worker`]. The pool implementation lives
 //! in [`super::worker_pool`].
 
-use serde::{Deserialize, Serialize};
-use std::io::{BufRead, Write};
+use std::io::{Read, Write};
 use tracing::{error, trace};
+
+use rkyv::rancor::Error as RkyvError;
+use rkyv::util::AlignedVec;
 
 use crate::nix::nix_eval::NixEvaluator;
 use crate::worker_pool::eval_stats::StatsDelta;
 
-/// Request from parent → worker. One JSON object per line on the worker's stdin.
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(tag = "op", rename_all = "snake_case")]
+/// Guards against a corrupt length prefix allocating an absurd buffer. The
+/// child is trusted, but a torn frame must fail fast, not OOM the parent.
+pub(crate) const MAX_EVAL_FRAME: usize = 512 * 1024 * 1024;
+
+/// Request from parent to worker. One rkyv frame per message on stdin.
+#[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize, Debug, Clone, PartialEq)]
+#[rkyv(derive(Debug))]
 pub enum EvalRequest {
-    /// Split `wildcards` into disjoint sub-patterns (one per first-wildcard
-    /// child) so the parent can fan discovery across the pool, one shard per
-    /// system within each worker's memory budget.
-    Plan {
-        repository: String,
-        wildcards: Vec<String>,
-    },
-    /// Discover all attribute paths in `repository` matching `wildcards`.
-    List {
-        repository: String,
-        wildcards: Vec<String>,
-    },
-    /// Resolve a batch of attribute paths to `(drv_path, references)` tuples.
-    /// Per-attr failures are reported in the response, not as a top-level err.
-    Resolve {
-        repository: String,
-        attrs: Vec<String>,
-    },
-    /// Return `repository`'s eval-cache fingerprint without evaluating it.
-    /// `None` in the response for mutable/dirty flakes.
+    Plan { repository: String, wildcards: Vec<String> },
+    List { repository: String, wildcards: Vec<String> },
+    Resolve { repository: String, attrs: Vec<String> },
     Fingerprint { repository: String },
-    /// Fold the eval-cache WAL into the main `.sqlite` (truncate checkpoint).
-    /// Run once after all shards finish, before the fleet-share push.
     Checkpoint { repository: String },
-    /// Ask the worker to exit cleanly. Parent uses this on graceful shutdown.
     Shutdown,
 }
 
-/// Response from worker → parent. One JSON object per line on the worker's stdout.
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+/// Response from worker to parent. One rkyv frame per message on stdout.
+#[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize, Debug, Clone, PartialEq)]
+#[rkyv(derive(Debug))]
 pub enum EvalResponse {
-    PlanOk {
-        sub_patterns: Vec<String>,
-    },
+    PlanOk { sub_patterns: Vec<String> },
     ListOk {
         attrs: Vec<String>,
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
         warnings: Vec<String>,
-        #[serde(default)]
-        stats: Option<crate::worker_pool::eval_stats::StatsDelta>,
+        stats: Option<StatsDelta>,
     },
     ResolveOk {
         items: Vec<ResolvedItem>,
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
         warnings: Vec<String>,
-        #[serde(default)]
-        stats: Option<crate::worker_pool::eval_stats::StatsDelta>,
+        stats: Option<StatsDelta>,
     },
-    FingerprintOk {
-        fingerprint: Option<String>,
-    },
+    FingerprintOk { fingerprint: Option<String> },
     CheckpointOk,
-    Err {
-        message: String,
-    },
+    Err { message: String },
 }
 
-/// One element of a `ResolveOk` payload. Either `drv_path` is set (success)
-/// or `error` is set (failure for that one attr).
-#[derive(Debug, Serialize, Deserialize)]
+/// One element of a `ResolveOk` payload: `drv_path` set on success, `error`
+/// set on a per-attr failure.
+#[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize, Debug, Clone, PartialEq)]
+#[rkyv(derive(Debug))]
 pub struct ResolvedItem {
     pub attr: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub drv_path: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub references: Vec<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
 
-/// Subprocess entry point. Reads `EvalRequest` lines from stdin, processes
-/// them with one persistent `NixEvaluator`, writes `EvalResponse` lines to
+pub(crate) fn encode_request(req: &EvalRequest) -> Result<AlignedVec, RkyvError> {
+    rkyv::to_bytes::<RkyvError>(req)
+}
+
+pub(crate) fn encode_response(resp: &EvalResponse) -> Result<AlignedVec, RkyvError> {
+    rkyv::to_bytes::<RkyvError>(resp)
+}
+
+pub(crate) fn decode_request(bytes: &[u8]) -> Result<EvalRequest, RkyvError> {
+    let mut aligned = AlignedVec::<16>::new();
+    aligned.extend_from_slice(bytes);
+    rkyv::from_bytes::<EvalRequest, RkyvError>(&aligned)
+}
+
+pub(crate) fn decode_response(bytes: &[u8]) -> Result<EvalResponse, RkyvError> {
+    let mut aligned = AlignedVec::<16>::new();
+    aligned.extend_from_slice(bytes);
+    rkyv::from_bytes::<EvalResponse, RkyvError>(&aligned)
+}
+
+/// Read one `u32`-length-prefixed frame from a blocking reader. `Ok(None)` is a
+/// clean EOF at a frame boundary (the parent closed the pipe).
+fn read_frame<R: Read>(r: &mut R) -> std::io::Result<Option<Vec<u8>>> {
+    let mut len_buf = [0u8; 4];
+    match r.read_exact(&mut len_buf) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(e) => return Err(e),
+    }
+
+    let len = u32::from_le_bytes(len_buf) as usize;
+    if len > MAX_EVAL_FRAME {
+        return Err(std::io::Error::other(format!("frame too large: {len}")));
+    }
+
+    let mut buf = vec![0u8; len];
+    r.read_exact(&mut buf)?;
+    Ok(Some(buf))
+}
+
+fn write_frame<W: Write>(w: &mut W, payload: &[u8]) -> std::io::Result<()> {
+    w.write_all(&(payload.len() as u32).to_le_bytes())?;
+    w.write_all(payload)?;
+    w.flush()
+}
+
+/// Subprocess entry point. Reads `EvalRequest` frames from stdin, processes
+/// them with one persistent `NixEvaluator`, writes `EvalResponse` frames to
 /// stdout. Returns when stdin reaches EOF or a `Shutdown` request is received.
 ///
 /// Diagnostics go through `tracing` (configured in `worker::main` to write
@@ -107,11 +127,6 @@ pub struct ResolvedItem {
 /// and stdin errors stay visible to JSON log aggregators with structured
 /// fields, target metadata, and `RUST_LOG` filtering applied.
 pub fn run_eval_worker() -> std::io::Result<()> {
-    let stdin = std::io::stdin();
-    let stdout = std::io::stdout();
-    let mut reader = stdin.lock();
-    let mut writer = stdout.lock();
-
     // Construct the evaluator once. If init fails we still loop so that the
     // parent gets an error response per request instead of a silent EOF; the
     // parent will then mark this worker dead and respawn.
@@ -160,29 +175,25 @@ pub fn run_eval_worker() -> std::io::Result<()> {
         })
     };
 
-    let mut line = String::new();
+    let mut reader = std::io::BufReader::new(std::io::stdin());
+    let mut writer = std::io::BufWriter::new(std::io::stdout());
+
     loop {
-        line.clear();
-        let n = match reader.read_line(&mut line) {
-            Ok(n) => n,
+        let frame = match read_frame(&mut reader) {
+            Ok(Some(f)) => f,
+            Ok(None) => return Ok(()),
             Err(e) => {
                 error!(error = %e, "eval worker: stdin read error");
                 return Err(e);
             }
         };
-        if n == 0 {
-            // EOF: parent closed the pipe.
-            return Ok(());
-        }
 
-        let req: EvalRequest = match serde_json::from_str(line.trim_end()) {
+        let req: EvalRequest = match decode_request(&frame) {
             Ok(r) => r,
             Err(e) => {
                 write_response(
                     &mut writer,
-                    &EvalResponse::Err {
-                        message: format!("malformed request: {}", e),
-                    },
+                    &EvalResponse::Err { message: format!("malformed request: {e}") },
                 )?;
                 continue;
             }
@@ -371,10 +382,8 @@ pub fn run_eval_worker() -> std::io::Result<()> {
 }
 
 fn write_response<W: Write>(w: &mut W, resp: &EvalResponse) -> std::io::Result<()> {
-    let mut bytes = serde_json::to_vec(resp).map_err(std::io::Error::other)?;
-    bytes.push(b'\n');
-    w.write_all(&bytes)?;
-    w.flush()
+    let payload = encode_response(resp).map_err(std::io::Error::other)?;
+    write_frame(w, &payload)
 }
 
 /// Runs `f` while capturing everything written to stderr (fd 2).
@@ -499,7 +508,7 @@ mod tests {
     }
 
     #[test]
-    fn eval_request_serde_roundtrip() {
+    fn eval_request_rkyv_roundtrip() {
         let requests = [
             EvalRequest::Plan {
                 repository: "github:nixos/nixpkgs".into(),
@@ -523,19 +532,14 @@ mod tests {
         ];
 
         for req in &requests {
-            let json = serde_json::to_string(req).expect("serialize failed");
-            let back: EvalRequest = serde_json::from_str(&json).expect("deserialize failed");
-            // Re-serialize and compare JSON strings (no PartialEq on enums)
-            assert_eq!(
-                serde_json::to_string(&back).unwrap(),
-                json,
-                "roundtrip mismatch for request"
-            );
+            let bytes = encode_request(req).expect("encode");
+            let back = decode_request(&bytes).expect("decode");
+            assert_eq!(&back, req);
         }
     }
 
     #[test]
-    fn eval_response_serde_roundtrip() {
+    fn eval_response_rkyv_roundtrip() {
         let responses: Vec<EvalResponse> = vec![
             EvalResponse::PlanOk {
                 sub_patterns: vec!["packages.x86_64-linux.#".into()],
@@ -565,13 +569,9 @@ mod tests {
         ];
 
         for resp in &responses {
-            let json = serde_json::to_string(resp).expect("serialize failed");
-            let back: EvalResponse = serde_json::from_str(&json).expect("deserialize failed");
-            assert_eq!(
-                serde_json::to_string(&back).unwrap(),
-                json,
-                "roundtrip mismatch for response"
-            );
+            let bytes = encode_response(resp).expect("encode");
+            let back = decode_response(&bytes).expect("decode");
+            assert_eq!(&back, resp);
         }
     }
 }

--- a/backend/gradient-worker/src/nix/eval_worker.rs
+++ b/backend/gradient-worker/src/nix/eval_worker.rs
@@ -6,15 +6,9 @@
 
 //! Long-lived Nix evaluator worker subprocess.
 //!
-//! The parent process spawns one or more copies of the gradient-worker binary
-//! with `--eval-worker` to host a persistent [`NixEvaluator`]. Parent and
-//! worker exchange line-delimited JSON over the worker's stdin/stdout, so the
-//! libnix init cost is paid only once per worker (vs. once per `resolve` call
-//! when using the in-process resolver).
-//!
-//! This file defines the wire protocol shared by both sides plus the
-//! subprocess entry point [`run_eval_worker`]. The pool implementation lives
-//! in [`super::worker_pool`].
+//! Parent and worker exchange rkyv length-prefixed frames (`u32 LE` + payload)
+//! over stdin/stdout. `Resolve` streams one `ResolveItem` frame per attr then a
+//! `ResolveEnd` terminator; all other exchanges are single-response.
 
 use std::io::{Read, Write};
 use tracing::{error, trace};
@@ -51,8 +45,8 @@ pub enum EvalResponse {
         warnings: Vec<String>,
         stats: Option<StatsDelta>,
     },
-    ResolveOk {
-        items: Vec<ResolvedItem>,
+    ResolveItem { item: ResolvedItem },
+    ResolveEnd {
         warnings: Vec<String>,
         stats: Option<StatsDelta>,
     },
@@ -61,8 +55,7 @@ pub enum EvalResponse {
     Err { message: String },
 }
 
-/// One element of a `ResolveOk` payload: `drv_path` set on success, `error`
-/// set on a per-attr failure.
+/// One resolved attr: `drv_path` set on success, `error` set on per-attr failure.
 #[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize, Debug, Clone, PartialEq)]
 #[rkyv(derive(Debug))]
 pub struct ResolvedItem {
@@ -269,15 +262,12 @@ pub fn run_eval_worker() -> std::io::Result<()> {
                 let Some(ev) = evaluator.as_ref() else {
                     write_response(
                         &mut writer,
-                        &EvalResponse::Err {
-                            message: "evaluator not initialized".to_string(),
-                        },
+                        &EvalResponse::Err { message: "evaluator not initialized".to_string() },
                     )?;
                     continue;
                 };
 
                 let mut all_warnings = Vec::new();
-                let mut items = Vec::with_capacity(attrs.len());
                 let (walker, build_warnings) = capture_warnings_during(|| ev.walker(&repository));
                 all_warnings.extend(build_warnings);
 
@@ -287,44 +277,46 @@ pub fn run_eval_worker() -> std::io::Result<()> {
                             let (result, warnings) =
                                 capture_warnings_during(|| walker.resolve(&attr));
                             all_warnings.extend(warnings);
-                            match result {
-                                Ok((drv, references)) => items.push(ResolvedItem {
+                            let item = match result {
+                                Ok((drv, references)) => ResolvedItem {
                                     attr,
                                     drv_path: Some(drv),
                                     references,
                                     error: None,
-                                }),
-                                Err(e) => items.push(ResolvedItem {
+                                },
+                                Err(e) => ResolvedItem {
                                     attr,
                                     drv_path: None,
                                     references: vec![],
-                                    error: Some(format!("{:#}", e)),
-                                }),
-                            }
+                                    error: Some(format!("{e:#}")),
+                                },
+                            };
+                            write_response(&mut writer, &EvalResponse::ResolveItem { item })?;
                         }
 
                         let _ = walker.commit_cache();
                     }
                     Err(e) => {
-                        let msg = format!("{:#}", e);
+                        let msg = format!("{e:#}");
                         for attr in attrs {
-                            items.push(ResolvedItem {
+                            let item = ResolvedItem {
                                 attr,
                                 drv_path: None,
                                 references: vec![],
                                 error: Some(msg.clone()),
-                            });
+                            };
+                            write_response(&mut writer, &EvalResponse::ResolveItem { item })?;
                         }
                     }
                 }
 
                 all_warnings.dedup();
                 let stats = take_delta(ev);
-                EvalResponse::ResolveOk {
-                    items,
-                    warnings: all_warnings,
-                    stats,
-                }
+                write_response(
+                    &mut writer,
+                    &EvalResponse::ResolveEnd { warnings: all_warnings, stats },
+                )?;
+                continue;
             }
             EvalRequest::Fingerprint { repository } => {
                 let Some(ev) = evaluator.as_ref() else {
@@ -369,12 +361,12 @@ pub fn run_eval_worker() -> std::io::Result<()> {
                 format!("PlanOk({} shards)", sub_patterns.len())
             }
             EvalResponse::ListOk { attrs, .. } => format!("ListOk({} attrs)", attrs.len()),
-            EvalResponse::ResolveOk { items, .. } => format!("ResolveOk({} items)", items.len()),
             EvalResponse::FingerprintOk { fingerprint } => {
                 format!("FingerprintOk({})", fingerprint.is_some())
             }
             EvalResponse::CheckpointOk => "CheckpointOk".to_string(),
             EvalResponse::Err { message } => format!("Err({message})"),
+            EvalResponse::ResolveItem { .. } | EvalResponse::ResolveEnd { .. } => unreachable!(),
         };
         trace!(%kind, "eval worker sending response");
         write_response(&mut writer, &resp)?;
@@ -549,14 +541,16 @@ mod tests {
                 warnings: vec![],
                 stats: None,
             },
-            EvalResponse::ResolveOk {
-                items: vec![ResolvedItem {
+            EvalResponse::ResolveItem {
+                item: ResolvedItem {
                     attr: "packages.x86_64-linux.hello".into(),
                     drv_path: Some("aaaa-hello.drv".into()),
                     references: vec![],
                     error: None,
-                }],
-                warnings: vec![],
+                },
+            },
+            EvalResponse::ResolveEnd {
+                warnings: vec!["warning: insecure".into()],
                 stats: None,
             },
             EvalResponse::FingerprintOk {

--- a/backend/gradient-worker/src/worker_pool/eval_stats.rs
+++ b/backend/gradient-worker/src/worker_pool/eval_stats.rs
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// Whether per-eval metrics collection is enabled (default on). Disabling skips
@@ -32,7 +31,8 @@ pub(crate) fn eval_worker_stats_env(metrics_enabled: bool) -> &'static [(&'stati
 /// Counters are diffs since the worker's prior request; gc_heap_size is the
 /// current gauge at report time. Canonical delta type, shared internally and
 /// on the eval-worker wire protocol.
-#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
+#[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize, Clone, Copy, Debug, Default, PartialEq)]
+#[rkyv(derive(Debug))]
 pub struct StatsDelta {
     pub nr_thunks: u64,
     pub nr_function_calls: u64,

--- a/backend/gradient-worker/src/worker_pool/pool.rs
+++ b/backend/gradient-worker/src/worker_pool/pool.rs
@@ -286,19 +286,10 @@ impl EvalWorker {
         repository: String,
         attrs: Vec<String>,
     ) -> Result<(Vec<ResolvedItem>, Vec<String>, Option<StatsDelta>)> {
+        // TODO(task-3): replace with streaming ResolveItem/ResolveEnd reader
+        let _ = (repository, attrs);
         self.evaluations_served += 1;
-        match self
-            .request(&EvalRequest::Resolve { repository, attrs })
-            .await?
-        {
-            EvalResponse::ResolveOk {
-                items,
-                warnings,
-                stats,
-            } => Ok((items, warnings, stats)),
-            EvalResponse::Err { message } => Err(anyhow::anyhow!("eval worker: {}", message)),
-            _ => anyhow::bail!("eval worker: unexpected response to Resolve"),
-        }
+        anyhow::bail!("resolve not yet implemented for streaming protocol")
     }
 
     /// Resident set size of the subprocess in bytes, read from

--- a/backend/gradient-worker/src/worker_pool/pool.rs
+++ b/backend/gradient-worker/src/worker_pool/pool.rs
@@ -42,6 +42,13 @@ async fn read_frame_async<R: tokio::io::AsyncRead + Unpin>(r: &mut R) -> std::io
     Ok(buf)
 }
 
+pub(super) struct ResolveStream {
+    pub items: Vec<ResolvedItem>,
+    pub warnings: Vec<String>,
+    pub stats: Option<StatsDelta>,
+    pub crashed: bool,
+}
+
 /// Handle to a single live eval-worker subprocess.
 ///
 /// Owns the child plus its piped stdin/stdout. The protocol is strictly
@@ -285,11 +292,33 @@ impl EvalWorker {
         &mut self,
         repository: String,
         attrs: Vec<String>,
-    ) -> Result<(Vec<ResolvedItem>, Vec<String>, Option<StatsDelta>)> {
-        // TODO(task-3): replace with streaming ResolveItem/ResolveEnd reader
-        let _ = (repository, attrs);
+    ) -> Result<ResolveStream> {
         self.evaluations_served += 1;
-        anyhow::bail!("resolve not yet implemented for streaming protocol")
+        let payload = encode_request(&EvalRequest::Resolve { repository, attrs })
+            .context("serializing Resolve")?;
+        write_frame_async(&mut self.stdin, &payload)
+            .await
+            .context("writing Resolve to eval worker stdin")?;
+
+        let mut items = Vec::new();
+        loop {
+            let bytes = match read_frame_async(&mut self.stdout).await {
+                Ok(b) => b,
+                Err(_eof) => {
+                    return Ok(ResolveStream { items, warnings: vec![], stats: None, crashed: true });
+                }
+            };
+            match decode_response(&bytes).context("decoding Resolve frame")? {
+                EvalResponse::ResolveItem { item } => items.push(item),
+                EvalResponse::ResolveEnd { warnings, stats } => {
+                    return Ok(ResolveStream { items, warnings, stats, crashed: false });
+                }
+                EvalResponse::Err { .. } => {
+                    return Ok(ResolveStream { items, warnings: vec![], stats: None, crashed: true });
+                }
+                _ => anyhow::bail!("eval worker: unexpected frame during Resolve"),
+            }
+        }
     }
 
     /// Resident set size of the subprocess in bytes, read from

--- a/backend/gradient-worker/src/worker_pool/pool.rs
+++ b/backend/gradient-worker/src/worker_pool/pool.rs
@@ -10,24 +10,47 @@ use std::ops::{Deref, DerefMut};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tracing::{debug, error, trace, warn};
 
-use crate::nix::eval_worker::{EvalRequest, EvalResponse, ResolvedItem};
+use crate::nix::eval_worker::{
+    EvalRequest, EvalResponse, ResolvedItem, MAX_EVAL_FRAME, decode_response, encode_request,
+};
 use crate::worker_pool::eval_stats::StatsDelta;
+
+async fn write_frame_async<W: tokio::io::AsyncWrite + Unpin>(
+    w: &mut W,
+    payload: &[u8],
+) -> std::io::Result<()> {
+    w.write_all(&(payload.len() as u32).to_le_bytes()).await?;
+    w.write_all(payload).await?;
+    w.flush().await
+}
+
+async fn read_frame_async<R: tokio::io::AsyncRead + Unpin>(r: &mut R) -> std::io::Result<Vec<u8>> {
+    let mut len_buf = [0u8; 4];
+    r.read_exact(&mut len_buf).await?;
+    let len = u32::from_le_bytes(len_buf) as usize;
+    if len > MAX_EVAL_FRAME {
+        return Err(std::io::Error::other(format!("frame too large: {len}")));
+    }
+
+    let mut buf = vec![0u8; len];
+    r.read_exact(&mut buf).await?;
+    Ok(buf)
+}
 
 /// Handle to a single live eval-worker subprocess.
 ///
-/// Owns the child plus its piped stdin/stdout. Each request writes one JSON
-/// line to stdin and reads one JSON line back from stdout - the protocol is
-/// strictly request/response so a single buffer is sufficient.
+/// Owns the child plus its piped stdin/stdout. The protocol is strictly
+/// request/response: one rkyv frame written to stdin, one rkyv frame read
+/// from stdout.
 pub struct EvalWorker {
     child: Child,
     stdin: ChildStdin,
     stdout: BufReader<ChildStdout>,
-    line: String,
     /// Number of `list` / `resolve` calls served since spawn. The pool
     /// uses this to recycle the subprocess after a configurable number
     /// of evaluations so Nix's Boehm-GC-allocated memory (which is
@@ -107,7 +130,6 @@ impl EvalWorker {
             child,
             stdin,
             stdout,
-            line: String::new(),
             evaluations_served: 0,
         })
     }
@@ -117,30 +139,20 @@ impl EvalWorker {
     /// instead of being returned to the pool).
     async fn request(&mut self, req: &EvalRequest) -> Result<EvalResponse> {
         trace!(pid = self.child.id(), ?req, "sending eval worker request");
-        let mut bytes = serde_json::to_vec(req).context("serializing request")?;
-        bytes.push(b'\n');
-        self.stdin
-            .write_all(&bytes)
+        let payload = encode_request(req).context("serializing request")?;
+        write_frame_async(&mut self.stdin, &payload)
             .await
             .context("writing to eval worker stdin")?;
 
-        self.stdin
-            .flush()
-            .await
-            .context("flushing eval worker stdin")?;
-
-        self.line.clear();
-        let n = self
-            .stdout
-            .read_line(&mut self.line)
-            .await
-            .context("reading eval worker response")?;
-
-        if n == 0 {
-            let pid = self.child.id();
-            let status =
-                match tokio::time::timeout(std::time::Duration::from_secs(2), self.child.wait())
-                    .await
+        let bytes = match read_frame_async(&mut self.stdout).await {
+            Ok(b) => b,
+            Err(_eof) => {
+                let pid = self.child.id();
+                let status = match tokio::time::timeout(
+                    std::time::Duration::from_secs(2),
+                    self.child.wait(),
+                )
+                .await
                 {
                     Ok(Ok(s)) => format!("{s}"),
                     Ok(Err(e)) => format!("wait error: {e}"),
@@ -162,23 +174,14 @@ impl EvalWorker {
                         diag
                     }
                 };
-            anyhow::bail!("eval worker closed pipe (pid={pid:?}, exit={status})");
-        }
+                anyhow::bail!("eval worker closed pipe (pid={pid:?}, exit={status})");
+            }
+        };
 
-        trace!(
-            pid = self.child.id(),
-            bytes = n,
-            "received eval worker response"
-        );
-        serde_json::from_str(self.line.trim_end())
-            .inspect_err(|error| {
-                error!(
-                    %error,
-                    raw_input = self.line.trim_end(),
-                    "Failed to parse eval worker JSON response"
-                );
-            })
-            .context("parsing eval worker response")
+        trace!(pid = self.child.id(), bytes = bytes.len(), "received eval worker response");
+        decode_response(&bytes)
+            .inspect_err(|error| error!(%error, "Failed to decode eval worker rkyv response"))
+            .context("decoding eval worker response")
     }
 
     pub(super) async fn plan(
@@ -255,19 +258,17 @@ impl EvalWorker {
     pub(super) async fn shutdown(mut self) {
         let pid = self.child.id();
         trace!(pid, "sending Shutdown to eval worker");
-        let mut bytes = match serde_json::to_vec(&EvalRequest::Shutdown) {
+        let payload = match encode_request(&EvalRequest::Shutdown) {
             Ok(b) => b,
             Err(e) => {
                 warn!(pid, error = %e, "failed to serialize Shutdown request");
                 return;
             }
         };
-        bytes.push(b'\n');
-        if let Err(e) = self.stdin.write_all(&bytes).await {
+        if let Err(e) = write_frame_async(&mut self.stdin, &payload).await {
             debug!(pid, error = %e, "failed to write Shutdown to eval worker");
             return;
         }
-        let _ = self.stdin.flush().await;
         drop(self.stdin);
         trace!(pid, "Shutdown sent; waiting for eval worker to exit");
         match tokio::time::timeout(std::time::Duration::from_secs(5), self.child.wait()).await {

--- a/backend/gradient-worker/src/worker_pool/resolver.rs
+++ b/backend/gradient-worker/src/worker_pool/resolver.rs
@@ -96,11 +96,11 @@ fn crashed_derivation(attr: String) -> ResolvedDerivation {
     )
 }
 
-/// Resolves one batch of attrs on a single fresh worker. `Ok` means the
-/// subprocess lived (per-attr eval errors ride inside the items); `Err` means
-/// it crashed mid-batch. Injected so the crash-isolation policy is testable
-/// without real subprocesses.
-type ResolveOnce<'a> = dyn Fn(Vec<String>) -> BoxFuture<'a, Result<Vec<ResolvedItem>>> + Sync + 'a;
+/// Resolves one batch of attrs on a single fresh worker. Returns a
+/// `ResolveStream` where `crashed: true` means the worker died (the `items`
+/// prefix was already streamed). Injected so the crash-isolation policy is
+/// testable without real subprocesses.
+type ResolveOnce<'a> = dyn Fn(Vec<String>) -> BoxFuture<'a, super::pool::ResolveStream> + Sync + 'a;
 
 /// Crashes tolerated for a single attr before it becomes a per-attr error.
 const MAX_CRASH_ATTEMPTS: u32 = 2;
@@ -110,12 +110,11 @@ const MAX_CRASH_ATTEMPTS: u32 = 2;
 /// persists across batches and is recycled once it crosses the cap).
 const MAX_RESOLVE_BATCH: usize = 64;
 
-/// Pure crash-isolation policy. Resolves `chunk` via `resolve_once`; an `Err`
-/// (subprocess crash, never a per-attr eval failure) is recovered by bisection:
-/// split a multi-attr chunk in half so the crasher is isolated in `O(log n)`
-/// while the rest resolve, and retry a single attr once before recording a
-/// per-attr error. `attempt` counts crashes for a single-attr chunk, capped at
-/// [`MAX_CRASH_ATTEMPTS`].
+/// Pure crash-isolation policy. Resolves `chunk` via `resolve_once`; a crash
+/// (`stream.crashed`) is recovered by bisecting only the unstreamed remainder
+/// so the prefix already delivered is never re-run. Retry a single-attr chunk
+/// once before recording a per-attr error. `attempt` counts crashes for a
+/// single-attr chunk, capped at [`MAX_CRASH_ATTEMPTS`].
 fn resolve_chunk<'a>(
     resolve_once: &'a ResolveOnce<'a>,
     mut chunk: Vec<(usize, String)>,
@@ -127,41 +126,53 @@ fn resolve_chunk<'a>(
         }
 
         let attrs: Vec<String> = chunk.iter().map(|(_, a)| a.clone()).collect();
-        match resolve_once(attrs).await {
-            Ok(items) => {
-                if items.len() != chunk.len() {
-                    anyhow::bail!(
-                        "eval worker returned {} items for {} attrs",
-                        items.len(),
-                        chunk.len()
-                    );
-                }
+        let stream = resolve_once(attrs).await;
 
-                Ok(chunk
-                    .into_iter()
-                    .zip(items)
-                    .map(|((idx, _attr), item)| (idx, item_to_resolved(item)))
-                    .collect())
-            }
-            Err(_crash) if chunk.len() == 1 => {
-                let (idx, attr) = chunk.into_iter().next().expect("len == 1");
-                if attempt + 1 >= MAX_CRASH_ATTEMPTS {
-                    return Ok(vec![(idx, crashed_derivation(attr))]);
-                }
+        let done: Vec<IndexedDerivation> = chunk
+            .iter()
+            .zip(stream.items)
+            .map(|((idx, _attr), item)| (*idx, item_to_resolved(item)))
+            .collect();
+        let resolved_n = done.len();
 
-                resolve_chunk(resolve_once, vec![(idx, attr)], attempt + 1).await
+        if !stream.crashed {
+            if resolved_n != chunk.len() {
+                anyhow::bail!(
+                    "eval worker streamed {resolved_n} items for {} attrs",
+                    chunk.len()
+                );
             }
-            Err(_crash) => {
-                let right = chunk.split_off(chunk.len() / 2);
-                let (mut a, b) = futures::future::try_join(
-                    resolve_chunk(resolve_once, chunk, 0),
-                    resolve_chunk(resolve_once, right, 0),
-                )
-                .await?;
-                a.extend(b);
-                Ok(a)
-            }
+
+            return Ok(done);
         }
+
+        let remainder = chunk.split_off(resolved_n);
+        if remainder.len() == 1 {
+            let (idx, attr) = remainder.into_iter().next().expect("len == 1");
+            if attempt + 1 >= MAX_CRASH_ATTEMPTS {
+                let mut out = done;
+                out.push((idx, crashed_derivation(attr)));
+                return Ok(out);
+            }
+
+            let mut out = done;
+            out.extend(resolve_chunk(resolve_once, vec![(idx, attr)], attempt + 1).await?);
+            return Ok(out);
+        }
+
+        let mid = remainder.len() / 2;
+        let mut left = remainder;
+        let right = left.split_off(mid);
+        let (a, b) = futures::future::try_join(
+            resolve_chunk(resolve_once, left, 0),
+            resolve_chunk(resolve_once, right, 0),
+        )
+        .await?;
+
+        let mut out = done;
+        out.extend(a);
+        out.extend(b);
+        Ok(out)
     })
 }
 
@@ -281,38 +292,47 @@ impl WorkerPoolResolver {
         }
     }
 
-    /// Resolve `attrs` on one fresh worker. `Ok` means the subprocess lived
-    /// (per-attr eval errors ride inside the items); `Err` means it crashed.
-    /// An over-RSS worker is discarded after a successful call so the next
-    /// `acquire` spawns a fresh subprocess.
-    async fn resolve_once(
-        &self,
-        repository: &str,
-        attrs: Vec<String>,
-    ) -> Result<(Vec<ResolvedItem>, Vec<String>)> {
-        // A batch's delta is one number, so it is attributed whole to the
-        // entry-point of its first attr; the dynamic queue keeps batches small
-        // and same-prefix, so cross-bucket bleed is minor.
+    async fn resolve_once(&self, repository: &str, attrs: Vec<String>) -> super::pool::ResolveStream {
         let bucket = attrs
             .first()
             .map(|a| entry_point_of(a, &self.patterns.lock().unwrap()))
             .unwrap_or_default();
-        let mut worker = self.pool.acquire().await?;
-        match worker.resolve(repository.to_string(), attrs).await {
-            Ok((items, warnings, stats)) => {
-                let rss = worker.rss_bytes();
-                if let Some(delta) = stats {
-                    self.observe_stats(&bucket, delta, rss);
-                }
-                if rss > self.pool.max_eval_rss() {
-                    worker.mark_dead();
-                }
 
-                Ok((items, warnings))
+        let mut worker = match self.pool.acquire().await {
+            Ok(w) => w,
+            Err(_) => {
+                return super::pool::ResolveStream {
+                    items: vec![],
+                    warnings: vec![],
+                    stats: None,
+                    crashed: true,
+                };
             }
-            Err(e) => {
+        };
+
+        match worker.resolve(repository.to_string(), attrs).await {
+            Ok(mut stream) => {
+                if stream.crashed {
+                    worker.mark_dead();
+                } else {
+                    let rss = worker.rss_bytes();
+                    if let Some(delta) = stream.stats.take() {
+                        self.observe_stats(&bucket, delta, rss);
+                    }
+                    if rss > self.pool.max_eval_rss() {
+                        worker.mark_dead();
+                    }
+                }
+                stream
+            }
+            Err(_) => {
                 worker.mark_dead();
-                Err(e)
+                super::pool::ResolveStream {
+                    items: vec![],
+                    warnings: vec![],
+                    stats: None,
+                    crashed: true,
+                }
             }
         }
     }
@@ -449,14 +469,13 @@ impl DerivationResolver for WorkerPoolResolver {
         {
             let repo = repository.as_str();
             let sink = &warnings;
-            let resolve_batch =
-                move |attrs: Vec<String>| -> BoxFuture<'_, Result<Vec<ResolvedItem>>> {
-                    Box::pin(async move {
-                        let (items, w) = self.resolve_once(repo, attrs).await?;
-                        sink.lock().unwrap().extend(w);
-                        Ok(items)
-                    })
-                };
+            let resolve_batch = move |attrs: Vec<String>| -> BoxFuture<'_, super::pool::ResolveStream> {
+                Box::pin(async move {
+                    let stream = self.resolve_once(repo, attrs).await;
+                    sink.lock().unwrap().extend(stream.warnings.clone());
+                    stream
+                })
+            };
 
             let (queue, indexed, resolve_batch) = (&queue, &indexed, &resolve_batch);
             let mut tasks: FuturesUnordered<_> = (0..n_workers)
@@ -512,6 +531,7 @@ impl DerivationResolver for WorkerPoolResolver {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use super::super::pool::ResolveStream;
     use std::collections::HashSet;
     use std::sync::Mutex;
 
@@ -589,9 +609,8 @@ mod tests {
         Stub::new(move |attrs, _call| attrs.iter().any(|a| set.contains(a.as_str())))
     }
 
-    /// Drive the pure core over a chunk built from `attrs` (index = position).
-    /// Owns the stub so the closure and its futures share one scope (mirroring
-    /// the production block); returns the result plus the stub's call count.
+    /// Stream items for the prefix of `attrs` before the first crasher; mark
+    /// `crashed` when any crasher is present in the batch.
     async fn run(stub: Stub, attrs: &[&str]) -> (Vec<(String, bool)>, usize) {
         let chunk: Vec<(usize, String)> = attrs
             .iter()
@@ -601,22 +620,31 @@ mod tests {
 
         let mut out = {
             let stub = &stub;
-            let resolve_once =
-                move |attrs: Vec<String>| -> BoxFuture<'_, Result<Vec<ResolvedItem>>> {
-                    Box::pin(async move {
-                        let prior = {
-                            let mut n = stub.calls.lock().unwrap();
-                            let prior = *n;
-                            *n += 1;
-                            prior
-                        };
-                        if (stub.crash_if)(&attrs, prior) {
-                            anyhow::bail!("worker crashed");
-                        }
-
-                        Ok(attrs.iter().map(|a| ok_item(a)).collect())
-                    })
-                };
+            let resolve_once = move |attrs: Vec<String>| -> BoxFuture<'_, ResolveStream> {
+                Box::pin(async move {
+                    let prior = {
+                        let mut n = stub.calls.lock().unwrap();
+                        let prior = *n;
+                        *n += 1;
+                        prior
+                    };
+                    let crash_at = attrs.iter().position(|a| (stub.crash_if)(std::slice::from_ref(a), prior));
+                    match crash_at {
+                        Some(k) => ResolveStream {
+                            items: attrs[..k].iter().map(|a| ok_item(a)).collect(),
+                            warnings: vec![],
+                            stats: None,
+                            crashed: true,
+                        },
+                        None => ResolveStream {
+                            items: attrs.iter().map(|a| ok_item(a)).collect(),
+                            warnings: vec![],
+                            stats: None,
+                            crashed: false,
+                        },
+                    }
+                })
+            };
             resolve_chunk(&resolve_once, chunk, 0).await.unwrap()
         };
         out.sort_by_key(|(idx, _)| *idx);

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -3059,6 +3059,39 @@ Unit tests in `backend/worker/src/worker_pool/pool.rs`:
   branch in `Drop` instead of being pushed back into the (now drained)
   idle vec.
 
+## Eval-worker IPC - rkyv framing + streaming resolve crash isolation
+
+The parent to `--eval-worker` subprocess IPC moved from line-delimited JSON to
+rkyv messages framed as a `u32` length prefix plus the archived bytes
+(`backend/gradient-worker/src/nix/eval_worker.rs`). `decode_request` /
+`decode_response` realign into `AlignedVec<16>` before `rkyv::from_bytes` (same
+constraint as the proto wire decoders above; a pipe-read `Vec<u8>` carries only
+`align_of::<u8>()`), and a `MAX_EVAL_FRAME` guard rejects a corrupt length
+prefix before allocating. `Resolve` now streams: the worker emits one
+`ResolveItem` frame per attr in request order, then a `ResolveEnd` terminator
+carrying the batch's warnings and stats; `Plan` / `List` / `Fingerprint` /
+`Checkpoint` stay single-frame.
+
+Unit tests (`backend/gradient-worker/src/nix/eval_worker.rs`):
+
+- `eval_request_rkyv_roundtrip` / `eval_response_rkyv_roundtrip` - every
+  request and response variant (including `ResolveItem` / `ResolveEnd`) survives
+  `encode` then `decode` unchanged, asserting via `PartialEq`.
+
+Crash-isolation tests (`backend/gradient-worker/src/worker_pool/resolver.rs`): a
+mid-stream worker death is recoverable because items stream in request order, so
+the streamed prefix is already resolved and only the unstreamed remainder is
+bisected. The stub models this by streaming the prefix before the first crasher
+and flagging `crashed`.
+
+- `no_crash_resolves_all_in_one_call` - a clean batch resolves in a single call
+  (no bisection).
+- `single_crasher_among_healthy_isolates_one_error` /
+  `two_crashers_isolate_independently` - a crashing attr is bisected down to a
+  per-attr error while its neighbours still resolve.
+- `transient_crash_succeeds_on_retry` - a single-attr remainder that crashes
+  once is retried (capped by `MAX_CRASH_ATTEMPTS`) and resolves on the retry.
+
 ## Prometheus metrics endpoint - `web/tests/metrics.rs`
 
 Covers `GET /metrics`, the Prometheus exposition endpoint introduced


### PR DESCRIPTION
Replaces the eval-worker parent/subprocess JSON-line IPC with rkyv length-prefixed frames, then streams `Resolve` results per attr (`ResolveItem`/`ResolveEnd`) with crash isolation bisecting only the unstreamed remainder. Internal IPC only (no API/config change); verified via cargo check/clippy/workspace, unit tests run in CI.