### PR TITLE
worker: fix: discard dead idle eval workers on pool checkout

### DIFF
--- a/backend/gradient-worker/src/worker_pool/pool.rs
+++ b/backend/gradient-worker/src/worker_pool/pool.rs
@@ -148,6 +148,19 @@ impl EvalWorker {
         })
     }
 
+    pub(super) fn pid(&self) -> Option<u32> {
+        self.child.id()
+    }
+
+    /// Whether the subprocess is still running, reaping its exit status if it
+    /// has already exited. The pool calls this on checkout to discard an idle
+    /// worker whose subprocess died while pooled (memory reaper, kernel OOM via
+    /// the elevated `oom_score_adj`, or crash) instead of handing out a corpse
+    /// that fails the next write with a broken pipe.
+    fn is_alive(&mut self) -> bool {
+        matches!(self.child.try_wait(), Ok(None))
+    }
+
     /// Send one request and read one response. Errors here mean the worker is
     /// no longer usable (the caller marks it dead so it gets discarded
     /// instead of being returned to the pool).
@@ -547,12 +560,27 @@ impl EvalWorkerPool {
             tokio::time::sleep(Duration::from_millis(200)).await;
         }
 
-        let worker = self.idle.lock().unwrap().pop();
-        let worker = match worker {
-            Some(w) => w,
-            None => EvalWorker::spawn(&self.eval_cache_dir, Arc::clone(&self.live))
-                .await
-                .context("spawning fresh eval worker")?,
+        // Test-on-borrow: an idle subprocess can die while pooled (memory
+        // reaper SIGKILL, kernel OOM via the elevated oom_score_adj, or crash).
+        // Skip such corpses so we never hand out a worker whose first stdin
+        // write fails with a broken pipe; spawn fresh once the idle vec drains.
+        let worker = loop {
+            let candidate = self.idle.lock().unwrap().pop();
+            match candidate {
+                Some(mut w) => {
+                    let pid = w.pid();
+                    if w.is_alive() {
+                        break w;
+                    }
+                    debug!(?pid, "discarding dead idle eval worker on checkout");
+                    drop(w);
+                }
+                None => {
+                    break EvalWorker::spawn(&self.eval_cache_dir, Arc::clone(&self.live))
+                        .await
+                        .context("spawning fresh eval worker")?;
+                }
+            }
         };
 
         Ok(PooledEvalWorker {
@@ -720,7 +748,37 @@ mod tests {
         EvalWorker::from_command(Command::new("cat")).expect("spawn cat")
     }
 
+    /// A worker whose subprocess has already been killed and reaped - stands in
+    /// for an idle worker the memory reaper or kernel OOM-killer took out while
+    /// it sat in the pool.
+    async fn dead_worker() -> EvalWorker {
+        let mut w = fake_worker();
+        w.child.start_kill().expect("kill cat");
+        w.child.wait().await.expect("reap cat");
+        w
+    }
+
     const GIB: u64 = 1024 * 1024 * 1024;
+
+    #[tokio::test]
+    async fn acquire_skips_dead_idle_worker() {
+        let pool = EvalWorkerPool::new(4, 2 * GIB, String::new());
+        let live = fake_worker();
+        let live_pid = live.pid();
+        assert!(live_pid.is_some());
+
+        // idle is a stack: push the live worker first so the dead corpse (pushed
+        // last) is popped first and must be skipped.
+        pool.push_for_test(live);
+        pool.push_for_test(dead_worker().await);
+
+        let worker = pool.acquire().await.expect("acquire a live worker");
+        assert_eq!(
+            worker.pid(),
+            live_pid,
+            "acquire must skip the dead idle corpse and return the live worker"
+        );
+    }
 
     #[test]
     fn budgeted_pool_size_caps_by_memory() {

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -5459,3 +5459,15 @@ enforces the gate; the frontend additionally hides the create buttons and
 - `backend/gradient-web/tests/config_endpoint.rs` -
   `config_defaults_to_everyone` and `config_reflects_configured_permissions`
   cover the `/config` surface.
+
+## Eval-worker pool discards dead idle subprocesses on checkout
+
+`EvalWorkerPool::acquire` handed out pooled workers without checking the
+subprocess was alive. An idle worker killed while pooled - by the memory reaper,
+the kernel OOM-killer (eval workers set `oom_score_adj=600`), or a crash -
+lingered in the idle vec and the next `acquire` returned the corpse, so the eval
+failed on the first stdin write with `Broken pipe (os error 32)`. `acquire` now
+test-on-borrows via `Child::try_wait`, skipping dead workers and spawning fresh.
+
+- `worker_pool::pool::tests::acquire_skips_dead_idle_worker` - a killed idle
+  worker pushed ahead of a live one is skipped; `acquire` returns the live pid.


### PR DESCRIPTION
## Symptom
Evals intermittently fail with `list_flake_derivations failed: writing to eval worker stdin: Broken pipe (os error 32)` (and `eval-cache fingerprint failed; evaluating local-only`), alongside `discarding eval worker (unhealthy or pool poisoned)`.

## Root cause
`EvalWorkerPool::acquire` popped an idle worker and returned it **without checking the subprocess was alive**. An idle worker can be killed while pooled — by the pool's own `memory_reaper_loop` (SIGKILLs the largest-RSS live subprocess, idle included), by the kernel OOM-killer (eval workers set `oom_score_adj=600`, making them preferred victims), or by a crash. The corpse stayed in the idle vec, and the next `acquire` handed it out; the first stdin write hit `EPIPE`.

## Fix
`acquire` now test-on-borrows via `Child::try_wait`: dead idle workers are discarded and a fresh one is spawned once the idle vec drains. Covers every death cause, not just the reaper.

Test: `worker_pool::pool::tests::acquire_skips_dead_idle_worker`. Documented in `docs/src/tests.md`.