### PR TITLE
db,migration: fix: anchor build_attempt and its log to the build, not the eval

### DIFF
--- a/backend/gradient-db/src/build_attempt.rs
+++ b/backend/gradient-db/src/build_attempt.rs
@@ -6,7 +6,8 @@
 
 //! Attempt helpers, keyed on the global `derivation_build` anchor (the actual
 //! build work). Each attempt is attributed to one `build_job` (the eval that
-//! drove the dispatch) and owns its log under its own id.
+//! drove the dispatch, `None` after that eval is GC'd) and owns its log under
+//! its own id.
 
 use chrono::NaiveDateTime;
 use gradient_entity::build_attempt::{
@@ -34,7 +35,7 @@ pub async fn open_attempt<C: ConnectionTrait>(
 ) -> Result<Model, DbErr> {
     Model {
         id: BuildAttemptId::now_v7(),
-        build_job,
+        build_job: Some(build_job),
         derivation_build,
         dispatched_job,
         substitute,
@@ -53,7 +54,8 @@ pub async fn open_attempt<C: ConnectionTrait>(
 /// the attempt's `build_job`) rather than the anchor's whole history, so a new
 /// evaluation retries substitution from zero instead of inheriting a previous
 /// eval's exhausted budget and escalating straight to a build. Pairs with zero
-/// misses are absent from the map.
+/// misses are absent from the map. Attempts orphaned by a GC'd eval
+/// (`build_job IS NULL`) drop out of the inner join, as intended.
 pub async fn substitute_miss_counts<C: ConnectionTrait>(
     db: &C,
     anchors: &[DerivationBuildId],

--- a/backend/gradient-db/src/gc.rs
+++ b/backend/gradient-db/src/gc.rs
@@ -10,7 +10,7 @@ use gradient_entity::evaluation::EvaluationStatus;
 use sea_orm::ActiveValue::Set;
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, ConnectionTrait, DatabaseBackend, EntityTrait, IntoActiveModel,
-    QueryFilter, QueryOrder, QuerySelect, Statement,
+    QueryFilter, QueryOrder, Statement,
 };
 use tracing::{info, warn};
 use uuid::Uuid;
@@ -88,33 +88,11 @@ pub async fn gc_project_evaluations(
     }
 
     for eval in &to_delete {
-        // Remove the log of every attempt attributed to this eval's build_jobs
-        // (logs are keyed by attempt id). DB rows cascade with the eval; NAR
-        // files and GC roots are owned by `derivation_output` / `cache_derivation`
-        // and are cleaned up by the derivation GC pass.
-        let job_ids: Vec<gradient_types::ids::BuildJobId> = EBuildJob::find()
-            .select_only()
-            .column(CBuildJob::Id)
-            .filter(CBuildJob::Evaluation.eq(eval.id))
-            .into_tuple::<gradient_types::ids::BuildJobId>()
-            .all(&ctx.worker_db)
-            .await
-            .context("GC: failed to query build_jobs")?;
-
-        let attempts = crate::fetch_in_chunks(&job_ids, |chunk| async move {
-            gradient_entity::build_attempt::Entity::find()
-                .filter(gradient_entity::build_attempt::Column::BuildJob.is_in(chunk))
-                .all(&ctx.worker_db)
-                .await
-        })
-        .await
-        .context("GC: failed to query build attempts")?;
-
-        for att in &attempts {
-            if let Err(e) = ctx.storage.log_storage.delete(att.id).await {
-                warn!(error = %e, attempt_id = %att.id, "GC: failed to remove build log");
-            }
-        }
+        // The eval's `build_job` rows cascade away, but its `build_attempt` rows
+        // (and their logs) are set-null'd onto the surviving `derivation_build`
+        // anchor - their true, build-once owner - and reclaimed only when the
+        // derivation GC deletes that anchor. NAR files and GC roots are likewise
+        // owned by `derivation_output` / `cache_derivation` and cleaned up there.
 
         // Collect commit ID before deletion (not cascaded).
         let commit_id = eval.commit;
@@ -271,6 +249,35 @@ pub async fn gc_orphan_derivations(ctx: &DbContext, grace_hours: i64) -> Result<
     .await
     .context("GC: failed to query orphan derivation outputs")?;
 
+    // Snapshot each candidate derivation's build-attempt logs before the delete
+    // cascades the attempt rows away: their log files live in `log_storage`
+    // (keyed by attempt id), outside the DB, so they must be reclaimed by hand
+    // like the NARs. `pass_logs` in the deep GC is the backstop for any missed.
+    let candidate_anchors = crate::fetch_in_chunks(&candidate_ids, |chunk| async move {
+        EDerivationBuild::find()
+            .filter(CDerivationBuild::Derivation.is_in(chunk))
+            .all(db)
+            .await
+    })
+    .await
+    .context("GC: failed to query orphan derivation anchors")?;
+    let anchor_derivation: std::collections::HashMap<DerivationBuildId, DerivationId> =
+        candidate_anchors.iter().map(|a| (a.id, a.derivation)).collect();
+    let anchor_ids: Vec<DerivationBuildId> = anchor_derivation.keys().copied().collect();
+
+    let candidate_attempts = crate::fetch_in_chunks(&anchor_ids, |chunk| async move {
+        EBuildAttempt::find()
+            .filter(CBuildAttempt::DerivationBuild.is_in(chunk))
+            .all(db)
+            .await
+    })
+    .await
+    .context("GC: failed to query orphan derivation build attempts")?;
+    let attempt_snapshot: Vec<(DerivationId, BuildAttemptId)> = candidate_attempts
+        .iter()
+        .filter_map(|a| anchor_derivation.get(&a.derivation_build).map(|d| (*d, a.id)))
+        .collect();
+
     let delete_sql = format!(
         "{reachable}
          DELETE FROM derivation d
@@ -300,6 +307,14 @@ pub async fn gc_orphan_derivations(ctx: &DbContext, grace_hours: i64) -> Result<
 
     if deleted.is_empty() {
         return Ok(());
+    }
+
+    // Reclaim the log files of every attempt whose derivation was just deleted;
+    // their `build_attempt`/`build_log_chunk` rows already cascaded away.
+    for attempt_id in attempt_logs_to_reclaim(&attempt_snapshot, &deleted) {
+        if let Err(e) = ctx.storage.log_storage.delete(attempt_id).await {
+            warn!(error = %e, %attempt_id, "GC: failed to remove orphan build log");
+        }
     }
 
     let deleted_hashes: HashSet<String> = candidate_outputs
@@ -426,6 +441,21 @@ fn reclaimable_after_delete(
     out
 }
 
+/// From a pre-delete `(derivation, attempt)` snapshot, the attempt ids whose
+/// derivation was actually reclaimed - their `log_storage` files can now be
+/// deleted. Attempts of derivations that survived the delete re-check (a
+/// concurrent eval re-attached a `build_job`) keep their logs.
+fn attempt_logs_to_reclaim(
+    snapshot: &[(DerivationId, BuildAttemptId)],
+    deleted: &std::collections::HashSet<DerivationId>,
+) -> Vec<BuildAttemptId> {
+    snapshot
+        .iter()
+        .filter(|(derivation, _)| deleted.contains(derivation))
+        .map(|(_, attempt)| *attempt)
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -463,6 +493,19 @@ mod tests {
     #[test]
     fn reclaims_nothing_when_all_hashes_survive() {
         assert!(reclaimable_hashes(set(&["a", "b"]), &set(&["a", "b"])).is_empty());
+    }
+
+    #[test]
+    fn reclaims_attempt_logs_only_for_deleted_derivations() {
+        // `d_kept` survived the delete re-check (a concurrent eval re-attached a
+        // build_job), so its attempt's log is retained; `d_gone`'s is reclaimed.
+        let d_gone = DerivationId::now_v7();
+        let d_kept = DerivationId::now_v7();
+        let a_gone = BuildAttemptId::now_v7();
+        let a_kept = BuildAttemptId::now_v7();
+        let snapshot = vec![(d_gone, a_gone), (d_kept, a_kept)];
+        let deleted: HashSet<DerivationId> = [d_gone].into_iter().collect();
+        assert_eq!(attempt_logs_to_reclaim(&snapshot, &deleted), vec![a_gone]);
     }
 
     #[test]

--- a/backend/gradient-entity/src/build_attempt.rs
+++ b/backend/gradient-entity/src/build_attempt.rs
@@ -59,7 +59,10 @@ pub enum AttemptFailureReason {
 pub struct Model {
     #[sea_orm(primary_key)]
     pub id: BuildAttemptId,
-    pub build_job: BuildJobId,
+    /// The eval that drove this attempt's dispatch. `None` once that evaluation
+    /// is GC'd: the attempt (and its log) live on with the `derivation_build`
+    /// anchor, its true owner, until the derivation itself is reclaimed.
+    pub build_job: Option<BuildJobId>,
     pub derivation_build: DerivationBuildId,
     pub dispatched_job: DispatchedJobId,
     pub substitute: bool,
@@ -87,7 +90,7 @@ pub enum Relation {
         belongs_to = "super::build_job::Entity",
         from = "Column::BuildJob",
         to = "super::build_job::Column::Id",
-        on_delete = "Cascade"
+        on_delete = "SetNull"
     )]
     BuildJob,
     #[sea_orm(

--- a/backend/gradient-migration/src/lib.rs
+++ b/backend/gradient-migration/src/lib.rs
@@ -30,6 +30,7 @@ mod m20260703_000000_drop_derivation_build_prefer_local_build;
 mod m20260703_000001_terminal_failed_partial_index;
 mod m20260704_000000_flag_partial_indexes;
 mod m20260705_000000_upstream_metric_by_url;
+mod m20260706_000000_build_attempt_build_job_set_null;
 
 pub struct Migrator;
 
@@ -61,6 +62,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260703_000001_terminal_failed_partial_index::Migration),
             Box::new(m20260704_000000_flag_partial_indexes::Migration),
             Box::new(m20260705_000000_upstream_metric_by_url::Migration),
+            Box::new(m20260706_000000_build_attempt_build_job_set_null::Migration),
         ]
     }
 }

--- a/backend/gradient-migration/src/m20260706_000000_build_attempt_build_job_set_null.rs
+++ b/backend/gradient-migration/src/m20260706_000000_build_attempt_build_job_set_null.rs
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! A `build_attempt` (and its log) outlives the evaluation that drove it: its
+//! real owner is the global `derivation_build` anchor (build-once), not the
+//! per-eval `build_job`. Under the old `ON DELETE CASCADE` an eval GC deleted
+//! the attempt and its log, so a `Completed` anchor reused by a later eval had
+//! no retrievable log. Switch the FK to `ON DELETE SET NULL`: eval GC now
+//! orphans the attempt from its build_job while it stays attached to the
+//! surviving anchor; the attempt (and log) die only when the derivation GC
+//! reclaims that anchor.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                ALTER TABLE build_attempt DROP CONSTRAINT IF EXISTS build_attempt_build_job_fkey;
+                ALTER TABLE build_attempt ALTER COLUMN build_job DROP NOT NULL;
+                ALTER TABLE build_attempt
+                  ADD CONSTRAINT build_attempt_build_job_fkey
+                  FOREIGN KEY (build_job) REFERENCES build_job (id) ON DELETE SET NULL;
+                "#,
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                ALTER TABLE build_attempt DROP CONSTRAINT IF EXISTS build_attempt_build_job_fkey;
+                DELETE FROM build_attempt WHERE build_job IS NULL;
+                ALTER TABLE build_attempt ALTER COLUMN build_job SET NOT NULL;
+                ALTER TABLE build_attempt
+                  ADD CONSTRAINT build_attempt_build_job_fkey
+                  FOREIGN KEY (build_job) REFERENCES build_job (id) ON DELETE CASCADE;
+                "#,
+            )
+            .await?;
+
+        Ok(())
+    }
+}

--- a/docs/src/scheduler.md
+++ b/docs/src/scheduler.md
@@ -12,7 +12,10 @@ A derivation is built exactly once, globally. Build state lives on a
 (UNIQUE on `derivation`, so the database itself enforces build-once). Every
 evaluation that needs a derivation gets a per-eval `build_job` linking it to
 that anchor; each execution attempt and its log live on `build_attempt` under
-the anchor.
+the anchor. `build_attempt.build_job` is `ON DELETE SET NULL`, so an attempt
+outlives the evaluation that drove it - its true owner is the build-once anchor,
+and a `Completed` anchor reused by a later evaluation keeps a retrievable log
+until the derivation itself is GC'd.
 
 When two evaluations - in the same or different organisations - need the same
 derivation, they share the one anchor: whichever is dispatched first builds
@@ -268,7 +271,11 @@ re-pushes them), so a terminal-failed anchor a later eval requeues must still fi
 its `.drv`; gating that clause on status purged the `.drv` of a failed-but-requeueable
 build and dead-ended its retry on `InputsUnavailable`. Outputs stay status-gated (they
 are rebuildable, TTL-evicted), and `gc_orphan_derivations` reclaims a derivation's
-`.drv`/sources once it leaves the live closure.
+`.drv`/sources once it leaves the live closure. Because attempts now outlive their
+evaluations (set-null'd onto the anchor), the same pass also deletes the
+`log_storage` files of every reclaimed derivation's attempts - the DB rows cascade,
+but the log objects live outside the database, so they are reclaimed by hand like
+the NARs. `pass_logs` in the deep GC is the backstop for any log object left behind.
 
 The keep-set is built from committed DB rows, so it cannot reference a NAR that is
 already on disk but whose `derivation`/`cached_path` rows have not been written yet

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -143,6 +143,18 @@ started skipping the whole project while any evaluation is active. Previously GC
 preferentially deleted failed/aborted evaluations (dropping the completed NARs
 they held) and could race an in-flight run.
 
+## Build logs outlive their evaluation, anchored to the build
+
+`backend/gradient-db/src/gc.rs`: `reclaims_attempt_logs_only_for_deleted_derivations`
+covers `attempt_logs_to_reclaim`, which selects an attempt's log for deletion
+only once its derivation is actually reclaimed by the orphan-derivation GC.
+`build_attempt.build_job` is now `ON DELETE SET NULL` (migration
+`m20260706_000000_build_attempt_build_job_set_null`), so evaluation GC orphans an
+attempt onto its surviving `derivation_build` anchor instead of cascade-deleting
+it - a `Completed` anchor reused by a later evaluation keeps a retrievable log.
+`gradient-cache/src/cacher/deep_gc.rs`: `pass_logs_removes_orphan_log` remains the
+backstop, deleting any `log_storage` object whose `build_attempt` row is gone.
+
 ## GitHub App installation org-binding
 
 `backend/gradient-web/src/endpoints/forge_hooks/trigger.rs`:

--- a/nix/modules/gradient-deploy.nix
+++ b/nix/modules/gradient-deploy.nix
@@ -119,27 +119,17 @@ in {
 
           API_KEY=$(cat ${cfg.apiKeyFile})
 
-          PROJECT_DETAILS=$(curl --silent --fail --max-time 10 \
+          # Entry points of the project's latest evaluation are the candidate deployments.
+          ENTRY_POINTS=$(curl --silent --fail --max-time 10 \
             --header "Authorization: Bearer $API_KEY" \
-            "${cfg.server}/api/v1/projects/${cfg.project}/details"
+            "${cfg.server}/api/v1/projects/${cfg.project}/entry-points"
             )
 
-          if [ -z "$PROJECT_DETAILS" ]; then
-            echo "Error: No project details received"
-            exit 1
-          fi
-
-          PROJECT_LAST_EVAL=$(echo "$PROJECT_DETAILS" | jq -r '.message.latest_evaluation.id // empty')
-          if [ -z "$PROJECT_LAST_EVAL" ]; then
-            echo "Error: No latest_evaluation found for project ${cfg.project}"
-            exit 1
-          fi
-
-          # Entry-point build IDs are the candidate deployments for this project.
-          BUILD_IDS=$(echo "$PROJECT_DETAILS" | jq -r '.message.entry_points[].build_id')
+          BUILD_IDS=$(echo "$ENTRY_POINTS" | jq -r \
+            '.message[] | select(.build_status == "Completed" or .build_status == "Substituted") | .build_id')
           if [ -z "$BUILD_IDS" ]; then
-            echo "Error: No entry points found for evaluation $PROJECT_LAST_EVAL"
-            exit 1
+            echo "No successfully built entry points for project ${cfg.project}"
+            exit 0
           fi
 
           DEPLOYMENT_STORE_PATH=""
@@ -149,17 +139,16 @@ in {
               --header "Authorization: Bearer $API_KEY" \
               "${cfg.server}/api/v1/builds/$BUILD_ID"
               )
+            [ -n "$BUILD_INFO" ] || continue
 
-            if [ -n "$BUILD_INFO" ]; then
-              BUILD_STATUS=$(echo "$BUILD_INFO" | jq -r '.message.status')
-              if [ "$BUILD_STATUS" != "Succeeded" ]; then
-                continue
-              fi
-              STORE_PATH=$(echo "$BUILD_INFO" | jq -r '.message.output.out // empty')
-              if echo "$STORE_PATH" | grep -qE "^/nix/store/[a-z0-9]{32}-nixos-system-${cfg.deployFor}-[0-9]{2}\.[0-9]{2}(\.[0-9]{8}\.[a-f0-9]+)?$"; then
-                DEPLOYMENT_STORE_PATH="$STORE_PATH"
-                break
-              fi
+            # The API returns prefix-free `<hash>-<name>` output paths.
+            OUT_BASE=$(echo "$BUILD_INFO" | jq -r '.message.output.out // empty')
+            [ -n "$OUT_BASE" ] || continue
+            STORE_PATH="/nix/store/$OUT_BASE"
+
+            if echo "$STORE_PATH" | grep -qE "^/nix/store/[a-z0-9]{32}-nixos-system-${cfg.deployFor}-[0-9]{2}\.[0-9]{2}(\.[0-9]{8}\.[a-f0-9]+)?$"; then
+              DEPLOYMENT_STORE_PATH="$STORE_PATH"
+              break
             fi
           done
 


### PR DESCRIPTION
A build-once `derivation_build` anchor reused across evaluations lost its log once the evaluation that first built it aged past `keep_evaluations`: `build_attempt.build_job` cascade-deleted the attempt and its log. Switch that FK to `ON DELETE SET NULL` so the attempt outlives its eval on the surviving anchor, and reclaim attempt log files in the orphan-derivation GC (with deep-GC `pass_logs` as the backstop).