### PR TITLE
eval,worker: refactor: consolidate the eval-worker subprocess and dedupe the walkers (#481)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2170,6 +2170,7 @@ dependencies = [
  "anyhow",
  "libc",
  "nix-bindings",
+ "rkyv",
  "serde",
  "serde_json",
  "tracing",

--- a/backend/gradient-eval/Cargo.toml
+++ b/backend/gradient-eval/Cargo.toml
@@ -23,6 +23,7 @@ doctest = false
 anyhow       = { version = "1.0", default-features = false, features = ["std"] }
 libc         = { version = "0.2", default-features = false }
 nix-bindings = { git = "https://github.com/DerDennisOP/nix-bindings", branch = "feat/eval-metrics-stats", default-features = false, features = ["flake"] }
+rkyv         = { version = "0.8", default-features = false, features = ["alloc", "bytecheck"] }
 serde        = { version = "1", default-features = false, features = ["std", "derive"] }
 serde_json   = { version = "1.0", default-features = false, features = ["std"] }
 tracing      = { version = "0.1", default-features = false, features = ["std", "attributes"] }

--- a/backend/gradient-eval/src/eval_worker.rs
+++ b/backend/gradient-eval/src/eval_worker.rs
@@ -8,99 +8,26 @@
 //!
 //! The parent process spawns one or more copies of the gradient-worker binary
 //! with `--eval-worker` to host a persistent [`NixEvaluator`]. Parent and
-//! worker exchange line-delimited JSON over the worker's stdin/stdout, so the
-//! libnix init cost is paid only once per worker (vs. once per `resolve` call
-//! when using the in-process resolver).
+//! worker exchange rkyv frames over the worker's stdin/stdout (see
+//! [`crate::ipc`]), so the libnix init cost is paid only once per worker.
 //!
-//! This file defines the wire protocol shared by both sides plus the
-//! subprocess entry point [`run_eval_worker`]. The pool implementation lives
-//! in [`super::worker_pool`].
+//! This file is the subprocess entry point [`run_eval_worker`]; the protocol
+//! lives in [`crate::ipc`] and the parent-side pool in the worker crate.
 
-use serde::{Deserialize, Serialize};
-use std::io::{BufRead, Write};
+use std::io::Write;
 use tracing::{error, trace};
 
+use crate::flake_walk::FlakeWalker;
+use crate::ipc::{
+    EVAL_IPC_VERSION, EvalRequest, EvalResponse, ResolvedItem, decode_request, encode_response,
+    read_frame, write_frame,
+};
 use crate::nix_eval::NixEvaluator;
 use crate::stats::StatsDelta;
 
-/// Request from parent → worker. One JSON object per line on the worker's stdin.
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(tag = "op", rename_all = "snake_case")]
-pub enum EvalRequest {
-    /// Split `wildcards` into disjoint sub-patterns (one per first-wildcard
-    /// child) so the parent can fan discovery across the pool, one shard per
-    /// system within each worker's memory budget.
-    Plan {
-        repository: String,
-        wildcards: Vec<String>,
-    },
-    /// Discover all attribute paths in `repository` matching `wildcards`.
-    List {
-        repository: String,
-        wildcards: Vec<String>,
-    },
-    /// Resolve a batch of attribute paths to `(drv_path, references)` tuples.
-    /// Per-attr failures are reported in the response, not as a top-level err.
-    Resolve {
-        repository: String,
-        attrs: Vec<String>,
-    },
-    /// Return `repository`'s eval-cache fingerprint without evaluating it.
-    /// `None` in the response for mutable/dirty flakes.
-    Fingerprint { repository: String },
-    /// Fold the eval-cache WAL into the main `.sqlite` (truncate checkpoint).
-    /// Run once after all shards finish, before the fleet-share push.
-    Checkpoint { repository: String },
-    /// Ask the worker to exit cleanly. Parent uses this on graceful shutdown.
-    Shutdown,
-}
-
-/// Response from worker → parent. One JSON object per line on the worker's stdout.
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-pub enum EvalResponse {
-    PlanOk {
-        sub_patterns: Vec<String>,
-    },
-    ListOk {
-        attrs: Vec<String>,
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        warnings: Vec<String>,
-        #[serde(default)]
-        stats: Option<crate::stats::StatsDelta>,
-    },
-    ResolveOk {
-        items: Vec<ResolvedItem>,
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        warnings: Vec<String>,
-        #[serde(default)]
-        stats: Option<crate::stats::StatsDelta>,
-    },
-    FingerprintOk {
-        fingerprint: Option<String>,
-    },
-    CheckpointOk,
-    Err {
-        message: String,
-    },
-}
-
-/// One element of a `ResolveOk` payload. Either `drv_path` is set (success)
-/// or `error` is set (failure for that one attr).
-#[derive(Debug, Serialize, Deserialize)]
-pub struct ResolvedItem {
-    pub attr: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub drv_path: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub references: Vec<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
-}
-
-/// Subprocess entry point. Reads `EvalRequest` lines from stdin, processes
-/// them with one persistent `NixEvaluator`, writes `EvalResponse` lines to
-/// stdout. Returns when stdin reaches EOF or a `Shutdown` request is received.
+/// Subprocess entry point. Reads [`EvalRequest`] frames from stdin, processes
+/// them with one persistent [`NixEvaluator`], writes [`EvalResponse`] frames
+/// to stdout. Returns when stdin reaches EOF or a `Shutdown` request arrives.
 ///
 /// Diagnostics go through `tracing` (configured in `worker::main` to write
 /// formatted records to stderr, which the parent inherits) so init failures
@@ -111,6 +38,11 @@ pub fn run_eval_worker() -> std::io::Result<()> {
     let stdout = std::io::stdout();
     let mut reader = stdin.lock();
     let mut writer = stdout.lock();
+
+    // Version handshake before the (slow) evaluator init, so the parent can
+    // reject a mid-run binary swap without waiting on libnix.
+    writer.write_all(&[EVAL_IPC_VERSION])?;
+    writer.flush()?;
 
     // Construct the evaluator once. If init fails we still loop so that the
     // parent gets an error response per request instead of a silent EOF; the
@@ -160,28 +92,30 @@ pub fn run_eval_worker() -> std::io::Result<()> {
         })
     };
 
-    let mut line = String::new();
+    // One walker (locked flake + open eval cache) reused across consecutive
+    // requests for the same repository, so a Plan/List/Resolve sequence pays
+    // the lock + cache open once. Writes are committed to the WAL after every
+    // request, so holding it open never withholds progress from shard peers.
+    let mut walkers = WalkerCache { entry: None };
+
     loop {
-        line.clear();
-        let n = match reader.read_line(&mut line) {
-            Ok(n) => n,
-            Err(e) => {
-                error!(error = %e, "eval worker: stdin read error");
-                return Err(e);
-            }
-        };
-        if n == 0 {
+        let Some(payload) = read_frame(&mut reader).inspect_err(|e| {
+            error!(error = %e, "eval worker: stdin read error");
+        })?
+        else {
             // EOF: parent closed the pipe.
             return Ok(());
-        }
+        };
 
-        let req: EvalRequest = match serde_json::from_str(line.trim_end()) {
+        let req = match decode_request(&payload) {
             Ok(r) => r,
             Err(e) => {
-                write_response(
+                // The length prefix kept the stream aligned, so an undecodable
+                // payload is per-request recoverable: report and keep serving.
+                send(
                     &mut writer,
                     &EvalResponse::Err {
-                        message: format!("malformed request: {}", e),
+                        message: format!("malformed request: {e}"),
                     },
                 )?;
                 continue;
@@ -197,184 +131,214 @@ pub fn run_eval_worker() -> std::io::Result<()> {
             EvalRequest::Plan {
                 repository,
                 wildcards,
-            } => {
-                let Some(ev) = evaluator.as_ref() else {
-                    write_response(
-                        &mut writer,
-                        &EvalResponse::Err {
-                            message: "evaluator not initialized".to_string(),
-                        },
-                    )?;
-                    continue;
-                };
+            } => with_evaluator(&evaluator, |ev| {
                 // Warnings from priming the prefix attrset resurface when each
                 // shard re-forces it, so they are not captured here.
-                let result = (|| -> anyhow::Result<Vec<String>> {
-                    let walker = ev.walker(&repository)?;
+                or_err(walkers.with(ev, &repository, |walker| {
                     let shards = walker.plan_shards(&wildcards)?;
                     let _ = walker.commit_cache();
                     Ok(shards)
-                })();
-                match result {
-                    Ok(sub_patterns) => EvalResponse::PlanOk { sub_patterns },
-                    Err(e) => EvalResponse::Err {
-                        message: format!("{:#}", e),
-                    },
-                }
-            }
+                })
+                .map(|sub_patterns| EvalResponse::PlanOk { sub_patterns }))
+            }),
             EvalRequest::List {
                 repository,
                 wildcards,
-            } => {
-                let Some(ev) = evaluator.as_ref() else {
-                    write_response(
-                        &mut writer,
-                        &EvalResponse::Err {
-                            message: "evaluator not initialized".to_string(),
-                        },
-                    )?;
-                    continue;
-                };
-                let (result, warnings) =
-                    capture_warnings_during(|| -> anyhow::Result<Vec<String>> {
-                        let walker = ev.walker(&repository)?;
+            } => with_evaluator(&evaluator, |ev| {
+                let (result, warnings) = capture_warnings_during(|| {
+                    walkers.with(ev, &repository, |walker| {
                         let attrs = walker.discover(&wildcards)?;
                         let _ = walker.commit_cache();
                         Ok(attrs)
-                    });
+                    })
+                });
                 let stats = take_delta(ev);
-                match result {
-                    Ok(attrs) => EvalResponse::ListOk {
-                        attrs,
-                        warnings,
-                        stats,
-                    },
-                    Err(e) => EvalResponse::Err {
-                        message: format!("{:#}", e),
-                    },
-                }
-            }
-            EvalRequest::Resolve { repository, attrs } => {
-                let Some(ev) = evaluator.as_ref() else {
-                    write_response(
-                        &mut writer,
-                        &EvalResponse::Err {
-                            message: "evaluator not initialized".to_string(),
-                        },
-                    )?;
-                    continue;
-                };
-
-                let mut all_warnings = Vec::new();
-                let mut items = Vec::with_capacity(attrs.len());
-                let (walker, build_warnings) = capture_warnings_during(|| ev.walker(&repository));
-                all_warnings.extend(build_warnings);
-
-                match walker {
-                    Ok(walker) => {
-                        for attr in attrs {
-                            let (result, warnings) =
-                                capture_warnings_during(|| walker.resolve(&attr));
-                            all_warnings.extend(warnings);
-                            match result {
-                                Ok((drv, references)) => items.push(ResolvedItem {
-                                    attr,
-                                    drv_path: Some(drv),
-                                    references,
-                                    error: None,
-                                }),
-                                Err(e) => items.push(ResolvedItem {
-                                    attr,
-                                    drv_path: None,
-                                    references: vec![],
-                                    error: Some(format!("{:#}", e)),
-                                }),
-                            }
-                        }
-
-                        let _ = walker.commit_cache();
-                    }
-                    Err(e) => {
-                        let msg = format!("{:#}", e);
-                        for attr in attrs {
-                            items.push(ResolvedItem {
-                                attr,
-                                drv_path: None,
-                                references: vec![],
-                                error: Some(msg.clone()),
-                            });
-                        }
-                    }
-                }
-
-                all_warnings.dedup();
-                let stats = take_delta(ev);
-                EvalResponse::ResolveOk {
-                    items,
-                    warnings: all_warnings,
+                or_err(result.map(|attrs| EvalResponse::ListOk {
+                    attrs,
+                    warnings,
                     stats,
-                }
-            }
-            EvalRequest::Fingerprint { repository } => {
-                let Some(ev) = evaluator.as_ref() else {
-                    write_response(
-                        &mut writer,
-                        &EvalResponse::Err {
-                            message: "evaluator not initialized".to_string(),
-                        },
-                    )?;
-                    continue;
-                };
-                match ev.fingerprint(&repository) {
-                    Ok(fingerprint) => EvalResponse::FingerprintOk { fingerprint },
-                    Err(e) => EvalResponse::Err {
-                        message: format!("{:#}", e),
+                }))
+            }),
+            EvalRequest::Resolve { repository, attrs } => {
+                let resp = match evaluator.as_ref() {
+                    None => EvalResponse::Err {
+                        message: "evaluator not initialized".to_string(),
                     },
-                }
-            }
-            EvalRequest::Checkpoint { repository } => {
-                let Some(ev) = evaluator.as_ref() else {
-                    write_response(
-                        &mut writer,
-                        &EvalResponse::Err {
-                            message: "evaluator not initialized".to_string(),
-                        },
-                    )?;
-                    continue;
+                    Some(ev) => {
+                        let (warnings, io) =
+                            stream_resolve(&mut writer, ev, &mut walkers, &repository, attrs);
+                        // A failed item-frame write means the parent is gone.
+                        io?;
+                        EvalResponse::ResolveEnd {
+                            warnings,
+                            stats: take_delta(ev),
+                        }
+                    }
                 };
-                let result =
-                    (|| -> anyhow::Result<()> { ev.walker(&repository)?.checkpoint_cache() })();
-                match result {
-                    Ok(()) => EvalResponse::CheckpointOk,
-                    Err(e) => EvalResponse::Err {
-                        message: format!("{:#}", e),
-                    },
-                }
+                send(&mut writer, &resp)?;
+                continue;
             }
+            EvalRequest::Fingerprint { repository } => with_evaluator(&evaluator, |ev| {
+                or_err(
+                    ev.fingerprint(&repository)
+                        .map(|fingerprint| EvalResponse::FingerprintOk { fingerprint }),
+                )
+            }),
+            EvalRequest::Checkpoint { repository } => with_evaluator(&evaluator, |ev| {
+                or_err(walkers
+                    .with(ev, &repository, |walker| walker.checkpoint_cache())
+                    .map(|()| EvalResponse::CheckpointOk))
+            }),
         };
 
-        let kind = match &resp {
-            EvalResponse::PlanOk { sub_patterns } => {
-                format!("PlanOk({} shards)", sub_patterns.len())
-            }
-            EvalResponse::ListOk { attrs, .. } => format!("ListOk({} attrs)", attrs.len()),
-            EvalResponse::ResolveOk { items, .. } => format!("ResolveOk({} items)", items.len()),
-            EvalResponse::FingerprintOk { fingerprint } => {
-                format!("FingerprintOk({})", fingerprint.is_some())
-            }
-            EvalResponse::CheckpointOk => "CheckpointOk".to_string(),
-            EvalResponse::Err { message } => format!("Err({message})"),
-        };
-        trace!(%kind, "eval worker sending response");
-        write_response(&mut writer, &resp)?;
+        trace!(kind = response_kind(&resp), "eval worker sending response");
+        send(&mut writer, &resp)?;
     }
 }
 
-fn write_response<W: Write>(w: &mut W, resp: &EvalResponse) -> std::io::Result<()> {
-    let mut bytes = serde_json::to_vec(resp).map_err(std::io::Error::other)?;
-    bytes.push(b'\n');
-    w.write_all(&bytes)?;
-    w.flush()
+/// Runs `f` against the initialized evaluator, or answers the one canonical
+/// error when libnix failed to come up (the parent then discards this worker).
+fn with_evaluator<'ev>(
+    evaluator: &'ev Option<NixEvaluator>,
+    f: impl FnOnce(&'ev NixEvaluator) -> EvalResponse,
+) -> EvalResponse {
+    match evaluator {
+        Some(ev) => f(ev),
+        None => EvalResponse::Err {
+            message: "evaluator not initialized".to_string(),
+        },
+    }
+}
+
+/// Collapses an operation's error into the wire's `Err` response.
+fn or_err(result: anyhow::Result<EvalResponse>) -> EvalResponse {
+    result.unwrap_or_else(|e| EvalResponse::Err {
+        message: format!("{e:#}"),
+    })
+}
+
+/// Single-entry walker cache keyed by repository. Consecutive requests for the
+/// same flake (the common Plan/List/Resolve sequence) reuse one locked flake +
+/// open eval cache; a different repository replaces the entry.
+struct WalkerCache<'ev> {
+    entry: Option<(String, FlakeWalker<'ev>)>,
+}
+
+impl<'ev> WalkerCache<'ev> {
+    /// The cached walker for `repository`, opening (and caching) it if absent.
+    fn open(
+        &mut self,
+        ev: &'ev NixEvaluator,
+        repository: &str,
+    ) -> anyhow::Result<&FlakeWalker<'ev>> {
+        let stale = self.entry.as_ref().is_none_or(|(repo, _)| repo != repository);
+        if stale {
+            // Drop the previous walker before locking the next flake.
+            self.entry = None;
+            let walker = ev.walker(repository)?;
+            self.entry = Some((repository.to_string(), walker));
+        }
+
+        Ok(&self.entry.as_ref().expect("entry just ensured").1)
+    }
+
+    fn with<T>(
+        &mut self,
+        ev: &'ev NixEvaluator,
+        repository: &str,
+        f: impl FnOnce(&FlakeWalker<'ev>) -> anyhow::Result<T>,
+    ) -> anyhow::Result<T> {
+        f(self.open(ev, repository)?)
+    }
+}
+
+/// Resolve each attr in order, streaming one `ResolveItem` frame per attr the
+/// moment it is resolved. Returns the batch's captured warnings plus the IO
+/// status of the frame writes. A walker that cannot open becomes one per-attr
+/// error item per attr (streamed), never a top-level `Err`, matching the
+/// per-attr isolation contract of `Resolve`.
+fn stream_resolve<'ev, W: Write>(
+    writer: &mut W,
+    ev: &'ev NixEvaluator,
+    walkers: &mut WalkerCache<'ev>,
+    repository: &str,
+    attrs: Vec<String>,
+) -> (Vec<String>, std::io::Result<()>) {
+    let mut all_warnings = Vec::new();
+    let mut io = Ok(());
+    let emit = |writer: &mut W, io: &mut std::io::Result<()>, item: ResolvedItem| {
+        if io.is_ok() {
+            *io = send(writer, &EvalResponse::ResolveItem { item });
+        }
+    };
+
+    let (walker_result, build_warnings) = capture_warnings_during(|| walkers.open(ev, repository));
+    all_warnings.extend(build_warnings);
+
+    match walker_result {
+        Ok(walker) => {
+            for attr in attrs {
+                let (result, warnings) = capture_warnings_during(|| walker.resolve(&attr));
+                all_warnings.extend(warnings);
+                let item = match result {
+                    Ok((drv, references)) => ResolvedItem {
+                        attr,
+                        drv_path: Some(drv),
+                        references,
+                        error: None,
+                    },
+                    Err(e) => ResolvedItem {
+                        attr,
+                        drv_path: None,
+                        references: vec![],
+                        error: Some(format!("{e:#}")),
+                    },
+                };
+                emit(writer, &mut io, item);
+            }
+
+            let _ = walker.commit_cache();
+        }
+        Err(e) => {
+            let msg = format!("{e:#}");
+            for attr in attrs {
+                emit(
+                    writer,
+                    &mut io,
+                    ResolvedItem {
+                        attr,
+                        drv_path: None,
+                        references: vec![],
+                        error: Some(msg.clone()),
+                    },
+                );
+            }
+        }
+    }
+
+    all_warnings.dedup();
+    (all_warnings, io)
+}
+
+fn send<W: Write>(w: &mut W, resp: &EvalResponse) -> std::io::Result<()> {
+    let payload = encode_response(resp).map_err(std::io::Error::other)?;
+    write_frame(w, &payload)
+}
+
+fn response_kind(resp: &EvalResponse) -> String {
+    match resp {
+        EvalResponse::PlanOk { sub_patterns } => format!("PlanOk({} shards)", sub_patterns.len()),
+        EvalResponse::ListOk { attrs, .. } => format!("ListOk({} attrs)", attrs.len()),
+        EvalResponse::ResolveItem { item } => format!("ResolveItem({})", item.attr),
+        EvalResponse::ResolveEnd { warnings, .. } => {
+            format!("ResolveEnd({} warnings)", warnings.len())
+        }
+        EvalResponse::FingerprintOk { fingerprint } => {
+            format!("FingerprintOk({})", fingerprint.is_some())
+        }
+        EvalResponse::CheckpointOk => "CheckpointOk".to_string(),
+        EvalResponse::Err { message } => format!("Err({message})"),
+    }
 }
 
 /// Runs `f` while capturing everything written to stderr (fd 2).
@@ -496,82 +460,5 @@ mod tests {
             parse_warnings(captured),
             vec!["warning: first", "warning: second"]
         );
-    }
-
-    #[test]
-    fn eval_request_serde_roundtrip() {
-        let requests = [
-            EvalRequest::Plan {
-                repository: "github:nixos/nixpkgs".into(),
-                wildcards: vec!["packages.*.*".into()],
-            },
-            EvalRequest::List {
-                repository: "github:nixos/nixpkgs".into(),
-                wildcards: vec!["packages.*.*".into()],
-            },
-            EvalRequest::Resolve {
-                repository: "github:nixos/nixpkgs".into(),
-                attrs: vec!["packages.x86_64-linux.hello".into()],
-            },
-            EvalRequest::Fingerprint {
-                repository: "github:nixos/nixpkgs".into(),
-            },
-            EvalRequest::Checkpoint {
-                repository: "github:nixos/nixpkgs".into(),
-            },
-            EvalRequest::Shutdown,
-        ];
-
-        for req in &requests {
-            let json = serde_json::to_string(req).expect("serialize failed");
-            let back: EvalRequest = serde_json::from_str(&json).expect("deserialize failed");
-            // Re-serialize and compare JSON strings (no PartialEq on enums)
-            assert_eq!(
-                serde_json::to_string(&back).unwrap(),
-                json,
-                "roundtrip mismatch for request"
-            );
-        }
-    }
-
-    #[test]
-    fn eval_response_serde_roundtrip() {
-        let responses: Vec<EvalResponse> = vec![
-            EvalResponse::PlanOk {
-                sub_patterns: vec!["packages.x86_64-linux.#".into()],
-            },
-            EvalResponse::ListOk {
-                attrs: vec!["packages.x86_64-linux.hello".into()],
-                warnings: vec![],
-                stats: None,
-            },
-            EvalResponse::ResolveOk {
-                items: vec![ResolvedItem {
-                    attr: "packages.x86_64-linux.hello".into(),
-                    drv_path: Some("aaaa-hello.drv".into()),
-                    references: vec![],
-                    error: None,
-                }],
-                warnings: vec![],
-                stats: None,
-            },
-            EvalResponse::FingerprintOk {
-                fingerprint: Some("deadbeef".into()),
-            },
-            EvalResponse::CheckpointOk,
-            EvalResponse::Err {
-                message: "something went wrong".into(),
-            },
-        ];
-
-        for resp in &responses {
-            let json = serde_json::to_string(resp).expect("serialize failed");
-            let back: EvalResponse = serde_json::from_str(&json).expect("deserialize failed");
-            assert_eq!(
-                serde_json::to_string(&back).unwrap(),
-                json,
-                "roundtrip mismatch for response"
-            );
-        }
     }
 }

--- a/backend/gradient-eval/src/ipc.rs
+++ b/backend/gradient-eval/src/ipc.rs
@@ -1,0 +1,315 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Wire protocol between the worker parent and its eval-worker subprocesses.
+//!
+//! Frames are `u32` little-endian payload length + rkyv bytes, following the
+//! main gradient protocol's rkyv conventions (rancor errors, 16-byte realign
+//! before decode) over a pipe instead of WebSocket message boundaries. The
+//! subprocess announces [`EVAL_IPC_VERSION`] as a single raw byte before its
+//! first frame so a parent never talks a stale binary's dialect.
+//!
+//! `Resolve` streams: the subprocess answers with one [`EvalResponse::ResolveItem`]
+//! per attr as soon as it is resolved, terminated by [`EvalResponse::ResolveEnd`].
+//! Every other request is strictly one request, one response. Streaming means a
+//! subprocess crash mid-batch only loses the attrs not yet streamed, so the
+//! parent can isolate the crasher precisely instead of bisecting the batch.
+//!
+//! Types keep serde derives alongside rkyv: JSON is never on the subprocess
+//! wire, but the worker's `--eval-driver` test harness and debug logging speak
+//! it, and the serde tags are the protocol's readable documentation.
+
+use rkyv::rancor::Error as RkyvError;
+use rkyv::util::AlignedVec;
+use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
+use serde::{Deserialize, Serialize};
+use std::io::{Read, Write};
+
+use crate::stats::StatsDelta;
+
+/// Bumped whenever the frame layout or the rkyv shape of the types below
+/// changes. Parent and subprocess are the same re-exec'd binary, so a mismatch
+/// only happens when the binary is replaced mid-run; the handshake turns that
+/// from undecodable frames into one clear error.
+pub const EVAL_IPC_VERSION: u8 = 1;
+
+/// Upper bound on a single frame's payload. Far above any real message (a
+/// discovery response for a huge flake is a few MiB); its job is to turn a
+/// corrupted length prefix into an immediate error instead of a giant alloc.
+pub const MAX_FRAME_BYTES: u32 = 64 * 1024 * 1024;
+
+/// Request from parent to worker, one frame each.
+#[derive(Debug, Clone, Archive, RkyvSerialize, RkyvDeserialize, Serialize, Deserialize)]
+#[rkyv(derive(Debug))]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum EvalRequest {
+    /// Split `wildcards` into disjoint sub-patterns (one per first-wildcard
+    /// child) so the parent can fan discovery across the pool, one shard per
+    /// system within each worker's memory budget.
+    Plan {
+        repository: String,
+        wildcards: Vec<String>,
+    },
+    /// Discover all attribute paths in `repository` matching `wildcards`.
+    List {
+        repository: String,
+        wildcards: Vec<String>,
+    },
+    /// Resolve a batch of attribute paths to `(drv_path, references)` tuples.
+    /// Answered by a `ResolveItem` stream terminated with `ResolveEnd`;
+    /// per-attr failures ride inside their item, not as a top-level `Err`.
+    Resolve {
+        repository: String,
+        attrs: Vec<String>,
+    },
+    /// Return `repository`'s eval-cache fingerprint without evaluating it.
+    /// `None` in the response for mutable/dirty flakes.
+    Fingerprint { repository: String },
+    /// Fold the eval-cache WAL into the main `.sqlite` (truncate checkpoint).
+    /// Run once after all shards finish, before the fleet-share push.
+    Checkpoint { repository: String },
+    /// Ask the worker to exit cleanly. Parent uses this on graceful shutdown.
+    Shutdown,
+}
+
+/// Response from worker to parent, one frame each.
+#[derive(Debug, Clone, Archive, RkyvSerialize, RkyvDeserialize, Serialize, Deserialize)]
+#[rkyv(derive(Debug))]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum EvalResponse {
+    PlanOk {
+        sub_patterns: Vec<String>,
+    },
+    ListOk {
+        attrs: Vec<String>,
+        warnings: Vec<String>,
+        stats: Option<StatsDelta>,
+    },
+    /// One resolved attr of an in-flight `Resolve`, streamed in request order.
+    ResolveItem { item: ResolvedItem },
+    /// Terminates a `Resolve` stream, carrying the batch-wide leftovers.
+    ResolveEnd {
+        warnings: Vec<String>,
+        stats: Option<StatsDelta>,
+    },
+    FingerprintOk {
+        fingerprint: Option<String>,
+    },
+    CheckpointOk,
+    Err {
+        message: String,
+    },
+}
+
+/// One streamed element of a `Resolve`. Either `drv_path` is set (success)
+/// or `error` is set (failure for that one attr).
+#[derive(Debug, Clone, Archive, RkyvSerialize, RkyvDeserialize, Serialize, Deserialize)]
+#[rkyv(derive(Debug))]
+pub struct ResolvedItem {
+    pub attr: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub drv_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub references: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+pub fn encode_request(req: &EvalRequest) -> Result<AlignedVec, RkyvError> {
+    rkyv::to_bytes::<RkyvError>(req)
+}
+
+pub fn encode_response(resp: &EvalResponse) -> Result<AlignedVec, RkyvError> {
+    rkyv::to_bytes::<RkyvError>(resp)
+}
+
+pub fn decode_request(bytes: &[u8]) -> Result<EvalRequest, RkyvError> {
+    rkyv::from_bytes::<EvalRequest, RkyvError>(&realign(bytes))
+}
+
+pub fn decode_response(bytes: &[u8]) -> Result<EvalResponse, RkyvError> {
+    rkyv::from_bytes::<EvalResponse, RkyvError>(&realign(bytes))
+}
+
+/// rkyv validation requires its archive-aligned input; bytes that crossed the
+/// pipe land at whatever alignment the reader's buffer had, so copy them into
+/// an [`AlignedVec`] first (same rule as the main protocol's wire decode).
+fn realign(bytes: &[u8]) -> AlignedVec {
+    let mut aligned = AlignedVec::with_capacity(bytes.len());
+    aligned.extend_from_slice(bytes);
+    aligned
+}
+
+/// Write one length-prefixed frame and flush, so a streamed item is visible to
+/// the parent even if the subprocess dies on the very next attr.
+pub fn write_frame<W: Write>(w: &mut W, payload: &[u8]) -> std::io::Result<()> {
+    let len = u32::try_from(payload.len())
+        .ok()
+        .filter(|&l| l <= MAX_FRAME_BYTES)
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("frame of {} bytes exceeds MAX_FRAME_BYTES", payload.len()),
+            )
+        })?;
+    w.write_all(&len.to_le_bytes())?;
+    w.write_all(payload)?;
+    w.flush()
+}
+
+/// Read one frame. `Ok(None)` on clean EOF at a frame boundary (the peer
+/// closed the pipe between messages); an EOF inside a frame is an error.
+pub fn read_frame<R: Read>(r: &mut R) -> std::io::Result<Option<Vec<u8>>> {
+    let mut len_buf = [0u8; 4];
+    match r.read_exact(&mut len_buf) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(e) => return Err(e),
+    }
+
+    let len = u32::from_le_bytes(len_buf);
+    if len > MAX_FRAME_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("frame length {len} exceeds MAX_FRAME_BYTES (corrupt stream?)"),
+        ));
+    }
+
+    let mut payload = vec![0u8; len as usize];
+    r.read_exact(&mut payload)?;
+    Ok(Some(payload))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roundtrip_request(req: &EvalRequest) -> EvalRequest {
+        decode_request(&encode_request(req).unwrap()).unwrap()
+    }
+
+    fn roundtrip_response(resp: &EvalResponse) -> EvalResponse {
+        decode_response(&encode_response(resp).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn requests_roundtrip_through_rkyv() {
+        let requests = [
+            EvalRequest::Plan {
+                repository: "github:nixos/nixpkgs".into(),
+                wildcards: vec!["packages.*.*".into()],
+            },
+            EvalRequest::List {
+                repository: "github:nixos/nixpkgs".into(),
+                wildcards: vec!["packages.*.*".into(), "!packages.x.broken".into()],
+            },
+            EvalRequest::Resolve {
+                repository: "github:nixos/nixpkgs".into(),
+                attrs: vec!["packages.x86_64-linux.hello".into()],
+            },
+            EvalRequest::Fingerprint {
+                repository: "github:nixos/nixpkgs".into(),
+            },
+            EvalRequest::Checkpoint {
+                repository: "github:nixos/nixpkgs".into(),
+            },
+            EvalRequest::Shutdown,
+        ];
+
+        for req in &requests {
+            assert_eq!(
+                format!("{:?}", roundtrip_request(req)),
+                format!("{req:?}"),
+                "rkyv roundtrip mismatch"
+            );
+        }
+    }
+
+    #[test]
+    fn responses_roundtrip_through_rkyv() {
+        let responses = [
+            EvalResponse::PlanOk {
+                sub_patterns: vec!["packages.x86_64-linux.#".into()],
+            },
+            EvalResponse::ListOk {
+                attrs: vec!["packages.x86_64-linux.hello".into()],
+                warnings: vec!["warning: insecure".into()],
+                stats: Some(StatsDelta {
+                    nr_thunks: 7,
+                    gc_heap_size: 42,
+                    ..Default::default()
+                }),
+            },
+            EvalResponse::ResolveItem {
+                item: ResolvedItem {
+                    attr: "packages.x86_64-linux.hello".into(),
+                    drv_path: Some("aaaa-hello.drv".into()),
+                    references: vec!["bbbb-dep".into()],
+                    error: None,
+                },
+            },
+            EvalResponse::ResolveEnd {
+                warnings: vec![],
+                stats: None,
+            },
+            EvalResponse::FingerprintOk {
+                fingerprint: Some("deadbeef".into()),
+            },
+            EvalResponse::CheckpointOk,
+            EvalResponse::Err {
+                message: "something went wrong".into(),
+            },
+        ];
+
+        for resp in &responses {
+            assert_eq!(
+                format!("{:?}", roundtrip_response(resp)),
+                format!("{resp:?}"),
+                "rkyv roundtrip mismatch"
+            );
+        }
+    }
+
+    #[test]
+    fn frames_roundtrip_and_eof_between_frames_is_clean() {
+        let mut buf = Vec::new();
+        write_frame(&mut buf, b"first").unwrap();
+        write_frame(&mut buf, b"").unwrap();
+
+        let mut r = std::io::Cursor::new(buf);
+        assert_eq!(read_frame(&mut r).unwrap().as_deref(), Some(&b"first"[..]));
+        assert_eq!(read_frame(&mut r).unwrap().as_deref(), Some(&b""[..]));
+        assert!(read_frame(&mut r).unwrap().is_none(), "clean EOF is None");
+    }
+
+    #[test]
+    fn truncated_frame_is_an_error_not_eof() {
+        let mut buf = Vec::new();
+        write_frame(&mut buf, b"payload").unwrap();
+        buf.truncate(buf.len() - 2);
+
+        let mut r = std::io::Cursor::new(buf);
+        assert!(read_frame(&mut r).is_err(), "EOF inside a frame must error");
+    }
+
+    #[test]
+    fn oversized_length_prefix_is_rejected() {
+        let mut buf = (MAX_FRAME_BYTES + 1).to_le_bytes().to_vec();
+        buf.extend_from_slice(&[0u8; 8]);
+        let mut r = std::io::Cursor::new(buf);
+        assert!(read_frame(&mut r).is_err());
+    }
+
+    #[test]
+    fn decode_survives_misaligned_input() {
+        // Simulate an arbitrary-alignment read buffer by shifting the payload
+        // one byte inside a larger allocation.
+        let bytes = encode_request(&EvalRequest::Shutdown).unwrap();
+        let mut shifted = vec![0u8; bytes.len() + 1];
+        shifted[1..].copy_from_slice(&bytes);
+        assert!(decode_request(&shifted[1..]).is_ok());
+    }
+}

--- a/backend/gradient-eval/src/lib.rs
+++ b/backend/gradient-eval/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod eval_worker;
 pub mod flake_walk;
+pub mod ipc;
 pub mod jobs;
 pub mod nix_eval;
 pub mod stats;

--- a/backend/gradient-eval/src/stats.rs
+++ b/backend/gradient-eval/src/stats.rs
@@ -7,6 +7,7 @@
 //! Eval-cache counter deltas shared by the eval-worker wire protocol and the
 //! worker's per-eval stats accumulator.
 
+use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 use serde::{Deserialize, Serialize};
 
 /// Whether per-eval metrics collection is enabled (default on). Disabling skips
@@ -21,8 +22,11 @@ pub fn metrics_enabled() -> bool {
 /// Per-request counter delta a worker reports after serving List/Resolve.
 /// Counters are diffs since the worker's prior request; gc_heap_size is the
 /// current gauge at report time. Canonical delta type, shared internally and
-/// on the eval-worker wire protocol.
-#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
+/// on the eval-worker wire protocol (rkyv frames; serde for the test driver).
+#[derive(
+    Clone, Copy, Debug, Default, Archive, RkyvSerialize, RkyvDeserialize, Serialize, Deserialize,
+)]
+#[rkyv(derive(Debug))]
 pub struct StatsDelta {
     pub nr_thunks: u64,
     pub nr_function_calls: u64,

--- a/backend/gradient-eval/src/wildcard_walk.rs
+++ b/backend/gradient-eval/src/wildcard_walk.rs
@@ -70,20 +70,46 @@ pub fn parse_pattern(pat: &str) -> (bool, Vec<String>) {
     (exclude, segs)
 }
 
-/// Walk `node` matching `segs`, pushing full dotted attr paths of matched
-/// derivations into `out`. `path` is the accumulated path to `node`.
-fn walk<N: WalkNode>(
+/// Where the shared traversal emits: full dotted attr paths of matched
+/// derivations (discovery), or one disjoint sub-pattern per first-wildcard
+/// child (shard planning). Keeping both behind one [`traverse`] makes the
+/// `*` / `#` / opaque / literal semantics structurally identical, so the
+/// split-then-union invariant holds by construction instead of by test.
+enum Sink<'a> {
+    Derivations(&'a mut Vec<String>),
+    Shards(&'a mut Vec<Vec<String>>),
+}
+
+impl Sink<'_> {
+    /// A fully matched node: discovery emits the dotted path, planning emits
+    /// the concrete segments as a wildcard-free shard.
+    fn emit_leaf(&mut self, path: Vec<String>) {
+        match self {
+            Sink::Derivations(out) => out.push(path.join(".")),
+            Sink::Shards(out) => out.push(path),
+        }
+    }
+}
+
+/// Walk `node` matching `segs`. `path` is the accumulated path to `node`.
+/// Literal segments recurse in both modes; at a wildcard segment discovery
+/// keeps walking while planning emits `path + residual` and stops, so a shard
+/// carries the unexpanded remainder for its own worker to force.
+fn traverse<N: WalkNode>(
     node: &N,
     path: &[String],
     segs: &[String],
-    out: &mut Vec<String>,
+    sink: &mut Sink<'_>,
 ) -> Result<()> {
     match segs.split_first() {
-        None => {
-            if node.is_derivation()? {
-                out.push(path.join("."));
+        None => match sink {
+            Sink::Derivations(out) => {
+                if node.is_derivation()? {
+                    out.push(path.join("."));
+                }
             }
-        }
+            Sink::Shards(out) => out.push(path.to_vec()),
+        },
         Some((seg, rest)) if seg == "*" => {
             for name in node.child_names()? {
                 let Some(child) = node.child(&name)? else {
@@ -94,26 +120,37 @@ fn walk<N: WalkNode>(
 
                 if rest.is_empty() {
                     if child.is_derivation()? {
-                        out.push(p.join("."));
+                        sink.emit_leaf(p);
                     } else if child.is_opaque()? {
                         continue;
                     } else {
-                        for sub in child.child_names()? {
-                            let Some(gc) = child.child(&sub)? else {
-                                continue;
-                            };
+                        // Trailing `*` recovers the collapsed second level:
+                        // discovery enumerates derivation grandchildren now,
+                        // planning defers that to the shard via a `#` residual.
+                        match sink {
+                            Sink::Derivations(out) => {
+                                for sub in child.child_names()? {
+                                    let Some(gc) = child.child(&sub)? else {
+                                        continue;
+                                    };
 
-                            if gc.is_derivation()? {
-                                let mut q = p.clone();
-                                q.push(sub);
-                                out.push(q.join("."));
+                                    if gc.is_derivation()? {
+                                        let mut q = p.clone();
+                                        q.push(sub);
+                                        out.push(q.join("."));
+                                    }
+                                }
+                            }
+                            Sink::Shards(out) => {
+                                p.push("#".to_string());
+                                out.push(p);
                             }
                         }
                     }
                 } else if child.is_opaque()? {
                     continue;
                 } else {
-                    walk(&child, &p, rest, out)?;
+                    descend(&child, p, rest, sink)?;
                 }
             }
         }
@@ -127,10 +164,10 @@ fn walk<N: WalkNode>(
 
                 if rest.is_empty() {
                     if child.is_derivation()? {
-                        out.push(p.join("."));
+                        sink.emit_leaf(p);
                     }
                 } else {
-                    walk(&child, &p, rest, out)?;
+                    descend(&child, p, rest, sink)?;
                 }
             }
         }
@@ -138,12 +175,31 @@ fn walk<N: WalkNode>(
             if let Some(child) = node.child(seg)? {
                 let mut p = path.to_vec();
                 p.push(seg.clone());
-                walk(&child, &p, rest, out)?;
+                traverse(&child, &p, rest, sink)?;
             }
         }
     }
 
     Ok(())
+}
+
+/// Past a wildcard: discovery recurses into the child, planning emits the
+/// shard `path + rest` so forcing beyond the first wildcard happens in the
+/// shard's own worker.
+fn descend<N: WalkNode>(
+    child: &N,
+    mut path: Vec<String>,
+    rest: &[String],
+    sink: &mut Sink<'_>,
+) -> Result<()> {
+    match sink {
+        Sink::Shards(out) => {
+            path.extend_from_slice(rest);
+            out.push(path);
+            Ok(())
+        }
+        Sink::Derivations(_) => traverse(child, &path, rest, sink),
+    }
 }
 
 /// Discover all derivation attr paths matching `includes`, minus `excludes`
@@ -156,7 +212,7 @@ pub fn discover<N: WalkNode>(
     let mut out = Vec::new();
     for inc in includes {
         let segs = collapse_stars(inc);
-        walk(root, &[], &segs, &mut out)?;
+        traverse(root, &[], &segs, &mut Sink::Derivations(&mut out))?;
     }
 
     out.retain(|p| {
@@ -190,9 +246,9 @@ pub fn discover_patterns<N: WalkNode>(root: &N, wildcards: &[String]) -> Result<
 
 /// Split `includes` into disjoint sub-patterns for memory-bounded, parallel
 /// discovery: descend each pattern's literal prefix, then expand its **first**
-/// wildcard into one concrete shard per matched child - mirroring [`walk`]'s
-/// `*`/`#`/opaque/recover-one-level branch logic so the union of `discover` over
-/// the shards equals `discover` over the original pattern. Forcing past the first
+/// wildcard into one concrete shard per matched child. The same [`traverse`]
+/// drives discovery, so the union of `discover` over the shards equals
+/// `discover` over the original pattern by construction. Forcing past the first
 /// wildcard is left to each shard's worker, so a `system`-level wildcard yields
 /// one shard per system, each sized to a single eval-worker's RAM budget. A
 /// wildcard-free pattern yields itself unchanged.
@@ -200,75 +256,10 @@ pub fn plan_shards<N: WalkNode>(root: &N, includes: &[Vec<String>]) -> Result<Ve
     let mut shards = Vec::new();
     for inc in includes {
         let segs = collapse_stars(inc);
-        plan_one(root, &[], &segs, &mut shards)?;
+        traverse(root, &[], &segs, &mut Sink::Shards(&mut shards))?;
     }
 
     Ok(shards)
-}
-
-/// One include's split. Recurses through literal segments; at the first wildcard
-/// emits a shard per matched child instead of recursing into it.
-fn plan_one<N: WalkNode>(
-    node: &N,
-    path: &[String],
-    segs: &[String],
-    out: &mut Vec<Vec<String>>,
-) -> Result<()> {
-    match segs.split_first() {
-        None => out.push(path.to_vec()),
-        Some((seg, rest)) if seg == "*" => {
-            for name in node.child_names()? {
-                let Some(child) = node.child(&name)? else {
-                    continue;
-                };
-                let mut p = path.to_vec();
-                p.push(name);
-
-                if rest.is_empty() {
-                    if child.is_derivation()? {
-                        out.push(p);
-                    } else if child.is_opaque()? {
-                        continue;
-                    } else {
-                        p.push("#".to_string());
-                        out.push(p);
-                    }
-                } else if child.is_opaque()? {
-                    continue;
-                } else {
-                    p.extend_from_slice(rest);
-                    out.push(p);
-                }
-            }
-        }
-        Some((seg, rest)) if seg == "#" => {
-            for name in node.child_names()? {
-                let Some(child) = node.child(&name)? else {
-                    continue;
-                };
-                let mut p = path.to_vec();
-                p.push(name);
-
-                if rest.is_empty() {
-                    if child.is_derivation()? {
-                        out.push(p);
-                    }
-                } else {
-                    p.extend_from_slice(rest);
-                    out.push(p);
-                }
-            }
-        }
-        Some((seg, rest)) => {
-            if let Some(child) = node.child(seg)? {
-                let mut p = path.to_vec();
-                p.push(seg.clone());
-                plan_one(&child, &p, rest, out)?;
-            }
-        }
-    }
-
-    Ok(())
 }
 
 /// Render shard segments back to a pattern string for the wire: `*`/`#` stay
@@ -539,8 +530,9 @@ mod tests {
         plan_shards(&root, &[segs(pattern)]).unwrap()
     }
 
-    /// The contract that justifies the whole split: discovering each shard and
-    /// unioning must equal discovering the original pattern in one pass.
+    /// Discovering each shard and unioning must equal discovering the original
+    /// pattern in one pass. One shared traversal makes this structural; a single
+    /// behavioural test guards the emit-vs-descend split points.
     fn assert_split_equivalent(root: &StubNode, pattern: &[&str]) {
         let original = discover(&root, &[segs(pattern)], &[]).unwrap();
 
@@ -567,7 +559,6 @@ mod tests {
                 segs(&["packages", "x86_64-linux", "#"]),
             ]
         );
-        assert_split_equivalent(&root, &["packages", "*", "*"]);
     }
 
     #[test]
@@ -580,7 +571,6 @@ mod tests {
                 segs(&["packages", "x86_64-linux", "hello"]),
             ]
         );
-        assert_split_equivalent(&root, &["packages", "*", "hello"]);
     }
 
     #[test]
@@ -593,7 +583,6 @@ mod tests {
                 segs(&["packages", "x86_64-linux", "hello"]),
             ]
         );
-        assert_split_equivalent(&root, &["packages", "x86_64-linux", "#"]);
     }
 
     #[test]

--- a/backend/gradient-worker/src/config.rs
+++ b/backend/gradient-worker/src/config.rs
@@ -78,6 +78,12 @@ pub struct WorkerConfig {
     #[arg(long, env = "GRADIENT_EVAL_WORKER", hide = true)]
     pub eval_worker: bool,
 
+    /// Drive one eval-worker subprocess over the production rkyv transport
+    /// from a JSONL request file, printing JSON responses (internal test
+    /// harness for the NixOS VM integration test).
+    #[arg(long, env = "GRADIENT_EVAL_DRIVER", hide = true)]
+    pub eval_driver: Option<String>,
+
     /// Number of parallel Nix evaluator subprocesses.
     /// Only effective when `--capability-eval` is enabled.
     #[arg(long, env = "GRADIENT_WORKER_EVAL_WORKERS", default_value_t = 1)]
@@ -405,6 +411,7 @@ mod tests {
             binpath_ssh: "ssh".to_owned(),
             gcroots_dir: String::new(),
             eval_worker: false,
+            eval_driver: None,
             eval_workers: 1,
             eval_fork_workers: 2,
             max_eval_rss: 8 * 1024 * 1024 * 1024,
@@ -502,6 +509,7 @@ mod tests {
             binpath_ssh: "ssh".to_owned(),
             gcroots_dir: String::new(),
             eval_worker: false,
+            eval_driver: None,
             eval_workers: 1,
             eval_fork_workers: 2,
             max_eval_rss: 8 * 1024 * 1024 * 1024,
@@ -576,6 +584,7 @@ mod tests {
             binpath_ssh: "ssh".to_owned(),
             gcroots_dir: String::new(),
             eval_worker: false,
+            eval_driver: None,
             eval_workers: 1,
             eval_fork_workers: 2,
             max_eval_rss: 8 * 1024 * 1024 * 1024,

--- a/backend/gradient-worker/src/executor/build.rs
+++ b/backend/gradient-worker/src/executor/build.rs
@@ -24,7 +24,7 @@ use anyhow::{Context, Result};
 use bytes::Bytes;
 use futures::StreamExt as _;
 use gradient_db::{DrvOutputSpec, parse_drv};
-use gradient_exec::path_utils::{nix_store_path, strip_nix_store_prefix};
+use gradient_exec::path_utils::{nix_store_path, strip_nix_store_prefix, strip_store_prefix};
 use gradient_util::hydra::parse_hydra_product_line;
 use gradient_sources::get_hash_from_path;
 use harmonia_protocol::daemon_wire::types2::{BuildMode, BuildResultInner, Microseconds};
@@ -43,7 +43,7 @@ use tokio::sync::watch;
 use tracing::{debug, info, warn};
 
 use crate::metrics::cgroup::{BuildMetricsRaw, read_build_cgroup};
-use crate::nix::store::{LocalNixStore, strip_store_prefix};
+use crate::nix::store::LocalNixStore;
 use crate::proto::job::JobUpdater;
 
 const BYTES_PER_MB: u64 = 1_048_576;

--- a/backend/gradient-worker/src/executor/eval.rs
+++ b/backend/gradient-worker/src/executor/eval.rs
@@ -67,7 +67,11 @@ const DRV_READ_CONCURRENCY: usize = 64;
 /// leaving headroom for the OS, the parent worker, and a concurrent build.
 const EVAL_RAM_SHARE: f64 = 0.75;
 
-/// Total physical RAM in bytes, or a 4 GiB fallback if it cannot be read.
+/// Assumed host RAM when `sysinfo` cannot read it (containers without
+/// /proc/meminfo): small enough to keep the pool conservative.
+const TOTAL_RAM_FALLBACK_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+
+/// Total physical RAM in bytes, or [`TOTAL_RAM_FALLBACK_BYTES`] if unreadable.
 fn total_memory_bytes() -> u64 {
     use sysinfo::{MemoryRefreshKind, RefreshKind, System};
     let sys = System::new_with_specifics(
@@ -75,7 +79,7 @@ fn total_memory_bytes() -> u64 {
     );
     let total = sys.total_memory();
     if total == 0 {
-        4 * 1024 * 1024 * 1024
+        TOTAL_RAM_FALLBACK_BYTES
     } else {
         total
     }

--- a/backend/gradient-worker/src/executor/mod.rs
+++ b/backend/gradient-worker/src/executor/mod.rs
@@ -138,14 +138,14 @@ pub(crate) async fn push_drv_closure(
 /// cannot be read or parsed is skipped (logged), not fatal - the daemon closure
 /// still covers it.
 async fn drv_input_sources(drv_paths: &[String]) -> std::collections::HashSet<String> {
-    use crate::nix::store::canonicalize_store_path;
     use futures::stream::{self, StreamExt as _};
+    use gradient_exec::path_utils::nix_store_path;
 
     const DRV_READ_CONCURRENCY: usize = 64;
 
     stream::iter(drv_paths.iter().cloned())
         .map(|drv_path| async move {
-            let full = canonicalize_store_path(&drv_path);
+            let full = nix_store_path(&drv_path);
             match tokio::fs::read(&full).await {
                 Ok(bytes) => match gradient_db::parse_drv(&bytes) {
                     Ok(drv) => drv.input_sources,

--- a/backend/gradient-worker/src/main.rs
+++ b/backend/gradient-worker/src/main.rs
@@ -38,9 +38,9 @@ const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
 fn main() -> Result<()> {
     let config = WorkerConfig::parse();
 
-    // stderr, not stdout: eval-worker subprocesses use stdout for line-delimited
-    // JSON to the parent (see worker_pool::pool), so any tracing line on stdout
-    // would be parsed as a protocol response and crash the eval.
+    // stderr, not stdout: eval-worker subprocesses use stdout for rkyv frames
+    // to the parent (see worker_pool::transport), so any tracing line on stdout
+    // would corrupt the frame stream and crash the eval.
     tracing_subscriber::fmt()
         .with_env_filter(build_env_filter(&config))
         .with_writer(std::io::stderr)
@@ -50,6 +50,16 @@ fn main() -> Result<()> {
     // The Nix C API (Boehm GC) must run single-threaded, isolated from Tokio.
     if config.eval_worker {
         return nix::eval_worker::run_eval_worker().map_err(anyhow::Error::from);
+    }
+
+    // Internal JSONL harness over the eval-worker transport (VM test seam).
+    if let Some(requests_path) = config.eval_driver.clone() {
+        let rt = tokio::runtime::Runtime::new()?;
+        let code = rt.block_on(worker_pool::driver::run_eval_driver(
+            &requests_path,
+            &config.eval_cache_dir(),
+        ))?;
+        std::process::exit(code);
     }
 
     // Must precede the first TLS handshake - `connect_async` for `wss://` is

--- a/backend/gradient-worker/src/nix/gcroots.rs
+++ b/backend/gradient-worker/src/nix/gcroots.rs
@@ -19,6 +19,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
+use gradient_exec::path_utils::strip_store_prefix;
 use tokio::fs;
 use tracing::{debug, warn};
 
@@ -90,7 +91,7 @@ impl GcRootKeeper {
         let Some(dir) = self.inner.dir.as_ref() else {
             return GcRootHandle::inert();
         };
-        let hash_name = store_path.strip_prefix("/nix/store/").unwrap_or(store_path);
+        let hash_name = strip_store_prefix(store_path);
         let symlink = dir.join(hash_name);
 
         if let Err(e) = create_symlink_idempotent(&symlink, store_path).await {

--- a/backend/gradient-worker/src/nix/store.rs
+++ b/backend/gradient-worker/src/nix/store.rs
@@ -30,6 +30,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use gradient_exec::path_utils::{nix_store_path, strip_store_prefix};
 use harmonia_store_path::StorePath;
 use harmonia_store_remote::pool::{ConnectionPool, PoolConfig, PooledConnectionGuard};
 use harmonia_store_remote::{DaemonClient, DaemonStore as _};
@@ -175,18 +176,10 @@ impl LocalNixStore {
         Ok(info
             .references
             .iter()
-            .map(|r| canonicalize_store_path(&r.to_string()))
+            .map(|r| nix_store_path(&r.to_string()))
             .collect())
     }
 
-    /// BFS the runtime reference closure of `seeds` via `query_path_info`.
-    ///
-    /// Returns every reachable store path including the seeds themselves,
-    /// each canonicalised to `/nix/store/<hash>-<name>` form so consumers
-    /// (e.g. NAR push) see a single, well-defined string per path.
-    /// Paths that fail individual `query_references` calls (e.g. removed
-    /// between calls) are logged and skipped - the walk continues so the
-    /// caller still gets a best-effort closure for the remaining paths.
     /// Register `gcroot_symlink` as an indirect GC root with the daemon.
     ///
     /// The caller must have already created the symlink on disk; the daemon
@@ -208,11 +201,19 @@ impl LocalNixStore {
         }
     }
 
+    /// BFS the runtime reference closure of `seeds` via `query_path_info`.
+    ///
+    /// Returns every reachable store path including the seeds themselves,
+    /// each canonicalised to `/nix/store/<hash>-<name>` form so consumers
+    /// (e.g. NAR push) see a single, well-defined string per path.
+    /// Paths that fail individual `query_references` calls (e.g. removed
+    /// between calls) are logged and skipped - the walk continues so the
+    /// caller still gets a best-effort closure for the remaining paths.
     pub async fn collect_runtime_closure(&self, seeds: &[String]) -> HashSet<String> {
         let mut visited: HashSet<String> = HashSet::new();
         let mut queue: VecDeque<String> = VecDeque::new();
         for s in seeds {
-            queue.push_back(canonicalize_store_path(s));
+            queue.push_back(nix_store_path(s));
         }
         while let Some(path) = queue.pop_front() {
             if !visited.insert(path.clone()) {
@@ -296,26 +297,11 @@ impl<G: DiscardOnDrop> Drop for ScopedGuard<G> {
     }
 }
 
-/// Normalise to absolute `/nix/store/<hash>-<name>`. Bare hash-name input is
-/// prefixed; already-absolute input is left as-is.
-pub(crate) fn canonicalize_store_path(path: &str) -> String {
-    if path.starts_with('/') {
-        path.to_owned()
-    } else {
-        format!("/nix/store/{}", path)
-    }
-}
-
 #[async_trait]
 impl WorkerStore for LocalNixStore {
     async fn has_path(&self, store_path: &str) -> Result<bool> {
         self.has_path(store_path).await
     }
-}
-
-/// Strips `/nix/store/` prefix, returning just the hash-name component.
-pub(crate) fn strip_store_prefix(path: &str) -> &str {
-    path.strip_prefix("/nix/store/").unwrap_or(path)
 }
 
 #[cfg(test)]
@@ -355,22 +341,6 @@ mod tests {
             "connection_timeout must tolerate a saturated daemon's handshake; \
              the 10 s harmonia default fails prefetch imports under load; got {:?}",
             cfg.connection_timeout
-        );
-    }
-
-    #[test]
-    fn canonicalize_store_path_prefixes_bare_hash_name() {
-        assert_eq!(
-            canonicalize_store_path("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-foo"),
-            "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-foo"
-        );
-    }
-
-    #[test]
-    fn canonicalize_store_path_preserves_absolute() {
-        assert_eq!(
-            canonicalize_store_path("/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-foo"),
-            "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-foo"
         );
     }
 

--- a/backend/gradient-worker/src/proto/nar.rs
+++ b/backend/gradient-worker/src/proto/nar.rs
@@ -26,8 +26,10 @@ use gradient_proto::messages::ClientMessage;
 use sha2::{Digest, Sha256};
 use tracing::{debug, warn};
 
+use gradient_exec::path_utils::{nix_store_path, strip_store_prefix};
+
 use crate::connection::ProtoWriter;
-use crate::nix::store::{LocalNixStore, strip_store_prefix};
+use crate::nix::store::LocalNixStore;
 use crate::proto::nar_recv::NarReceiver;
 
 /// Chunk size for direct NAR streaming (4 MiB). Sized to amortise per-message
@@ -59,20 +61,6 @@ fn trim_for_resume(
     } else {
         let skip = (resume_from - produced) as usize;
         Some((resume_from, skip..part_len))
-    }
-}
-
-/// Normalise a store path so it always carries the `/nix/store/` prefix.
-///
-/// Some upstream sources (e.g. eval-worker `FlakeWalker::resolve`) return drv
-/// paths as bare hash-name strings. NarByteStream needs the absolute filesystem
-/// path, and the server stores `cached_path.store_path` verbatim - both must
-/// see the canonical `/nix/store/<hash>-<name>` form.
-fn ensure_full_store_path(path: &str) -> String {
-    if path.starts_with('/') {
-        path.to_owned()
-    } else {
-        format!("/nix/store/{}", path)
     }
 }
 
@@ -189,7 +177,7 @@ pub async fn push_direct(
     nar_recv: &NarReceiver,
     store: Option<&LocalNixStore>,
 ) -> Result<()> {
-    let store_path = ensure_full_store_path(store_path);
+    let store_path = nix_store_path(store_path);
     let store_path = store_path.as_str();
     debug!(store_path, "NAR direct push");
 
@@ -354,7 +342,7 @@ pub async fn upload_presigned_compressed(
     headers: &[(String, String)],
     writer: &ProtoWriter,
 ) -> Result<()> {
-    let store_path = ensure_full_store_path(store_path);
+    let store_path = nix_store_path(store_path);
     let store_path = store_path.as_str();
 
     let client = crate::http::client();
@@ -415,7 +403,7 @@ pub async fn push_compressed_direct(
     writer: &ProtoWriter,
     nar_recv: &NarReceiver,
 ) -> Result<()> {
-    let store_path = ensure_full_store_path(store_path);
+    let store_path = nix_store_path(store_path);
     let store_path = store_path.as_str();
     debug!(store_path, bytes = compressed.len(), "compressed NAR direct push");
 
@@ -488,7 +476,7 @@ pub async fn upload_presigned(
     writer: &ProtoWriter,
     store: Option<&LocalNixStore>,
 ) -> Result<()> {
-    let store_path = ensure_full_store_path(store_path);
+    let store_path = nix_store_path(store_path);
     let store_path = store_path.as_str();
     debug!(store_path, method, "presigned NAR upload");
 
@@ -570,26 +558,6 @@ pub async fn upload_presigned(
 mod tests {
     use super::*;
     use gradient_test_support::prelude::MockProtoServer;
-
-    #[test]
-    fn ensure_full_store_path_prefixes_bare_hash_name() {
-        assert_eq!(
-            ensure_full_store_path("25sx4kmwawf8kixj5a6mvpbjwyh8hm7m-gradient-1.1.1.drv"),
-            "/nix/store/25sx4kmwawf8kixj5a6mvpbjwyh8hm7m-gradient-1.1.1.drv",
-        );
-    }
-
-    #[test]
-    fn ensure_full_store_path_preserves_absolute() {
-        let p = "/nix/store/aaaa-foo";
-        assert_eq!(ensure_full_store_path(p), p);
-    }
-
-    #[test]
-    fn ensure_full_store_path_preserves_other_absolute_paths() {
-        let p = "/tmp/some/test/dir";
-        assert_eq!(ensure_full_store_path(p), p);
-    }
 
     /// Create a temporary directory with a single file and return its path.
     ///

--- a/backend/gradient-worker/src/traits.rs
+++ b/backend/gradient-worker/src/traits.rs
@@ -10,6 +10,7 @@ pub use gradient_proto::traits::{DrvReader, JobReporter};
 
 use anyhow::Result;
 use async_trait::async_trait;
+use gradient_exec::path_utils::nix_store_path;
 
 /// Production [`DrvReader`] that reads from the filesystem.
 pub struct FsDrvReader;
@@ -17,11 +18,7 @@ pub struct FsDrvReader;
 #[async_trait]
 impl DrvReader for FsDrvReader {
     async fn read_drv(&self, store_path: &str) -> Result<Vec<u8>> {
-        let full_path = if store_path.starts_with('/') {
-            store_path.to_string()
-        } else {
-            format!("/nix/store/{}", store_path)
-        };
+        let full_path = nix_store_path(store_path);
         let bytes = tokio::fs::read(&full_path).await?;
         Ok(bytes)
     }

--- a/backend/gradient-worker/src/worker_pool/driver.rs
+++ b/backend/gradient-worker/src/worker_pool/driver.rs
@@ -1,0 +1,81 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! JSONL harness for the eval-worker IPC, behind the hidden `--eval-driver`
+//! flag. Reads [`EvalRequest`]s as JSON lines, drives one real subprocess over
+//! the production rkyv transport (spawn, handshake, frames, streamed resolve),
+//! and prints one JSON response line per request. Exists for the NixOS VM
+//! integration test, which cannot speak binary frames from Python; going
+//! through [`EvalWorker`] means the test covers both sides of the wire.
+
+use anyhow::{Context, Result};
+use serde_json::json;
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
+
+use super::transport::EvalWorker;
+use gradient_eval::ipc::EvalRequest;
+
+pub async fn run_eval_driver(requests_path: &str, eval_cache_dir: &str) -> Result<i32> {
+    let text = tokio::fs::read_to_string(requests_path)
+        .await
+        .with_context(|| format!("reading eval driver requests from {requests_path}"))?;
+
+    let live = Arc::new(Mutex::new(HashSet::new()));
+    let mut worker = EvalWorker::spawn(eval_cache_dir, live)
+        .await
+        .context("spawning eval worker for driver")?;
+
+    for line in text.lines().filter(|l| !l.trim().is_empty()) {
+        let req: EvalRequest =
+            serde_json::from_str(line).with_context(|| format!("parsing request: {line}"))?;
+
+        let output = match req {
+            EvalRequest::Shutdown => {
+                worker.shutdown().await;
+                return Ok(0);
+            }
+            EvalRequest::Plan {
+                repository,
+                wildcards,
+            } => worker
+                .plan(repository, wildcards)
+                .await
+                .map(|sub_patterns| json!({"kind": "plan_ok", "sub_patterns": sub_patterns})),
+            EvalRequest::List {
+                repository,
+                wildcards,
+            } => worker
+                .list(repository, wildcards)
+                .await
+                .map(|(attrs, warnings, _stats)| {
+                    json!({"kind": "list_ok", "attrs": attrs, "warnings": warnings})
+                }),
+            EvalRequest::Resolve { repository, attrs } => {
+                let (items, end) = worker.resolve(repository, attrs).await;
+                end.map(|(warnings, _stats)| {
+                    json!({"kind": "resolve_ok", "items": items, "warnings": warnings})
+                })
+            }
+            EvalRequest::Fingerprint { repository } => worker
+                .fingerprint(repository)
+                .await
+                .map(|fingerprint| json!({"kind": "fingerprint_ok", "fingerprint": fingerprint})),
+            EvalRequest::Checkpoint { repository } => worker
+                .checkpoint(repository)
+                .await
+                .map(|()| json!({"kind": "checkpoint_ok"})),
+        };
+
+        match output {
+            Ok(v) => println!("{v}"),
+            Err(e) => println!("{}", json!({"kind": "err", "message": format!("{e:#}")})),
+        }
+    }
+
+    worker.shutdown().await;
+    Ok(0)
+}

--- a/backend/gradient-worker/src/worker_pool/memory.rs
+++ b/backend/gradient-worker/src/worker_pool/memory.rs
@@ -1,0 +1,140 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Memory accounting for the eval pool: the pool-size budget, the free-RAM
+//! guard margin, and the background reaper that converts host memory pressure
+//! into one bounded eval failure instead of a host OOM.
+
+use std::sync::Weak;
+use std::time::Duration;
+use tracing::warn;
+
+use super::pool::EvalWorkerPool;
+
+/// How often the reaper samples host `MemAvailable`.
+const REAPER_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Eval-pool size that keeps `size * max_eval_rss` within `ram_budget` (the
+/// no-OOM invariant), capped at the configured `fork_workers` and floored at 1
+/// so even a tiny host still evaluates - one shard at a time, slower, but it
+/// completes. Lowering `max_eval_rss` therefore trades parallelism for a smaller
+/// footprint, never the ability to finish.
+pub fn budgeted_pool_size(fork_workers: usize, max_eval_rss: u64, ram_budget: u64) -> usize {
+    let mem_bound = (ram_budget / max_eval_rss.max(1)).max(1) as usize;
+
+    fork_workers.min(mem_bound).max(1)
+}
+
+/// Adaptive free-RAM margin (bytes): the configured `min_free_ram_mb` if set,
+/// else `max(1 GiB, 10% of total RAM)`. Below this the reaper acts and `acquire`
+/// back-pressures. Lifted out for unit testing.
+pub fn memory_guard_bytes(min_free_ram_mb: u64, total_ram_bytes: u64) -> u64 {
+    if min_free_ram_mb > 0 {
+        min_free_ram_mb * 1024 * 1024
+    } else {
+        (total_ram_bytes / 10).max(1024 * 1024 * 1024)
+    }
+}
+
+/// RSS (bytes) of an arbitrary pid from `/proc/<pid>/statm` (field 2 = resident
+/// pages x 4 KiB). `None` if the pid is gone or the read fails. A sub-page
+/// procfs read; cheap enough for async callers without a spawn_blocking hop.
+#[cfg(target_os = "linux")]
+pub(super) fn rss_of_pid(pid: u32) -> Option<u64> {
+    let statm = std::fs::read_to_string(format!("/proc/{pid}/statm")).ok()?;
+    statm
+        .split_whitespace()
+        .nth(1)
+        .and_then(|pages| pages.parse::<u64>().ok())
+        .map(|pages| pages * 4096)
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(super) fn rss_of_pid(_pid: u32) -> Option<u64> {
+    None
+}
+
+/// Background memory guard: when host `MemAvailable` drops below
+/// `min_free_bytes`, SIGKILL the largest live eval subprocess so a runaway
+/// evaluation cannot take the whole host down. The victim's parent task then
+/// sees its pipe close and reports the eval failed - converting a would-be host
+/// OOM (which could kill the worker itself and strand the job, since the server
+/// only learns of a clean disconnect) into a single bounded eval failure.
+///
+/// Exits when the pool is dropped (worker shutdown). A no-op when disabled.
+pub(super) async fn memory_reaper_loop(pool: Weak<EvalWorkerPool>, min_free_bytes: u64) {
+    if min_free_bytes == 0 {
+        return;
+    }
+
+    use sysinfo::{MemoryRefreshKind, RefreshKind, System};
+    let mut sys = System::new_with_specifics(
+        RefreshKind::nothing().with_memory(MemoryRefreshKind::nothing().with_ram()),
+    );
+    let mut interval = tokio::time::interval(REAPER_INTERVAL);
+    loop {
+        interval.tick().await;
+        let Some(pool) = pool.upgrade() else {
+            return;
+        };
+
+        sys.refresh_memory();
+        let available = sys.available_memory();
+        let pressured = available < min_free_bytes;
+        pool.note_pressure(pressured);
+        if !pressured {
+            continue;
+        }
+
+        let victim = pool
+            .live_pids()
+            .into_iter()
+            .filter_map(|pid| rss_of_pid(pid).map(|rss| (pid, rss)))
+            .max_by_key(|&(_, rss)| rss);
+        if let Some((pid, rss)) = victim {
+            warn!(
+                pid,
+                rss_mb = rss / (1024 * 1024),
+                available_mb = available / (1024 * 1024),
+                min_free_mb = min_free_bytes / (1024 * 1024),
+                "host memory below safety margin; reaping largest eval subprocess to avoid OOM"
+            );
+            #[cfg(unix)]
+            unsafe {
+                libc::kill(pid as i32, libc::SIGKILL);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GIB: u64 = 1024 * 1024 * 1024;
+
+    #[test]
+    fn budgeted_pool_size_caps_by_memory() {
+        // 8 GiB box, 2 GiB cap, 75% budget (6 GiB) -> 3 shards, capped at cores.
+        assert_eq!(budgeted_pool_size(16, 2 * GIB, 6 * GIB), 3);
+        // Plenty of RAM -> the configured worker count wins.
+        assert_eq!(budgeted_pool_size(8, 2 * GIB, 256 * GIB), 8);
+        // Cap >= budget -> still one worker (slower, but never zero).
+        assert_eq!(budgeted_pool_size(16, 8 * GIB, 6 * GIB), 1);
+        // Degenerate cap never divides by zero.
+        assert_eq!(budgeted_pool_size(4, 0, 6 * GIB), 4);
+    }
+
+    #[test]
+    fn memory_guard_bytes_configured_and_adaptive() {
+        // A configured margin wins, converted MiB -> bytes.
+        assert_eq!(memory_guard_bytes(2048, 64 * GIB), 2048 * 1024 * 1024);
+        // Adaptive: 10% of total when that clears the 1 GiB floor.
+        assert_eq!(memory_guard_bytes(0, 64 * GIB), 64 * GIB / 10);
+        // Adaptive floor: at least 1 GiB on a small host (10% of 4 GiB < 1 GiB).
+        assert_eq!(memory_guard_bytes(0, 4 * GIB), GIB);
+    }
+}

--- a/backend/gradient-worker/src/worker_pool/mod.rs
+++ b/backend/gradient-worker/src/worker_pool/mod.rs
@@ -4,9 +4,17 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+//! The eval-worker subprocess pool, split along its seams: [`transport`] owns
+//! one subprocess handle + the rkyv frame wire, [`pool`] the checkout/return
+//! lifecycle, [`memory`] the RAM budget and reaper, [`resolver`] the pooled
+//! fan-out driving it all, and [`driver`] a JSONL test harness over the lot.
+
+pub mod driver;
 pub(crate) mod eval_stats;
+mod memory;
 mod pool;
 mod resolver;
+mod transport;
 
-pub use self::pool::{budgeted_pool_size, memory_guard_bytes};
+pub use self::memory::{budgeted_pool_size, memory_guard_bytes};
 pub use self::resolver::WorkerPoolResolver;

--- a/backend/gradient-worker/src/worker_pool/pool.rs
+++ b/backend/gradient-worker/src/worker_pool/pool.rs
@@ -4,484 +4,33 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+//! Pool lifecycle for eval-worker subprocesses: lazy spawn, test-on-borrow
+//! checkout, RAII return, and graceful shutdown. The subprocess handle and
+//! wire transport live in [`super::transport`], the RAM math and reaper in
+//! [`super::memory`].
+
 use anyhow::{Context, Result};
 use futures::stream::{FuturesUnordered, StreamExt};
 use std::collections::HashSet;
 use std::ops::{Deref, DerefMut};
-use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
-use tracing::{debug, error, trace, warn};
+use tracing::{debug, trace};
 
-use crate::nix::eval_worker::{EvalRequest, EvalResponse, ResolvedItem};
-use crate::worker_pool::eval_stats::StatsDelta;
+use super::transport::EvalWorker;
 
-/// Handle to a single live eval-worker subprocess.
-///
-/// Owns the child plus its piped stdin/stdout. Each request writes one JSON
-/// line to stdin and reads one JSON line back from stdout - the protocol is
-/// strictly request/response so a single buffer is sufficient.
-pub struct EvalWorker {
-    child: Child,
-    stdin: ChildStdin,
-    stdout: BufReader<ChildStdout>,
-    line: String,
-    /// Number of `list` / `resolve` calls served since spawn. The pool
-    /// uses this to recycle the subprocess after a configurable number
-    /// of evaluations so Nix's Boehm-GC-allocated memory (which is
-    /// never released back to the OS) cannot grow unbounded.
-    pub(super) evaluations_served: usize,
-    /// RAII deregistration of this subprocess's pid from the pool's live
-    /// registry. A field (rather than `impl Drop for EvalWorker`) so `shutdown`
-    /// can still move individual fields out of `self`.
-    pid_guard: PidGuard,
-}
-
-/// Removes an eval subprocess pid from the pool's live registry on drop, so the
-/// memory reaper never targets a worker we have already discarded. The child
-/// itself is reaped by `kill_on_drop`.
-struct PidGuard {
-    /// Live-pid registry of the owning pool. `None` for test workers built via
-    /// `from_command` (no pool, nothing to deregister from).
-    live: Option<Arc<Mutex<HashSet<u32>>>>,
-    pid: Option<u32>,
-}
-
-impl Drop for PidGuard {
-    fn drop(&mut self) {
-        if let (Some(live), Some(pid)) = (&self.live, self.pid) {
-            live.lock().unwrap().remove(&pid);
-        }
-    }
-}
-
-impl EvalWorker {
-    /// Spawn a new worker by re-execing the current binary with `--eval-worker`.
-    /// The subprocess is single-threaded and does not fork; pool size is the
-    /// eval concurrency and RSS is bounded parent-side (see [`Self::rss_bytes`]).
-    ///
-    /// `eval_cache_dir` is exported as `NIX_CACHE_HOME` so parent and worker
-    /// agree on where Nix's `eval-cache-v6/<fingerprint>.sqlite` lives.
-    pub(super) async fn spawn(
-        eval_cache_dir: &str,
-        live: Arc<Mutex<HashSet<u32>>>,
-    ) -> Result<Self> {
-        let exe = std::env::current_exe().context("locating current executable")?;
-        trace!(exe = %exe.display(), "spawning eval worker subprocess");
-        let mut command = Command::new(&exe);
-        command.arg("--eval-worker");
-        command.env("NIX_CACHE_HOME", eval_cache_dir);
-        for &(k, v) in super::eval_stats::eval_worker_stats_env(super::eval_stats::metrics_enabled()) {
-            command.env(k, v);
-        }
-
-        // Match the Nix CLI: bump the subprocess's stack to 64 MiB so libnix's
-        // libstdc++ std::regex DFS executor (used by `builtins.match` /
-        // `builtins.split`) doesn't overflow on deep patterns. Upstream Nix
-        // calls `setStackSize(64 * 1024 * 1024)` in `initNix`; we use the C
-        // API directly and inherit the default 8 MiB, which is too small for
-        // some flakes.
-        // SAFETY: `pre_exec` runs in the forked child before `exec`, so its body
-        // must be async-signal-safe; it only builds an `rlimit` and calls
-        // `setrlimit`, both of which are signal-safe.
-        #[cfg(unix)]
-        unsafe {
-            command.pre_exec(|| {
-                let lim = libc::rlimit {
-                    rlim_cur: 64 * 1024 * 1024,
-                    rlim_max: 64 * 1024 * 1024,
-                };
-                if libc::setrlimit(libc::RLIMIT_STACK, &lim) != 0 {
-                    return Err(std::io::Error::last_os_error());
-                }
-                Ok(())
-            });
-        }
-
-        let mut worker = Self::from_command(command)?;
-
-        // Register the pid so the memory reaper can find this subprocess even
-        // while it is checked out of the pool. Deregistered by `PidGuard`.
-        if let Some(pid) = worker.pid_guard.pid {
-            live.lock().unwrap().insert(pid);
-        }
-        worker.pid_guard.live = Some(live);
-
-        // Mark the subprocess as the preferred OOM-kill target so that the kernel
-        // sacrifices eval workers (which hold large Nix/Boehm-GC heaps) before
-        // the parent process or other services when memory runs low.
-        #[cfg(target_os = "linux")]
-        if let Some(pid) = worker.child.id() {
-            let path = format!("/proc/{pid}/oom_score_adj");
-            if let Err(e) = std::fs::write(&path, "600") {
-                tracing::warn!(pid, error = %e, "failed to set oom_score_adj for eval worker");
-            }
-        }
-
-        Ok(worker)
-    }
-
-    /// Spawn the given pre-configured command and wrap its stdin/stdout into
-    /// an [`EvalWorker`]. Test seam used by pool tests to stand up a
-    /// controllable subprocess (e.g. `cat`) without depending on libnix.
-    fn from_command(mut command: Command) -> Result<Self> {
-        command
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::inherit())
-            .kill_on_drop(true);
-        let mut child = command.spawn().context("spawning eval worker subprocess")?;
-        let pid = child.id();
-        let stdin = child.stdin.take().context("worker stdin missing")?;
-        let stdout = BufReader::new(child.stdout.take().context("worker stdout missing")?);
-        Ok(Self {
-            child,
-            stdin,
-            stdout,
-            line: String::new(),
-            evaluations_served: 0,
-            pid_guard: PidGuard { live: None, pid },
-        })
-    }
-
-    pub(super) fn pid(&self) -> Option<u32> {
-        self.child.id()
-    }
-
-    /// Whether the subprocess is still running, reaping its exit status if it
-    /// has already exited. The pool calls this on checkout to discard an idle
-    /// worker whose subprocess died while pooled (memory reaper, kernel OOM via
-    /// the elevated `oom_score_adj`, or crash) instead of handing out a corpse
-    /// that fails the next write with a broken pipe.
-    fn is_alive(&mut self) -> bool {
-        matches!(self.child.try_wait(), Ok(None))
-    }
-
-    /// Send one request and read one response. Errors here mean the worker is
-    /// no longer usable (the caller marks it dead so it gets discarded
-    /// instead of being returned to the pool).
-    async fn request(&mut self, req: &EvalRequest) -> Result<EvalResponse> {
-        trace!(pid = self.child.id(), ?req, "sending eval worker request");
-        let mut bytes = serde_json::to_vec(req).context("serializing request")?;
-        bytes.push(b'\n');
-        self.stdin
-            .write_all(&bytes)
-            .await
-            .context("writing to eval worker stdin")?;
-
-        self.stdin
-            .flush()
-            .await
-            .context("flushing eval worker stdin")?;
-
-        self.line.clear();
-        let n = self
-            .stdout
-            .read_line(&mut self.line)
-            .await
-            .context("reading eval worker response")?;
-
-        if n == 0 {
-            let pid = self.child.id();
-            let status =
-                match tokio::time::timeout(std::time::Duration::from_secs(2), self.child.wait())
-                    .await
-                {
-                    Ok(Ok(s)) => format!("{s}"),
-                    Ok(Err(e)) => format!("wait error: {e}"),
-                    Err(_) => {
-                        let mut diag = String::from("still alive after 2s");
-                        if let Some(p) = pid {
-                            if let Ok(target) = std::fs::read_link(format!("/proc/{p}/fd/1")) {
-                                diag.push_str(&format!("; /proc/{p}/fd/1 -> {}", target.display()));
-                            }
-                            if let Ok(state) = std::fs::read_to_string(format!("/proc/{p}/status"))
-                                && let Some(line) = state.lines().find(|l| l.starts_with("State:"))
-                            {
-                                diag.push_str(&format!("; {line}"));
-                            }
-                            if let Ok(wchan) = std::fs::read_to_string(format!("/proc/{p}/wchan")) {
-                                diag.push_str(&format!("; wchan={}", wchan.trim()));
-                            }
-                        }
-                        diag
-                    }
-                };
-            anyhow::bail!("eval worker closed pipe (pid={pid:?}, exit={status})");
-        }
-
-        trace!(
-            pid = self.child.id(),
-            bytes = n,
-            "received eval worker response"
-        );
-        serde_json::from_str(self.line.trim_end())
-            .inspect_err(|error| {
-                error!(
-                    %error,
-                    raw_input = self.line.trim_end(),
-                    "Failed to parse eval worker JSON response"
-                );
-            })
-            .context("parsing eval worker response")
-    }
-
-    pub(super) async fn plan(
-        &mut self,
-        repository: String,
-        wildcards: Vec<String>,
-    ) -> Result<Vec<String>> {
-        self.evaluations_served += 1;
-        match self
-            .request(&EvalRequest::Plan {
-                repository,
-                wildcards,
-            })
-            .await?
-        {
-            EvalResponse::PlanOk { sub_patterns } => Ok(sub_patterns),
-            EvalResponse::Err { message } => Err(anyhow::anyhow!("eval worker: {}", message)),
-            _ => anyhow::bail!("eval worker: unexpected response to Plan"),
-        }
-    }
-
-    pub(super) async fn list(
-        &mut self,
-        repository: String,
-        wildcards: Vec<String>,
-    ) -> Result<(Vec<String>, Vec<String>, Option<StatsDelta>)> {
-        self.evaluations_served += 1;
-        match self
-            .request(&EvalRequest::List {
-                repository,
-                wildcards,
-            })
-            .await?
-        {
-            EvalResponse::ListOk {
-                attrs,
-                warnings,
-                stats,
-            } => Ok((attrs, warnings, stats)),
-            EvalResponse::Err { message } => Err(anyhow::anyhow!("eval worker: {}", message)),
-            _ => anyhow::bail!("eval worker: unexpected response to List"),
-        }
-    }
-
-    pub(super) async fn fingerprint(&mut self, repository: String) -> Result<Option<String>> {
-        self.evaluations_served += 1;
-        match self
-            .request(&EvalRequest::Fingerprint { repository })
-            .await?
-        {
-            EvalResponse::FingerprintOk { fingerprint } => Ok(fingerprint),
-            EvalResponse::Err { message } => Err(anyhow::anyhow!("eval worker: {}", message)),
-            _ => anyhow::bail!("eval worker: unexpected response to Fingerprint"),
-        }
-    }
-
-    pub(super) async fn checkpoint(&mut self, repository: String) -> Result<()> {
-        self.evaluations_served += 1;
-        match self
-            .request(&EvalRequest::Checkpoint { repository })
-            .await?
-        {
-            EvalResponse::CheckpointOk => Ok(()),
-            EvalResponse::Err { message } => Err(anyhow::anyhow!("eval worker: {}", message)),
-            _ => anyhow::bail!("eval worker: unexpected response to Checkpoint"),
-        }
-    }
-
-    /// Send a `Shutdown` request and wait briefly for the child to exit.
-    /// Used when the parent is recycling a still-healthy worker so the
-    /// subprocess can run libnix's atexit handlers (flush eval-cache
-    /// SQLite, release locks, drop temp roots) instead of being SIGKILL'd
-    /// by `kill_on_drop`.
-    pub(super) async fn shutdown(mut self) {
-        let pid = self.child.id();
-        trace!(pid, "sending Shutdown to eval worker");
-        let mut bytes = match serde_json::to_vec(&EvalRequest::Shutdown) {
-            Ok(b) => b,
-            Err(e) => {
-                warn!(pid, error = %e, "failed to serialize Shutdown request");
-                return;
-            }
-        };
-        bytes.push(b'\n');
-        if let Err(e) = self.stdin.write_all(&bytes).await {
-            debug!(pid, error = %e, "failed to write Shutdown to eval worker");
-            return;
-        }
-        let _ = self.stdin.flush().await;
-        drop(self.stdin);
-        trace!(pid, "Shutdown sent; waiting for eval worker to exit");
-        match tokio::time::timeout(std::time::Duration::from_secs(5), self.child.wait()).await {
-            Ok(Ok(status)) => trace!(pid, ?status, "eval worker exited cleanly"),
-            Ok(Err(e)) => debug!(pid, error = %e, "waiting on eval worker exit failed"),
-            Err(_) => warn!(
-                pid,
-                "eval worker did not exit within 5s of Shutdown; will be killed"
-            ),
-        }
-    }
-
-    pub(super) async fn resolve(
-        &mut self,
-        repository: String,
-        attrs: Vec<String>,
-    ) -> Result<(Vec<ResolvedItem>, Vec<String>, Option<StatsDelta>)> {
-        self.evaluations_served += 1;
-        match self
-            .request(&EvalRequest::Resolve { repository, attrs })
-            .await?
-        {
-            EvalResponse::ResolveOk {
-                items,
-                warnings,
-                stats,
-            } => Ok((items, warnings, stats)),
-            EvalResponse::Err { message } => Err(anyhow::anyhow!("eval worker: {}", message)),
-            _ => anyhow::bail!("eval worker: unexpected response to Resolve"),
-        }
-    }
-
-    /// Resident set size of the subprocess in bytes, read from
-    /// `/proc/<pid>/statm` (field 2 = resident pages × 4 KiB). Returns 0 if
-    /// the pid is gone or the read fails so the pool never panics on it.
-    #[cfg(target_os = "linux")]
-    pub(super) fn rss_bytes(&self) -> u64 {
-        let Some(pid) = self.child.id() else {
-            return 0;
-        };
-
-        let Ok(statm) = std::fs::read_to_string(format!("/proc/{pid}/statm")) else {
-            return 0;
-        };
-
-        statm
-            .split_whitespace()
-            .nth(1)
-            .and_then(|pages| pages.parse::<u64>().ok())
-            .map(|pages| pages * 4096)
-            .unwrap_or(0)
-    }
-
-    #[cfg(not(target_os = "linux"))]
-    pub(super) fn rss_bytes(&self) -> u64 {
-        0
-    }
-}
-
-impl std::fmt::Debug for EvalWorker {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("EvalWorker")
-            .field("pid", &self.child.id())
-            .finish()
-    }
-}
-
-/// Eval-pool size that keeps `size * max_eval_rss` within `ram_budget` (the
-/// no-OOM invariant), capped at the configured `fork_workers` and floored at 1
-/// so even a tiny host still evaluates - one shard at a time, slower, but it
-/// completes. Lowering `max_eval_rss` therefore trades parallelism for a smaller
-/// footprint, never the ability to finish.
-pub fn budgeted_pool_size(fork_workers: usize, max_eval_rss: u64, ram_budget: u64) -> usize {
-    let mem_bound = (ram_budget / max_eval_rss.max(1)).max(1) as usize;
-
-    fork_workers.min(mem_bound).max(1)
-}
-
-/// Adaptive free-RAM margin (bytes): the configured `min_free_ram_mb` if set,
-/// else `max(1 GiB, 10% of total RAM)`. Below this the reaper acts and `acquire`
-/// back-pressures. Lifted out for unit testing.
-pub fn memory_guard_bytes(min_free_ram_mb: u64, total_ram_bytes: u64) -> u64 {
-    if min_free_ram_mb > 0 {
-        min_free_ram_mb * 1024 * 1024
-    } else {
-        (total_ram_bytes / 10).max(1024 * 1024 * 1024)
-    }
-}
-
-/// RSS (bytes) of an arbitrary pid from `/proc/<pid>/statm` (field 2 = resident
-/// pages × 4 KiB). `None` if the pid is gone or the read fails.
-#[cfg(target_os = "linux")]
-fn rss_of_pid(pid: u32) -> Option<u64> {
-    let statm = std::fs::read_to_string(format!("/proc/{pid}/statm")).ok()?;
-    statm
-        .split_whitespace()
-        .nth(1)
-        .and_then(|pages| pages.parse::<u64>().ok())
-        .map(|pages| pages * 4096)
-}
-
-#[cfg(not(target_os = "linux"))]
-fn rss_of_pid(_pid: u32) -> Option<u64> {
-    None
-}
-
-/// Background memory guard: when host `MemAvailable` drops below
-/// `min_free_bytes`, SIGKILL the largest live eval subprocess so a runaway
-/// evaluation cannot take the whole host down. The victim's parent task then
-/// sees its pipe close and reports the eval failed - converting a would-be host
-/// OOM (which could kill the worker itself and strand the job, since the server
-/// only learns of a clean disconnect) into a single bounded eval failure.
-///
-/// Exits when the pool is dropped (worker shutdown). A no-op when disabled.
-pub(super) async fn memory_reaper_loop(pool: std::sync::Weak<EvalWorkerPool>, min_free_bytes: u64) {
-    if min_free_bytes == 0 {
-        return;
-    }
-
-    use sysinfo::{MemoryRefreshKind, RefreshKind, System};
-    let mut sys = System::new_with_specifics(
-        RefreshKind::nothing().with_memory(MemoryRefreshKind::nothing().with_ram()),
-    );
-    let mut interval = tokio::time::interval(Duration::from_millis(500));
-    loop {
-        interval.tick().await;
-        let Some(pool) = pool.upgrade() else {
-            return;
-        };
-
-        sys.refresh_memory();
-        let available = sys.available_memory();
-        let pressured = available < min_free_bytes;
-        pool.under_pressure.store(pressured, Ordering::Relaxed);
-        if !pressured {
-            continue;
-        }
-
-        let victim = pool
-            .live_pids()
-            .into_iter()
-            .filter_map(|pid| rss_of_pid(pid).map(|rss| (pid, rss)))
-            .max_by_key(|&(_, rss)| rss);
-        if let Some((pid, rss)) = victim {
-            warn!(
-                pid,
-                rss_mb = rss / (1024 * 1024),
-                available_mb = available / (1024 * 1024),
-                min_free_mb = min_free_bytes / (1024 * 1024),
-                "host memory below safety margin; reaping largest eval subprocess to avoid OOM"
-            );
-            #[cfg(unix)]
-            unsafe {
-                libc::kill(pid as i32, libc::SIGKILL);
-            }
-        }
-    }
-}
+/// How long `acquire` sleeps between pressure checks while the host is below
+/// the free-RAM margin.
+const PRESSURE_BACKOFF: Duration = Duration::from_millis(200);
 
 /// Pool of [`EvalWorker`]s.
 ///
 /// Workers are created lazily on `acquire`. Idle workers are reused; broken
 /// ones are discarded so the next `acquire` spawns a fresh replacement.
 #[derive(Debug)]
-pub struct EvalWorkerPool {
+pub(super) struct EvalWorkerPool {
     idle: Arc<Mutex<Vec<EvalWorker>>>,
     semaphore: Arc<Semaphore>,
     max: usize,
@@ -507,7 +56,7 @@ pub struct EvalWorkerPool {
 }
 
 impl EvalWorkerPool {
-    pub fn new(max: usize, max_eval_rss: u64, eval_cache_dir: String) -> Self {
+    pub(super) fn new(max: usize, max_eval_rss: u64, eval_cache_dir: String) -> Self {
         let max = max.max(1);
         Self {
             idle: Arc::new(Mutex::new(Vec::new())),
@@ -522,17 +71,17 @@ impl EvalWorkerPool {
         }
     }
 
-    pub fn max(&self) -> usize {
+    pub(super) fn max(&self) -> usize {
         self.max
     }
 
-    pub fn max_eval_rss(&self) -> u64 {
+    pub(super) fn max_eval_rss(&self) -> u64 {
         self.max_eval_rss
     }
 
     /// Arm the memory guard: the back-pressure margin read by `acquire`. The
     /// reaper loop uses the same value. `0` leaves it disabled.
-    pub fn configure_memory_guard(&self, min_free_bytes: u64) {
+    pub(super) fn configure_memory_guard(&self, min_free_bytes: u64) {
         self.min_free_bytes.store(min_free_bytes, Ordering::Relaxed);
     }
 
@@ -541,9 +90,14 @@ impl EvalWorkerPool {
         self.live.lock().unwrap().iter().copied().collect()
     }
 
+    /// Reaper feedback: latches the pressure flag `acquire` throttles on.
+    pub(super) fn note_pressure(&self, pressured: bool) {
+        self.under_pressure.store(pressured, Ordering::Relaxed);
+    }
+
     /// Acquire a worker, blocking until one is available. Reuses an idle
     /// worker if any, otherwise spawns a fresh subprocess.
-    pub async fn acquire(&self) -> Result<PooledEvalWorker> {
+    pub(super) async fn acquire(&self) -> Result<PooledEvalWorker> {
         let permit = Arc::clone(&self.semaphore)
             .acquire_owned()
             .await
@@ -557,7 +111,7 @@ impl EvalWorkerPool {
             && self.under_pressure.load(Ordering::Relaxed)
             && self.semaphore.available_permits() + 1 < self.max
         {
-            tokio::time::sleep(Duration::from_millis(200)).await;
+            tokio::time::sleep(PRESSURE_BACKOFF).await;
         }
 
         // Test-on-borrow: an idle subprocess can die while pooled (memory
@@ -587,7 +141,6 @@ impl EvalWorkerPool {
             worker: Some(worker),
             idle: Arc::clone(&self.idle),
             healthy: true,
-            recycle_after: 0,
             shutting_down: Arc::clone(&self.shutting_down),
             _permit: permit,
         })
@@ -600,10 +153,10 @@ impl EvalWorkerPool {
     /// that gets dropped after this point gracefully terminates its
     /// subprocess instead of being returned to the idle vec), then
     /// concurrently sends `Shutdown` to every currently-idle worker and
-    /// waits up to 5 s per worker for it to exit.
+    /// waits for each within the transport's grace period.
     ///
     /// Idempotent.
-    pub async fn shutdown(&self) {
+    pub(super) async fn shutdown(&self) {
         // Order matters: set the flag BEFORE closing the semaphore. If we
         // closed first, an in-flight `acquire().await` could resolve with
         // an Err, bypass `PooledEvalWorker::drop` entirely, and the parent
@@ -644,23 +197,44 @@ impl EvalWorkerPool {
     }
 }
 
+/// What `PooledEvalWorker::drop` does with its worker, computed once from
+/// the pool state + health so the action code exists exactly once.
+#[derive(Debug, PartialEq, Eq)]
+enum Disposition {
+    /// Pool is shutting down and the worker is healthy: let the subprocess
+    /// run libnix's atexit handlers instead of SIGKILL via `kill_on_drop`.
+    GracefulShutdown,
+    /// Healthy worker, pool still open: back into the idle vec for reuse.
+    ReturnToIdle,
+    /// Broken (or the pool cannot take it back): drop it, `kill_on_drop`
+    /// ensures the child does not linger.
+    Kill,
+}
+
+fn dispose(shutting_down: bool, healthy: bool) -> Disposition {
+    match (shutting_down, healthy) {
+        (true, true) => Disposition::GracefulShutdown,
+        (false, true) => Disposition::ReturnToIdle,
+        (_, false) => Disposition::Kill,
+    }
+}
+
 /// RAII handle returned by [`EvalWorkerPool::acquire`].
 ///
 /// Dereferences to `&mut EvalWorker`. On drop, returns the worker to the pool
 /// if [`PooledEvalWorker::healthy`] is `true`, otherwise discards it (the
 /// child is killed by `kill_on_drop`).
-pub struct PooledEvalWorker {
+pub(super) struct PooledEvalWorker {
     worker: Option<EvalWorker>,
     idle: Arc<Mutex<Vec<EvalWorker>>>,
     healthy: bool,
-    recycle_after: usize,
     shutting_down: Arc<AtomicBool>,
     _permit: OwnedSemaphorePermit,
 }
 
 impl PooledEvalWorker {
     /// Mark this worker as broken so it won't be returned to the pool.
-    pub fn mark_dead(&mut self) {
+    pub(super) fn mark_dead(&mut self) {
         self.healthy = false;
     }
 }
@@ -680,57 +254,33 @@ impl DerefMut for PooledEvalWorker {
 
 impl Drop for PooledEvalWorker {
     fn drop(&mut self) {
-        if let Some(worker) = self.worker.take() {
-            // Pool is shutting down: gracefully terminate the subprocess so
-            // it can run libnix's atexit handlers instead of being SIGKILL'd
-            // by `kill_on_drop`. Mirrors the recycle path below.
-            if self.shutting_down.load(Ordering::SeqCst) {
-                if self.healthy {
-                    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-                        trace!("pool shutting down; gracefully terminating eval worker");
-                        handle.spawn(async move {
-                            worker.shutdown().await;
-                        });
-                        return;
-                    }
+        let Some(worker) = self.worker.take() else {
+            return;
+        };
+
+        match dispose(self.shutting_down.load(Ordering::SeqCst), self.healthy) {
+            Disposition::GracefulShutdown => {
+                if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                    trace!("pool shutting down; gracefully terminating eval worker");
+                    handle.spawn(worker.shutdown());
+                } else {
+                    // No runtime to drive the graceful path: kill_on_drop it.
                     trace!("pool shutting down; no tokio runtime - killing eval worker via Drop");
+                    drop(worker);
                 }
-                drop(worker);
-                return;
             }
-
-            // recycle disabled; RSS-based reclamation lands in a later task
-            let overused =
-                self.recycle_after > 0 && worker.evaluations_served >= self.recycle_after;
-            if overused {
-                debug!(
-                    evaluations = worker.evaluations_served,
-                    "recycling eval worker (max evaluations reached)"
-                );
-                if self.healthy {
-                    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-                        trace!("scheduling graceful shutdown of eval worker");
-                        handle.spawn(async move {
-                            worker.shutdown().await;
-                        });
-                        return;
-                    }
-                    trace!("no tokio runtime available; killing eval worker via Drop");
+            Disposition::ReturnToIdle => {
+                if let Ok(mut idle) = self.idle.lock() {
+                    idle.push(worker);
+                } else {
+                    debug!("discarding eval worker (idle mutex poisoned)");
+                    drop(worker);
                 }
+            }
+            Disposition::Kill => {
+                debug!("discarding eval worker (unhealthy)");
                 drop(worker);
-                return;
             }
-
-            if self.healthy
-                && let Ok(mut idle) = self.idle.lock()
-            {
-                idle.push(worker);
-                return;
-            }
-            // Unhealthy or poisoned mutex: drop the worker. `kill_on_drop`
-            // ensures the child does not linger.
-            debug!("discarding eval worker (unhealthy or pool poisoned)");
-            drop(worker);
         }
     }
 }
@@ -739,11 +289,12 @@ impl Drop for PooledEvalWorker {
 mod tests {
     use super::*;
     use std::time::Duration;
+    use tokio::process::Command;
 
     /// Spawn a `cat` subprocess wrapped as an `EvalWorker`. `cat` echoes
     /// stdin to stdout and exits cleanly when stdin closes - exactly the
     /// behaviour `EvalWorker::shutdown` relies on (it writes the Shutdown
-    /// JSON line then drops stdin).
+    /// frame then drops stdin).
     fn fake_worker() -> EvalWorker {
         EvalWorker::from_command(Command::new("cat")).expect("spawn cat")
     }
@@ -753,12 +304,20 @@ mod tests {
     /// it sat in the pool.
     async fn dead_worker() -> EvalWorker {
         let mut w = fake_worker();
-        w.child.start_kill().expect("kill cat");
-        w.child.wait().await.expect("reap cat");
+        w.child_mut().start_kill().expect("kill cat");
+        w.child_mut().wait().await.expect("reap cat");
         w
     }
 
     const GIB: u64 = 1024 * 1024 * 1024;
+
+    #[test]
+    fn disposition_covers_all_states() {
+        assert_eq!(dispose(true, true), Disposition::GracefulShutdown);
+        assert_eq!(dispose(false, true), Disposition::ReturnToIdle);
+        assert_eq!(dispose(true, false), Disposition::Kill);
+        assert_eq!(dispose(false, false), Disposition::Kill);
+    }
 
     #[tokio::test]
     async fn acquire_skips_dead_idle_worker() {
@@ -781,29 +340,9 @@ mod tests {
     }
 
     #[test]
-    fn budgeted_pool_size_caps_by_memory() {
-        // 8 GiB box, 2 GiB cap, 75% budget (6 GiB) -> 3 shards, capped at cores.
-        assert_eq!(budgeted_pool_size(16, 2 * GIB, 6 * GIB), 3);
-        // Plenty of RAM -> the configured worker count wins.
-        assert_eq!(budgeted_pool_size(8, 2 * GIB, 256 * GIB), 8);
-        // Cap >= budget -> still one worker (slower, but never zero).
-        assert_eq!(budgeted_pool_size(16, 8 * GIB, 6 * GIB), 1);
-        // Degenerate cap never divides by zero.
-        assert_eq!(budgeted_pool_size(4, 0, 6 * GIB), 4);
-    }
-
-    #[test]
-    fn memory_guard_bytes_configured_and_adaptive() {
-        // A configured margin wins, converted MiB -> bytes.
-        assert_eq!(memory_guard_bytes(2048, 64 * GIB), 2048 * 1024 * 1024);
-        // Adaptive: 10% of total when that clears the 1 GiB floor.
-        assert_eq!(memory_guard_bytes(0, 64 * GIB), 64 * GIB / 10);
-        // Adaptive floor: at least 1 GiB on a small host (10% of 4 GiB < 1 GiB).
-        assert_eq!(memory_guard_bytes(0, 4 * GIB), GIB);
-    }
-
-    #[test]
     fn pid_guard_deregisters_pid_on_drop() {
+        use super::super::transport::PidGuard;
+
         let live = Arc::new(Mutex::new(HashSet::new()));
         live.lock().unwrap().insert(4242u32);
         {
@@ -821,7 +360,7 @@ mod tests {
 
     #[tokio::test]
     async fn shutdown_with_no_idle_workers_returns_immediately() {
-        let pool = EvalWorkerPool::new(2, 2 * 1024 * 1024 * 1024, String::new());
+        let pool = EvalWorkerPool::new(2, 2 * GIB, String::new());
         tokio::time::timeout(Duration::from_secs(1), pool.shutdown())
             .await
             .expect("shutdown should not hang on empty pool");
@@ -831,14 +370,14 @@ mod tests {
 
     #[tokio::test]
     async fn shutdown_drains_idle_workers_gracefully() {
-        let pool = EvalWorkerPool::new(2, 2 * 1024 * 1024 * 1024, String::new());
+        let pool = EvalWorkerPool::new(2, 2 * GIB, String::new());
         pool.push_for_test(fake_worker());
         pool.push_for_test(fake_worker());
         assert_eq!(pool.idle_count(), 2);
 
         tokio::time::timeout(Duration::from_secs(6), pool.shutdown())
             .await
-            .expect("shutdown should complete within the per-worker 5s budget");
+            .expect("shutdown should complete within the per-worker grace budget");
 
         assert!(pool.is_shutting_down());
         assert_eq!(pool.idle_count(), 0, "idle vec must be drained");
@@ -846,7 +385,7 @@ mod tests {
 
     #[tokio::test]
     async fn acquire_after_shutdown_errors() {
-        let pool = EvalWorkerPool::new(2, 2 * 1024 * 1024 * 1024, String::new());
+        let pool = EvalWorkerPool::new(2, 2 * GIB, String::new());
         pool.shutdown().await;
         match pool.acquire().await {
             Ok(_) => panic!("acquire after shutdown must fail"),
@@ -859,11 +398,7 @@ mod tests {
 
     #[tokio::test]
     async fn inflight_worker_shuts_down_gracefully_on_pool_shutdown() {
-        let pool = Arc::new(EvalWorkerPool::new(
-            1,
-            2 * 1024 * 1024 * 1024,
-            String::new(),
-        ));
+        let pool = Arc::new(EvalWorkerPool::new(1, 2 * GIB, String::new()));
         pool.push_for_test(fake_worker());
 
         let pooled = pool.acquire().await.expect("acquire");

--- a/backend/gradient-worker/src/worker_pool/resolver.rs
+++ b/backend/gradient-worker/src/worker_pool/resolver.rs
@@ -9,29 +9,25 @@ use async_trait::async_trait;
 use futures::future::BoxFuture;
 use futures::stream::{FuturesUnordered, StreamExt};
 use gradient_db::{Derivation, parse_drv};
+use gradient_eval::ipc::ResolvedItem;
+use gradient_exec::path_utils::nix_store_path;
 use gradient_nix::{DerivationResolver, ResolvedDerivation};
+use std::collections::VecDeque;
+use std::future::Future;
 use std::sync::{Arc, Mutex};
+use tracing::debug;
 
-use super::pool::EvalWorkerPool;
-use crate::nix::eval_worker::ResolvedItem;
-use crate::worker_pool::eval_stats::{EvalStatsAccumulator, EvalStatsTotals, StatsDelta};
-
-/// Strips `/nix/store/` and returns just the hash-name component (mirrors the
-/// helper in [`super::resolver`]).
-fn nix_store_path(hash_name: &str) -> String {
-    if hash_name.starts_with('/') {
-        hash_name.to_string()
-    } else {
-        format!("/nix/store/{}", hash_name)
-    }
-}
+use super::eval_stats::{EvalStatsAccumulator, EvalStatsTotals, StatsDelta};
+use super::pool::{EvalWorkerPool, PooledEvalWorker};
 
 /// `DerivationResolver` impl that drives an [`EvalWorkerPool`].
 ///
-/// `list_flake_derivations` is dispatched to a single worker (the wildcard
-/// `*` is recursive in the cursor walk, so one call discovers all depths).
-/// `resolve_derivation_paths` splits attrs across the pool for parallelism and
-/// bisects on subprocess crash so one bad attr never fails the whole eval.
+/// `list_flake_derivations` plans per-system shards on one worker and fans
+/// them across the pool; `resolve_derivation_paths` splits attrs into batches
+/// the same way. Both fan-outs run through [`pooled_fan_out`] and recover from
+/// subprocess crashes with the same [`MAX_CRASH_ATTEMPTS`] tolerance: a shard
+/// retries whole (its response is atomic), a resolve batch salvages its
+/// streamed prefix and isolates the exact in-flight attr.
 /// `get_derivation` and `get_features` parse `.drv` files directly from disk.
 #[derive(Debug)]
 pub struct WorkerPoolResolver {
@@ -43,10 +39,23 @@ pub struct WorkerPoolResolver {
     /// The eval's user entry-point patterns, set by `list_flake_derivations` so
     /// the later resolve pass can bucket each delta under its owning pattern.
     patterns: Arc<Mutex<Vec<String>>>,
+    /// Warning sink for the resolve pass: batches funnel their `ResolveEnd`
+    /// warnings here, drained once per `resolve_derivation_paths` call.
+    resolve_warnings: Arc<Mutex<Vec<String>>>,
 }
 
 /// One resolved attr keyed by its index in the original request.
 type IndexedDerivation = (usize, ResolvedDerivation);
+
+/// Crashes tolerated for a single work item (a shard, or one attr) before it
+/// becomes an error. Shared by listing and resolving so both recover from a
+/// subprocess death with the same tolerance.
+const MAX_CRASH_ATTEMPTS: u32 = 2;
+
+/// Upper bound on attrs resolved in a single worker call, so one batch's
+/// eval-heap growth stays small relative to `max_eval_rss` (the worker's heap
+/// persists across batches and is recycled once it crosses the cap).
+const MAX_RESOLVE_BATCH: usize = 64;
 
 /// Pick `attr`'s owning entry-point: the longest wildcard `pattern` whose
 /// segments all match `attr`'s leading segments (a `*` segment matches any one
@@ -86,7 +95,8 @@ fn item_to_resolved(item: ResolvedItem) -> ResolvedDerivation {
     (item.attr, result)
 }
 
-/// Per-attr error recorded when a subprocess crashes twice on the same attr.
+/// Per-attr error recorded when a subprocess crashes on the same attr
+/// [`MAX_CRASH_ATTEMPTS`] times.
 fn crashed_derivation(attr: String) -> ResolvedDerivation {
     (
         attr,
@@ -96,26 +106,61 @@ fn crashed_derivation(attr: String) -> ResolvedDerivation {
     )
 }
 
-/// Resolves one batch of attrs on a single fresh worker. `Ok` means the
-/// subprocess lived (per-attr eval errors ride inside the items); `Err` means
-/// it crashed mid-batch. Injected so the crash-isolation policy is testable
-/// without real subprocesses.
-type ResolveOnce<'a> = dyn Fn(Vec<String>) -> BoxFuture<'a, Result<Vec<ResolvedItem>>> + Sync + 'a;
+/// Dynamic work queue over the pool: `workers` loops each pull the next item
+/// as soon as they are free, so one slow item never leaves the rest of the
+/// pool idle. The first hard error drains the fan-out and propagates.
+async fn pooled_fan_out<T, Fut>(
+    workers: usize,
+    items: Vec<T>,
+    run: impl Fn(T) -> Fut + Sync,
+) -> Result<()>
+where
+    T: Send,
+    Fut: Future<Output = Result<()>>,
+{
+    let queue = Mutex::new(VecDeque::from(items));
+    let (queue, run) = (&queue, &run);
+    let mut tasks: FuturesUnordered<_> = (0..workers.max(1))
+        .map(|_| async move {
+            loop {
+                // Scope the pop so the guard drops before the await; holding
+                // it across `.await` would deadlock the executor.
+                let item = queue.lock().unwrap().pop_front();
+                let Some(item) = item else { break };
+                run(item).await?;
+            }
 
-/// Crashes tolerated for a single attr before it becomes a per-attr error.
-const MAX_CRASH_ATTEMPTS: u32 = 2;
+            Ok::<(), anyhow::Error>(())
+        })
+        .collect();
 
-/// Upper bound on attrs resolved in a single worker call, so one batch's
-/// eval-heap growth stays small relative to `max_eval_rss` (the worker's heap
-/// persists across batches and is recycled once it crosses the cap).
-const MAX_RESOLVE_BATCH: usize = 64;
+    while let Some(drained) = tasks.next().await {
+        drained?;
+    }
 
-/// Pure crash-isolation policy. Resolves `chunk` via `resolve_once`; an `Err`
-/// (subprocess crash, never a per-attr eval failure) is recovered by bisection:
-/// split a multi-attr chunk in half so the crasher is isolated in `O(log n)`
-/// while the rest resolve, and retry a single attr once before recording a
-/// per-attr error. `attempt` counts crashes for a single-attr chunk, capped at
-/// [`MAX_CRASH_ATTEMPTS`].
+    Ok(())
+}
+
+/// Outcome of resolving one batch on one worker. `Complete` means the
+/// subprocess lived through `ResolveEnd` (per-attr eval errors ride inside
+/// the items); `Crashed` means it died mid-stream, keeping the item frames
+/// that made it out.
+enum BatchCall {
+    Complete(Vec<ResolvedItem>),
+    Crashed { streamed: Vec<ResolvedItem> },
+}
+
+/// Resolves one batch of attrs on a single pooled worker. Injected so the
+/// crash-isolation policy is testable without real subprocesses.
+type ResolveOnce<'a> = dyn Fn(Vec<String>) -> BoxFuture<'a, Result<BatchCall>> + Sync + 'a;
+
+/// Pure crash-isolation policy over the streamed `Resolve` protocol.
+///
+/// A crash keeps every item streamed before the subprocess died; the first
+/// unstreamed attr is the one that was in flight, so it is retried alone on a
+/// fresh worker (up to [`MAX_CRASH_ATTEMPTS`] attempts total, then a per-attr
+/// error) while the untouched remainder resolves independently. No bisection:
+/// streaming pinpoints the suspect in one step.
 fn resolve_chunk<'a>(
     resolve_once: &'a ResolveOnce<'a>,
     mut chunk: Vec<(usize, String)>,
@@ -127,15 +172,14 @@ fn resolve_chunk<'a>(
         }
 
         let attrs: Vec<String> = chunk.iter().map(|(_, a)| a.clone()).collect();
-        match resolve_once(attrs).await {
-            Ok(items) => {
-                if items.len() != chunk.len() {
-                    anyhow::bail!(
-                        "eval worker returned {} items for {} attrs",
-                        items.len(),
-                        chunk.len()
-                    );
-                }
+        match resolve_once(attrs).await? {
+            BatchCall::Complete(items) => {
+                anyhow::ensure!(
+                    items.len() == chunk.len(),
+                    "eval worker returned {} items for {} attrs",
+                    items.len(),
+                    chunk.len()
+                );
 
                 Ok(chunk
                     .into_iter()
@@ -143,23 +187,50 @@ fn resolve_chunk<'a>(
                     .map(|((idx, _attr), item)| (idx, item_to_resolved(item)))
                     .collect())
             }
-            Err(_crash) if chunk.len() == 1 => {
-                let (idx, attr) = chunk.into_iter().next().expect("len == 1");
+            BatchCall::Crashed { streamed } => {
+                anyhow::ensure!(
+                    streamed.len() <= chunk.len(),
+                    "eval worker streamed {} items for {} attrs",
+                    streamed.len(),
+                    chunk.len()
+                );
+
+                let rest = chunk.split_off(streamed.len());
+                for ((_, want), got) in chunk.iter().zip(&streamed) {
+                    anyhow::ensure!(
+                        &got.attr == want,
+                        "eval worker streamed item for '{}' where '{want}' was expected",
+                        got.attr
+                    );
+                }
+                let mut done: Vec<IndexedDerivation> = chunk
+                    .into_iter()
+                    .zip(streamed)
+                    .map(|((idx, _attr), item)| (idx, item_to_resolved(item)))
+                    .collect();
+
+                let mut rest = rest.into_iter();
+                let Some((idx, suspect)) = rest.next() else {
+                    // Died between the last item and ResolveEnd: every attr
+                    // resolved; only the batch's warnings/stats are lost.
+                    return Ok(done);
+                };
+                let remainder: Vec<_> = rest.collect();
+
                 if attempt + 1 >= MAX_CRASH_ATTEMPTS {
-                    return Ok(vec![(idx, crashed_derivation(attr))]);
+                    done.push((idx, crashed_derivation(suspect)));
+                    done.extend(resolve_chunk(resolve_once, remainder, 0).await?);
+                    return Ok(done);
                 }
 
-                resolve_chunk(resolve_once, vec![(idx, attr)], attempt + 1).await
-            }
-            Err(_crash) => {
-                let right = chunk.split_off(chunk.len() / 2);
-                let (mut a, b) = futures::future::try_join(
-                    resolve_chunk(resolve_once, chunk, 0),
-                    resolve_chunk(resolve_once, right, 0),
+                let (retried, resolved) = futures::future::try_join(
+                    resolve_chunk(resolve_once, vec![(idx, suspect)], attempt + 1),
+                    resolve_chunk(resolve_once, remainder, 0),
                 )
                 .await?;
-                a.extend(b);
-                Ok(a)
+                done.extend(retried);
+                done.extend(resolved);
+                Ok(done)
             }
         }
     })
@@ -176,6 +247,7 @@ impl WorkerPoolResolver {
             eval_cache_dir,
             stats: Arc::new(Mutex::new(EvalStatsAccumulator::default())),
             patterns: Arc::new(Mutex::new(Vec::new())),
+            resolve_warnings: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -190,12 +262,35 @@ impl WorkerPoolResolver {
         }
 
         let weak = Arc::downgrade(&self.pool);
-        tokio::spawn(super::pool::memory_reaper_loop(weak, min_free_bytes));
+        tokio::spawn(super::memory::memory_reaper_loop(weak, min_free_bytes));
     }
 
     /// Bucket one worker delta under `entry_point`, folding peak RSS in too.
     fn observe_stats(&self, entry_point: &str, delta: StatsDelta, rss: u64) {
         self.stats.lock().unwrap().observe(entry_point, delta, rss);
+    }
+
+    /// Post-call bookkeeping shared by every successful worker call: record
+    /// the stats delta and discard an over-RSS worker so its eval heap is
+    /// reclaimed before the next call (progress is durable in the eval cache).
+    fn finish_call(&self, worker: &mut PooledEvalWorker, bucket: &str, stats: Option<StatsDelta>) {
+        let rss = worker.rss_bytes();
+        if let Some(delta) = stats {
+            self.observe_stats(bucket, delta, rss);
+        }
+        if rss > self.pool.max_eval_rss() {
+            worker.mark_dead();
+        }
+    }
+
+    /// The entry-point bucket a call's stats delta is attributed to: the batch
+    /// delta is one number, so it goes whole to the first attr's entry-point;
+    /// the dynamic queue keeps batches small and same-prefix, so cross-bucket
+    /// bleed is minor.
+    fn bucket_of(&self, first_attr: Option<&String>) -> String {
+        first_attr
+            .map(|a| entry_point_of(a, &self.patterns.lock().unwrap()))
+            .unwrap_or_default()
     }
 
     /// Drain the accumulated per-eval stats, resetting the accumulator so the
@@ -219,8 +314,8 @@ impl WorkerPoolResolver {
     }
 
     /// Return `repository`'s eval-cache fingerprint without evaluating it.
-    /// `None` for mutable/dirty flakes. Mirrors [`Self::list_flake_derivations`]:
-    /// a dead worker is marked so it gets discarded instead of reused.
+    /// `None` for mutable/dirty flakes. A dead worker is marked so it gets
+    /// discarded instead of reused.
     pub async fn fingerprint(&self, repository: String) -> Result<Option<String>> {
         let mut worker = self.pool.acquire().await?;
         match worker.fingerprint(repository).await {
@@ -247,45 +342,42 @@ impl WorkerPoolResolver {
         }
     }
 
-    /// Discover one shard on a pooled worker, retrying once on a fresh worker
-    /// if the subprocess crashes (a transient stack/OOM death). A shard that
-    /// crashes twice propagates the error, failing the whole listing - matching
-    /// the single-worker behaviour this replaces.
+    /// Discover one shard, retrying on a fresh worker after a subprocess crash
+    /// up to [`MAX_CRASH_ATTEMPTS`] total attempts (the resolve-side tolerance).
+    /// A shard's response is atomic, so recovery is a whole-shard retry; a
+    /// shard that keeps crashing fails the whole listing, matching the
+    /// single-worker behaviour this replaces.
     async fn list_shard(
         &self,
         repository: &str,
         wildcards: Vec<String>,
     ) -> Result<(Vec<String>, Vec<String>)> {
-        match self.list_once(repository, wildcards.clone()).await {
-            Ok(v) => Ok(v),
-            Err(_crash) => self.list_once(repository, wildcards).await,
+        let mut attempt = 0;
+        loop {
+            match self.list_once(repository, wildcards.clone()).await {
+                Ok(v) => return Ok(v),
+                Err(crash) => {
+                    attempt += 1;
+                    if attempt >= MAX_CRASH_ATTEMPTS {
+                        return Err(crash);
+                    }
+                }
+            }
         }
     }
 
-    /// Discover one shard on a single worker. An over-RSS worker is discarded
-    /// after a successful call so its eval heap is reclaimed before the next
-    /// shard (progress is already durable in the eval cache); a crash marks the
-    /// worker dead. Mirrors [`Self::resolve_once`].
+    /// Discover one shard on a single pooled worker; a crash marks the worker
+    /// dead and surfaces as `Err` for [`Self::list_shard`] to retry.
     async fn list_once(
         &self,
         repository: &str,
         wildcards: Vec<String>,
     ) -> Result<(Vec<String>, Vec<String>)> {
-        let bucket = wildcards
-            .first()
-            .map(|w| entry_point_of(w, &self.patterns.lock().unwrap()))
-            .unwrap_or_default();
+        let bucket = self.bucket_of(wildcards.first());
         let mut worker = self.pool.acquire().await?;
         match worker.list(repository.to_string(), wildcards).await {
             Ok((attrs, warnings, stats)) => {
-                let rss = worker.rss_bytes();
-                if let Some(delta) = stats {
-                    self.observe_stats(&bucket, delta, rss);
-                }
-                if rss > self.pool.max_eval_rss() {
-                    worker.mark_dead();
-                }
-
+                self.finish_call(&mut worker, &bucket, stats);
                 Ok((attrs, warnings))
             }
             Err(e) => {
@@ -295,39 +387,34 @@ impl WorkerPoolResolver {
         }
     }
 
-    /// Resolve `attrs` on one fresh worker. `Ok` means the subprocess lived
-    /// (per-attr eval errors ride inside the items); `Err` means it crashed.
-    /// An over-RSS worker is discarded after a successful call so the next
-    /// `acquire` spawns a fresh subprocess.
-    async fn resolve_once(
-        &self,
-        repository: &str,
-        attrs: Vec<String>,
-    ) -> Result<(Vec<ResolvedItem>, Vec<String>)> {
-        // A batch's delta is one number, so it is attributed whole to the
-        // entry-point of its first attr; the dynamic queue keeps batches small
-        // and same-prefix, so cross-bucket bleed is minor.
-        let bucket = attrs
-            .first()
-            .map(|a| entry_point_of(a, &self.patterns.lock().unwrap()))
-            .unwrap_or_default();
+    /// Resolve one batch on a single pooled worker. A subprocess death becomes
+    /// [`BatchCall::Crashed`] carrying the streamed prefix; only pool failures
+    /// (e.g. shutdown) are `Err`.
+    async fn resolve_once(&self, repository: &str, attrs: Vec<String>) -> Result<BatchCall> {
+        let bucket = self.bucket_of(attrs.first());
         let mut worker = self.pool.acquire().await?;
-        match worker.resolve(repository.to_string(), attrs).await {
-            Ok((items, warnings, stats)) => {
-                let rss = worker.rss_bytes();
-                if let Some(delta) = stats {
-                    self.observe_stats(&bucket, delta, rss);
-                }
-                if rss > self.pool.max_eval_rss() {
-                    worker.mark_dead();
-                }
-
-                Ok((items, warnings))
+        let (items, end) = worker.resolve(repository.to_string(), attrs).await;
+        match end {
+            Ok((warnings, stats)) => {
+                self.finish_call(&mut worker, &bucket, stats);
+                self.record_warnings(warnings);
+                Ok(BatchCall::Complete(items))
             }
             Err(e) => {
                 worker.mark_dead();
-                Err(e)
+                debug!(
+                    error = format!("{e:#}"),
+                    streamed = items.len(),
+                    "eval worker died mid-resolve; salvaging streamed prefix"
+                );
+                Ok(BatchCall::Crashed { streamed: items })
             }
+        }
+    }
+
+    fn record_warnings(&self, warnings: Vec<String>) {
+        if !warnings.is_empty() {
+            self.resolve_warnings.lock().unwrap().extend(warnings);
         }
     }
 }
@@ -381,35 +468,22 @@ impl DerivationResolver for WorkerPoolResolver {
             .cloned()
             .collect();
 
-        let queue: std::sync::Mutex<std::collections::VecDeque<String>> =
-            std::sync::Mutex::new(shards.into_iter().collect());
-        let attrs = std::sync::Mutex::new(Vec::<String>::new());
-        let warnings = std::sync::Mutex::new(Vec::<String>::new());
+        let attrs = Mutex::new(Vec::<String>::new());
+        let warnings = Mutex::new(Vec::<String>::new());
         {
             let repo = repository.as_str();
-            let (queue, attrs, warnings, excludes) = (&queue, &attrs, &warnings, &excludes);
-            let mut tasks: FuturesUnordered<_> = (0..self.pool.max())
-                .map(|_| async move {
-                    loop {
-                        let shard = queue.lock().unwrap().pop_front();
-                        let Some(shard) = shard else { break };
+            let (attrs, warnings, excludes) = (&attrs, &warnings, &excludes);
+            pooled_fan_out(self.pool.max(), shards, |shard| async move {
+                let mut pattern = Vec::with_capacity(1 + excludes.len());
+                pattern.push(shard);
+                pattern.extend_from_slice(excludes);
 
-                        let mut pattern = Vec::with_capacity(1 + excludes.len());
-                        pattern.push(shard);
-                        pattern.extend_from_slice(excludes);
-
-                        let (a, w) = self.list_shard(repo, pattern).await?;
-                        attrs.lock().unwrap().extend(a);
-                        warnings.lock().unwrap().extend(w);
-                    }
-
-                    Ok::<(), anyhow::Error>(())
-                })
-                .collect();
-
-            while let Some(drained) = tasks.next().await {
-                drained?;
-            }
+                let (a, w) = self.list_shard(repo, pattern).await?;
+                attrs.lock().unwrap().extend(a);
+                warnings.lock().unwrap().extend(w);
+                Ok(())
+            })
+            .await?;
         }
 
         let mut attrs = attrs.into_inner().unwrap();
@@ -432,73 +506,46 @@ impl DerivationResolver for WorkerPoolResolver {
         }
 
         // Dynamic work queue: split into many small index-tagged batches and let
-        // each pooled worker pull the next as soon as it is free. A slow attr on
-        // one worker no longer leaves the others idle the way the old static
-        // round-robin partition did. ~4 batches per worker leaves enough slack to
-        // steal without paying a walker rebuild per attr, but the size is capped
-        // so one batch's eval-heap growth cannot blow a worker far past
-        // `max_eval_rss` before the post-call recycle check sees it (the heap is
-        // persistent across batches, so the cap bounds the per-call overshoot,
-        // not the base cost).
+        // each pooled worker pull the next as soon as it is free. ~4 batches per
+        // worker leaves enough slack to steal without paying a walker rebuild
+        // per attr; the size cap bounds one batch's eval-heap overshoot past
+        // `max_eval_rss` (the heap persists across batches, so the cap bounds
+        // the per-call overshoot, not the base cost).
         let n_workers = self.pool.max().min(attrs.len());
         let batch_size = attrs
             .len()
             .div_ceil(n_workers * 4)
             .clamp(1, MAX_RESOLVE_BATCH);
-        let queue: std::sync::Mutex<std::collections::VecDeque<Vec<(usize, String)>>> =
-            std::sync::Mutex::new(
-                attrs
-                    .into_iter()
-                    .enumerate()
-                    .collect::<Vec<_>>()
-                    .chunks(batch_size)
-                    .map(|c| c.to_vec())
-                    .collect(),
-            );
+        let batches: Vec<Vec<(usize, String)>> = attrs
+            .into_iter()
+            .enumerate()
+            .collect::<Vec<_>>()
+            .chunks(batch_size)
+            .map(|c| c.to_vec())
+            .collect();
 
-        // Shared warning sink: the pure core's `Ok` payload is items only, so
-        // warnings are funnelled here instead of through `resolve_chunk`.
-        let warnings = std::sync::Mutex::new(Vec::<String>::new());
-        let indexed = std::sync::Mutex::new(Vec::<IndexedDerivation>::new());
+        let indexed = Mutex::new(Vec::<IndexedDerivation>::new());
         {
             let repo = repository.as_str();
-            let sink = &warnings;
             let resolve_batch =
-                move |attrs: Vec<String>| -> BoxFuture<'_, Result<Vec<ResolvedItem>>> {
-                    Box::pin(async move {
-                        let (items, w) = self.resolve_once(repo, attrs).await?;
-                        sink.lock().unwrap().extend(w);
-                        Ok(items)
-                    })
+                move |attrs: Vec<String>| -> BoxFuture<'_, Result<BatchCall>> {
+                    Box::pin(self.resolve_once(repo, attrs))
                 };
 
-            let (queue, indexed, resolve_batch) = (&queue, &indexed, &resolve_batch);
-            let mut tasks: FuturesUnordered<_> = (0..n_workers)
-                .map(|_| async move {
-                    loop {
-                        // Scope the pop so the guard drops before the await;
-                        // holding it across `.await` would deadlock the executor.
-                        let batch = queue.lock().unwrap().pop_front();
-                        let Some(batch) = batch else { break };
-
-                        // A crash became per-attr errors in the core; only a
-                        // protocol violation (item-count mismatch) is a hard fail.
-                        let resolved = resolve_chunk(resolve_batch, batch, 0).await?;
-                        indexed.lock().unwrap().extend(resolved);
-                    }
-
-                    Ok::<(), anyhow::Error>(())
-                })
-                .collect();
-
-            while let Some(drained) = tasks.next().await {
-                drained?;
-            }
+            let (indexed, resolve_batch) = (&indexed, &resolve_batch);
+            pooled_fan_out(n_workers, batches, |batch| async move {
+                // A crash became per-attr errors in the pure core; only a
+                // protocol violation or pool failure is a hard error.
+                let resolved = resolve_chunk(resolve_batch, batch, 0).await?;
+                indexed.lock().unwrap().extend(resolved);
+                Ok(())
+            })
+            .await?;
         }
 
         let mut indexed = indexed.into_inner().unwrap();
         indexed.sort_by_key(|(idx, _)| *idx);
-        let mut all_warnings = warnings.into_inner().unwrap();
+        let mut all_warnings = std::mem::take(&mut *self.resolve_warnings.lock().unwrap());
         all_warnings.sort_unstable();
         all_warnings.dedup();
 
@@ -526,19 +573,8 @@ impl DerivationResolver for WorkerPoolResolver {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
     use std::sync::Mutex;
-
-    #[test]
-    fn nix_store_path_absolute_unchanged() {
-        let path = "/nix/store/hash-name";
-        assert_eq!(nix_store_path(path), path);
-    }
-
-    #[test]
-    fn nix_store_path_bare_prefixed() {
-        assert_eq!(nix_store_path("hash-name"), "/nix/store/hash-name");
-    }
 
     #[test]
     fn entry_point_longest_prefix_match() {
@@ -573,22 +609,21 @@ mod tests {
         }
     }
 
-    /// Scripts a `resolve_once` stub: counts calls and decides per batch whether
-    /// the worker crashes. `crash_if` returns true when the batch should die.
-    /// `calls` is borrowed by the returned futures, tying their lifetime to the
-    /// stub so it coerces to `&ResolveOnce<'_>` cleanly.
-    type CrashIf = Box<dyn Fn(&[String], usize) -> bool + Sync>;
+    /// Scripts a `resolve_once` stub: counts calls and decides per batch where
+    /// the worker crashes. `crash_at` returns the index of the attr the worker
+    /// dies on (items before it stream out), or `None` for a complete batch.
+    type CrashAt = Box<dyn Fn(&[String], usize) -> Option<usize> + Sync>;
 
     struct Stub {
         calls: Mutex<usize>,
-        crash_if: CrashIf,
+        crash_at: CrashAt,
     }
 
     impl Stub {
-        fn new(crash_if: impl Fn(&[String], usize) -> bool + Sync + 'static) -> Self {
+        fn new(crash_at: impl Fn(&[String], usize) -> Option<usize> + Sync + 'static) -> Self {
             Self {
                 calls: Mutex::new(0),
-                crash_if: Box::new(crash_if),
+                crash_at: Box::new(crash_at),
             }
         }
 
@@ -597,15 +632,15 @@ mod tests {
         }
     }
 
-    /// Crash any batch that contains one of `crashers`.
+    /// Crash while resolving any attr in `crashers`, streaming everything
+    /// before it (mirrors the real subprocess: items flush per attr).
     fn crashes_on(crashers: &'static [&'static str]) -> Stub {
         let set: HashSet<&str> = crashers.iter().copied().collect();
-        Stub::new(move |attrs, _call| attrs.iter().any(|a| set.contains(a.as_str())))
+        Stub::new(move |attrs, _call| attrs.iter().position(|a| set.contains(a.as_str())))
     }
 
     /// Drive the pure core over a chunk built from `attrs` (index = position).
-    /// Owns the stub so the closure and its futures share one scope (mirroring
-    /// the production block); returns the result plus the stub's call count.
+    /// Returns `(attr, resolved_ok)` in index order plus the stub's call count.
     async fn run(stub: Stub, attrs: &[&str]) -> (Vec<(String, bool)>, usize) {
         let chunk: Vec<(usize, String)> = attrs
             .iter()
@@ -615,22 +650,24 @@ mod tests {
 
         let mut out = {
             let stub = &stub;
-            let resolve_once =
-                move |attrs: Vec<String>| -> BoxFuture<'_, Result<Vec<ResolvedItem>>> {
-                    Box::pin(async move {
-                        let prior = {
-                            let mut n = stub.calls.lock().unwrap();
-                            let prior = *n;
-                            *n += 1;
-                            prior
-                        };
-                        if (stub.crash_if)(&attrs, prior) {
-                            anyhow::bail!("worker crashed");
-                        }
-
-                        Ok(attrs.iter().map(|a| ok_item(a)).collect())
-                    })
-                };
+            let resolve_once = move |attrs: Vec<String>| -> BoxFuture<'_, Result<BatchCall>> {
+                Box::pin(async move {
+                    let prior = {
+                        let mut n = stub.calls.lock().unwrap();
+                        let prior = *n;
+                        *n += 1;
+                        prior
+                    };
+                    match (stub.crash_at)(&attrs, prior) {
+                        Some(at) => Ok(BatchCall::Crashed {
+                            streamed: attrs[..at].iter().map(|a| ok_item(a)).collect(),
+                        }),
+                        None => Ok(BatchCall::Complete(
+                            attrs.iter().map(|a| ok_item(a)).collect(),
+                        )),
+                    }
+                })
+            };
             resolve_chunk(&resolve_once, chunk, 0).await.unwrap()
         };
         out.sort_by_key(|(idx, _)| *idx);
@@ -648,33 +685,93 @@ mod tests {
         let (out, calls) = run(crashes_on(&[]), &["a", "b", "c"]).await;
         assert_eq!(
             out,
-            vec![("a".into(), true), ("b".into(), true), ("c".into(), true),]
+            vec![("a".into(), true), ("b".into(), true), ("c".into(), true)]
         );
-        assert_eq!(calls, 1, "no crash → single batch call");
+        assert_eq!(calls, 1, "no crash means a single batch call");
     }
 
     #[tokio::test]
-    async fn single_crasher_among_healthy_isolates_one_error() {
-        let (out, _) = run(crashes_on(&["b"]), &["a", "b", "c", "d"]).await;
-        let map: std::collections::HashMap<_, _> = out.into_iter().collect();
+    async fn crash_salvages_streamed_prefix_and_isolates_suspect() {
+        // b always crashes the worker: the streamed prefix (a) survives the
+        // first call, b is retried alone and errors, c+d resolve untouched.
+        let (out, calls) = run(crashes_on(&["b"]), &["a", "b", "c", "d"]).await;
+        let map: HashMap<_, _> = out.into_iter().collect();
         assert!(!map["b"], "the crasher resolves to an error");
         assert!(map["a"] && map["c"] && map["d"], "the rest still resolve");
+        // 1 initial + 1 lone retry of b + 1 for the remainder [c, d]: streaming
+        // pinpoints the suspect, no bisection rework of the streamed prefix.
+        assert_eq!(calls, 3);
     }
 
     #[tokio::test]
     async fn two_crashers_isolate_independently() {
         let (out, _) = run(crashes_on(&["b", "d"]), &["a", "b", "c", "d", "e"]).await;
-        let map: std::collections::HashMap<_, _> = out.into_iter().collect();
+        let map: HashMap<_, _> = out.into_iter().collect();
         assert!(!map["b"] && !map["d"], "both crashers error");
         assert!(map["a"] && map["c"] && map["e"], "the rest resolve");
     }
 
     #[tokio::test]
     async fn transient_crash_succeeds_on_retry() {
-        // A single-attr chunk crashes on the first call (attempt 0) and resolves
-        // on the one retry (attempt 1) - no per-attr error is recorded.
-        let (out, calls) = run(Stub::new(|_attrs, call| call == 0), &["a"]).await;
+        // The single-attr chunk crashes on the first call (attempt 0) and
+        // resolves on the one retry (attempt 1) - no per-attr error recorded.
+        let (out, calls) = run(
+            Stub::new(|_attrs, call| (call == 0).then_some(0)),
+            &["a"],
+        )
+        .await;
         assert_eq!(out, vec![("a".into(), true)]);
         assert_eq!(calls, 2, "one crash + one successful retry");
+    }
+
+    #[tokio::test]
+    async fn crash_after_last_item_keeps_all_results() {
+        // Worker streams every item, then dies before ResolveEnd: nothing to
+        // retry, all results are kept.
+        let (out, calls) = run(
+            Stub::new(|attrs, call| (call == 0).then_some(attrs.len())),
+            &["a", "b"],
+        )
+        .await;
+        assert_eq!(out, vec![("a".into(), true), ("b".into(), true)]);
+        assert_eq!(calls, 1);
+    }
+
+    #[tokio::test]
+    async fn streamed_attr_mismatch_is_a_protocol_error() {
+        fn resolve_once(_attrs: Vec<String>) -> BoxFuture<'static, Result<BatchCall>> {
+            Box::pin(async move {
+                Ok(BatchCall::Crashed {
+                    streamed: vec![ok_item("unrelated")],
+                })
+            })
+        }
+        let err = resolve_chunk(&resolve_once, vec![(0, "a".into()), (1, "b".into())], 0)
+            .await
+            .expect_err("mismatched stream must fail");
+        assert!(err.to_string().contains("streamed item"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn pooled_fan_out_drains_all_items_and_propagates_errors() {
+        let seen = Mutex::new(Vec::new());
+        let seen_ref = &seen;
+        pooled_fan_out(3, (0..10).collect(), |n| async move {
+            seen_ref.lock().unwrap().push(n);
+            Ok(())
+        })
+        .await
+        .expect("no errors");
+        let mut got = seen.into_inner().unwrap();
+        got.sort_unstable();
+        assert_eq!(got, (0..10).collect::<Vec<_>>());
+
+        let err = pooled_fan_out(2, vec![1, 2, 3], |n| async move {
+            anyhow::ensure!(n != 2, "boom on {n}");
+            Ok(())
+        })
+        .await
+        .expect_err("error must propagate");
+        assert!(err.to_string().contains("boom on 2"));
     }
 }

--- a/backend/gradient-worker/src/worker_pool/transport.rs
+++ b/backend/gradient-worker/src/worker_pool/transport.rs
@@ -1,0 +1,440 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Parent-side handle to one eval-worker subprocess: spawn, the rkyv frame
+//! transport over its stdin/stdout, and the typed request methods. Pool
+//! lifecycle lives in [`super::pool`], memory accounting in [`super::memory`].
+
+use anyhow::{Context, Result};
+use std::collections::HashSet;
+use std::process::Stdio;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tracing::{debug, trace, warn};
+
+use gradient_eval::ipc::{
+    EVAL_IPC_VERSION, EvalRequest, EvalResponse, MAX_FRAME_BYTES, ResolvedItem, decode_response,
+    encode_request,
+};
+use gradient_eval::stats::StatsDelta;
+
+/// Stack size for the subprocess, matching upstream Nix's `initNix`
+/// `setStackSize(64 MiB)`: libnix's libstdc++ `std::regex` DFS executor (used
+/// by `builtins.match` / `builtins.split`) overflows the default 8 MiB on
+/// deep patterns.
+const EVAL_WORKER_STACK_BYTES: u64 = 64 * 1024 * 1024;
+
+/// `oom_score_adj` for eval subprocesses: the kernel sacrifices them (large
+/// Nix/Boehm-GC heaps) before the parent worker or other services.
+const EVAL_WORKER_OOM_SCORE_ADJ: &str = "600";
+
+/// How long `spawn` waits for the subprocess's version byte. Covers exec +
+/// Rust init only; the slow libnix init happens after the handshake.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Grace period for a `Shutdown`n worker to run libnix's atexit handlers
+/// (flush eval-cache SQLite, release locks) before it is SIGKILL'd.
+const SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
+
+/// How long the dead-pipe diagnostics wait for the child's exit status before
+/// falling back to `/proc` state sampling.
+const EXIT_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Handle to a single live eval-worker subprocess.
+///
+/// Owns the child plus its piped stdin/stdout. The wire is `u32` LE length +
+/// rkyv frames ([`gradient_eval::ipc`]); every request is one frame, every
+/// response one frame, except `Resolve` which streams item frames until a
+/// terminating `ResolveEnd`.
+pub(super) struct EvalWorker {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    /// RAII deregistration of this subprocess's pid from the pool's live
+    /// registry. A field (rather than `impl Drop for EvalWorker`) so `shutdown`
+    /// can still move individual fields out of `self`.
+    pid_guard: PidGuard,
+}
+
+/// Removes an eval subprocess pid from the pool's live registry on drop, so the
+/// memory reaper never targets a worker we have already discarded. The child
+/// itself is reaped by `kill_on_drop`.
+pub(super) struct PidGuard {
+    /// Live-pid registry of the owning pool. `None` for test workers built via
+    /// `from_command` (no pool, nothing to deregister from).
+    pub(super) live: Option<Arc<Mutex<HashSet<u32>>>>,
+    pub(super) pid: Option<u32>,
+}
+
+impl Drop for PidGuard {
+    fn drop(&mut self) {
+        if let (Some(live), Some(pid)) = (&self.live, self.pid) {
+            live.lock().unwrap().remove(&pid);
+        }
+    }
+}
+
+impl EvalWorker {
+    /// Spawn a new worker by re-execing the current binary with `--eval-worker`
+    /// and verify its IPC version byte. The subprocess is single-threaded and
+    /// does not fork; pool size is the eval concurrency and RSS is bounded
+    /// parent-side (see [`Self::rss_bytes`]).
+    ///
+    /// `eval_cache_dir` is exported as `NIX_CACHE_HOME` so parent and worker
+    /// agree on where Nix's `eval-cache-v6/<fingerprint>.sqlite` lives.
+    pub(super) async fn spawn(
+        eval_cache_dir: &str,
+        live: Arc<Mutex<HashSet<u32>>>,
+    ) -> Result<Self> {
+        let exe = std::env::current_exe().context("locating current executable")?;
+        trace!(exe = %exe.display(), "spawning eval worker subprocess");
+        let mut command = Command::new(&exe);
+        command.arg("--eval-worker");
+        command.env("NIX_CACHE_HOME", eval_cache_dir);
+        for &(k, v) in
+            super::eval_stats::eval_worker_stats_env(super::eval_stats::metrics_enabled())
+        {
+            command.env(k, v);
+        }
+
+        // SAFETY: `pre_exec` runs in the forked child before `exec`, so its body
+        // must be async-signal-safe; it only builds an `rlimit` and calls
+        // `setrlimit`, both of which are signal-safe.
+        #[cfg(unix)]
+        unsafe {
+            command.pre_exec(|| {
+                let lim = libc::rlimit {
+                    rlim_cur: EVAL_WORKER_STACK_BYTES,
+                    rlim_max: EVAL_WORKER_STACK_BYTES,
+                };
+                if libc::setrlimit(libc::RLIMIT_STACK, &lim) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+
+        let mut worker = Self::from_command(command)?;
+
+        // Register the pid so the memory reaper can find this subprocess even
+        // while it is checked out of the pool. Deregistered by `PidGuard`.
+        if let Some(pid) = worker.pid_guard.pid {
+            live.lock().unwrap().insert(pid);
+        }
+        worker.pid_guard.live = Some(live);
+
+        // Mark the subprocess as the preferred OOM-kill target. A cheap
+        // sub-page procfs write; not worth a spawn_blocking hop.
+        #[cfg(target_os = "linux")]
+        if let Some(pid) = worker.child.id() {
+            let path = format!("/proc/{pid}/oom_score_adj");
+            if let Err(e) = std::fs::write(&path, EVAL_WORKER_OOM_SCORE_ADJ) {
+                warn!(pid, error = %e, "failed to set oom_score_adj for eval worker");
+            }
+        }
+
+        worker.expect_handshake().await?;
+
+        Ok(worker)
+    }
+
+    /// Spawn the given pre-configured command and wrap its stdin/stdout into
+    /// an [`EvalWorker`]. Test seam used by pool tests to stand up a
+    /// controllable subprocess (e.g. `cat`) without depending on libnix; no
+    /// version handshake is performed here.
+    pub(super) fn from_command(mut command: Command) -> Result<Self> {
+        command
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .kill_on_drop(true);
+        let mut child = command.spawn().context("spawning eval worker subprocess")?;
+        let pid = child.id();
+        let stdin = child.stdin.take().context("worker stdin missing")?;
+        let stdout = BufReader::new(child.stdout.take().context("worker stdout missing")?);
+        Ok(Self {
+            child,
+            stdin,
+            stdout,
+            pid_guard: PidGuard { live: None, pid },
+        })
+    }
+
+    /// Read and verify the one-byte version handshake the subprocess writes
+    /// before its first frame, so a binary swapped mid-run fails loudly here
+    /// instead of as undecodable frames later.
+    async fn expect_handshake(&mut self) -> Result<()> {
+        let mut version = [0u8; 1];
+        tokio::time::timeout(HANDSHAKE_TIMEOUT, self.stdout.read_exact(&mut version))
+            .await
+            .context("eval worker handshake timed out")?
+            .context("reading eval worker handshake")?;
+        anyhow::ensure!(
+            version[0] == EVAL_IPC_VERSION,
+            "eval worker IPC version mismatch: parent {EVAL_IPC_VERSION}, subprocess {} (binary replaced mid-run?)",
+            version[0]
+        );
+        Ok(())
+    }
+
+    pub(super) fn pid(&self) -> Option<u32> {
+        self.child.id()
+    }
+
+    /// Whether the subprocess is still running, reaping its exit status if it
+    /// has already exited. The pool calls this on checkout to discard an idle
+    /// worker whose subprocess died while pooled (memory reaper, kernel OOM via
+    /// the elevated `oom_score_adj`, or crash) instead of handing out a corpse
+    /// that fails the next write with a broken pipe.
+    pub(super) fn is_alive(&mut self) -> bool {
+        matches!(self.child.try_wait(), Ok(None))
+    }
+
+    /// Write one request frame. An error means the worker is no longer usable.
+    async fn send(&mut self, req: &EvalRequest) -> Result<()> {
+        trace!(pid = self.child.id(), ?req, "sending eval worker request");
+        let payload = encode_request(req).context("encoding eval worker request")?;
+        self.stdin
+            .write_all(&u32::try_from(payload.len())?.to_le_bytes())
+            .await
+            .context("writing to eval worker stdin")?;
+        self.stdin
+            .write_all(&payload)
+            .await
+            .context("writing to eval worker stdin")?;
+        self.stdin
+            .flush()
+            .await
+            .context("flushing eval worker stdin")
+    }
+
+    /// Read one response frame. An error means the worker is no longer usable
+    /// (the caller marks it dead so it gets discarded instead of pooled).
+    async fn recv(&mut self) -> Result<EvalResponse> {
+        let mut len_buf = [0u8; 4];
+        if let Err(e) = self.stdout.read_exact(&mut len_buf).await {
+            anyhow::bail!("eval worker closed pipe ({})", self.describe_death(e).await);
+        }
+
+        let len = u32::from_le_bytes(len_buf);
+        anyhow::ensure!(
+            len <= MAX_FRAME_BYTES,
+            "eval worker frame length {len} exceeds MAX_FRAME_BYTES (corrupt stream?)"
+        );
+
+        let mut payload = vec![0u8; len as usize];
+        self.stdout
+            .read_exact(&mut payload)
+            .await
+            .context("reading eval worker response frame")?;
+
+        trace!(
+            pid = self.child.id(),
+            bytes = payload.len(),
+            "received eval worker response"
+        );
+        decode_response(&payload).context("decoding eval worker response")
+    }
+
+    /// Best-effort post-mortem for a dead read side: exit status if the child
+    /// is gone, `/proc` state samples if it is somehow still alive. Sub-page
+    /// procfs reads, cheap enough to stay on the async path.
+    async fn describe_death(&mut self, read_err: std::io::Error) -> String {
+        let pid = self.child.id();
+        let status = match tokio::time::timeout(EXIT_PROBE_TIMEOUT, self.child.wait()).await {
+            Ok(Ok(s)) => format!("{s}"),
+            Ok(Err(e)) => format!("wait error: {e}"),
+            Err(_) => {
+                let mut diag = String::from("still alive after 2s");
+                if let Some(p) = pid {
+                    if let Ok(target) = std::fs::read_link(format!("/proc/{p}/fd/1")) {
+                        diag.push_str(&format!("; /proc/{p}/fd/1 -> {}", target.display()));
+                    }
+                    if let Ok(state) = std::fs::read_to_string(format!("/proc/{p}/status"))
+                        && let Some(line) = state.lines().find(|l| l.starts_with("State:"))
+                    {
+                        diag.push_str(&format!("; {line}"));
+                    }
+                    if let Ok(wchan) = std::fs::read_to_string(format!("/proc/{p}/wchan")) {
+                        diag.push_str(&format!("; wchan={}", wchan.trim()));
+                    }
+                }
+                diag
+            }
+        };
+        format!("pid={pid:?}, read error={read_err}, exit={status}")
+    }
+
+    /// One request, one typed response. `extract` returns the unexpected
+    /// response so the single shape-check here can name it; `EvalResponse::Err`
+    /// becomes the worker's own error message.
+    async fn call<T>(
+        &mut self,
+        req: EvalRequest,
+        what: &'static str,
+        extract: impl FnOnce(EvalResponse) -> std::result::Result<T, EvalResponse>,
+    ) -> Result<T> {
+        self.send(&req).await?;
+        match extract(self.recv().await?) {
+            Ok(v) => Ok(v),
+            Err(EvalResponse::Err { message }) => Err(anyhow::anyhow!("eval worker: {message}")),
+            Err(other) => anyhow::bail!("eval worker: unexpected response to {what}: {other:?}"),
+        }
+    }
+
+    pub(super) async fn plan(
+        &mut self,
+        repository: String,
+        wildcards: Vec<String>,
+    ) -> Result<Vec<String>> {
+        self.call(
+            EvalRequest::Plan {
+                repository,
+                wildcards,
+            },
+            "Plan",
+            |resp| match resp {
+                EvalResponse::PlanOk { sub_patterns } => Ok(sub_patterns),
+                other => Err(other),
+            },
+        )
+        .await
+    }
+
+    pub(super) async fn list(
+        &mut self,
+        repository: String,
+        wildcards: Vec<String>,
+    ) -> Result<(Vec<String>, Vec<String>, Option<StatsDelta>)> {
+        self.call(
+            EvalRequest::List {
+                repository,
+                wildcards,
+            },
+            "List",
+            |resp| match resp {
+                EvalResponse::ListOk {
+                    attrs,
+                    warnings,
+                    stats,
+                } => Ok((attrs, warnings, stats)),
+                other => Err(other),
+            },
+        )
+        .await
+    }
+
+    pub(super) async fn fingerprint(&mut self, repository: String) -> Result<Option<String>> {
+        self.call(
+            EvalRequest::Fingerprint { repository },
+            "Fingerprint",
+            |resp| match resp {
+                EvalResponse::FingerprintOk { fingerprint } => Ok(fingerprint),
+                other => Err(other),
+            },
+        )
+        .await
+    }
+
+    pub(super) async fn checkpoint(&mut self, repository: String) -> Result<()> {
+        self.call(
+            EvalRequest::Checkpoint { repository },
+            "Checkpoint",
+            |resp| match resp {
+                EvalResponse::CheckpointOk => Ok(()),
+                other => Err(other),
+            },
+        )
+        .await
+    }
+
+    /// Resolve `attrs`, returning every item streamed before the terminal
+    /// result. `Ok` carries the batch's warnings + stats delta; `Err` means
+    /// the subprocess died mid-stream, in which case the streamed prefix is
+    /// still valid and the first unstreamed attr is the crash suspect.
+    pub(super) async fn resolve(
+        &mut self,
+        repository: String,
+        attrs: Vec<String>,
+    ) -> (
+        Vec<ResolvedItem>,
+        Result<(Vec<String>, Option<StatsDelta>)>,
+    ) {
+        let mut items = Vec::new();
+        let end = self.resolve_inner(repository, attrs, &mut items).await;
+        (items, end)
+    }
+
+    async fn resolve_inner(
+        &mut self,
+        repository: String,
+        attrs: Vec<String>,
+        items: &mut Vec<ResolvedItem>,
+    ) -> Result<(Vec<String>, Option<StatsDelta>)> {
+        self.send(&EvalRequest::Resolve { repository, attrs })
+            .await?;
+        loop {
+            match self.recv().await? {
+                EvalResponse::ResolveItem { item } => items.push(item),
+                EvalResponse::ResolveEnd { warnings, stats } => return Ok((warnings, stats)),
+                EvalResponse::Err { message } => {
+                    anyhow::bail!("eval worker: {message}")
+                }
+                other => {
+                    anyhow::bail!("eval worker: unexpected response to Resolve: {other:?}")
+                }
+            }
+        }
+    }
+
+    /// Send a `Shutdown` request and wait briefly for the child to exit.
+    /// Used when the parent is recycling a still-healthy worker so the
+    /// subprocess can run libnix's atexit handlers (flush eval-cache
+    /// SQLite, release locks, drop temp roots) instead of being SIGKILL'd
+    /// by `kill_on_drop`.
+    pub(super) async fn shutdown(mut self) {
+        let pid = self.child.id();
+        trace!(pid, "sending Shutdown to eval worker");
+        if let Err(e) = self.send(&EvalRequest::Shutdown).await {
+            debug!(pid, error = %e, "failed to write Shutdown to eval worker");
+            return;
+        }
+        drop(self.stdin);
+        trace!(pid, "Shutdown sent; waiting for eval worker to exit");
+        match tokio::time::timeout(SHUTDOWN_GRACE, self.child.wait()).await {
+            Ok(Ok(status)) => trace!(pid, ?status, "eval worker exited cleanly"),
+            Ok(Err(e)) => debug!(pid, error = %e, "waiting on eval worker exit failed"),
+            Err(_) => warn!(
+                pid,
+                "eval worker did not exit within the shutdown grace period; will be killed"
+            ),
+        }
+    }
+
+    /// Resident set size of the subprocess in bytes. Returns 0 if the pid is
+    /// gone or the read fails so the pool never panics on it.
+    pub(super) fn rss_bytes(&self) -> u64 {
+        self.child
+            .id()
+            .and_then(super::memory::rss_of_pid)
+            .unwrap_or(0)
+    }
+
+    #[cfg(test)]
+    pub(super) fn child_mut(&mut self) -> &mut Child {
+        &mut self.child
+    }
+}
+
+impl std::fmt::Debug for EvalWorker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EvalWorker")
+            .field("pid", &self.child.id())
+            .finish()
+    }
+}

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -330,6 +330,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
+name = "bytecheck"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "rancor",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,6 +1266,7 @@ dependencies = [
  "anyhow",
  "libc",
  "nix-bindings",
+ "rkyv",
  "serde",
  "serde_json",
  "tracing",
@@ -2146,6 +2170,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "munge"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2602,6 +2646,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2677,6 +2741,15 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rancor"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daff8b7b3ccf5f7ba270b3e7a0a4d4c701c5797e38dec27c7e2c3dbb830fed1c"
+dependencies = [
+ "ptr_meta",
+]
 
 [[package]]
 name = "rand"
@@ -2882,6 +2955,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "rend"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "663ba70707f96e871406fe10d68128412e619b06d1d47cb91c3a4c6501176240"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2954,6 +3036,33 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874"
+dependencies = [
+ "bytecheck",
+ "hashbrown 0.17.1",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/docs/src/development/eval-worker.md
+++ b/docs/src/development/eval-worker.md
@@ -2,6 +2,12 @@
 
 Gradient evaluates flakes with a pool of `--eval-worker` subprocesses that drive the embedded Nix C API. A single evaluation is split into one shard per system and fanned across the pool, with the pool sized to fit the host's memory. Results are written to a persistent, fleet-shared eval-cache, so a repeat evaluation of the same locked flake is mostly cache hits.
 
+## Subprocess IPC
+
+Parent and subprocess speak rkyv over the subprocess's stdin/stdout: each message is a `u32` little-endian length prefix plus an rkyv payload (`gradient-eval/src/ipc.rs`), mirroring the main `/proto` protocol's serialization conventions. The subprocess announces a one-byte IPC version before its first frame so a binary swapped mid-run fails the handshake instead of producing undecodable frames. `Resolve` is streamed: the subprocess emits one `ResolveItem` frame per attribute the moment it resolves, terminated by `ResolveEnd` with the batch's warnings and stats delta. Every other request is strictly one request, one response. A subprocess keeps one walker (locked flake + open eval cache) warm across consecutive requests for the same repository, so a Plan/List/Resolve sequence pays the flake lock and cache open once.
+
+The parent side lives in `gradient-worker/src/worker_pool/`, split along its seams: `transport.rs` (subprocess handle + frame wire + typed requests), `pool.rs` (checkout/return lifecycle with test-on-borrow), `memory.rs` (pool-size budget, free-RAM guard, reaper), and `resolver.rs` (the pooled fan-out and crash isolation). The hidden `--eval-driver <file>` flag runs JSONL requests through the real transport against a real subprocess and prints JSON responses; the NixOS VM test uses it to exercise both sides of the binary wire from Python.
+
 ## Compared to nix-eval-jobs
 
 | Dimension | Gradient | nix-eval-jobs |
@@ -12,8 +18,8 @@ Gradient evaluates flakes with a pool of `--eval-worker` subprocesses that drive
 | Concurrent shared cache | Concurrent shards write one eval-cache without deadlock (WAL-append commits plus a single end-of-eval checkpoint) | Not applicable, as there is no shared cache |
 | Memory safety | Automatic pool sizing so `pool_size * maxEvalRss` stays within a host-RAM share; a many-system flake completes even on a small host (degrading to one shard) and never OOMs | Manual `--workers` and `--max-memory-size` |
 | Pipeline integration | Native: discovery feeds DB rows and build dispatch starts mid-eval (incremental flush); the closure walk prunes server-known derivations and marks cache-status substitution | Emits a JSON job stream that the consumer (Hydra and similar) integrates |
-| Per-attribute failure isolation | A bad attribute becomes a per-attribute error and the eval continues; a crash triggers chunk bisection that isolates the crasher | Per-job error reporting via the fork boundary |
-| Crash isolation | Subprocess boundary with retry and bisection | Fork boundary with re-fork |
+| Per-attribute failure isolation | A bad attribute becomes a per-attribute error and the eval continues; resolve results stream per attribute, so a crash keeps everything already streamed and retries exactly the in-flight attribute | Per-job error reporting via the fork boundary |
+| Crash isolation | Subprocess boundary; the streamed protocol pinpoints the crashing attribute in one step (no bisection rework) | Fork boundary with re-fork |
 | Cross-machine eval compute | Roadmap; today it is a single-host pool | Single-host |
 
 Gradient's main advantage is treating the eval-cache as a first-class, persistent, fleet-shared artifact, so repeat and CI evaluations of the same locked flake are near-instant across the whole worker fleet, together with automatic memory-budgeted sizing that guarantees an evaluation completes instead of relying on manual worker and memory tuning.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -5560,3 +5560,48 @@ test-on-borrows via `Child::try_wait`, skipping dead workers and spawning fresh.
 
 - `worker_pool::pool::tests::acquire_skips_dead_idle_worker` - a killed idle
   worker pushed ahead of a live one is skipped; `acquire` returns the live pid.
+
+## Eval-worker consolidation: rkyv IPC, streamed resolve, module split (#481)
+
+The eval subsystem's four-concern `worker_pool/pool.rs` was split into
+`transport.rs` (subprocess handle + wire + typed requests), `pool.rs`
+(checkout/return lifecycle), `memory.rs` (budget math + free-RAM reaper) and
+`resolver.rs` (pooled fan-out); the dead recycle-by-count machinery
+(`recycle_after`/`evaluations_served`) was deleted. The subprocess IPC moved
+from line-delimited JSON to `u32` LE length-prefixed rkyv frames
+(`gradient-eval/src/ipc.rs`) with a one-byte version handshake, and `Resolve`
+now streams one `ResolveItem` frame per attr plus a terminal `ResolveEnd`
+(reimplements the PR #465 idea), so a subprocess crash keeps the streamed
+prefix and retries exactly the in-flight attr instead of bisecting. The
+`walk`/`plan_one` twins in `wildcard_walk.rs` collapsed into one
+visitor-parameterized `traverse`, making split-then-union structural. The
+subprocess reuses one walker (locked flake + open eval cache) across
+consecutive same-repo requests. A hidden `--eval-driver` JSONL harness drives
+the real transport for the VM test.
+
+- `gradient-eval` `ipc::tests` - `requests_roundtrip_through_rkyv` /
+  `responses_roundtrip_through_rkyv` (every variant), frame codec
+  (`frames_roundtrip_and_eof_between_frames_is_clean`,
+  `truncated_frame_is_an_error_not_eof`, `oversized_length_prefix_is_rejected`)
+  and `decode_survives_misaligned_input` (the AlignedVec realign rule).
+- `worker_pool::resolver::tests` - the crash policy over the streamed protocol:
+  `crash_salvages_streamed_prefix_and_isolates_suspect` (exactly 3 worker calls
+  for one crasher among four attrs: no bisection rework),
+  `crash_after_last_item_keeps_all_results`,
+  `streamed_attr_mismatch_is_a_protocol_error`, plus the retained
+  `no_crash_resolves_all_in_one_call` / `two_crashers_isolate_independently` /
+  `transient_crash_succeeds_on_retry`; and
+  `pooled_fan_out_drains_all_items_and_propagates_errors` for the shared
+  fan-out primitive.
+- `worker_pool::pool::tests` - `disposition_covers_all_states` (the one-shot
+  Drop decision), with the existing lifecycle tests
+  (`acquire_skips_dead_idle_worker`, shutdown drain/idempotence) carried over;
+  `worker_pool::memory::tests` keeps `budgeted_pool_size_caps_by_memory` and
+  `memory_guard_bytes_configured_and_adaptive` in their new home.
+- `wildcard_walk::tests` - all discovery/planning semantics tests pass
+  unchanged against the unified traversal; the split-equivalence helper stays
+  as one behavioural guard instead of policing two hand-synced twins.
+- `nix/tests/gradient/eval` (VM) - drives list/resolve/fingerprint through
+  `--eval-driver`, covering spawn, handshake, framing and the streamed resolve
+  on both sides of the wire, and asserts the eval-cache lands under the
+  configured `GRADIENT_EVAL_CACHE_DIR`.

--- a/nix/tests/gradient/eval/default.nix
+++ b/nix/tests/gradient/eval/default.nix
@@ -55,9 +55,13 @@
       machine.succeed("${nix} flake lock /root/fixture")
       machine.succeed("${git} -C /root/fixture add -A && ${git} -C /root/fixture commit -qm lock --allow-empty")
 
-      # ── Drive the eval-worker over its line-delimited JSON protocol ────────
-      # Shutdown produces no response, so we expect one line per List/Resolve.
-      banner("Run eval-worker")
+      # ── Drive the eval-worker over the production rkyv transport ───────────
+      # The wire is binary frames, so the hidden `--eval-driver` harness reads
+      # these requests as JSON lines, runs them through the real parent-side
+      # transport (spawn, version handshake, frames, streamed resolve) against
+      # a real subprocess, and prints one JSON response line per request.
+      # Shutdown produces no response, so we expect one line per other request.
+      banner("Run eval-worker via --eval-driver")
       requests = [
           {"op": "list", "repository": REPO, "wildcards": ["packages.x86_64-linux.*"]},
           {"op": "list", "repository": REPO, "wildcards": ["packages.x86_64-linux.#"]},
@@ -72,15 +76,14 @@
       b64 = base64.b64encode(payload.encode()).decode()
       machine.succeed(f"echo {b64} | base64 -d > /root/reqs.jsonl")
 
-      # `--eval-worker` is a flag (clap SetTrue); the env form GRADIENT_EVAL_WORKER=1
-      # is rejected by clap's bool parser. Mirror the production spawn (pool.rs).
       status, _ = machine.execute(
           "HOME=/root GRADIENT_WORKER_SERVER_URL=ws://dummy/proto "
-          "${worker} --eval-worker < /root/reqs.jsonl > /root/out.jsonl 2> /root/eval.log"
+          "GRADIENT_EVAL_CACHE_DIR=/root/eval-cache "
+          "${worker} --eval-driver /root/reqs.jsonl > /root/out.jsonl 2> /root/eval.log"
       )
       print(machine.succeed("cat /root/out.jsonl || true"))
       print(machine.succeed("cat /root/eval.log || true"))
-      assert status == 0, f"eval-worker exited {status}; see eval.log above"
+      assert status == 0, f"eval driver exited {status}; see eval.log above"
 
       responses = [json.loads(l) for l in machine.succeed("cat /root/out.jsonl").splitlines() if l.strip()]
       assert len(responses) == 5, f"expected 5 responses, got {len(responses)}: {responses}"
@@ -116,12 +119,14 @@
 
       # ── Fingerprint ↔ on-disk eval-cache path agreement (#386 L3) ──────────
       # The lock-only `fingerprint` op must yield the same key Nix names the
-      # on-disk cache after, so the worker can stage/pull `<fp>.sqlite`.
+      # on-disk cache after, so the worker can stage/pull `<fp>.sqlite`. The
+      # driver spawns the subprocess like the production pool, exporting the
+      # configured eval-cache dir as NIX_CACHE_HOME.
       banner("Assert fingerprint matches the eval-cache filename")
       assert responses[4]["kind"] == "fingerprint_ok", responses[4]
       fp = responses[4].get("fingerprint")
       assert fp, f"expected a fingerprint for the committed flake, got {fp}"
-      machine.succeed(f"test -f /root/.cache/nix/eval-cache-v6/{fp}.sqlite")
+      machine.succeed(f"test -f /root/eval-cache/eval-cache-v6/{fp}.sqlite")
 
       banner("Eval test PASSED")
       '';


### PR DESCRIPTION
Closes #481. Reimplements the #465 idea (rkyv frames + streamed resolve) fresh on current main, so closes #465 as superseded.

- worker_pool split along its seams: transport.rs (subprocess handle + wire + typed requests), pool.rs (lifecycle, Drop collapsed to one Disposition decision), memory.rs (budget math + reaper), resolver.rs (pooled fan-out); dead recycle-by-count machinery deleted.
- Subprocess IPC moved from JSON lines to u32 LE length-prefixed rkyv frames (gradient-eval/src/ipc.rs, mirrors the /proto rkyv conventions) with a one-byte version handshake; Resolve streams ResolveItem per attr + ResolveEnd, so a crash keeps the streamed prefix and retries exactly the in-flight attr (no bisection). Subprocess reuses one walker across same-repo requests; the five copy-pasted response-shape checks collapsed into one call/with_evaluator pair.
- walk/plan_one unified into one visitor-parameterized traverse; listing and resolving share pooled_fan_out and MAX_CRASH_ATTEMPTS.
- Store-path helpers consolidated onto gradient_exec::path_utils (gradient-eval keeps its two-line copy to stay a lean standalone CLI dep); merged store.rs docstring fixed; magic constants named.
- VM test drives the binary wire via a hidden --eval-driver JSONL harness, covering both sides of the transport.

Deferred with rationale on the issue: stats-module naming (smell 12), /proc IO stays sync (documented as sub-page procfs reads), IPC framing stays in gradient-eval rather than gradient-proto (the standalone CLI contract forbids the dep; #477 can extract a shared leaf crate).