### PR TITLE
cli: add gradient eval subcommand (nix-eval-jobs-like)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2164,6 +2164,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gradient-eval"
+version = "1.2.0"
+dependencies = [
+ "anyhow",
+ "libc",
+ "nix-bindings",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
 name = "gradient-exec"
 version = "1.2.0"
 dependencies = [
@@ -2585,6 +2597,7 @@ dependencies = [
  "gradient-core",
  "gradient-db",
  "gradient-entity",
+ "gradient-eval",
  "gradient-exec",
  "gradient-flake-lock",
  "gradient-nix",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
-members      = [".", "gradient-cache", "gradient-ci", "gradient-core", "gradient-db", "gradient-entity", "gradient-exec", "gradient-flake-lock", "gradient-forge", "gradient-migration", "gradient-nix", "gradient-proto", "gradient-scheduler", "gradient-score", "gradient-sources", "gradient-state", "gradient-storage", "gradient-test-support", "gradient-types", "gradient-util", "gradient-web", "gradient-worker"]
-default-members = [".", "gradient-cache", "gradient-ci", "gradient-core", "gradient-db", "gradient-entity", "gradient-exec", "gradient-flake-lock", "gradient-forge", "gradient-migration", "gradient-nix", "gradient-proto", "gradient-scheduler", "gradient-score", "gradient-sources", "gradient-state", "gradient-storage", "gradient-test-support", "gradient-types", "gradient-util", "gradient-web", "gradient-worker"]
+members      = [".", "gradient-cache", "gradient-ci", "gradient-core", "gradient-db", "gradient-entity", "gradient-eval", "gradient-exec", "gradient-flake-lock", "gradient-forge", "gradient-migration", "gradient-nix", "gradient-proto", "gradient-scheduler", "gradient-score", "gradient-sources", "gradient-state", "gradient-storage", "gradient-test-support", "gradient-types", "gradient-util", "gradient-web", "gradient-worker"]
+default-members = [".", "gradient-cache", "gradient-ci", "gradient-core", "gradient-db", "gradient-entity", "gradient-eval", "gradient-exec", "gradient-flake-lock", "gradient-forge", "gradient-migration", "gradient-nix", "gradient-proto", "gradient-scheduler", "gradient-score", "gradient-sources", "gradient-state", "gradient-storage", "gradient-test-support", "gradient-types", "gradient-util", "gradient-web", "gradient-worker"]
 resolver     = "2"
 
 [workspace.package]

--- a/backend/gradient-eval/Cargo.toml
+++ b/backend/gradient-eval/Cargo.toml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Self-contained manifest (no workspace inheritance) so this crate is usable as a
+# lone path dependency from the separate gradient-cli workspace.
+[package]
+name = "gradient-eval"
+description = "Standalone Nix flake evaluator shared by the gradient worker and CLI"
+version = "1.2.0"
+edition = "2024"
+license = "AGPL-3.0"
+authors = ["Wavelens GmbH <info@wavelens.io>"]
+repository = "https://github.com/wavelens/gradient"
+publish = false
+
+[lib]
+name = "gradient_eval"
+path = "src/lib.rs"
+doctest = false
+
+[dependencies]
+anyhow       = { version = "1.0", default-features = false, features = ["std"] }
+libc         = { version = "0.2", default-features = false }
+nix-bindings = { git = "https://github.com/DerDennisOP/nix-bindings", branch = "feat/eval-metrics-stats", default-features = false, features = ["flake"] }
+serde        = { version = "1", default-features = false, features = ["std", "derive"] }
+serde_json   = { version = "1.0", default-features = false, features = ["std"] }
+tracing      = { version = "0.1", default-features = false, features = ["std", "attributes"] }

--- a/backend/gradient-eval/src/eval_worker.rs
+++ b/backend/gradient-eval/src/eval_worker.rs
@@ -20,8 +20,8 @@ use serde::{Deserialize, Serialize};
 use std::io::{BufRead, Write};
 use tracing::{error, trace};
 
-use crate::nix::nix_eval::NixEvaluator;
-use crate::worker_pool::eval_stats::StatsDelta;
+use crate::nix_eval::NixEvaluator;
+use crate::stats::StatsDelta;
 
 /// Request from parent → worker. One JSON object per line on the worker's stdin.
 #[derive(Debug, Serialize, Deserialize)]
@@ -67,14 +67,14 @@ pub enum EvalResponse {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         warnings: Vec<String>,
         #[serde(default)]
-        stats: Option<crate::worker_pool::eval_stats::StatsDelta>,
+        stats: Option<crate::stats::StatsDelta>,
     },
     ResolveOk {
         items: Vec<ResolvedItem>,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         warnings: Vec<String>,
         #[serde(default)]
-        stats: Option<crate::worker_pool::eval_stats::StatsDelta>,
+        stats: Option<crate::stats::StatsDelta>,
     },
     FingerprintOk {
         fingerprint: Option<String>,
@@ -128,7 +128,7 @@ pub fn run_eval_worker() -> std::io::Result<()> {
 
     // Per-request delta collection is on by default; disabling it skips every
     // `ev.stats()` call so the subprocess pays zero overhead.
-    let collect_stats = crate::worker_pool::eval_stats::metrics_enabled();
+    let collect_stats = crate::stats::metrics_enabled();
     let mut last = if collect_stats {
         evaluator
             .as_ref()

--- a/backend/gradient-eval/src/flake_walk.rs
+++ b/backend/gradient-eval/src/flake_walk.rs
@@ -15,7 +15,6 @@
 use std::sync::Arc;
 
 use anyhow::{Context as _, Result, anyhow};
-use gradient_exec::strip_nix_store_prefix;
 use nix_bindings::eval_cache::{AttrCursor, EvalCache};
 use nix_bindings::flake::{
     FetchersSettings, FlakeReference, FlakeReferenceParseFlags, FlakeSettings, LockFlags,
@@ -23,17 +22,18 @@ use nix_bindings::flake::{
 };
 use nix_bindings::{Context, EvalState, Store};
 
-use crate::nix::wildcard_walk::{self, WalkNode};
+use crate::strip_nix_store_prefix;
+use crate::wildcard_walk::{self, WalkNode};
 
 /// A locked flake with an open eval cache, walked via a borrowed `EvalState`.
-pub(crate) struct FlakeWalker<'a> {
+pub struct FlakeWalker<'a> {
     cache: EvalCache,
     _locked: LockedFlake,
     state: &'a EvalState,
 }
 
 impl<'a> FlakeWalker<'a> {
-    pub(crate) fn open(
+    pub fn open(
         ctx: &Arc<Context>,
         fetch: &FetchersSettings,
         flake: &FlakeSettings,
@@ -57,7 +57,7 @@ impl<'a> FlakeWalker<'a> {
         })
     }
 
-    pub(crate) fn discover(&self, wildcards: &[String]) -> Result<Vec<String>> {
+    pub fn discover(&self, wildcards: &[String]) -> Result<Vec<String>> {
         let root = self.root()?;
 
         wildcard_walk::discover_patterns(&root, wildcards)
@@ -67,7 +67,7 @@ impl<'a> FlakeWalker<'a> {
     /// parallel discovery (one shard per first-wildcard child). Exclusions are
     /// dropped here; the caller re-attaches them to every shard so each worker's
     /// `discover` applies them.
-    pub(crate) fn plan_shards(&self, wildcards: &[String]) -> Result<Vec<String>> {
+    pub fn plan_shards(&self, wildcards: &[String]) -> Result<Vec<String>> {
         let root = self.root()?;
         let includes: Vec<Vec<String>> = wildcards
             .iter()
@@ -82,7 +82,7 @@ impl<'a> FlakeWalker<'a> {
             .collect())
     }
 
-    pub(crate) fn resolve(&self, attr_path: &str) -> Result<(String, Vec<String>)> {
+    pub fn resolve(&self, attr_path: &str) -> Result<(String, Vec<String>)> {
         let (_, segs) = wildcard_walk::parse_pattern(attr_path);
         let mut cursor = self.cache.root()?;
         for seg in &segs {
@@ -102,14 +102,14 @@ impl<'a> FlakeWalker<'a> {
     /// checkpoint), so concurrent shard workers don't deadlock on the WAL
     /// read-slot locks. The writes are durable; [`Self::checkpoint_cache`]
     /// folds them into the main `.sqlite` once at end-of-eval.
-    pub(crate) fn commit_cache(&self) -> Result<()> {
+    pub fn commit_cache(&self) -> Result<()> {
         self.cache.commit().context("committing eval cache")
     }
 
     /// Fold the WAL into the main `.sqlite` (PASSIVE checkpoint) so the
     /// fleet-share push sees the shards' writes. Never blocks: safe to call even
     /// while another evaluator of the same flake is reading the cache.
-    pub(crate) fn checkpoint_cache(&self) -> Result<()> {
+    pub fn checkpoint_cache(&self) -> Result<()> {
         self.cache.checkpoint().context("checkpointing eval cache")
     }
 }
@@ -134,7 +134,7 @@ fn lock_flake(
 
 /// Lock `flake_ref` and return its eval-cache fingerprint without opening (and
 /// thus creating) the on-disk eval cache. `None` for mutable/dirty flakes.
-pub(crate) fn fingerprint(
+pub fn fingerprint(
     ctx: &Arc<Context>,
     fetch: &FetchersSettings,
     flake: &FlakeSettings,

--- a/backend/gradient-eval/src/jobs.rs
+++ b/backend/gradient-eval/src/jobs.rs
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! nix-eval-jobs-style streaming driver over the gradient evaluator: discover
+//! the attribute paths matching a set of wildcards, resolve each to its
+//! `.drv`, and report one [`Job`] per attribute. Per-attribute failures are
+//! reported in the `Job` (mirroring nix-eval-jobs) instead of aborting.
+
+use anyhow::Result;
+use serde::Serialize;
+
+use crate::nix_eval::NixEvaluator;
+use crate::nix_store_path;
+
+/// One newline-delimited JSON record, shaped after nix-eval-jobs' output.
+#[derive(Debug, Serialize)]
+pub struct Job {
+    pub attr: String,
+    #[serde(rename = "attrPath")]
+    pub attr_path: Vec<String>,
+    #[serde(rename = "drvPath", skip_serializing_if = "Option::is_none")]
+    pub drv_path: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub references: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl Job {
+    /// A successfully resolved attribute. `drv` is a bare hash-name; the full
+    /// `/nix/store` path is emitted to match nix-eval-jobs.
+    pub fn resolved(attr: String, drv: String, references: Vec<String>) -> Self {
+        Job {
+            attr_path: attr.split('.').map(str::to_string).collect(),
+            attr,
+            drv_path: Some(nix_store_path(&drv)),
+            references,
+            error: None,
+        }
+    }
+
+    /// An attribute whose evaluation failed.
+    pub fn failed(attr: String, error: String) -> Self {
+        Job {
+            attr_path: attr.split('.').map(str::to_string).collect(),
+            attr,
+            drv_path: None,
+            references: vec![],
+            error: Some(error),
+        }
+    }
+}
+
+/// Evaluate `wildcards` against `flake_ref`, invoking `sink` once per discovered
+/// attribute (in sorted order) as soon as it is resolved.
+///
+/// Synchronous and Boehm-GC bound: call from a context without a Tokio runtime
+/// (the CLI runs it before the runtime starts, mirroring the eval worker).
+pub fn eval_jobs(flake_ref: &str, wildcards: &[String], mut sink: impl FnMut(Job)) -> Result<()> {
+    let evaluator = NixEvaluator::new()?;
+    let walker = evaluator.walker(flake_ref)?;
+    for attr in walker.discover(wildcards)? {
+        let job = match walker.resolve(&attr) {
+            Ok((drv, references)) => Job::resolved(attr, drv, references),
+            Err(e) => Job::failed(attr, format!("{e:#}")),
+        };
+        sink(job);
+    }
+    let _ = walker.commit_cache();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn success_job_serializes_like_nix_eval_jobs() {
+        let job = Job::resolved(
+            "packages.x86_64-linux.hello".into(),
+            "aaaa-hello.drv".into(),
+            vec![],
+        );
+        let v: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&job).unwrap()).unwrap();
+        assert_eq!(v["attr"], "packages.x86_64-linux.hello");
+        assert_eq!(
+            v["attrPath"],
+            serde_json::json!(["packages", "x86_64-linux", "hello"])
+        );
+        assert_eq!(v["drvPath"], "/nix/store/aaaa-hello.drv");
+        assert!(v.get("error").is_none(), "no error key on success");
+        assert!(v.get("references").is_none(), "empty references omitted");
+    }
+
+    #[test]
+    fn failed_job_serializes_error_without_drv_path() {
+        let job = Job::failed("packages.x86_64-linux.broken".into(), "boom".into());
+        let v: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&job).unwrap()).unwrap();
+        assert_eq!(v["attr"], "packages.x86_64-linux.broken");
+        assert_eq!(v["error"], "boom");
+        assert!(v.get("drvPath").is_none(), "no drvPath on failure");
+    }
+}

--- a/backend/gradient-eval/src/lib.rs
+++ b/backend/gradient-eval/src/lib.rs
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Standalone Nix flake evaluator extracted from the gradient worker so both the
+//! worker and the CLI (`gradient eval`) can drive the same evaluator.
+
+pub mod eval_worker;
+pub mod flake_walk;
+pub mod jobs;
+pub mod nix_eval;
+pub mod stats;
+pub mod wildcard_walk;
+
+/// Returns the full `/nix/store/` path for a hash-name stored without prefix.
+pub fn nix_store_path(hash_name: &str) -> String {
+    if hash_name.starts_with('/') {
+        hash_name.to_string()
+    } else {
+        format!("/nix/store/{hash_name}")
+    }
+}
+
+/// Strips the `/nix/store/` prefix from a path, returning just the hash-name.
+pub fn strip_nix_store_prefix(path: &str) -> String {
+    path.strip_prefix("/nix/store/").unwrap_or(path).to_string()
+}

--- a/backend/gradient-eval/src/nix_eval.rs
+++ b/backend/gradient-eval/src/nix_eval.rs
@@ -7,7 +7,7 @@
 //! Nix flake evaluator backed by the high-level `nix-bindings` wrappers.
 //!
 //! Holds one `EvalState` (built with flake support + a warm on-disk eval cache)
-//! and hands out a [`FlakeWalker`](crate::nix::flake_walk::FlakeWalker) per
+//! and hands out a [`FlakeWalker`](crate::flake_walk::FlakeWalker) per
 //! flake reference that drives a cursor walk over its output attribute tree.
 //!
 //! `nix_bindings` embeds Boehm GC into the process. Boehm GC cannot coexist
@@ -77,11 +77,8 @@ impl NixEvaluator {
 
     /// Lock `flake_ref` and open its eval cache, returning a walker that reuses
     /// the one locked flake + warm cursor for all discover/resolve calls.
-    pub(crate) fn walker(
-        &self,
-        flake_ref: &str,
-    ) -> Result<crate::nix::flake_walk::FlakeWalker<'_>> {
-        crate::nix::flake_walk::FlakeWalker::open(
+    pub fn walker(&self, flake_ref: &str) -> Result<crate::flake_walk::FlakeWalker<'_>> {
+        crate::flake_walk::FlakeWalker::open(
             &self.ctx,
             &self.fetch_settings,
             &self.flake_settings,
@@ -92,8 +89,8 @@ impl NixEvaluator {
 
     /// Lock `flake_ref` and return its eval-cache fingerprint without
     /// evaluating or creating the on-disk eval cache. `None` for mutable flakes.
-    pub(crate) fn fingerprint(&self, flake_ref: &str) -> Result<Option<String>> {
-        crate::nix::flake_walk::fingerprint(
+    pub fn fingerprint(&self, flake_ref: &str) -> Result<Option<String>> {
+        crate::flake_walk::fingerprint(
             &self.ctx,
             &self.fetch_settings,
             &self.flake_settings,

--- a/backend/gradient-eval/src/stats.rs
+++ b/backend/gradient-eval/src/stats.rs
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Eval-cache counter deltas shared by the eval-worker wire protocol and the
+//! worker's per-eval stats accumulator.
+
+use serde::{Deserialize, Serialize};
+
+/// Whether per-eval metrics collection is enabled (default on). Disabling skips
+/// the worker's `ev.stats()` reads and the subprocess's `NIX_SHOW_STATS`
+/// counters so eval pays zero stats overhead.
+pub fn metrics_enabled() -> bool {
+    std::env::var("GRADIENT_EVAL_METRICS_ENABLED")
+        .map(|v| v != "false" && v != "0")
+        .unwrap_or(true)
+}
+
+/// Per-request counter delta a worker reports after serving List/Resolve.
+/// Counters are diffs since the worker's prior request; gc_heap_size is the
+/// current gauge at report time. Canonical delta type, shared internally and
+/// on the eval-worker wire protocol.
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
+pub struct StatsDelta {
+    pub nr_thunks: u64,
+    pub nr_function_calls: u64,
+    pub nr_primop_calls: u64,
+    pub nr_lookups: u64,
+    pub alloc_bytes: u64,
+    pub gc_heap_size: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metrics_default_on_roundtrips_through_serde() {
+        let d = StatsDelta {
+            nr_thunks: 3,
+            gc_heap_size: 42,
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&d).unwrap();
+        let back: StatsDelta = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.nr_thunks, 3);
+        assert_eq!(back.gc_heap_size, 42);
+    }
+}

--- a/backend/gradient-eval/src/wildcard_walk.rs
+++ b/backend/gradient-eval/src/wildcard_walk.rs
@@ -16,7 +16,7 @@
 use anyhow::Result;
 
 /// A node in the flake-output attr tree (a real impl wraps an eval-cache AttrCursor).
-pub(crate) trait WalkNode: Sized {
+pub trait WalkNode: Sized {
     /// Child attribute names (sorted).
     fn child_names(&self) -> Result<Vec<String>>;
     /// Child node by name, or `None` if absent.
@@ -29,7 +29,7 @@ pub(crate) trait WalkNode: Sized {
 }
 
 /// Drop a `*` segment immediately following another `*` (`packages.*.*` == `packages.*`).
-pub(crate) fn collapse_stars(segs: &[String]) -> Vec<String> {
+pub fn collapse_stars(segs: &[String]) -> Vec<String> {
     let mut out: Vec<String> = Vec::new();
     for s in segs {
         if s == "*" && out.last().map(|p| p == "*").unwrap_or(false) {
@@ -46,7 +46,7 @@ pub(crate) fn collapse_stars(segs: &[String]) -> Vec<String> {
 /// pattern format: `.`-separated segments, optional leading `!` = exclude.
 /// Double-quoted spans keep an inner `.` within one segment (the quotes are
 /// stripped), e.g. `pkgs."python3.12".*` → `["pkgs", "python3.12", "*"]`.
-pub(crate) fn parse_pattern(pat: &str) -> (bool, Vec<String>) {
+pub fn parse_pattern(pat: &str) -> (bool, Vec<String>) {
     let (exclude, body) = match pat.strip_prefix('!') {
         Some(rest) => (true, rest),
         None => (false, pat),
@@ -72,7 +72,12 @@ pub(crate) fn parse_pattern(pat: &str) -> (bool, Vec<String>) {
 
 /// Walk `node` matching `segs`, pushing full dotted attr paths of matched
 /// derivations into `out`. `path` is the accumulated path to `node`.
-fn walk<N: WalkNode>(node: &N, path: &[String], segs: &[String], out: &mut Vec<String>) -> Result<()> {
+fn walk<N: WalkNode>(
+    node: &N,
+    path: &[String],
+    segs: &[String],
+    out: &mut Vec<String>,
+) -> Result<()> {
     match segs.split_first() {
         None => {
             if node.is_derivation()? {
@@ -143,7 +148,7 @@ fn walk<N: WalkNode>(node: &N, path: &[String], segs: &[String], out: &mut Vec<S
 
 /// Discover all derivation attr paths matching `includes`, minus `excludes`
 /// (exact-path matches). `includes`/`excludes` are pre-parsed segment lists.
-pub(crate) fn discover<N: WalkNode>(
+pub fn discover<N: WalkNode>(
     root: &N,
     includes: &[Vec<String>],
     excludes: &[Vec<String>],
@@ -168,7 +173,7 @@ pub(crate) fn discover<N: WalkNode>(
 
 /// Discover from raw wildcard strings: parse each into include/exclude segment
 /// lists, then run [`discover`].
-pub(crate) fn discover_patterns<N: WalkNode>(root: &N, wildcards: &[String]) -> Result<Vec<String>> {
+pub fn discover_patterns<N: WalkNode>(root: &N, wildcards: &[String]) -> Result<Vec<String>> {
     let mut includes = Vec::new();
     let mut excludes = Vec::new();
     for w in wildcards {
@@ -191,7 +196,7 @@ pub(crate) fn discover_patterns<N: WalkNode>(root: &N, wildcards: &[String]) -> 
 /// wildcard is left to each shard's worker, so a `system`-level wildcard yields
 /// one shard per system, each sized to a single eval-worker's RAM budget. A
 /// wildcard-free pattern yields itself unchanged.
-pub(crate) fn plan_shards<N: WalkNode>(root: &N, includes: &[Vec<String>]) -> Result<Vec<Vec<String>>> {
+pub fn plan_shards<N: WalkNode>(root: &N, includes: &[Vec<String>]) -> Result<Vec<Vec<String>>> {
     let mut shards = Vec::new();
     for inc in includes {
         let segs = collapse_stars(inc);
@@ -269,7 +274,7 @@ fn plan_one<N: WalkNode>(
 /// Render shard segments back to a pattern string for the wire: `*`/`#` stay
 /// bare; a literal segment with a `.` or `"` is double-quoted so [`parse_pattern`]
 /// rebuilds the same segments.
-pub(crate) fn segments_to_pattern(segs: &[String]) -> String {
+pub fn segments_to_pattern(segs: &[String]) -> String {
     segs.iter()
         .map(|s| {
             if s == "*" || s == "#" || !(s.contains('.') || s.contains('"')) {
@@ -306,7 +311,10 @@ mod tests {
             StubNode {
                 derivation: false,
                 opaque: false,
-                children: children.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
+                children: children
+                    .into_iter()
+                    .map(|(k, v)| (k.to_string(), v))
+                    .collect(),
             }
         }
 
@@ -379,14 +387,20 @@ mod tests {
 
     #[test]
     fn parse_pattern_include_wildcard() {
-        assert_eq!(parse_pattern("packages.*"), (false, segs(&["packages", "*"])));
+        assert_eq!(
+            parse_pattern("packages.*"),
+            (false, segs(&["packages", "*"]))
+        );
     }
 
     #[test]
     fn parse_pattern_quoted_segment() {
         assert_eq!(
             parse_pattern(r#"packages.x86_64-linux."python3.12".*"#),
-            (false, segs(&["packages", "x86_64-linux", "python3.12", "*"]))
+            (
+                false,
+                segs(&["packages", "x86_64-linux", "python3.12", "*"])
+            )
         );
         assert_eq!(parse_pattern(r#"!a."b.c""#), (true, segs(&["a", "b.c"])));
     }
@@ -419,7 +433,10 @@ mod tests {
         let got = discover(&&root, &[segs(&["packages", "x86_64-linux", "#"])], &[]).unwrap();
         assert_eq!(
             got,
-            vec!["packages.x86_64-linux.cowsay", "packages.x86_64-linux.hello"]
+            vec![
+                "packages.x86_64-linux.cowsay",
+                "packages.x86_64-linux.hello"
+            ]
         );
     }
 
@@ -441,7 +458,10 @@ mod tests {
         .unwrap();
         assert_eq!(
             got,
-            vec!["packages.x86_64-linux.cowsay", "packages.x86_64-linux.hello"]
+            vec![
+                "packages.x86_64-linux.cowsay",
+                "packages.x86_64-linux.hello"
+            ]
         );
     }
 
@@ -531,45 +551,58 @@ mod tests {
         union.sort();
         union.dedup();
 
-        assert_eq!(union, original, "split of {pattern:?} must match one-pass discover");
+        assert_eq!(
+            union, original,
+            "split of {pattern:?} must match one-pass discover"
+        );
     }
 
     #[test]
     fn plan_trailing_star_splits_per_child_with_recover_shard() {
         let root = tree();
-        assert_eq!(shards(&root, &["packages", "*", "*"]), vec![
-            segs(&["packages", "aarch64-linux", "#"]),
-            segs(&["packages", "x86_64-linux", "#"]),
-        ]);
+        assert_eq!(
+            shards(&root, &["packages", "*", "*"]),
+            vec![
+                segs(&["packages", "aarch64-linux", "#"]),
+                segs(&["packages", "x86_64-linux", "#"]),
+            ]
+        );
         assert_split_equivalent(&root, &["packages", "*", "*"]);
     }
 
     #[test]
     fn plan_non_trailing_wildcard_keeps_residual() {
         let root = tree();
-        assert_eq!(shards(&root, &["packages", "*", "hello"]), vec![
-            segs(&["packages", "aarch64-linux", "hello"]),
-            segs(&["packages", "x86_64-linux", "hello"]),
-        ]);
+        assert_eq!(
+            shards(&root, &["packages", "*", "hello"]),
+            vec![
+                segs(&["packages", "aarch64-linux", "hello"]),
+                segs(&["packages", "x86_64-linux", "hello"]),
+            ]
+        );
         assert_split_equivalent(&root, &["packages", "*", "hello"]);
     }
 
     #[test]
     fn plan_hash_terminal_splits_only_derivation_children() {
         let root = tree();
-        assert_eq!(shards(&root, &["packages", "x86_64-linux", "#"]), vec![
-            segs(&["packages", "x86_64-linux", "cowsay"]),
-            segs(&["packages", "x86_64-linux", "hello"]),
-        ]);
+        assert_eq!(
+            shards(&root, &["packages", "x86_64-linux", "#"]),
+            vec![
+                segs(&["packages", "x86_64-linux", "cowsay"]),
+                segs(&["packages", "x86_64-linux", "hello"]),
+            ]
+        );
         assert_split_equivalent(&root, &["packages", "x86_64-linux", "#"]);
     }
 
     #[test]
     fn plan_literal_pattern_passes_through() {
         let root = tree();
-        assert_eq!(shards(&root, &["packages", "x86_64-linux", "hello"]), vec![segs(
-            &["packages", "x86_64-linux", "hello"]
-        )]);
+        assert_eq!(
+            shards(&root, &["packages", "x86_64-linux", "hello"]),
+            vec![segs(&["packages", "x86_64-linux", "hello"])]
+        );
     }
 
     #[test]
@@ -587,9 +620,10 @@ mod tests {
                 ("sysB", StubNode::set(vec![("hello", StubNode::drv())])),
             ]),
         )]);
-        assert_eq!(shards(&root, &["packages", "*", "hello"]), vec![segs(&[
-            "packages", "sysB", "hello"
-        ])]);
+        assert_eq!(
+            shards(&root, &["packages", "*", "hello"]),
+            vec![segs(&["packages", "sysB", "hello"])]
+        );
         assert_split_equivalent(&root, &["packages", "*", "hello"]);
         assert_split_equivalent(&root, &["packages", "*", "*"]);
     }
@@ -603,18 +637,27 @@ mod tests {
     #[test]
     fn plan_multiple_includes_concatenate() {
         let root = tree();
-        let got = plan_shards(&&root, &[segs(&["packages", "*", "*"]), segs(&["checks", "*", "*"])])
-            .unwrap();
-        assert_eq!(got, vec![
-            segs(&["packages", "aarch64-linux", "#"]),
-            segs(&["packages", "x86_64-linux", "#"]),
-            segs(&["checks", "x86_64-linux", "#"]),
-        ]);
+        let got = plan_shards(
+            &&root,
+            &[segs(&["packages", "*", "*"]), segs(&["checks", "*", "*"])],
+        )
+        .unwrap();
+        assert_eq!(
+            got,
+            vec![
+                segs(&["packages", "aarch64-linux", "#"]),
+                segs(&["packages", "x86_64-linux", "#"]),
+                segs(&["checks", "x86_64-linux", "#"]),
+            ]
+        );
     }
 
     #[test]
     fn segments_to_pattern_quotes_dotted_segments_only() {
-        assert_eq!(segments_to_pattern(&segs(&["packages", "x86_64-linux", "#"])), "packages.x86_64-linux.#");
+        assert_eq!(
+            segments_to_pattern(&segs(&["packages", "x86_64-linux", "#"])),
+            "packages.x86_64-linux.#"
+        );
         assert_eq!(segments_to_pattern(&segs(&["packages", "*"])), "packages.*");
         let dotted = segs(&["packages", "x86_64-linux", "python3.12"]);
         let rendered = segments_to_pattern(&dotted);

--- a/backend/gradient-worker/Cargo.toml
+++ b/backend/gradient-worker/Cargo.toml
@@ -20,6 +20,7 @@ workspace = true
 
 [dependencies]
 gradient-core = { workspace = true }
+gradient-eval = { path = "../gradient-eval" }
 gradient-exec = { workspace = true }
 gradient-flake-lock = { workspace = true }
 gradient-sources = { workspace = true }

--- a/backend/gradient-worker/src/nix/mod.rs
+++ b/backend/gradient-worker/src/nix/mod.rs
@@ -4,13 +4,12 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-//! Nix-specific functionality: evaluation subprocesses, flake parsing, store interaction.
+//! Nix-specific functionality: store interaction, GC roots, logging. The flake
+//! evaluator lives in the shared `gradient-eval` crate (so the CLI can reuse it)
+//! and is re-exported here to keep existing `crate::nix::…` paths resolving.
 
-pub mod eval_worker;
-pub(crate) mod flake_walk;
+pub use gradient_eval::{eval_worker, wildcard_walk};
+
 pub mod gcroots;
 pub mod log;
-pub mod nix_eval;
 pub mod store;
-
-pub(crate) mod wildcard_walk;

--- a/backend/gradient-worker/src/proto/nar.rs
+++ b/backend/gradient-worker/src/proto/nar.rs
@@ -309,23 +309,11 @@ pub struct CompressedNarMeta {
     pub nar_size: u64,
 }
 
-/// Upload an already-in-memory raw NAR (e.g. relayed from an upstream
-/// substituter) to the presigned `url`: zstd-compress it at level 6, then hand
-/// off to [`upload_presigned_compressed`]. Used when the upstream payload's
-/// compression is weaker than our level-6 window (or absent) and must be
-/// re-encoded before storing.
-#[allow(clippy::too_many_arguments)]
-pub async fn upload_presigned_bytes(
-    job_id: &str,
-    store_path: &str,
-    raw_nar: &[u8],
-    references: Vec<String>,
-    deriver: Option<String>,
-    url: &str,
-    method: &str,
-    headers: &[(String, String)],
-    writer: &ProtoWriter,
-) -> Result<()> {
+/// Zstd-compress a raw in-memory NAR at level 6 and return the compressed bytes
+/// plus their [`CompressedNarMeta`] (`file_*` describe the compressed object,
+/// `nar_*` the uncompressed NAR). Shared by the presigned and direct relay
+/// paths so a substituted output is stored identically over either transport.
+pub fn compress_nar(raw_nar: &[u8]) -> Result<(Vec<u8>, CompressedNarMeta)> {
     let nar_size = raw_nar.len() as u64;
     let nar_hash = format!("sha256:{}", nix32_encode(&Sha256::digest(raw_nar)));
 
@@ -333,27 +321,18 @@ pub async fn upload_presigned_bytes(
         .context("failed to create zstd encoder")?;
     encoder.write_all(raw_nar).context("zstd compression failed")?;
     let compressed = encoder.finish().context("failed to finish zstd encoder")?;
+
     let file_size = compressed.len() as u64;
     let file_hash = format!("sha256:{}", nix32_encode(&Sha256::digest(&compressed)));
-
-    upload_presigned_compressed(
-        job_id,
-        store_path,
-        &compressed,
+    Ok((
+        compressed,
         CompressedNarMeta {
             file_hash,
             file_size,
             nar_hash,
             nar_size,
         },
-        references,
-        deriver,
-        url,
-        method,
-        headers,
-        writer,
-    )
-    .await
+    ))
 }
 
 /// PUT an already-compressed NAR to the presigned `url` verbatim and confirm
@@ -414,6 +393,80 @@ pub async fn upload_presigned_compressed(
         file_size = meta.file_size,
         nar_size = meta.nar_size,
         "relayed NAR upload complete"
+    );
+    Ok(())
+}
+
+/// Stream an already-compressed in-memory NAR to the server via chunked
+/// [`ClientMessage::NarPush`] frames and confirm with [`ClientMessage::NarUploaded`].
+///
+/// The WebSocket counterpart of [`upload_presigned_compressed`]: used by the
+/// substitute relay when the cache is local-disk and the server returns no
+/// presigned PUT URL, so a substituted output is still mirrored into our cache
+/// without a nix-store import. Uses the same resume handshake as [`push_direct`].
+#[allow(clippy::too_many_arguments)]
+pub async fn push_compressed_direct(
+    job_id: &str,
+    store_path: &str,
+    compressed: &[u8],
+    meta: CompressedNarMeta,
+    references: Vec<String>,
+    deriver: Option<String>,
+    writer: &ProtoWriter,
+    nar_recv: &NarReceiver,
+) -> Result<()> {
+    let store_path = ensure_full_store_path(store_path);
+    let store_path = store_path.as_str();
+    debug!(store_path, bytes = compressed.len(), "compressed NAR direct push");
+
+    let token = push_stream_token(6);
+    let gate = nar_recv.register_push(job_id, store_path);
+    writer.send(ClientMessage::NarStreamHeader {
+        job_id: job_id.to_owned(),
+        store_path: store_path.to_owned(),
+        total_bytes: Some(compressed.len() as u64),
+        stream_token: token,
+    })?;
+    let resume_from = gate.await_resume().await;
+
+    let mut produced: u64 = 0;
+    for part in compressed.chunks(NAR_CHUNK_SIZE) {
+        if let Some((offset, range)) = trim_for_resume(part.len(), produced, resume_from) {
+            writer.send(ClientMessage::NarPush {
+                job_id: job_id.to_owned(),
+                store_path: store_path.to_owned(),
+                data: part[range].to_vec(),
+                offset,
+                is_final: false,
+            })?;
+        }
+        produced += part.len() as u64;
+    }
+
+    writer.send(ClientMessage::NarPush {
+        job_id: job_id.to_owned(),
+        store_path: store_path.to_owned(),
+        data: vec![],
+        offset: produced,
+        is_final: true,
+    })?;
+
+    writer.send(ClientMessage::NarUploaded {
+        job_id: job_id.to_owned(),
+        store_path: store_path.to_owned(),
+        file_hash: meta.file_hash,
+        file_size: meta.file_size,
+        nar_size: meta.nar_size,
+        nar_hash: meta.nar_hash,
+        references,
+        deriver,
+    })?;
+
+    debug!(
+        store_path,
+        compressed_bytes = produced,
+        resumed_from = resume_from,
+        "compressed NAR direct push complete"
     );
     Ok(())
 }
@@ -854,5 +907,80 @@ mod tests {
             "error should explain the abort reason, got: {err}"
         );
         let _ = std::fs::remove_dir_all(&store_path);
+    }
+
+    /// Relay fallback for local-disk caches (no presigned PUT URL): an
+    /// already-compressed in-memory NAR must reach the server as `NarPush`
+    /// chunks that reconstruct the bytes verbatim, followed by a `NarUploaded`
+    /// carrying the supplied compressed/uncompressed metadata.
+    #[tokio::test]
+    async fn push_compressed_direct_streams_bytes_and_confirms() {
+        let raw = b"relayed substitute nar payload";
+        let mut encoder = zstd::stream::Encoder::new(Vec::new(), 6).unwrap();
+        encoder.write_all(raw).unwrap();
+        let compressed = encoder.finish().unwrap();
+
+        let meta = CompressedNarMeta {
+            file_hash: format!("sha256:{}", nix32_encode(&Sha256::digest(&compressed))),
+            file_size: compressed.len() as u64,
+            nar_hash: format!("sha256:{}", nix32_encode(&Sha256::digest(raw))),
+            nar_size: raw.len() as u64,
+        };
+
+        let store_path = "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-relay";
+        let server = MockProtoServer::bind().await;
+        let url = server.url().to_owned();
+
+        let expected_bytes = compressed.clone();
+        let expected_file_hash = meta.file_hash.clone();
+        let server_task = tokio::spawn(async move {
+            let mut sc = server.accept().await;
+            let mut data: Vec<u8> = Vec::new();
+            loop {
+                match sc.recv().await.unwrap() {
+                    ClientMessage::NarStreamHeader { .. } => continue,
+                    ClientMessage::NarPush { data: chunk, .. } => data.extend_from_slice(&chunk),
+                    ClientMessage::NarUploaded {
+                        store_path: sp,
+                        file_hash,
+                        file_size,
+                        nar_size,
+                        references,
+                        ..
+                    } => {
+                        assert_eq!(data, expected_bytes, "streamed bytes must reconstruct the compressed NAR");
+                        assert_eq!(sp, store_path);
+                        assert_eq!(file_hash, expected_file_hash);
+                        assert_eq!(file_size, expected_bytes.len() as u64);
+                        assert_eq!(nar_size, raw.len() as u64);
+                        assert_eq!(references, vec!["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-dep".to_owned()]);
+                        break;
+                    }
+                    msg => panic!("unexpected {msg:?}"),
+                }
+            }
+        });
+
+        let conn = crate::connection::ProtoConnection::open(&url).await.unwrap();
+        let (writer, _reader) = conn.split();
+        let recv = NarReceiver::new();
+        let recv2 = recv.clone();
+        let push = tokio::spawn(async move {
+            push_compressed_direct(
+                "job-relay",
+                store_path,
+                &compressed,
+                meta,
+                vec!["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-dep".to_owned()],
+                None,
+                &writer,
+                &recv2,
+            )
+            .await
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        recv.resolve_push("job-relay", store_path, 0);
+        push.await.unwrap().unwrap();
+        server_task.await.unwrap();
     }
 }

--- a/backend/gradient-worker/src/proto/nar_import.rs
+++ b/backend/gradient-worker/src/proto/nar_import.rs
@@ -865,10 +865,6 @@ pub async fn relay_external_cached_outputs(
 
         let kind = meta.url.as_deref().map(detect_compression).unwrap_or(Compression::Zstd);
 
-        let put_url = push
-            .get(path)
-            .and_then(|c| c.url.clone())
-            .ok_or_else(|| anyhow::anyhow!("no presigned PUT url for {path}"))?;
         // Upstream references arrive as full /nix/store paths; NarUploaded wants
         // hash-name tokens.
         let references: Vec<String> = meta
@@ -887,17 +883,37 @@ pub async fn relay_external_cached_outputs(
             .then(|| Some((meta.file_hash.clone()?, meta.nar_hash.clone()?, meta.nar_size?)))
             .flatten();
 
-        if let Some((file_hash, nar_hash, nar_size)) = verbatim {
-            crate::proto::nar::upload_presigned_compressed(
+        let (bytes, cmeta) = if let Some((file_hash, nar_hash, nar_size)) = verbatim {
+            let file_size = compressed.len() as u64;
+            (
+                compressed,
+                crate::proto::nar::CompressedNarMeta { file_hash, file_size, nar_hash, nar_size },
+            )
+        } else {
+            // Weaker/absent upstream compression: decompress (verifying against
+            // the upstream nar_hash) and recompress at our level-6 threshold.
+            let raw = decompress(&compressed, kind)
+                .with_context(|| format!("{kind:?} decompress for {path}"))?;
+            if let Some(claimed) = meta.nar_hash.as_deref() {
+                let actual: [u8; 32] = Sha256::digest(&raw).into();
+                let want = parse_nar_hash_to_bytes(claimed)
+                    .with_context(|| format!("invalid upstream nar_hash for {path}"))?;
+                if actual != want {
+                    anyhow::bail!("upstream NAR hash mismatch for {path}");
+                }
+            }
+            crate::proto::nar::compress_nar(&raw)
+                .with_context(|| format!("recompress relay NAR for {path}"))?
+        };
+
+        // Transport: S3-backed caches expose a presigned PUT URL; local-disk
+        // caches return none and accept the bytes via direct NarPush frames.
+        match push.get(path).and_then(|c| c.url.clone()) {
+            Some(put_url) => crate::proto::nar::upload_presigned_compressed(
                 &updater.job_id,
                 path,
-                &compressed,
-                crate::proto::nar::CompressedNarMeta {
-                    file_hash,
-                    file_size: compressed.len() as u64,
-                    nar_hash,
-                    nar_size,
-                },
+                &bytes,
+                cmeta,
                 references,
                 meta.deriver.clone(),
                 &put_url,
@@ -905,38 +921,19 @@ pub async fn relay_external_cached_outputs(
                 &[],
                 &updater.writer,
             )
-            .await
-            .with_context(|| format!("relay-push {path} into our cache"))?;
-
-            debug!(%path, "relayed substitute NAR verbatim into our cache");
-            continue;
+            .await,
+            None => crate::proto::nar::push_compressed_direct(
+                &updater.job_id,
+                path,
+                &bytes,
+                cmeta,
+                references,
+                meta.deriver.clone(),
+                &updater.writer,
+                &updater.nar_recv,
+            )
+            .await,
         }
-
-        // Weaker/absent upstream compression: decompress (verifying against the
-        // upstream nar_hash) and let upload_presigned_bytes recompress at level 6.
-        let raw = decompress(&compressed, kind)
-            .with_context(|| format!("{kind:?} decompress for {path}"))?;
-        if let Some(claimed) = meta.nar_hash.as_deref() {
-            let actual: [u8; 32] = Sha256::digest(&raw).into();
-            let want = parse_nar_hash_to_bytes(claimed)
-                .with_context(|| format!("invalid upstream nar_hash for {path}"))?;
-            if actual != want {
-                anyhow::bail!("upstream NAR hash mismatch for {path}");
-            }
-        }
-
-        crate::proto::nar::upload_presigned_bytes(
-            &updater.job_id,
-            path,
-            &raw,
-            references,
-            meta.deriver.clone(),
-            &put_url,
-            "PUT",
-            &[],
-            &updater.writer,
-        )
-        .await
         .with_context(|| format!("relay-push {path} into our cache"))?;
 
         debug!(%path, "relayed substitute NAR into our cache");

--- a/backend/gradient-worker/src/worker_pool/eval_stats.rs
+++ b/backend/gradient-worker/src/worker_pool/eval_stats.rs
@@ -4,17 +4,10 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-/// Whether per-eval metrics collection is enabled (default on). Disabling skips
-/// the worker's `ev.stats()` reads and the subprocess's `NIX_SHOW_STATS`
-/// counters so eval pays zero stats overhead.
-pub fn metrics_enabled() -> bool {
-    std::env::var("GRADIENT_EVAL_METRICS_ENABLED")
-        .map(|v| v != "false" && v != "0")
-        .unwrap_or(true)
-}
+// The wire-level delta and the metrics toggle live in the shared evaluator crate.
+pub use gradient_eval::stats::{StatsDelta, metrics_enabled};
 
 /// Environment the eval-worker subprocess needs for thunk/function-call counts.
 /// libnixexpr's `Counter`s are no-ops unless `NIX_SHOW_STATS` is set (otherwise
@@ -25,28 +18,6 @@ pub(crate) fn eval_worker_stats_env(metrics_enabled: bool) -> &'static [(&'stati
         &[("NIX_SHOW_STATS", "1"), ("NIX_SHOW_STATS_PATH", "/dev/null")]
     } else {
         &[]
-    }
-}
-
-/// Per-request counter delta a worker reports after serving List/Resolve.
-/// Counters are diffs since the worker's prior request; gc_heap_size is the
-/// current gauge at report time. Canonical delta type, shared internally and
-/// on the eval-worker wire protocol.
-#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
-pub struct StatsDelta {
-    pub nr_thunks: u64,
-    pub nr_function_calls: u64,
-    pub nr_primop_calls: u64,
-    pub nr_lookups: u64,
-    pub alloc_bytes: u64,
-    pub gc_heap_size: u64,
-}
-
-impl StatsDelta {
-    #[cfg(test)]
-    fn with_heap(mut self, h: u64) -> Self {
-        self.gc_heap_size = h;
-        self
     }
 }
 
@@ -153,8 +124,8 @@ mod tests {
     #[test]
     fn heap_peak_is_max_gauge_not_sum() {
         let mut acc = EvalStatsAccumulator::default();
-        acc.observe("a", d(0, 0, 0).with_heap(900), 0);
-        acc.observe("a", d(0, 0, 0).with_heap(300), 0);
+        acc.observe("a", StatsDelta { gc_heap_size: 900, ..d(0, 0, 0) }, 0);
+        acc.observe("a", StatsDelta { gc_heap_size: 300, ..d(0, 0, 0) }, 0);
         assert_eq!(acc.finish().peak_heap_bytes, 900);
     }
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -220,6 +220,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.13.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex 1.3.0",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,6 +372,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +401,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -828,6 +867,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "doxygen-bindgen"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ba4ed6eedf7f4ace1632149d8f0e8a65a480534024d65a7c3b9daacdedbad3"
+dependencies = [
+ "yap",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,6 +1196,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "gradient-cli"
 version = "1.2.0"
 dependencies = [
@@ -1161,6 +1215,7 @@ dependencies = [
  "dirs",
  "futures",
  "git2",
+ "gradient-eval",
  "harmonia-file-nar",
  "harmonia-store-path",
  "harmonia-store-remote",
@@ -1179,6 +1234,18 @@ dependencies = [
  "tokio",
  "toml",
  "wiremock",
+]
+
+[[package]]
+name = "gradient-eval"
+version = "1.2.0"
+dependencies = [
+ "anyhow",
+ "libc",
+ "nix-bindings",
+ "serde",
+ "serde_json",
+ "tracing",
 ]
 
 [[package]]
@@ -1774,6 +1841,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1902,6 +1978,16 @@ dependencies = [
  "libc",
  "libz-sys",
  "pkg-config",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
 ]
 
 [[package]]
@@ -2083,6 +2169,25 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nix-bindings"
+version = "0.2347.2"
+source = "git+https://github.com/DerDennisOP/nix-bindings?branch=feat%2Feval-metrics-stats#b1abd9b8dd7ea8a7df3b23a41af64ac7de586106"
+dependencies = [
+ "nix-bindings-sys",
+]
+
+[[package]]
+name = "nix-bindings-sys"
+version = "0.2347.2"
+source = "git+https://github.com/DerDennisOP/nix-bindings?branch=feat%2Feval-metrics-stats#b1abd9b8dd7ea8a7df3b23a41af64ac7de586106"
+dependencies = [
+ "bindgen",
+ "cc",
+ "doxygen-bindgen",
+ "pkg-config",
 ]
 
 [[package]]
@@ -2663,7 +2768,7 @@ dependencies = [
  "critical-section",
  "hashbrown 0.17.1",
  "indoc",
- "itertools",
+ "itertools 0.14.0",
  "kasuari",
  "lru",
  "palette",
@@ -2717,7 +2822,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
  "serde",
@@ -3738,7 +3843,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -4444,6 +4549,12 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yap"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe269e7b803a5e8e20cbd97860e136529cd83bf2c9c6d37b142467e7e1f051f"
 
 [[package]]
 name = "yoke"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -39,6 +39,13 @@ ratatui = "0.30"
 [features]
 default = []
 nix = ["dep:harmonia-file-nar", "dep:harmonia-store-path", "dep:harmonia-store-remote", "dep:harmonia-utils-hash", "dep:tempfile"]
+# `gradient eval` (nix-eval-jobs-like). Pulls the shared evaluator crate and
+# thus libnix; off by default so the lean CLI builds without Nix dev libraries.
+eval = ["dep:gradient-eval"]
+
+[dependencies.gradient-eval]
+path = "../backend/gradient-eval"
+optional = true
 
 [dependencies.tempfile]
 version = "3"

--- a/cli/src/commands/base.rs
+++ b/cli/src/commands/base.rs
@@ -136,6 +136,9 @@ enum MainCommands {
         #[command(subcommand)]
         cmd: generate::Commands,
     },
+    /// Evaluate a flake's outputs to derivations, like nix-eval-jobs
+    #[cfg(feature = "eval")]
+    Eval(eval::EvalArgs),
     /// Hash a password as an argon2id PHC string for use in
     /// `services.gradient.state.users.<name>.password_file`.
     Hash,
@@ -147,8 +150,28 @@ pub fn complete_env() {
     CompleteEnv::with_factory(Cli::command).complete();
 }
 
-pub async fn run_cli() -> std::io::Result<()> {
+/// Entry point: parse, then dispatch. `eval` runs synchronously before any
+/// runtime starts (the embedded Nix evaluator uses Boehm GC, which must run
+/// isolated from Tokio's thread pool); everything else runs on the runtime.
+pub fn run() -> std::io::Result<()> {
+    complete_env();
     let cli = Cli::parse();
+
+    #[cfg(feature = "eval")]
+    if matches!(cli.cmd, MainCommands::Eval(_)) {
+        let MainCommands::Eval(args) = cli.cmd else {
+            unreachable!()
+        };
+        return crate::commands::eval::run(args);
+    }
+
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?
+        .block_on(run_cli(cli))
+}
+
+async fn run_cli(cli: Cli) -> std::io::Result<()> {
     let out = Output::new(cli.json);
 
     match cli.cmd {
@@ -321,6 +344,8 @@ pub async fn run_cli() -> std::io::Result<()> {
         MainCommands::Cache { cmd } => cache::handle(cmd, out).await,
         MainCommands::Builds { cmd } => builds::handle(cmd, out).await,
         MainCommands::Generate { cmd } => generate::handle(cmd, out).await,
+        #[cfg(feature = "eval")]
+        MainCommands::Eval(_) => unreachable!("eval is dispatched before the runtime starts"),
         MainCommands::Hash => {
             let password = ask_for_password();
             let confirm = ask_for_password();

--- a/cli/src/commands/eval.rs
+++ b/cli/src/commands/eval.rs
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use clap::Args;
+use std::io::Write;
+
+#[derive(Args, Debug)]
+pub struct EvalArgs {
+    /// Attribute wildcard patterns, e.g. 'checks.*.*' 'packages.x86_64-linux.*'
+    #[arg(required = true, value_name = "PATTERN")]
+    patterns: Vec<String>,
+    /// Flake reference to evaluate
+    #[arg(long, default_value = ".", value_name = "REF")]
+    flake: String,
+}
+
+/// Evaluate a flake's outputs to derivations, like nix-eval-jobs, using the
+/// gradient worker evaluator. Streams one JSON line per attribute to stdout.
+///
+/// Runs synchronously without a Tokio runtime: the Nix C API uses Boehm GC,
+/// which must run isolated from Tokio's thread pool (see the worker's eval
+/// subprocess). Per-attribute failures are reported in their JSON line and do
+/// not abort the run; only a top-level failure (e.g. locking the flake) exits
+/// non-zero.
+pub fn run(args: EvalArgs) -> std::io::Result<()> {
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+
+    let result = gradient_eval::jobs::eval_jobs(&args.flake, &args.patterns, |job| {
+        if let Ok(line) = serde_json::to_string(&job) {
+            let _ = writeln!(out, "{line}");
+        }
+    });
+
+    out.flush()?;
+    if let Err(e) = result {
+        eprintln!("gradient eval: {e:#}");
+        std::process::exit(1);
+    }
+    Ok(())
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -18,6 +18,8 @@ pub mod cache_nar;
 pub mod cache_upload;
 pub mod completion;
 pub mod download;
+#[cfg(feature = "eval")]
+pub mod eval;
 pub mod generate;
 pub mod organization;
 pub mod project;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -14,9 +14,5 @@ mod tui;
 use commands::base;
 
 fn main() -> std::io::Result<()> {
-    base::complete_env();
-    tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()?
-        .block_on(base::run_cli())
+    base::run()
 }

--- a/cli/tests/eval.rs
+++ b/cli/tests/eval.rs
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+#![cfg(feature = "eval")]
+
+use assert_cmd::Command;
+
+#[test]
+fn eval_help_describes_nix_eval_jobs_like_output() {
+    let out = Command::cargo_bin("gradient")
+        .unwrap()
+        .args(["eval", "--help"])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "eval --help should succeed");
+    let text = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        text.contains("nix-eval-jobs"),
+        "help should reference nix-eval-jobs:\n{text}"
+    );
+    assert!(text.contains("--flake"), "missing --flake flag:\n{text}");
+}
+
+#[test]
+fn eval_requires_a_pattern() {
+    let out = Command::cargo_bin("gradient")
+        .unwrap()
+        .arg("eval")
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "eval with no pattern should fail with a usage error"
+    );
+}

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -5413,3 +5413,21 @@ rather than the host freezing. Covered in the same file:
 - SQL coverage (window stats query, per-batch upsert, rollup inserts) is by
   mirrored-query review plus CI E2E; no real-Postgres unit harness exists.
 - Org-scoping of `/board/cache/upstreams` mirrors `get_board_network` (MetricsScope) and is covered by CI E2E (no local real-Postgres harness).
+
+## Standalone evaluator crate + `gradient eval` (#472)
+
+The worker's flake evaluator (`wildcard_walk`, `flake_walk`, `nix_eval`,
+`eval_worker`, stats) moved into a self-contained `backend/gradient-eval` crate
+so the CLI can reuse it. Their existing unit tests moved with them
+(`wildcard_walk::tests::*` discovery/sharding, `eval_worker::tests::*` serde
+round-trips); the worker keeps the pool-internal `eval_stats` accumulator tests.
+
+- `gradient-eval` `jobs::tests::success_job_serializes_like_nix_eval_jobs` - a
+  resolved `Job` serializes to `{attr, attrPath, drvPath}` with the full
+  `/nix/store` path and omits empty `references`.
+- `jobs::tests::failed_job_serializes_error_without_drv_path` - a failed `Job`
+  serializes `{attr, error}` and no `drvPath`, matching nix-eval-jobs' per-attr
+  error lines.
+- `cli` `tests/eval.rs` (feature-gated on `eval`):
+  `eval_help_describes_nix_eval_jobs_like_output` and `eval_requires_a_pattern`
+  cover the subcommand surface.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -787,6 +787,27 @@ Backend (`cargo test -p worker --bins proto::nar::tests`):
 - `upload_presigned_fails_when_path_meta_unavailable` - same contract for
   the S3 / presigned-PUT branch.
 
+## Substitute relay - direct fallback for local-disk caches
+
+A substitutable build (`external_cached`) relays its outputs into our cache by
+downloading each NAR from upstream and pushing it back. The push asked the
+server for a presigned PUT URL (`CacheQuery {Push}`) and hard-failed `no
+presigned PUT url for <path>` when none came back - but `presigned_put_url`
+returns `None` by design for local-disk stores (they accept direct `NarPush`
+frames), so on a non-S3 cache every substitutable output (e.g. a `-source`
+patch like `CVE-2023-39810.patch`) broke. The relay now mirrors `upload_one_nar`:
+it branches on `push.url`, using a presigned PUT when present and the new
+`nar::push_compressed_direct` (streaming the already-compressed bytes over the
+WebSocket, same resume handshake as `push_direct`) when absent. Shared
+`nar::compress_nar` produces the compressed bytes + metadata for either
+transport, replacing `upload_presigned_bytes`.
+
+Backend (`cargo test -p worker --bins proto::nar::tests`):
+- `push_compressed_direct_streams_bytes_and_confirms` - an in-memory compressed
+  NAR with no presigned URL reaches the server as `NarPush` chunks that
+  reconstruct the bytes verbatim, followed by a `NarUploaded` carrying the
+  supplied compressed/uncompressed metadata and references.
+
 ## Resumable NAR transfers (#225)
 
 Interrupted NAR transfers resume from a byte offset instead of restarting

--- a/docs/src/usage/cli.md
+++ b/docs/src/usage/cli.md
@@ -241,6 +241,28 @@ gradient download '#a,#b,#c'
 
 The positional attribute argument matches the evaluation's artefact tree by exact `entry_points[].attr` equality. It cannot be combined with `--products`.
 
+### Local evaluation (`gradient eval`)
+
+Evaluate a flake's outputs to derivations locally, like
+[`nix-eval-jobs`](https://github.com/nix-community/nix-eval-jobs), using the
+same evaluator the Gradient worker runs. It streams one JSON line per resolved
+attribute (`attr`, `attrPath`, `drvPath`); a per-attribute failure is reported
+in its own line (`{"attr": ..., "error": ...}`) and does not abort the run.
+
+```sh
+gradient eval 'packages.x86_64-linux.*'                # current flake (.)
+gradient eval --flake github:NixOS/patchelf 'hydraJobs.*'
+gradient eval --flake . 'checks.*.*' 'packages.*.*'    # multiple wildcard patterns
+```
+
+This subcommand is gated behind the `nix` and `eval` cargo features (it pulls in
+libnix) and is therefore only shipped by the `gradient-cli-full` package, not the
+default lean `gradient-cli`:
+
+```sh
+nix run github:wavelens/gradient#gradient-cli-full -- eval 'packages.x86_64-linux.*'
+```
+
 ### Utilities
 
 ```sh

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1780532242,
-        "narHash": "sha256-D+BsdpxmtUwtqGoY0IXPhHgTlmqgcZKCEo1oMyn7ep0=",
+        "lastModified": 1781825982,
+        "narHash": "sha256-SlXKwIRIhrOSAcTjCB3ftPLzJWZStQIPS7J1FlZPnKk=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "59a82a1222dd3b2080b5cc52a1a2e8d5f1b77f37",
+        "rev": "469fd08d0bcf6926321fa973c6777fbc87785dd7",
         "type": "github"
       },
       "original": {
@@ -129,11 +129,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,10 @@
         inherit craneLib;
         cargoFeatures = [ "nix" ];
       };
+      gradient-cli-full = pkgs.callPackage ./nix/packages/gradient-cli.nix {
+        inherit craneLib;
+        cargoFeatures = [ "nix" "eval" ];
+      };
 
       default = gradient;
     };
@@ -110,8 +114,8 @@
       nix = final: prev: { gradient-nix = nix.packages.${final.stdenv.hostPlatform.system}.nix; };
       gradient = final: prev: { inherit (self.packages.${final.stdenv.hostPlatform.system}) gradient; };
       gradient-frontend = final: prev: { inherit (self.packages.${final.stdenv.hostPlatform.system}) gradient-frontend; };
-      gradient-cli = final: prev: { inherit (self.packages.${final.stdenv.hostPlatform.system}) gradient-cli; };
-      default = final: prev: { inherit (self.packages.${final.stdenv.hostPlatform.system}) gradient gradient-frontend gradient-cli gradient-nix; };
+      gradient-cli = final: prev: { inherit (self.packages.${final.stdenv.hostPlatform.system}) gradient-cli gradient-cli-full; };
+      default = final: prev: { inherit (self.packages.${final.stdenv.hostPlatform.system}) gradient gradient-frontend gradient-cli gradient-cli-full gradient-nix; };
     };
 
     nixosModules = rec {

--- a/nix/packages/gradient-cli.nix
+++ b/nix/packages/gradient-cli.nix
@@ -7,7 +7,9 @@
 { lib
 , craneLib
 , git
+, glibc
 , installShellFiles
+, llvmPackages
 , gradient-nix
 , openssl
 , pkg-config
@@ -15,12 +17,33 @@
 , cargoFeatures ? [ ]
 }:
 let
-  src = craneLib.cleanCargoSource ../../cli;
+  # The `eval` feature path-depends on backend/gradient-eval (the shared Nix
+  # evaluator) and thus on libnix; only then do we pull the Nix dev toolchain.
+  withEval = builtins.elem "eval" cargoFeatures;
 
-  # harmonia (git dep) ships crates whose Cargo.toml points at a README.md that
-  # isn't in the crate dir; strip the readme key so vendoring doesn't choke.
+  repoRoot = ../..;
+
+  # The CLI is its own cargo workspace, but `gradient-eval` lives under backend/,
+  # so the source tree must carry both crates. cargo builds from the cli subdir
+  # (sourceRoot below) and resolves the `../backend/gradient-eval` path dep.
+  mdFiles = dir: lib.fileset.fileFilter (f: f.hasExt "md") dir;
+  cliSrc = repoRoot + "/cli";
+  evalSrc = repoRoot + "/backend/gradient-eval";
+  src = lib.fileset.toSource {
+    root = repoRoot;
+    fileset = lib.fileset.unions [
+      (craneLib.fileset.commonCargoSources cliSrc)
+      (mdFiles cliSrc)
+      (craneLib.fileset.commonCargoSources evalSrc)
+      (mdFiles evalSrc)
+    ];
+  };
+
+  # harmonia/nix-bindings (git deps) ship crates whose Cargo.toml points at a
+  # README.md outside the crate dir; strip the readme key so vendoring works.
   cargoVendorDir = craneLib.vendorCargoDeps {
     inherit src;
+    cargoLock = cliSrc + "/Cargo.lock";
     overrideVendorGitCheckout = _ps: drv:
       drv.overrideAttrs (old: {
         postPatch = (old.postPatch or "") + ''
@@ -39,10 +62,15 @@ let
   commonArgs = {
     inherit src cargoExtraArgs cargoVendorDir;
     strictDeps = true;
+    sourceRoot = "${src.name}/cli";
+    cargoToml = cliSrc + "/Cargo.toml";
 
     nativeBuildInputs = [
       installShellFiles
       pkg-config
+    ] ++ lib.optionals withEval [
+      (lib.getDev gradient-nix)
+      (lib.getDev glibc)
     ];
 
     buildInputs = [
@@ -50,13 +78,16 @@ let
       gradient-nix
       openssl
     ];
+  } // lib.optionalAttrs withEval {
+    LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+    BINDGEN_EXTRA_CLANG_ARGS = "--sysroot=${glibc.dev}";
   };
-
-  # Cached dependency layer - only rebuilt when Cargo.lock or features change
-  cargoArtifacts = craneLib.buildDepsOnly commonArgs;
 in
+# Deps and crate build in one pass: the `eval` feature pulls gradient-eval from
+# backend/, so the cli workspace lives in a subdirectory of the source tree, and
+# crane's split deps layer assumes the workspace is at the source root.
 craneLib.buildPackage (commonArgs // {
-  inherit cargoArtifacts;
+  cargoArtifacts = null;
   pname = "gradient-cli";
   version = "1.2.0";
   separateDebugInfo = true;


### PR DESCRIPTION
Closes #472. Extracts the worker's flake evaluator into a self-contained `backend/gradient-eval` crate and adds `gradient eval` (nix-eval-jobs-like JSONL), gated behind the `nix`+`eval` features and shipped via the new `gradient-cli-full` package.