### PR TITLE
feat: create-permission gate for orgs/caches + login deep-link redirect

### DIFF
--- a/backend/gradient-test-support/src/fixtures.rs
+++ b/backend/gradient-test-support/src/fixtures.rs
@@ -66,6 +66,13 @@ pub fn user() -> user::Model {
     }
 }
 
+pub fn superuser_user() -> user::Model {
+    user::Model {
+        superuser: true,
+        ..user()
+    }
+}
+
 pub fn org_with_id(id: OrganizationId, slug: &str) -> organization::Model {
     organization::Model {
         id,

--- a/backend/gradient-test-support/src/web.rs
+++ b/backend/gradient-test-support/src/web.rs
@@ -100,6 +100,22 @@ pub fn make_test_server_with(
         Some(path) => test_cli_with_crypt(path),
         None => test_cli(),
     };
+    server_from_cli(db, cli)
+}
+
+/// Variant of [`make_test_server`] that lets callers tweak the parsed `Cli`
+/// (e.g. tighten `create_org` / `create_cache`) before the `RuntimeConfig` is
+/// resolved.
+pub fn make_test_server_configured(
+    db: DatabaseConnection,
+    configure: impl FnOnce(&mut gradient_types::Cli),
+) -> TestServer {
+    let mut cli = test_cli();
+    configure(&mut cli);
+    server_from_cli(db, cli)
+}
+
+fn server_from_cli(db: DatabaseConnection, cli: gradient_types::Cli) -> TestServer {
     let config = Arc::new(RuntimeConfig::from_cli(&cli).expect("valid test config"));
     let nar_storage = NarStore::local(&config.storage.base_path).expect("nar store");
     let state = Arc::new(ServerState {

--- a/backend/gradient-types/src/cli/mod.rs
+++ b/backend/gradient-types/src/cli/mod.rs
@@ -42,5 +42,5 @@ pub use registration::{DEFAULT_SENTRY_DSN, RegistrationArgs, effective_sentry_ds
 pub use s3::S3Args;
 pub use scim::ScimArgs;
 pub use secrets::SecretsArgs;
-pub use server::ServerArgs;
+pub use server::{CreatePermission, ServerArgs};
 pub use storage::StorageArgs;

--- a/backend/gradient-types/src/cli/server.rs
+++ b/backend/gradient-types/src/cli/server.rs
@@ -5,7 +5,22 @@
  */
 
 use crate::input::port_in_range;
-use clap::Args;
+use clap::{Args, ValueEnum};
+use serde::{Deserialize, Serialize};
+
+/// Who may create organizations / caches through the API.
+#[derive(ValueEnum, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+#[value(rename_all = "lowercase")]
+pub enum CreatePermission {
+    /// Nobody via the API; only the declarative state import may create them.
+    None,
+    /// Superusers only.
+    Superusers,
+    /// Any authenticated user.
+    #[default]
+    Everyone,
+}
 
 #[derive(Args, Debug, Clone)]
 pub struct ServerArgs {
@@ -37,6 +52,12 @@ pub struct ServerArgs {
     /// Author/committer email for commits the `OpenPr` action pushes.
     #[arg(long, env = "GRADIENT_PR_COMMIT_EMAIL", default_value = "gradient@localhost")]
     pub pr_commit_email: String,
+    /// Who may create organizations through the API.
+    #[arg(long, value_enum, env = "GRADIENT_CREATE_ORG", default_value_t = CreatePermission::Everyone)]
+    pub create_org: CreatePermission,
+    /// Who may create caches through the API.
+    #[arg(long, value_enum, env = "GRADIENT_CREATE_CACHE", default_value_t = CreatePermission::Everyone)]
+    pub create_cache: CreatePermission,
 }
 
 impl Default for ServerArgs {
@@ -49,6 +70,8 @@ impl Default for ServerArgs {
             use_tls: true,
             pr_commit_name: "Gradient".into(),
             pr_commit_email: "gradient@localhost".into(),
+            create_org: CreatePermission::default(),
+            create_cache: CreatePermission::default(),
         }
     }
 }

--- a/backend/gradient-types/src/lib.rs
+++ b/backend/gradient-types/src/lib.rs
@@ -33,9 +33,9 @@ pub use self::board_events::BoardEvent;
 pub use self::build_output_metadata::BuildOutputMetadata;
 pub use self::cached_path_info::CachedPathInfo;
 pub use self::cli::{
-    CidrParseError, DatabaseArgs, EmailArgs, EvalArgs, GitHubAppArgs, LimitsArgs, LoggingArgs,
-    MetricsArgs, NetworkArgs, OidcArgs, ProtoArgs, RegistrationArgs, S3Args, ScimArgs, SecretsArgs,
-    ServerArgs, StorageArgs, in_any, parse_cidr_list,
+    CidrParseError, CreatePermission, DatabaseArgs, EmailArgs, EvalArgs, GitHubAppArgs, LimitsArgs,
+    LoggingArgs, MetricsArgs, NetworkArgs, OidcArgs, ProtoArgs, RegistrationArgs, S3Args, ScimArgs,
+    SecretsArgs, ServerArgs, StorageArgs, in_any, parse_cidr_list,
 };
 pub use self::config::{
     ConfigError, EmailConfig, GitHubAppConfig, MetricsConfig, NetworkConfig, OidcConfig,

--- a/backend/gradient-web/src/endpoints/caches/management.rs
+++ b/backend/gradient-web/src/endpoints/caches/management.rs
@@ -7,7 +7,7 @@
 use crate::access::{CacheAccess, Caller, load_cache};
 use crate::audit::{RequestInfo, events, record as audit_record};
 use crate::authorization::{MaybeApiKey, MaybeUser};
-use crate::error::{WebError, WebResult};
+use crate::error::{WebError, WebResult, require_create_permission};
 use crate::helpers::ok_json;
 use crate::permissions::CachePermission;
 use axum::Extension;
@@ -143,6 +143,8 @@ pub async fn put(
     Extension(user): Extension<MUser>,
     Json(body): Json<MakeCacheRequest>,
 ) -> WebResult<Json<BaseResponse<String>>> {
+    require_create_permission(state.config.server.create_cache, &user)?;
+
     if check_index_name(body.name.clone().as_str()).is_err() {
         return Err(WebError::invalid_name("Cache Name"));
     }

--- a/backend/gradient-web/src/endpoints/mod.rs
+++ b/backend/gradient-web/src/endpoints/mod.rs
@@ -26,7 +26,7 @@ pub mod workers;
 
 use crate::error::WebResult;
 use axum::extract::{Json, State};
-use gradient_types::{BaseResponse};
+use gradient_types::{BaseResponse, CreatePermission};
 use gradient_core::ServerState;
 use serde::Serialize;
 use std::sync::Arc;
@@ -69,6 +69,8 @@ pub struct ServerConfig {
     pub email_verification_enabled: bool,
     pub smtp_enabled: bool,
     pub quic: bool,
+    pub create_org: CreatePermission,
+    pub create_cache: CreatePermission,
 }
 
 pub async fn get_config(
@@ -90,6 +92,8 @@ pub async fn get_config(
                     .is_some_and(|e| e.require_verification),
             smtp_enabled: state.email.is_enabled(),
             quic: state.config.proto.quic,
+            create_org: state.config.server.create_org,
+            create_cache: state.config.server.create_cache,
         },
     };
 

--- a/backend/gradient-web/src/endpoints/orgs/management.rs
+++ b/backend/gradient-web/src/endpoints/orgs/management.rs
@@ -7,7 +7,7 @@
 use crate::access::{Caller, OrgAccess, load_org};
 use crate::audit::{RequestInfo, events, record as audit_record};
 use crate::authorization::{MaybeApiKey, MaybeUser};
-use crate::error::{WebError, WebResult};
+use crate::error::{WebError, WebResult, require_create_permission};
 use crate::helpers::ok_json;
 use crate::permissions::Permission;
 use axum::extract::{Path, Query, State};
@@ -217,6 +217,8 @@ pub async fn put(
     Extension(user): Extension<MUser>,
     Json(body): Json<MakeOrganizationRequest>,
 ) -> WebResult<Json<BaseResponse<String>>> {
+    require_create_permission(state.config.server.create_org, &user)?;
+
     if check_index_name(body.name.clone().as_str()).is_err() {
         return Err(WebError::invalid_name("Organization Name"));
     }

--- a/backend/gradient-web/src/error.rs
+++ b/backend/gradient-web/src/error.rs
@@ -60,6 +60,7 @@ impl ErrorCode {
     // 403 Forbidden
     pub const FORBIDDEN: Self = Self("forbidden");
     pub const SUPERUSER_REQUIRED: Self = Self("superuser_required");
+    pub const CREATION_DISABLED: Self = Self("creation_disabled");
     pub const FORBIDDEN_SOURCE_IP: Self = Self("forbidden_source_ip");
 
     // Validation-specific bad-request codes
@@ -426,6 +427,22 @@ pub fn require_superuser(user: &gradient_types::MUser) -> Result<(), WebError> {
             ErrorCode::SUPERUSER_REQUIRED,
             "superuser required".into(),
         ))
+    }
+}
+
+/// Enforces a [`CreatePermission`] gate on organization/cache creation.
+pub fn require_create_permission(
+    permission: gradient_types::CreatePermission,
+    user: &gradient_types::MUser,
+) -> Result<(), WebError> {
+    use gradient_types::CreatePermission;
+    match permission {
+        CreatePermission::Everyone => Ok(()),
+        CreatePermission::Superusers => require_superuser(user),
+        CreatePermission::None => Err(WebError::Forbidden(
+            ErrorCode::CREATION_DISABLED,
+            "creation is managed by the declarative state".into(),
+        )),
     }
 }
 

--- a/backend/gradient-web/tests/config_endpoint.rs
+++ b/backend/gradient-web/tests/config_endpoint.rs
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! `GET /api/v1/config` exposes the `create_org` / `create_cache` permission
+//! knobs so the frontend can hide the create buttons (issue #470).
+
+use gradient_types::CreatePermission;
+use sea_orm::{DatabaseBackend, MockDatabase};
+use serde_json::Value;
+use gradient_test_support::web::{make_test_server, make_test_server_configured};
+
+fn run<F: std::future::Future>(f: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(f)
+}
+
+#[test]
+fn config_defaults_to_everyone() {
+    run(async {
+        let db = MockDatabase::new(DatabaseBackend::Postgres);
+        let server = make_test_server(db.into_connection());
+
+        let res = server.get("/api/v1/config").await;
+        res.assert_status_ok();
+        let body: Value = res.json();
+        assert_eq!(body["message"]["create_org"], "everyone");
+        assert_eq!(body["message"]["create_cache"], "everyone");
+    });
+}
+
+#[test]
+fn config_reflects_configured_permissions() {
+    run(async {
+        let db = MockDatabase::new(DatabaseBackend::Postgres);
+        let server = make_test_server_configured(db.into_connection(), |cli| {
+            cli.server.create_org = CreatePermission::None;
+            cli.server.create_cache = CreatePermission::Superusers;
+        });
+
+        let res = server.get("/api/v1/config").await;
+        res.assert_status_ok();
+        let body: Value = res.json();
+        assert_eq!(body["message"]["create_org"], "none");
+        assert_eq!(body["message"]["create_cache"], "superusers");
+    });
+}

--- a/backend/gradient-web/tests/create_permissions.rs
+++ b/backend/gradient-web/tests/create_permissions.rs
@@ -1,0 +1,215 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Integration tests for the `create_org` / `create_cache` permission gate on
+//! `PUT /api/v1/orgs` and `PUT /api/v1/caches` (issue #470).
+//!
+//! Each gate short-circuits before any DB write, so the rejection paths need
+//! only the auth query chain. The allow path is proven by reaching the
+//! name-taken pre-check (409) with the gate satisfied.
+
+use axum::http::StatusCode;
+use gradient_entity::{cache, organization};
+use gradient_entity::ids::*;
+use gradient_types::{CreatePermission, SessionId};
+use sea_orm::{DatabaseBackend, MockDatabase};
+use serde_json::{Value, json};
+use gradient_test_support::fixtures::{superuser_user, test_date, user, user_id};
+use gradient_test_support::web::{live_session, make_test_server_configured, make_token};
+
+fn with_auth(db: MockDatabase, session_id: SessionId, actor: gradient_entity::user::Model) -> MockDatabase {
+    let session = live_session(session_id);
+    db.append_query_results([vec![session.clone()]])
+        .append_query_results([vec![session]])
+        .append_query_results([vec![actor]])
+}
+
+fn org_row(name: &str) -> organization::Model {
+    organization::Model {
+        id: OrganizationId::now_v7(),
+        name: name.to_string(),
+        display_name: format!("{} display", name),
+        created_by: user_id(),
+        created_at: test_date(),
+        ..Default::default()
+    }
+}
+
+fn cache_row(name: &str) -> cache::Model {
+    cache::Model {
+        id: CacheId::now_v7(),
+        name: name.to_string(),
+        display_name: format!("{} display", name),
+        created_by: user_id(),
+        created_at: test_date(),
+        ..Default::default()
+    }
+}
+
+fn run<F: std::future::Future>(f: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(f)
+}
+
+fn org_body() -> Value {
+    json!({ "name": "acme", "display_name": "Acme", "description": "", "public": false })
+}
+
+fn cache_body() -> Value {
+    json!({
+        "name": "acme", "display_name": "Acme", "description": "",
+        "priority": 40, "local_priority": 40, "public": false,
+    })
+}
+
+#[test]
+fn create_org_superusers_rejects_regular_user() {
+    run(async {
+        let session_id = SessionId::now_v7();
+        let token = make_token(session_id);
+        let db = with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id, user());
+        let server = make_test_server_configured(db.into_connection(), |cli| {
+            cli.server.create_org = CreatePermission::Superusers;
+        });
+
+        let res = server
+            .put("/api/v1/orgs")
+            .add_header("authorization", format!("Bearer {}", token))
+            .json(&org_body())
+            .await;
+
+        res.assert_status(StatusCode::FORBIDDEN);
+        let body: Value = res.json();
+        assert_eq!(body["code"], "superuser_required");
+    });
+}
+
+#[test]
+fn create_org_none_rejects_superuser() {
+    run(async {
+        let session_id = SessionId::now_v7();
+        let token = make_token(session_id);
+        let db = with_auth(
+            MockDatabase::new(DatabaseBackend::Postgres),
+            session_id,
+            superuser_user(),
+        );
+        let server = make_test_server_configured(db.into_connection(), |cli| {
+            cli.server.create_org = CreatePermission::None;
+        });
+
+        let res = server
+            .put("/api/v1/orgs")
+            .add_header("authorization", format!("Bearer {}", token))
+            .json(&org_body())
+            .await;
+
+        res.assert_status(StatusCode::FORBIDDEN);
+        let body: Value = res.json();
+        assert_eq!(body["code"], "creation_disabled");
+    });
+}
+
+#[test]
+fn create_org_superusers_allows_superuser_past_gate() {
+    run(async {
+        let session_id = SessionId::now_v7();
+        let token = make_token(session_id);
+        let db = with_auth(
+            MockDatabase::new(DatabaseBackend::Postgres),
+            session_id,
+            superuser_user(),
+        )
+        .append_query_results([vec![org_row("acme")]]);
+        let server = make_test_server_configured(db.into_connection(), |cli| {
+            cli.server.create_org = CreatePermission::Superusers;
+        });
+
+        let res = server
+            .put("/api/v1/orgs")
+            .add_header("authorization", format!("Bearer {}", token))
+            .json(&org_body())
+            .await;
+
+        res.assert_status(StatusCode::CONFLICT);
+        let body: Value = res.json();
+        assert_eq!(body["code"], "already_exists");
+    });
+}
+
+#[test]
+fn create_cache_superusers_rejects_regular_user() {
+    run(async {
+        let session_id = SessionId::now_v7();
+        let token = make_token(session_id);
+        let db = with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id, user());
+        let server = make_test_server_configured(db.into_connection(), |cli| {
+            cli.server.create_cache = CreatePermission::Superusers;
+        });
+
+        let res = server
+            .put("/api/v1/caches")
+            .add_header("authorization", format!("Bearer {}", token))
+            .json(&cache_body())
+            .await;
+
+        res.assert_status(StatusCode::FORBIDDEN);
+        let body: Value = res.json();
+        assert_eq!(body["code"], "superuser_required");
+    });
+}
+
+#[test]
+fn create_cache_none_rejects_superuser() {
+    run(async {
+        let session_id = SessionId::now_v7();
+        let token = make_token(session_id);
+        let db = with_auth(
+            MockDatabase::new(DatabaseBackend::Postgres),
+            session_id,
+            superuser_user(),
+        );
+        let server = make_test_server_configured(db.into_connection(), |cli| {
+            cli.server.create_cache = CreatePermission::None;
+        });
+
+        let res = server
+            .put("/api/v1/caches")
+            .add_header("authorization", format!("Bearer {}", token))
+            .json(&cache_body())
+            .await;
+
+        res.assert_status(StatusCode::FORBIDDEN);
+        let body: Value = res.json();
+        assert_eq!(body["code"], "creation_disabled");
+    });
+}
+
+#[test]
+fn create_cache_everyone_allows_regular_user_past_gate() {
+    run(async {
+        let session_id = SessionId::now_v7();
+        let token = make_token(session_id);
+        let db = with_auth(MockDatabase::new(DatabaseBackend::Postgres), session_id, user())
+            .append_query_results([vec![cache_row("acme")]]);
+        let server = make_test_server_configured(db.into_connection(), |cli| {
+            cli.server.create_cache = CreatePermission::Everyone;
+        });
+
+        let res = server
+            .put("/api/v1/caches")
+            .add_header("authorization", format!("Bearer {}", token))
+            .json(&cache_body())
+            .await;
+
+        res.assert_status(StatusCode::CONFLICT);
+        let body: Value = res.json();
+        assert_eq!(body["code"], "already_exists");
+    });
+}

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -219,6 +219,8 @@ paths:
                   registration_enabled: false
                   email_verification_enabled: false
                   quic: false
+                  create_org: everyone
+                  create_cache: everyone
 
   /proto:
     get:
@@ -7205,7 +7207,7 @@ components:
 
     ServerConfig:
       type: object
-      required: [oidc_enabled, registration_enabled, email_verification_enabled, quic, smtp_enabled]
+      required: [oidc_enabled, registration_enabled, email_verification_enabled, quic, smtp_enabled, create_org, create_cache]
       properties:
         oidc_enabled:
           type: boolean
@@ -7225,6 +7227,14 @@ components:
         smtp_enabled:
           type: boolean
           description: Whether the server has SMTP configured (required for send_mail actions)
+        create_org:
+          type: string
+          enum: [none, superusers, everyone]
+          description: Who may create organizations via the API (`none` = only the declarative state).
+        create_cache:
+          type: string
+          enum: [none, superusers, everyone]
+          description: Who may create caches via the API (`none` = only the declarative state).
     # ── Auth ─────────────────────────────────────────────────────────────────
 
     MakeLoginRequest:

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -69,6 +69,8 @@ openssl rand -base64 48 > /run/secrets/gradient-crypt
 | `settings.logLevel.proto` | null | `gradient_proto` log level override (null inherits default) |
 | `settings.logLevel.scheduler` | null | `gradient_scheduler` log level override (null inherits default) |
 | `settings.enableRegistration` | `true` | Allow new user self-registration |
+| `settings.createOrg` | `everyone` | Who may create organizations via the API: `none` (only the declarative state), `superusers`, or `everyone`. The frontend hides the "Create Organization" button accordingly. (`GRADIENT_CREATE_ORG`) |
+| `settings.createCache` | `everyone` | Who may create caches via the API: `none` (only the declarative state), `superusers`, or `everyone`. The frontend hides the "Create Cache" button accordingly. (`GRADIENT_CREATE_CACHE`) |
 | `settings.deleteState` | `true` | Remove entities no longer in `state` (see below) |
 | `settings.cacheTtlHours` | `336` | TTL in hours for cached NARs not fetched recently (0 = disabled) |
 | `settings.narStorageOpenTimeoutSecs` | `60` | Max seconds the server will wait to open a NAR object stream (e.g. an S3 GET) before emitting `NarUnavailable`. Caps how long a stalled storage backend can block a `NarRequest`. |

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -5443,3 +5443,19 @@ the same "no custom events" rule as `forge_status_report`.
 - `state_action_validate_accepts_open_pr` - an `open_pr` action validates.
 - `state_action_validate_rejects_events_on_open_pr` - an `open_pr` action with a
   non-empty `events` list is rejected on the `.events` field.
+
+## Organization/cache creation permission gate (#470)
+
+`create_org` / `create_cache` (`CreatePermission`: `none` | `superusers` |
+`everyone`, default `everyone`) gate `PUT /orgs` and `PUT /caches`. The server
+enforces the gate; the frontend additionally hides the create buttons and
+`GET /config` exposes both values.
+
+- `backend/gradient-web/tests/create_permissions.rs` -
+  `create_{org,cache}_superusers_rejects_regular_user` (403 `superuser_required`),
+  `create_{org,cache}_none_rejects_superuser` (403 `creation_disabled`), and the
+  allow-path cases that reach the name-taken pre-check (409) once the gate is
+  satisfied.
+- `backend/gradient-web/tests/config_endpoint.rs` -
+  `config_defaults_to_everyone` and `config_reflects_configured_permissions`
+  cover the `/config` surface.

--- a/frontend/src/app/core/guards/auth.guard.ts
+++ b/frontend/src/app/core/guards/auth.guard.ts
@@ -13,7 +13,7 @@ import { AuthService } from '@core/services/auth.service';
  * Route guard that redirects unauthenticated users to the login page.
  * Waits for the initial auth check to complete before deciding.
  */
-export const authGuard: CanActivateFn = () => {
+export const authGuard: CanActivateFn = (_route, state) => {
   const authService = inject(AuthService);
   const router = inject(Router);
 
@@ -22,7 +22,7 @@ export const authGuard: CanActivateFn = () => {
       if (authService.isAuthenticated()) {
         return true;
       }
-      router.navigate(['/account/login']);
+      router.navigate(['/account/login'], { queryParams: { next: state.url } });
       return false;
     })
   );

--- a/frontend/src/app/core/interceptors/error.interceptor.ts
+++ b/frontend/src/app/core/interceptors/error.interceptor.ts
@@ -32,11 +32,14 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
   return next(req).pipe(
     catchError((error: HttpErrorResponse) => {
       switch (error.status) {
-        case 401:
+        case 401: {
           localStorage.removeItem('jwt_token');
           sessionStorage.removeItem('jwt_token');
-          router.navigate(['/account/login']);
+          const next = router.url;
+          const carry = next && !next.startsWith('/account/');
+          router.navigate(['/account/login'], carry ? { queryParams: { next } } : {});
           break;
+        }
 
         case 0:
           // Network error or server completely unreachable - treat as 503

--- a/frontend/src/app/core/services/config.service.ts
+++ b/frontend/src/app/core/services/config.service.ts
@@ -9,6 +9,8 @@ import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { environment } from '@environments/environment';
 
+export type CreatePermission = 'none' | 'superusers' | 'everyone';
+
 interface ServerConfig {
   version: string;
   oidc_enabled: boolean;
@@ -16,6 +18,8 @@ interface ServerConfig {
   registration_enabled: boolean;
   email_verification_enabled: boolean;
   smtp_enabled: boolean;
+  create_org: CreatePermission;
+  create_cache: CreatePermission;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -29,6 +33,19 @@ export class ConfigService {
   registrationDisabled = false;
   emailVerificationEnabled = false;
   smtpEnabled = false;
+  createOrg: CreatePermission = 'everyone';
+  createCache: CreatePermission = 'everyone';
+
+  canCreate(permission: CreatePermission, isSuperuser: boolean): boolean {
+    switch (permission) {
+      case 'everyone':
+        return true;
+      case 'superusers':
+        return isSuperuser;
+      default:
+        return false;
+    }
+  }
 
   load(): Promise<void> {
     return firstValueFrom(
@@ -44,6 +61,8 @@ export class ConfigService {
           this.registrationDisabled = !res.message.registration_enabled;
           this.emailVerificationEnabled = res.message.email_verification_enabled;
           this.smtpEnabled = res.message.smtp_enabled;
+          this.createOrg = res.message.create_org ?? 'everyone';
+          this.createCache = res.message.create_cache ?? 'everyone';
         }
       })
       .catch(() => {

--- a/frontend/src/app/features/auth/login/login.component.ts
+++ b/frontend/src/app/features/auth/login/login.component.ts
@@ -80,6 +80,10 @@ export class LoginComponent {
   }
 
   loginWithOIDC(): void {
+    const next = this.route.snapshot.queryParamMap.get('next');
+    if (next && next.startsWith('/')) {
+      sessionStorage.setItem('oidc_next', next);
+    }
     window.location.href = `${environment.apiUrl}/auth/oidc/login`;
   }
 }

--- a/frontend/src/app/features/auth/oidc-callback/oidc-callback.component.ts
+++ b/frontend/src/app/features/auth/oidc-callback/oidc-callback.component.ts
@@ -19,7 +19,15 @@ export class OidcCallbackComponent implements OnInit {
 
   ngOnInit(): void {
     this.authService.loginWithCookie().subscribe({
-      next: () => this.router.navigate(['/']),
+      next: () => {
+        const next = sessionStorage.getItem('oidc_next');
+        sessionStorage.removeItem('oidc_next');
+        if (next && next.startsWith('/')) {
+          this.router.navigateByUrl(next);
+        } else {
+          this.router.navigate(['/']);
+        }
+      },
       error: () => this.router.navigate(['/account/login']),
     });
   }

--- a/frontend/src/app/features/caches/cache-list/cache-list.component.html
+++ b/frontend/src/app/features/caches/cache-list/cache-list.component.html
@@ -10,7 +10,7 @@
       <h1>Caches</h1>
       <p class="text-secondary">Manage your build caches</p>
     </div>
-    @if (authService.isAuthenticated()) {
+    @if (canCreateCache) {
       <button pButton label="Create Cache" icon="pi pi-plus" (click)="openCreateDialog()"></button>
     }
   </div>

--- a/frontend/src/app/features/caches/cache-list/cache-list.component.ts
+++ b/frontend/src/app/features/caches/cache-list/cache-list.component.ts
@@ -16,6 +16,7 @@ import { InputTextModule } from 'primeng/inputtext';
 import { TextareaModule } from 'primeng/textarea';
 import { CachesService } from '@core/services/caches.service';
 import { AuthService } from '@core/services/auth.service';
+import { ConfigService } from '@core/services/config.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { EmptyStateComponent } from '@shared/components/empty-state/empty-state.component';
 import { slugify } from '@shared/text';
@@ -41,7 +42,13 @@ import { Cache } from '@core/models';
 export class CacheListComponent implements OnInit, OnDestroy {
   private cachesService = inject(CachesService);
   protected authService = inject(AuthService);
+  private config = inject(ConfigService);
   private nameCheck$ = new Subject<string>();
+
+  get canCreateCache(): boolean {
+    if (!this.authService.isAuthenticated()) return false;
+    return this.config.canCreate(this.config.createCache, this.authService.user()?.superuser === true);
+  }
 
   loading = signal(true);
   caches = signal<Cache[]>([]);

--- a/frontend/src/app/features/organizations/organization-list/organization-list.component.html
+++ b/frontend/src/app/features/organizations/organization-list/organization-list.component.html
@@ -10,7 +10,7 @@
       <h1>Organizations</h1>
       <p class="text-secondary">Manage your organizations</p>
     </div>
-    @if (authService.isAuthenticated()) {
+    @if (canCreateOrganization) {
       <button pButton label="Create Organization" icon="pi pi-plus" (click)="openCreateDialog()"></button>
     }
   </div>

--- a/frontend/src/app/features/organizations/organization-list/organization-list.component.ts
+++ b/frontend/src/app/features/organizations/organization-list/organization-list.component.ts
@@ -16,6 +16,7 @@ import { InputTextModule } from 'primeng/inputtext';
 import { TextareaModule } from 'primeng/textarea';
 import { OrganizationsService } from '@core/services/organizations.service';
 import { AuthService } from '@core/services/auth.service';
+import { ConfigService } from '@core/services/config.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { EmptyStateComponent } from '@shared/components/empty-state/empty-state.component';
 import { slugify } from '@shared/text';
@@ -41,7 +42,13 @@ import { Organization } from '@core/models';
 export class OrganizationListComponent implements OnInit, OnDestroy {
   private organizationsService = inject(OrganizationsService);
   protected authService = inject(AuthService);
+  private config = inject(ConfigService);
   private nameCheck$ = new Subject<string>();
+
+  get canCreateOrganization(): boolean {
+    if (!this.authService.isAuthenticated()) return false;
+    return this.config.canCreate(this.config.createOrg, this.authService.user()?.superuser === true);
+  }
 
   loading = signal(true);
   organizations = signal<Organization[]>([]);

--- a/nix/modules/gradient.nix
+++ b/nix/modules/gradient.nix
@@ -771,6 +771,18 @@ in {
           type = lib.types.str;
           default = "gradient@localhost";
         };
+
+        createOrg = lib.mkOption {
+          description = "Who may create organizations through the API. `none` disables API creation (organizations are then managed only by the declarative state), `superusers` restricts it to superusers, `everyone` allows any authenticated user.";
+          type = lib.types.enum [ "none" "superusers" "everyone" ];
+          default = "everyone";
+        };
+
+        createCache = lib.mkOption {
+          description = "Who may create caches through the API. `none` disables API creation (caches are then managed only by the declarative state), `superusers` restricts it to superusers, `everyone` allows any authenticated user.";
+          type = lib.types.enum [ "none" "superusers" "everyone" ];
+          default = "everyone";
+        };
       };
     };
   };
@@ -911,6 +923,8 @@ in {
         GRADIENT_PROTO_ANON_MAX_CONNECTIONS_PER_IP = toString cfg.settings.anonMaxConnectionsPerIp;
         GRADIENT_PR_COMMIT_NAME = cfg.settings.prCommitName;
         GRADIENT_PR_COMMIT_EMAIL = cfg.settings.prCommitEmail;
+        GRADIENT_CREATE_ORG = cfg.settings.createOrg;
+        GRADIENT_CREATE_CACHE = cfg.settings.createCache;
         GRADIENT_LOCAL_IPS = builtins.concatStringsSep "," cfg.settings.localIps;
         GRADIENT_TRUSTED_PROXIES = builtins.concatStringsSep "," cfg.settings.trustedProxies;
         GRADIENT_STATE_FILE = "%d/gradient_state";


### PR DESCRIPTION
Closes #470, closes #471.

- #470: `GRADIENT_CREATE_ORG` / `GRADIENT_CREATE_CACHE` (`none` = declarative state only, `superusers`, `everyone`; default `everyone`) enforced on `PUT /orgs` and `PUT /caches`, surfaced via `/config`; frontend hides the Create buttons accordingly.
- #471: auth guard, 401 interceptor and OIDC flow now carry the originally requested URL through login (`next` query param + `sessionStorage` across the OIDC roundtrip).

Tests: `create_permissions.rs`, `config_endpoint.rs`. Docs, nix module and API spec updated.