### PR TITLE
build: accept nix installable targets, fail eval on empty target

### DIFF
--- a/backend/gradient-worker/src/executor/eval.rs
+++ b/backend/gradient-worker/src/executor/eval.rs
@@ -55,6 +55,19 @@ fn explicit_attr_set(wildcards: &[String]) -> HashSet<String> {
         .collect()
 }
 
+/// Errors for explicitly requested attrs that discovery matched to nothing.
+/// Empty when every pattern was a wildcard (a wildcard legitimately spans attrs
+/// that aren't buildable), so only a pinpointed target fails the eval instead of
+/// silently completing with no outputs.
+fn unmatched_target_errors(wildcards: &[String]) -> Vec<String> {
+    let mut errors: Vec<String> = explicit_attr_set(wildcards)
+        .into_iter()
+        .map(|attr| format!("target '{attr}' matched no derivations in the flake"))
+        .collect();
+    errors.sort_unstable();
+    errors
+}
+
 /// How many `.drv` files to read+parse concurrently inside a single BFS wave.
 /// Reading a `.drv` is async filesystem IO, so the sequential walk would only
 /// keep one in-flight read at a time and bottleneck on round-trip latency.
@@ -759,7 +772,8 @@ pub async fn evaluate_derivations_with(
 
     if attrs.is_empty() {
         warn!("no derivations found for evaluation");
-        updater.report_eval_result(vec![], warnings, vec![]).await?;
+        let errors = unmatched_target_errors(&job.wildcards);
+        updater.report_eval_result(vec![], warnings, errors).await?;
         return Ok(EvalOutcome {
             flake_nodes: Vec::new(),
         });
@@ -854,6 +868,17 @@ mod tests {
             .parent()
             .unwrap()
             .join("test-store")
+    }
+
+    #[test]
+    fn unmatched_explicit_target_errors_but_wildcard_is_silent() {
+        assert_eq!(
+            unmatched_target_errors(&["packages.x86_64-linux.uxc".to_string()]),
+            vec!["target 'packages.x86_64-linux.uxc' matched no derivations in the flake".to_string()]
+        );
+        assert!(unmatched_target_errors(&["packages.x86_64-linux.#".to_string()]).is_empty());
+        assert!(unmatched_target_errors(&["packages.x86_64-linux.*".to_string()]).is_empty());
+        assert!(unmatched_target_errors(&["!nixosConfigurations.foo".to_string()]).is_empty());
     }
 
     fn make_flake_job(repo: &str) -> FlakeJob {

--- a/cli/src/commands/build.rs
+++ b/cli/src/commands/build.rs
@@ -39,6 +39,17 @@ pub async fn handle_build(
 
     let client = client_from_config(out);
 
+    // Accept `nix build`-style installables (`.#uxc`) and translate them into
+    // gradient's attr-path wildcard language before dispatch and result linking.
+    let target = target.map(|raw| {
+        let system = system.clone().unwrap_or_else(default_nix_system);
+        let normalized = normalize_target(&raw, &system);
+        if !quiet && normalized != raw {
+            out.progress(format!("Building '{}' (from '{}')", normalized, raw));
+        }
+        normalized
+    });
+
     let cwd = std::env::current_dir().unwrap_or_else(|e| {
         if !quiet {
             out.progress(format!("Failed to read current directory: {}", e));
@@ -366,6 +377,68 @@ async fn wait_for_terminal(
     }
 }
 
+/// Flake-output categories that are already gradient attr-path syntax; a target
+/// under one of these passes through, anything else is treated as a bare package.
+const OUTPUT_CATEGORIES: &[&str] = &[
+    "packages",
+    "legacyPackages",
+    "checks",
+    "devShells",
+    "apps",
+    "nixosConfigurations",
+    "darwinConfigurations",
+    "homeConfigurations",
+    "hydraJobs",
+    "formatter",
+    "bundlers",
+];
+
+/// The host's Nix system double (`x86_64-linux`, `aarch64-darwin`, ...), used to
+/// qualify a bare `.#uxc` as `packages.<system>.uxc` the way `nix build` does.
+fn default_nix_system() -> String {
+    let os = match std::env::consts::OS {
+        "macos" => "darwin",
+        other => other,
+    };
+    format!("{}-{}", std::env::consts::ARCH, os)
+}
+
+/// Translate a `nix build`-style installable into gradient's `.`-separated
+/// attr-path wildcard language. `gradient build .#uxc` mirrors `nix build .#uxc`:
+/// the flake ref is always the uploaded repo, so drop a leading local ref
+/// (`.`/empty) before `#` and qualify a bare attr as `packages.<system>.<attr>`.
+/// Fully-qualified paths and `*`/`#` wildcards (`packages.x86_64-linux.#`) and
+/// exclusions pass through untouched.
+fn normalize_target(raw: &str, system: &str) -> String {
+    raw.split(',')
+        .map(|pat| normalize_installable(pat.trim(), system))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn normalize_installable(pat: &str, system: &str) -> String {
+    let (excl, body) = pat
+        .strip_prefix('!')
+        .map(|r| ("!", r))
+        .unwrap_or(("", pat));
+
+    let attr = match body.split_once('#') {
+        Some(("" | "." | "./", attr)) => attr,
+        _ => return pat.to_string(),
+    };
+
+    if attr.is_empty() {
+        return format!("{excl}packages.{system}.#");
+    }
+
+    let head = attr.split('.').next().unwrap_or("");
+    if head == "*" || head == "#" || OUTPUT_CATEGORIES.contains(&head) {
+        format!("{excl}{attr}")
+    } else {
+        format!("{excl}packages.{system}.{attr}")
+    }
+}
+
 /// Pick the entry point matching `target` (exact or suffix), else the first.
 pub(crate) fn select_primary_entry_point<'a>(
     tree: &'a ArtefactTree,
@@ -448,4 +521,64 @@ fn hash_file(path: &Path) -> std::io::Result<(String, i64)> {
         size += n as i64;
     }
     Ok((hasher.finalize().to_hex().to_string(), size))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{normalize_installable, normalize_target};
+
+    #[test]
+    fn bare_installable_qualifies_to_packages() {
+        assert_eq!(
+            normalize_installable(".#uxc", "x86_64-linux"),
+            "packages.x86_64-linux.uxc"
+        );
+        assert_eq!(
+            normalize_installable("#uxc", "aarch64-darwin"),
+            "packages.aarch64-darwin.uxc"
+        );
+        // `.#` alone builds every package, like `nix build .#` picks the default.
+        assert_eq!(
+            normalize_installable(".#", "x86_64-linux"),
+            "packages.x86_64-linux.#"
+        );
+    }
+
+    #[test]
+    fn qualified_and_wildcard_targets_pass_through() {
+        // gradient's own trailing `#` wildcard segment must survive untouched.
+        assert_eq!(
+            normalize_installable("packages.x86_64-linux.#", "x86_64-linux"),
+            "packages.x86_64-linux.#"
+        );
+        assert_eq!(
+            normalize_installable("checks.x86_64-linux.*", "x86_64-linux"),
+            "checks.x86_64-linux.*"
+        );
+        assert_eq!(normalize_installable("*", "x86_64-linux"), "*");
+        assert_eq!(
+            normalize_installable(".#packages.aarch64-linux.uxc", "x86_64-linux"),
+            "packages.aarch64-linux.uxc"
+        );
+        assert_eq!(
+            normalize_installable(".#nixosConfigurations.foo", "x86_64-linux"),
+            "nixosConfigurations.foo"
+        );
+    }
+
+    #[test]
+    fn exclusions_and_comma_lists_preserved() {
+        assert_eq!(
+            normalize_installable("!.#uxc", "x86_64-linux"),
+            "!packages.x86_64-linux.uxc"
+        );
+        assert_eq!(
+            normalize_installable("!nixosConfigurations.foo", "x86_64-linux"),
+            "!nixosConfigurations.foo"
+        );
+        assert_eq!(
+            normalize_target(".#uxc,.#cli", "x86_64-linux"),
+            "packages.x86_64-linux.uxc,packages.x86_64-linux.cli"
+        );
+    }
 }

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -3321,7 +3321,11 @@ paths:
                   description: The packed source NAR.
                 target:
                   type: string
-                  description: Eval target attribute path (defaults to the project wildcard).
+                  description: >-
+                    Eval target: a gradient attr-path wildcard
+                    (`packages.x86_64-linux.#`) or a nix-style installable
+                    (`.#foo`, expanded client-side to `packages.<system>.foo`).
+                    Defaults to the project wildcard.
                 system:
                   type: string
                   description: Target system.
@@ -3435,7 +3439,11 @@ paths:
               properties:
                 target:
                   type: string
-                  description: Eval target attribute path (defaults to the project wildcard).
+                  description: >-
+                    Eval target: a gradient attr-path wildcard
+                    (`packages.x86_64-linux.#`) or a nix-style installable
+                    (`.#foo`, expanded client-side to `packages.<system>.foo`).
+                    Defaults to the project wildcard.
                 system:
                   type: string
                   description: Target system.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -5878,3 +5878,26 @@ the bounded attempt budget instead of poisoning the build-once anchor.
   advertised-but-missing 404 now carries the typed self-heal signal instead
   of a plain string) and `substitute_not_on_upstream_wins` cover the
   classifier precedence.
+
+## `gradient build` accepts nix-style installables; empty targets fail loudly
+
+`gradient build .#uxc` used to complete green with "No outputs to link": the
+target was stored verbatim as the eval wildcard, but gradient's wildcard
+language is a `.`-separated attr path where `*`/`#` are their own segments, so
+`.#uxc` parsed to `["", "#uxc"]` and matched nothing - then the eval reported
+success with zero derivations. Two fixes: the CLI translates nix installables
+into wildcard syntax, and the eval fails a pinpointed target that matches
+nothing instead of silently completing.
+
+- `gradient-cli` `commands::build::tests` - `bare_installable_qualifies_to_packages`
+  (`.#uxc` -> `packages.<system>.uxc`, `.#` -> `packages.<system>.#`),
+  `qualified_and_wildcard_targets_pass_through` (gradient's own trailing `#`
+  segment, `*`, and already-qualified `.#packages...`/`.#nixosConfigurations...`
+  are untouched), and `exclusions_and_comma_lists_preserved` (`!`-prefixes and
+  comma-separated multi-patterns each normalise independently).
+- `gradient-worker` `executor::eval::tests` -
+  `unmatched_explicit_target_errors_but_wildcard_is_silent`: an explicit attr
+  (no `*`/`#`) with no matches yields a `target '...' matched no derivations`
+  error (recorded as an error-level `evaluation_message`, which
+  `check_evaluation_done` turns into `Failed`), while a wildcard pattern that
+  spans no buildable attrs stays silent.

--- a/docs/src/usage/cli.md
+++ b/docs/src/usage/cli.md
@@ -149,17 +149,28 @@ an evaluation under a per-org reserved `build-request` project.
 ```sh
 # Inside a git working tree
 gradient build                          # eval the project's wildcard target
+gradient build .#foo                    # nix-style installable -> packages.<system>.foo
 gradient build checks.x86_64-linux.foo  # eval a specific attribute path
-gradient build --system x86_64-linux    # override target system (default: org preference)
+gradient build --system x86_64-linux    # system used to expand a bare `.#foo` target
 gradient build -b                       # dispatch and print the evaluation UUID, then exit
 gradient build --no-link                # skip producing a result symlink/folder
 ```
+
+The target accepts either gradient's attr-path wildcard syntax (`.`-separated,
+with `*`/`#` wildcard segments and `!`-prefixed exclusions, e.g.
+`packages.x86_64-linux.#`) or a `nix build`-style installable (`.#foo`). An
+installable's flake ref is always the uploaded repo, so `.#foo` is expanded to
+`packages.<system>.foo` (`<system>` from `--system` or the host). A pinpointed
+target that matches no derivation fails the evaluation with a clear message
+instead of completing empty.
 
 Requirements and limits:
 
 - Run from inside a git working tree (bare repos are not supported).
 - Only files git tracks are uploaded; untracked files and `.git/` are skipped.
-- Combined upload size must not exceed **20 MiB** (`MAX_BUILD_REQUEST_SIZE`).
+- Total source size is capped by `settings.maxSourceUploadSize` (512 MiB
+  default); the source is streamed in bounded chunks, so no single request
+  hits the reverse proxy's body limit.
 - The default flow streams logs from all queued builds until they complete;
   pass `-b`/`--background` to print only the evaluation UUID and return
   immediately. Pair it with [`gradient watch`](#watching-an-evaluation) to


### PR DESCRIPTION
`gradient build .#uxc` completed green with "No outputs to link": the target was stored verbatim as the eval wildcard, but gradient's wildcard language is a `.`-separated attr path where `*`/`#` are their own segments, so `.#uxc` parsed to `["", "#uxc"]`, matched nothing, and the eval reported success.

- **CLI**: translate `nix build`-style installables into wildcard syntax (`.#uxc` -> `packages.<system>.uxc`); fully-qualified paths, `*`/`#` wildcards, and exclusions pass through.
- **Eval**: a pinpointed target (no `*`/`#`) that matches nothing now fails the evaluation with a clear message instead of silently completing.