### PR TITLE
worker,cli: max build cores (#497) + login/org onboarding (#498)

### DIFF
--- a/backend/gradient-migration/src/lib.rs
+++ b/backend/gradient-migration/src/lib.rs
@@ -31,6 +31,7 @@ mod m20260703_000001_terminal_failed_partial_index;
 mod m20260704_000000_flag_partial_indexes;
 mod m20260705_000000_upstream_metric_by_url;
 mod m20260706_000000_build_attempt_build_job_set_null;
+mod m20260706_000001_disable_jit;
 
 pub struct Migrator;
 
@@ -63,6 +64,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260704_000000_flag_partial_indexes::Migration),
             Box::new(m20260705_000000_upstream_metric_by_url::Migration),
             Box::new(m20260706_000000_build_attempt_build_job_set_null::Migration),
+            Box::new(m20260706_000001_disable_jit::Migration),
         ]
     }
 }

--- a/backend/gradient-migration/src/m20260706_000001_disable_jit.rs
+++ b/backend/gradient-migration/src/m20260706_000001_disable_jit.rs
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Disable JIT for gradient's database. The dispatch-tick reconcile fixpoints
+//! and the cached_path consistency sweep run correlated `NOT EXISTS` predicates
+//! over the whole build graph, so their cost estimates trip Postgres's JIT
+//! thresholds - yet they execute sub-second, making per-call JIT compilation
+//! pure overhead (measured 2.9s -> 0.6s on the closure_complete CLEAR). JIT
+//! never pays for this OLTP-shaped workload. Scope via `current_database()` so
+//! it is name-portable across prod/CI/dev; owner role `gradient` may ALTER it.
+
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::ConnectionTrait;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "DO $$ BEGIN EXECUTE format('ALTER DATABASE %I SET jit = off', current_database()); END $$;",
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "DO $$ BEGIN EXECUTE format('ALTER DATABASE %I RESET jit', current_database()); END $$;",
+            )
+            .await?;
+        Ok(())
+    }
+}

--- a/backend/gradient-worker/src/config.rs
+++ b/backend/gradient-worker/src/config.rs
@@ -128,6 +128,11 @@ pub struct WorkerConfig {
     #[arg(long, env = "GRADIENT_MAX_CONCURRENT_BUILDS", default_value_t = 1)]
     pub max_concurrent_builds: u32,
 
+    /// Cap on CPU cores a single build may use (nix `--cores` / `NIX_BUILD_CORES`).
+    /// Unset (the default) passes `0` to the daemon, meaning all available cores.
+    #[arg(long, env = "GRADIENT_WORKER_MAX_BUILD_CORES")]
+    pub max_build_cores: Option<u32>,
+
     /// Maximum number of simultaneous connections in the local nix-daemon
     /// pool. Each in-flight `add_to_store_nar` (NAR import during prefetch)
     /// holds one connection for the duration of the upload, so the pool
@@ -381,6 +386,12 @@ impl WorkerConfig {
             .unwrap_or_else(|| format!("{}/eval-cache", self.data_dir))
     }
 
+    /// Resolve the nix `--cores` value for a build: the configured cap, or `0`
+    /// (all available cores) when unset.
+    pub fn build_cores(&self) -> u32 {
+        self.max_build_cores.unwrap_or(0)
+    }
+
     /// Build the `GradientCapabilities` struct from the CLI flags.
     pub fn capabilities(&self) -> GradientCapabilities {
         GradientCapabilities {
@@ -420,6 +431,7 @@ mod tests {
             eval_cache_share: true,
             max_concurrent_evaluations: 1,
             max_concurrent_builds: 1,
+            max_build_cores: None,
             max_nixdaemon_connections: 4,
             nar_partial_ttl_secs: 86400,
             log_level: "info".to_owned(),
@@ -457,6 +469,20 @@ mod tests {
         let cli = config_with_peers("");
         assert!(cli.eval_fork_workers >= 1);
         assert_eq!(cli.max_eval_rss, 8 * 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn build_cores_defaults_to_all_cores() {
+        let cfg = config_with_peers("");
+        assert_eq!(cfg.max_build_cores, None);
+        assert_eq!(cfg.build_cores(), 0);
+    }
+
+    #[test]
+    fn build_cores_uses_configured_cap() {
+        let mut cfg = config_with_peers("");
+        cfg.max_build_cores = Some(4);
+        assert_eq!(cfg.build_cores(), 4);
     }
 
     // ── peer_tokens() ─────────────────────────────────────────────────────────
@@ -518,6 +544,7 @@ mod tests {
             eval_cache_share: true,
             max_concurrent_evaluations: 1,
             max_concurrent_builds: 1,
+            max_build_cores: None,
             max_nixdaemon_connections: 4,
             nar_partial_ttl_secs: 86400,
             log_level: "info".to_owned(),
@@ -593,6 +620,7 @@ mod tests {
             eval_cache_share: true,
             max_concurrent_evaluations: 1,
             max_concurrent_builds: 1,
+            max_build_cores: None,
             max_nixdaemon_connections: 4,
             nar_partial_ttl_secs: 86400,
             log_level: "info".to_owned(),

--- a/backend/gradient-worker/src/executor/build.rs
+++ b/backend/gradient-worker/src/executor/build.rs
@@ -104,6 +104,7 @@ impl ParsedDerivation {
         abort: &mut watch::Receiver<bool>,
         log_limits: crate::executor::log_limit::LogRateLimits,
         log_fetch_from_store: bool,
+        build_cores: u32,
     ) -> Result<(Vec<BuildOutput>, bool, Option<u64>), BuildError> {
         let mut guard = store.acquire().await.map_err(BuildError::transient)?;
 
@@ -122,7 +123,7 @@ impl ParsedDerivation {
         opts.verbose_build = Verbosity::Talkative;
         opts.verbosity = Verbosity::Notice;
         opts.use_substitutes = false;
-        opts.build_cores = 0;
+        opts.build_cores = build_cores;
 
         guard
             .execute(|client| async move { client.set_options(&opts).await })
@@ -333,6 +334,7 @@ pub async fn build_derivation(
     cgroup_state_dir: &str,
     log_limits: crate::executor::log_limit::LogRateLimits,
     log_fetch_from_store: bool,
+    build_cores: u32,
 ) -> Result<Vec<BuildOutput>, BuildError> {
     // `report_building` is sent by the caller (`execute_build_job`) before the
     // prefetch step, so a `JobFailed` after a prefetch error finds the build
@@ -351,6 +353,7 @@ pub async fn build_derivation(
         abort,
         log_limits,
         log_fetch_from_store,
+        build_cores,
     );
 
     let net_sampler = build_metrics.then(NetworkPeakSampler::start);

--- a/backend/gradient-worker/src/executor/mod.rs
+++ b/backend/gradient-worker/src/executor/mod.rs
@@ -217,6 +217,7 @@ pub struct JobExecutor {
     pub(crate) build_cgroup_state_dir: String,
     pub(crate) log_limits: crate::executor::log_limit::LogRateLimits,
     pub(crate) log_fetch_from_store: bool,
+    pub(crate) build_cores: u32,
 }
 
 impl JobExecutor {
@@ -232,6 +233,7 @@ impl JobExecutor {
         build_cgroup_state_dir: String,
         log_limits: crate::executor::log_limit::LogRateLimits,
         log_fetch_from_store: bool,
+        build_cores: u32,
     ) -> Self {
         Self {
             store: Arc::new(store),
@@ -244,6 +246,7 @@ impl JobExecutor {
             build_cgroup_state_dir,
             log_limits,
             log_fetch_from_store,
+            build_cores,
         }
     }
 
@@ -422,6 +425,7 @@ impl JobExecutor {
                 &self.build_cgroup_state_dir,
                 self.log_limits,
                 self.log_fetch_from_store,
+                self.build_cores,
             )
             .await?;
             for o in &outputs {

--- a/backend/gradient-worker/src/worker/mod.rs
+++ b/backend/gradient-worker/src/worker/mod.rs
@@ -276,6 +276,7 @@ impl Worker<Connected> {
                 sustained_bytes_per_hour: config.log_sustained_bytes_per_hour,
             },
             config.log_fetch_from_store,
+            config.build_cores(),
         );
         if config.build_metrics {
             tracing::info!(

--- a/cli/src/commands/base.rs
+++ b/cli/src/commands/base.rs
@@ -54,6 +54,9 @@ enum MainCommands {
     },
     /// Login to the server
     Login {
+        /// Server URL to log in to; sets it as the configured server so a
+        /// separate `gradient config server` is not needed.
+        server: Option<String>,
         /// Use basic username/password instead of the default web flow
         #[arg(short, long)]
         username: Option<String>,
@@ -231,7 +234,7 @@ async fn run_cli(cli: Cli) -> std::io::Result<()> {
             if server_url.is_none() {
                 out.err(
                     ExitKind::Usage,
-                    "Server URL not set. Use `gradient config server <url>`.",
+                    "Server URL not set. Run `gradient login <url>` to set the server and authenticate.",
                 );
             }
 
@@ -263,10 +266,15 @@ async fn run_cli(cli: Cli) -> std::io::Result<()> {
         }
 
         MainCommands::Login {
+            server,
             username,
             password,
             no_browser,
         } => {
+            if let Some(url) = server {
+                set_get_value(ConfigKey::Server, Some(url), true).unwrap();
+            }
+
             let server_url = set_get_value(ConfigKey::Server, None, true);
             if server_url.is_none() {
                 set_get_value(ConfigKey::Server, Some(ask_for_input("Server URL")), true).unwrap();
@@ -291,6 +299,7 @@ async fn run_cli(cli: Cli) -> std::io::Result<()> {
                         set_get_value(ConfigKey::AuthToken, Some(token), true).unwrap();
                         out.ok(&serde_json::json!({"logged_in": true}));
                         out.human("Logged in.");
+                        organization::post_login_org_setup(&client_from_config(out), out).await;
                     }
                     Err(e) => out.err(to_exit_kind(&e), e),
                 }
@@ -403,6 +412,7 @@ async fn run_web_login(out: Output, no_browser: bool) {
                 set_get_value(ConfigKey::AuthToken, Some(token), true).unwrap();
                 out.ok(&serde_json::json!({"logged_in": true}));
                 out.human("Logged in.");
+                organization::post_login_org_setup(&client_from_config(out), out).await;
                 return;
             }
             Err(e) => out.err(to_exit_kind(&e), e),

--- a/cli/src/commands/build.rs
+++ b/cli/src/commands/build.rs
@@ -26,18 +26,28 @@ pub async fn handle_build(
     no_link: bool,
     out: Output,
 ) {
+    // Surface a missing server / session before the org check so an unconfigured
+    // first run points at `gradient login` rather than org selection (#498).
+    let client = client_from_config(out);
+    if let Err(ConnectorError::Unauthorized) = client.user().get().await {
+        out.err(
+            ExitKind::Unauthorized,
+            "Not authenticated: your gradient session is missing or expired. \
+             Run `gradient login <url>` and try again.",
+        );
+    }
+
     let organization = organization
         .or_else(|| set_get_value(ConfigKey::SelectedOrganization, None, true))
         .unwrap_or_else(|| {
             if !quiet {
                 out.progress(
-                    "Organization must be set for build command. Use 'gradient organization select <name>' to set one.",
+                    "Organization must be set for build command. Use 'gradient organization select <name>' \
+                     (it is selected automatically on `gradient login`).",
                 );
             }
             exit(1);
         });
-
-    let client = client_from_config(out);
 
     // Accept `nix build`-style installables (`.#uxc`) and translate them into
     // gradient's attr-path wildcard language before dispatch and result linking.
@@ -202,17 +212,6 @@ async fn upload_and_dispatch(
     quiet: bool,
     out: Output,
 ) -> DispatchResponse {
-    // Fail fast on a missing or expired session before packing and streaming a
-    // potentially large source NAR (#493). A cheap authenticated probe surfaces
-    // the auth problem clearly instead of as a confusing upload/multipart error.
-    if let Err(ConnectorError::Unauthorized) = client.user().get().await {
-        out.err(
-            ExitKind::Unauthorized,
-            "Not authenticated: your gradient session is missing or expired. \
-             Run `gradient login` and try again.",
-        );
-    }
-
     #[cfg(feature = "nix")]
     {
         crate::commands::build_nix::dispatch_via_nar(

--- a/cli/src/commands/organization.rs
+++ b/cli/src/commands/organization.rs
@@ -13,6 +13,7 @@ use clap_complete::engine::ArgValueCompleter;
 use connector::orgs::{
     AddUserRequest, MakeOrganizationRequest, PatchOrganizationRequest, RemoveUserRequest,
 };
+use connector::{Client, ConnectorError};
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
@@ -85,6 +86,21 @@ pub enum CacheCommands {
 pub async fn handle(cmd: Commands, out: Output) {
     match cmd {
         Commands::Select { organization } => {
+            let memberships = membership_names(out).await;
+            if !memberships.iter().any(|o| o == &organization) {
+                out.err(
+                    ExitKind::Usage,
+                    format!(
+                        "You are not a member of organization '{}'. Your organizations: {}",
+                        organization,
+                        if memberships.is_empty() {
+                            "(none)".to_string()
+                        } else {
+                            memberships.join(", ")
+                        }
+                    ),
+                );
+            }
             set_get_value(ConfigKey::SelectedOrganization, Some(organization), true).unwrap();
             out.human("Organization selected.");
         }
@@ -369,5 +385,121 @@ pub async fn handle(cmd: Commands, out: Output) {
                 }
             }
         }
+    }
+}
+
+/// Names of the organizations the current user belongs to, exiting with a clear
+/// login hint when no session is configured or the server rejects it.
+async fn membership_names(out: Output) -> Vec<String> {
+    if set_get_value(ConfigKey::AuthToken, None, true).is_none() {
+        out.err(
+            ExitKind::Unauthorized,
+            "Not logged in. Run `gradient login <url>` first.",
+        );
+    }
+    let client = client_from_config(out);
+    match client.orgs().list().await {
+        Ok(res) => res.items.into_iter().map(|i| i.name).collect(),
+        Err(ConnectorError::Unauthorized) => out.err(
+            ExitKind::Unauthorized,
+            "Not logged in. Run `gradient login <url>` first.",
+        ),
+        Err(e) => out.err(to_exit_kind(&e), e),
+    }
+}
+
+/// After a successful login, select the user's organization when it is
+/// unambiguous, otherwise guide them. Never blocks login on a list failure.
+pub async fn post_login_org_setup(client: &Client, out: Output) {
+    let orgs: Vec<String> = match client.orgs().list().await {
+        Ok(res) => res.items.into_iter().map(|i| i.name).collect(),
+        Err(_) => return,
+    };
+    let current = set_get_value(ConfigKey::SelectedOrganization, None, true);
+    match decide_org_onboarding(&orgs, current.as_deref()) {
+        OrgOnboarding::Keep(_) => {}
+        OrgOnboarding::AutoSelect(name) => {
+            set_get_value(ConfigKey::SelectedOrganization, Some(name.clone()), true);
+            out.human(format!("Selected organization {name}."));
+        }
+        OrgOnboarding::Choose(names) => {
+            out.human("You belong to multiple organizations:");
+            for n in &names {
+                out.human(format!("  {n}"));
+            }
+            out.human("Select one with `gradient organization select <name>`.");
+        }
+        OrgOnboarding::None => out.human(
+            "You are not a member of any organization yet. Create one with `gradient organization create`.",
+        ),
+    }
+}
+
+/// Post-login org handling derived from the user's memberships and any current
+/// selection. Pure so the decision is testable without a server.
+#[derive(Debug, PartialEq, Eq)]
+pub enum OrgOnboarding {
+    Keep(String),
+    AutoSelect(String),
+    Choose(Vec<String>),
+    None,
+}
+
+pub fn decide_org_onboarding(orgs: &[String], current: Option<&str>) -> OrgOnboarding {
+    if let Some(sel) = current
+        && orgs.iter().any(|o| o == sel)
+    {
+        return OrgOnboarding::Keep(sel.to_string());
+    }
+    match orgs {
+        [] => OrgOnboarding::None,
+        [one] => OrgOnboarding::AutoSelect(one.clone()),
+        _ => OrgOnboarding::Choose(orgs.to_vec()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{OrgOnboarding, decide_org_onboarding};
+
+    fn v(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn no_orgs_yields_none() {
+        assert_eq!(decide_org_onboarding(&[], None), OrgOnboarding::None);
+    }
+
+    #[test]
+    fn single_org_auto_selects() {
+        assert_eq!(
+            decide_org_onboarding(&v(&["solo"]), None),
+            OrgOnboarding::AutoSelect("solo".into())
+        );
+    }
+
+    #[test]
+    fn multiple_orgs_prompt_choice() {
+        assert_eq!(
+            decide_org_onboarding(&v(&["a", "b"]), None),
+            OrgOnboarding::Choose(v(&["a", "b"]))
+        );
+    }
+
+    #[test]
+    fn valid_current_selection_is_kept() {
+        assert_eq!(
+            decide_org_onboarding(&v(&["a", "b"]), Some("b")),
+            OrgOnboarding::Keep("b".into())
+        );
+    }
+
+    #[test]
+    fn stale_current_selection_falls_through() {
+        assert_eq!(
+            decide_org_onboarding(&v(&["a"]), Some("c")),
+            OrgOnboarding::AutoSelect("a".into())
+        );
     }
 }

--- a/cli/src/input.rs
+++ b/cli/src/input.rs
@@ -22,7 +22,7 @@ pub fn client_from_config(out: Output) -> Client {
         .unwrap_or_else(|| {
             out.err(
                 ExitKind::Usage,
-                "Server URL not set. Use `gradient config server <url>`.",
+                "Server URL not set. Run `gradient login <url>` to set the server and authenticate.",
             );
         });
     let token = cfg
@@ -45,7 +45,7 @@ pub fn server_base(out: Output) -> String {
         .unwrap_or_else(|| {
             out.err(
                 ExitKind::Usage,
-                "Server URL not set. Use `gradient config server <url>`.",
+                "Server URL not set. Run `gradient login <url>` to set the server and authenticate.",
             );
         })
 }

--- a/cli/tests/onboarding.rs
+++ b/cli/tests/onboarding.rs
@@ -1,0 +1,88 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn write_config(home: &TempDir, body: &str) {
+    let cfg_dir = home.path().join("gradient");
+    fs::create_dir_all(&cfg_dir).unwrap();
+    fs::write(cfg_dir.join("config.toml"), body).unwrap();
+}
+
+async fn orgs_mock(names: &[&str]) -> MockServer {
+    let server = MockServer::start().await;
+    let items: Vec<_> = names
+        .iter()
+        .map(|n| serde_json::json!({"id": format!("id-{n}"), "name": n}))
+        .collect();
+    Mock::given(method("GET"))
+        .and(path("/api/v1/orgs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "error": false,
+            "message": {"items": items, "total": items.len(), "page": 1, "per_page": 20}
+        })))
+        .mount(&server)
+        .await;
+    server
+}
+
+#[test]
+fn organization_select_without_login_is_rejected() {
+    let home = TempDir::new().unwrap();
+    write_config(&home, "Server = 'http://localhost:1'\n");
+
+    Command::cargo_bin("gradient")
+        .unwrap()
+        .env("XDG_CONFIG_HOME", home.path())
+        .args(["organization", "select", "sandro"])
+        .assert()
+        .failure()
+        .code(3)
+        .stderr(predicate::str::contains("Not logged in"))
+        .stderr(predicate::str::contains("gradient login"));
+}
+
+#[tokio::test]
+async fn organization_select_rejects_non_member() {
+    let server = orgs_mock(&["other"]).await;
+    let home = TempDir::new().unwrap();
+    write_config(
+        &home,
+        &format!("Server = '{}'\nAuthToken = 'test-token'\n", server.uri()),
+    );
+
+    Command::cargo_bin("gradient")
+        .unwrap()
+        .env("XDG_CONFIG_HOME", home.path())
+        .args(["organization", "select", "sandro"])
+        .assert()
+        .failure()
+        .code(2)
+        .stderr(predicate::str::contains("not a member"));
+}
+
+#[tokio::test]
+async fn organization_select_accepts_member() {
+    let server = orgs_mock(&["sandro"]).await;
+    let home = TempDir::new().unwrap();
+    write_config(
+        &home,
+        &format!("Server = '{}'\nAuthToken = 'test-token'\n", server.uri()),
+    );
+
+    Command::cargo_bin("gradient")
+        .unwrap()
+        .env("XDG_CONFIG_HOME", home.path())
+        .args(["organization", "select", "sandro"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Organization selected"));
+}

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -376,6 +376,7 @@ The token must be the 48-byte random secret returned by the registration API (ge
 | `capabilities.sign` | `false` | Sign store paths |
 | `capabilities.federate` | `false` | Act as a federation relay (requires `discoverable`) |
 | `settings.maxConcurrentBuilds` | `100` | Parallel build slots |
+| `settings.maxBuildCores` | `null` | Cap on CPU cores a single build may use (nix `--cores` / `NIX_BUILD_CORES`, `GRADIENT_WORKER_MAX_BUILD_CORES`). When null, a build may use all available cores |
 | `settings.evalWorkers` | `1` | Number of evaluator subprocesses |
 | `settings.maxConcurrentEvaluations` | `1` | Parallel evaluations |
 | `settings.cpuCoreScore` | `null` | Override the advertised single-core speed score (higher is faster, `GRADIENT_WORKER_CPU_CORE_SCORE`). When null, the worker benchmarks the host at startup |

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -5913,3 +5913,27 @@ nothing instead of silently completing.
   error (recorded as an error-level `evaluation_message`, which
   `check_evaluation_done` turns into `Failed`), while a wildcard pattern that
   spans no buildable attrs stays silent.
+
+## Worker max build cores (#497)
+
+`backend/gradient-worker/src/config.rs` `tests`:
+- `build_cores_defaults_to_all_cores` - an unset `max_build_cores` resolves to
+  `0` (nix `--cores` for "all available cores"), preserving prior behavior.
+- `build_cores_uses_configured_cap` - a configured cap is passed through to the
+  daemon verbatim.
+
+## CLI onboarding (#498)
+
+`cli/src/commands/organization.rs` `tests` - the pure `decide_org_onboarding`
+that drives post-login org selection:
+- `no_orgs_yields_none`, `single_org_auto_selects`, `multiple_orgs_prompt_choice`
+  cover the zero / one / many membership cases.
+- `valid_current_selection_is_kept` leaves an already-selected org untouched;
+  `stale_current_selection_falls_through` re-selects when the stored org is no
+  longer a membership.
+
+`cli/tests/onboarding.rs` (`assert_cmd` + `wiremock`):
+- `organization_select_without_login_is_rejected` - selecting an org with no
+  stored token exits `Unauthorized` and points at `gradient login <url>`.
+- `organization_select_rejects_non_member` / `organization_select_accepts_member`
+  - selection is validated against the caller's `/orgs` memberships.

--- a/docs/src/usage/cli.md
+++ b/docs/src/usage/cli.md
@@ -36,27 +36,23 @@ nix run github:wavelens/gradient#gradient-cli -- --help
 
 ## Configuration
 
-Before using the CLI, point it at your Gradient server:
+Log in and point the CLI at your Gradient server in one step:
 
 ```sh
-gradient config server https://gradient.example.com
+gradient login https://gradient.example.com
 ```
 
-Then log in:
-
-```sh
-gradient login
-```
+Passing the URL sets it as the configured server, so a separate `gradient config server` is no longer needed. On a successful first login the CLI selects your organization automatically when you belong to exactly one, and otherwise lists them so you can pick with `gradient organization select <name>`.
 
 By default this opens your browser to authorize the CLI session, which is what you want for interactive use and works the same when the Gradient server is configured for OIDC-only login. Pass `--no-browser` to print the URL instead - useful when running over SSH on a headless machine, where you can open the URL on your laptop. The browser flow asks you to confirm a short code that the CLI also prints, then issues a 30-day session token.
 
 For unattended scripts you can still pass credentials directly:
 
 ```sh
-gradient login --username alice --password "$PASSWORD"
+gradient login https://gradient.example.com --username alice --password "$PASSWORD"
 ```
 
-Either way, the resulting token is stored in the local configuration file (`~/.config/gradient/config`).
+The server URL can also be set on its own with `gradient config server <url>`, and `gradient organization select` requires a valid login and only accepts an organization you belong to. Either way, the resulting token is stored in the local configuration file (`~/.config/gradient/config`).
 
 ### Self-signed certificates
 

--- a/nix/modules/gradient-worker.nix
+++ b/nix/modules/gradient-worker.nix
@@ -174,6 +174,15 @@ in {
         default = 8;
       };
 
+      maxBuildCores = lib.mkOption {
+        description = ''
+          Cap on CPU cores a single build may use (nix `--cores` /
+          `NIX_BUILD_CORES`). Null (the default) means all available cores.
+        '';
+        type = lib.types.nullOr lib.types.ints.positive;
+        default = null;
+      };
+
       maxNixdaemonConnections = lib.mkOption {
         description = ''
           Maximum number of simultaneous local Nix daemon connections in
@@ -464,6 +473,8 @@ in {
           GRADIENT_WORKER_ARCHITECTURES = lib.concatStringsSep "," cfg.settings.architectures;
         } // lib.optionalAttrs (cfg.settings.systemFeatures != []) {
           GRADIENT_WORKER_SYSTEM_FEATURES = lib.concatStringsSep "," cfg.settings.systemFeatures;
+        } // lib.optionalAttrs (cfg.settings.maxBuildCores != null) {
+          GRADIENT_WORKER_MAX_BUILD_CORES = toString cfg.settings.maxBuildCores;
         } // lib.optionalAttrs (cfg.settings.cpuCoreScore != null) {
           GRADIENT_WORKER_CPU_CORE_SCORE = toString cfg.settings.cpuCoreScore;
         } // lib.optionalAttrs (cfg.settings.evalCacheDir != null) {


### PR DESCRIPTION
Closes #497, #498.

- **#497**: `GRADIENT_WORKER_MAX_BUILD_CORES` / `settings.maxBuildCores` caps nix `--cores` per build; null (default) keeps today's all-cores behavior.
- **#498**: `gradient login <url>` sets the server, authenticates, and auto-selects your org when you belong to one; `organization select` now requires a valid login and only accepts orgs you belong to; an unconfigured `build` surfaces the login hint first.
- **DB perf** (folded in per request): disable Postgres JIT for gradient's database. The 5s-tick reconcile fixpoints and consistency sweep trip JIT on inflated cost estimates (correlated `NOT EXISTS` over the build graph) but execute sub-second, so JIT added ~2.3s of pure overhead per call (measured 2.9s -> 0.6s).