### PR TITLE
cli,cache: fix cache upload: compression, eager signing, closure default (#506, #507, #509)

### DIFF
--- a/backend/gradient-proto/src/handler/nar.rs
+++ b/backend/gradient-proto/src/handler/nar.rs
@@ -7,17 +7,11 @@
 use crate::ingest::{IngestInput, SignTargets, ingest_metadata_only};
 use chrono::Timelike;
 use gradient_core::ServerState;
-use gradient_sources::CacheSigner;
-use gradient_types::ids::{CacheId, CacheMetricId, CachedPathId, OrganizationId};
+use gradient_types::ids::{CacheId, CacheMetricId, OrganizationId};
 use gradient_types::*;
-use gradient_util::nix_hash::normalize_nar_hash;
 use sea_orm::sea_query::Expr;
-use sea_orm::{
-    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, FromQueryResult, IntoActiveModel,
-    QueryFilter, Set, Statement,
-};
-use std::collections::{HashMap, HashSet};
-use tracing::{debug, warn};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, Set};
+use tracing::debug;
 
 pub(super) struct NarUploadRecord<'a> {
     pub file_hash: &'a str,
@@ -151,129 +145,19 @@ pub(super) async fn mark_nar_stored(
     // cache took it (OrgCaches); the periodic sweep stays the backfill for
     // subscription placeholders and anything left NULL.
     if org_id.is_some() {
-        sign_cached_path(state, cached_path_id, hash, store_path, record).await;
+        crate::signing::sign_cached_path(
+            &state.worker_db,
+            &state.config.secrets.crypt_secret_file,
+            &state.config.server.serve_url,
+            crate::signing::SignRequest {
+                cached_path: cached_path_id,
+                store_path,
+                nar_hash: record.nar_hash,
+                nar_size: record.nar_size,
+                references: record.references,
+            },
+        )
+        .await;
     }
     Ok(())
-}
-
-/// Fill the pending `cached_path_signature` rows for one freshly cached path.
-/// Skips paths whose every producing project has `sign_cache=false` (the
-/// reserved `build-request` project is always signable). Signing failures are
-/// logged, never propagated: the NAR is already stored and the periodic sweep
-/// re-signs whatever is left NULL.
-async fn sign_cached_path(
-    state: &ServerState,
-    cached_path_id: CachedPathId,
-    hash: &str,
-    store_path: &str,
-    record: &NarUploadRecord<'_>,
-) {
-    if producing_projects_all_private(&state.worker_db, hash).await {
-        return;
-    }
-
-    let pending = match ECachedPathSignature::find()
-        .filter(CCachedPathSignature::CachedPath.eq(cached_path_id))
-        .filter(CCachedPathSignature::Signature.is_null())
-        .all(&state.worker_db)
-        .await
-    {
-        Ok(rows) if !rows.is_empty() => rows,
-        Ok(_) => return,
-        Err(e) => {
-            warn!(store_path, error = %e, "eager sign: load pending signatures failed");
-            return;
-        }
-    };
-
-    // The just-stored references (hash-name form) are what the narinfo serve
-    // path reconstructs the fingerprint from; `fingerprint` sorts them, so this
-    // matches the sweep byte-for-byte without re-reading `cached_path_reference`.
-    let nar_hash_nix32 = normalize_nar_hash(record.nar_hash);
-    let nar_size = record.nar_size as u64;
-
-    // One signer per distinct cache (one crypt-secret read + key decrypt each),
-    // built up front; caches whose key is absent/undecodable are simply absent.
-    let mut signers: HashMap<CacheId, CacheSigner> = HashMap::new();
-    for cache_id in pending.iter().map(|r| r.cache).collect::<HashSet<_>>() {
-        if let Some(signer) = build_signer(state, cache_id).await {
-            signers.insert(cache_id, signer);
-        }
-    }
-
-    for row in pending {
-        let Some(signer) = signers.get(&row.cache) else {
-            continue;
-        };
-
-        let sig = signer.sign_narinfo_raw(store_path, &nar_hash_nix32, nar_size, record.references);
-        let mut am = row.into_active_model();
-        am.signature = Set(Some(sig));
-        if let Err(e) = am.update(&state.worker_db).await {
-            warn!(store_path, error = %e, "eager sign: persist signature failed");
-        }
-    }
-}
-
-/// Build a signer for `cache_id`, or `None` when the cache is gone or its key is
-/// empty/undecodable (the periodic sweep logs the same and skips those rows).
-async fn build_signer(state: &ServerState, cache_id: CacheId) -> Option<CacheSigner> {
-    let cache = ECache::find_by_id(cache_id)
-        .one(&state.worker_db)
-        .await
-        .ok()
-        .flatten()?;
-    if cache.private_key.is_empty() {
-        return None;
-    }
-    match CacheSigner::from_cache(
-        &state.config.secrets.crypt_secret_file,
-        &cache,
-        &state.config.server.serve_url,
-    ) {
-        Ok(s) => Some(s),
-        Err(e) => {
-            warn!(cache_name = %cache.name, error = %e, "eager sign: failed to prepare signer");
-            None
-        }
-    }
-}
-
-/// True iff the path is produced by at least one project and every producing
-/// project has `sign_cache=false` - mirrors the sweep's skip gate. The reserved
-/// per-org `build-request` project is always signable (its outputs must be
-/// substitutable by the submitting client). Paths with no producing project
-/// (`.drv` files, direct builds) return false → signed normally.
-async fn producing_projects_all_private<C: ConnectionTrait>(db: &C, hash: &str) -> bool {
-    #[derive(FromQueryResult)]
-    struct Flags {
-        producers: i64,
-        signable: i64,
-    }
-
-    let stmt = Statement::from_sql_and_values(
-        db.get_database_backend(),
-        r#"
-            SELECT count(*)::bigint AS producers,
-                   count(*) FILTER (
-                       WHERE p.sign_cache OR p.name = 'build-request'
-                   )::bigint AS signable
-            FROM derivation_output do_
-            JOIN derivation d ON d.id = do_.derivation
-            JOIN build_job b  ON b.derivation = d.id
-            JOIN evaluation e ON e.id = b.evaluation
-            JOIN project p    ON p.id = e.project
-            WHERE do_.hash = $1
-        "#,
-        [hash.into()],
-    );
-
-    match Flags::find_by_statement(stmt).one(db).await {
-        Ok(Some(f)) => f.producers > 0 && f.signable == 0,
-        Ok(None) => false,
-        Err(e) => {
-            warn!(%hash, error = %e, "eager sign: producer-flag query failed; signing");
-            false
-        }
-    }
 }

--- a/backend/gradient-proto/src/lib.rs
+++ b/backend/gradient-proto/src/lib.rs
@@ -37,6 +37,7 @@ pub mod messages;
 pub mod outbound;
 pub mod server;
 pub mod session;
+pub mod signing;
 pub mod traits;
 
 #[cfg(test)]

--- a/backend/gradient-proto/src/signing.rs
+++ b/backend/gradient-proto/src/signing.rs
@@ -1,0 +1,155 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Eager per-path narinfo signing, shared by the worker `NarPush` handler and
+//! the REST cache-upload endpoints so an uploaded path is servable immediately
+//! rather than waiting for the periodic sweep.
+
+use gradient_sources::CacheSigner;
+use gradient_types::ids::{CacheId, CachedPathId};
+use gradient_types::*;
+use gradient_util::nix_hash::normalize_nar_hash;
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, FromQueryResult, IntoActiveModel,
+    QueryFilter, Set, Statement,
+};
+use std::collections::{HashMap, HashSet};
+use tracing::warn;
+
+/// One freshly cached path to sign, in the narinfo terms the fingerprint needs.
+/// `nar_hash` may be in any recognised format; it is normalized to nix32 before
+/// fingerprinting. `references` are in hash-name form (no `/nix/store/` prefix).
+pub struct SignRequest<'a> {
+    pub cached_path: CachedPathId,
+    pub store_path: &'a str,
+    pub nar_hash: &'a str,
+    pub nar_size: i64,
+    pub references: &'a [String],
+}
+
+/// Fill the pending `cached_path_signature` rows for one freshly cached path.
+/// Skips paths whose every producing project has `sign_cache=false` (the
+/// reserved `build-request` project is always signable). Signing failures are
+/// logged, never propagated: the NAR is already stored and the periodic sweep
+/// re-signs whatever is left NULL.
+pub async fn sign_cached_path<C: ConnectionTrait>(
+    db: &C,
+    crypt_secret_file: &str,
+    serve_url: &str,
+    req: SignRequest<'_>,
+) {
+    let store_path = req.store_path;
+    let hash = store_path
+        .strip_prefix("/nix/store/")
+        .unwrap_or(store_path)
+        .split('-')
+        .next()
+        .unwrap_or("");
+    if hash.is_empty() || producing_projects_all_private(db, hash).await {
+        return;
+    }
+
+    let pending = match ECachedPathSignature::find()
+        .filter(CCachedPathSignature::CachedPath.eq(req.cached_path))
+        .filter(CCachedPathSignature::Signature.is_null())
+        .all(db)
+        .await
+    {
+        Ok(rows) if !rows.is_empty() => rows,
+        Ok(_) => return,
+        Err(e) => {
+            warn!(store_path, error = %e, "eager sign: load pending signatures failed");
+            return;
+        }
+    };
+
+    // The just-stored references (hash-name form) are what the narinfo serve
+    // path reconstructs the fingerprint from; `fingerprint` sorts them, so this
+    // matches the sweep byte-for-byte.
+    let nar_hash_nix32 = normalize_nar_hash(req.nar_hash);
+    let nar_size = req.nar_size as u64;
+
+    // One signer per distinct cache (one crypt-secret read + key decrypt each);
+    // caches whose key is absent/undecodable are simply absent.
+    let mut signers: HashMap<CacheId, CacheSigner> = HashMap::new();
+    for cache_id in pending.iter().map(|r| r.cache).collect::<HashSet<_>>() {
+        if let Some(signer) = build_signer(db, crypt_secret_file, serve_url, cache_id).await {
+            signers.insert(cache_id, signer);
+        }
+    }
+
+    for row in pending {
+        let Some(signer) = signers.get(&row.cache) else {
+            continue;
+        };
+
+        let sig = signer.sign_narinfo_raw(store_path, &nar_hash_nix32, nar_size, req.references);
+        let mut am = row.into_active_model();
+        am.signature = Set(Some(sig));
+        if let Err(e) = am.update(db).await {
+            warn!(store_path, error = %e, "eager sign: persist signature failed");
+        }
+    }
+}
+
+/// Build a signer for `cache_id`, or `None` when the cache is gone or its key is
+/// empty/undecodable (the periodic sweep logs the same and skips those rows).
+async fn build_signer<C: ConnectionTrait>(
+    db: &C,
+    crypt_secret_file: &str,
+    serve_url: &str,
+    cache_id: CacheId,
+) -> Option<CacheSigner> {
+    let cache = ECache::find_by_id(cache_id).one(db).await.ok().flatten()?;
+    if cache.private_key.is_empty() {
+        return None;
+    }
+    match CacheSigner::from_cache(crypt_secret_file, &cache, serve_url) {
+        Ok(s) => Some(s),
+        Err(e) => {
+            warn!(cache_name = %cache.name, error = %e, "eager sign: failed to prepare signer");
+            None
+        }
+    }
+}
+
+/// True iff the path is produced by at least one project and every producing
+/// project has `sign_cache=false` - mirrors the sweep's skip gate. The reserved
+/// per-org `build-request` project is always signable. Paths with no producing
+/// project (`.drv` files, direct uploads) return false -> signed normally.
+async fn producing_projects_all_private<C: ConnectionTrait>(db: &C, hash: &str) -> bool {
+    #[derive(FromQueryResult)]
+    struct Flags {
+        producers: i64,
+        signable: i64,
+    }
+
+    let stmt = Statement::from_sql_and_values(
+        db.get_database_backend(),
+        r#"
+            SELECT count(*)::bigint AS producers,
+                   count(*) FILTER (
+                       WHERE p.sign_cache OR p.name = 'build-request'
+                   )::bigint AS signable
+            FROM derivation_output do_
+            JOIN derivation d ON d.id = do_.derivation
+            JOIN build_job b  ON b.derivation = d.id
+            JOIN evaluation e ON e.id = b.evaluation
+            JOIN project p    ON p.id = e.project
+            WHERE do_.hash = $1
+        "#,
+        [hash.into()],
+    );
+
+    match Flags::find_by_statement(stmt).one(db).await {
+        Ok(Some(f)) => f.producers > 0 && f.signable == 0,
+        Ok(None) => false,
+        Err(e) => {
+            warn!(%hash, error = %e, "eager sign: producer-flag query failed; signing");
+            false
+        }
+    }
+}

--- a/backend/gradient-web/src/endpoints/caches/upload.rs
+++ b/backend/gradient-web/src/endpoints/caches/upload.rs
@@ -123,6 +123,8 @@ pub async fn nars_upload(
     .await
     .map_err(WebError::from)?;
 
+    sign_uploaded_path(&state, &narinfo, outcome.cached_path).await;
+
     audit_record(
         &state.web_db,
         Some(user.id),
@@ -144,6 +146,28 @@ pub async fn nars_upload(
             "created": outcome.created,
         })),
     ))
+}
+
+/// Sign the freshly ingested path in place so its narinfo is servable
+/// immediately, rather than lagging until the periodic sweep runs.
+async fn sign_uploaded_path(
+    state: &ServerState,
+    narinfo: &NarinfoPart,
+    cached_path: gradient_types::ids::CachedPathId,
+) {
+    gradient_proto::signing::sign_cached_path(
+        &state.web_db,
+        &state.config.secrets.crypt_secret_file,
+        &state.config.server.serve_url,
+        gradient_proto::signing::SignRequest {
+            cached_path,
+            store_path: &narinfo.store_path,
+            nar_hash: &narinfo.nar_hash,
+            nar_size: narinfo.nar_size,
+            references: &narinfo.references,
+        },
+    )
+    .await;
 }
 
 #[derive(Deserialize)]
@@ -284,6 +308,8 @@ pub async fn nar_finalize(
     .await
     .map_err(WebError::from)?;
     let _ = store.discard(&key);
+
+    sign_uploaded_path(&state, &narinfo, outcome.cached_path).await;
 
     audit_record(
         &state.web_db,

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1247,6 +1247,7 @@ dependencies = [
  "tokio",
  "toml",
  "wiremock",
+ "zstd",
 ]
 
 [[package]]
@@ -4520,3 +4521,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -38,7 +38,7 @@ ratatui = "0.30"
 
 [features]
 default = []
-nix = ["dep:harmonia-file-nar", "dep:harmonia-store-path", "dep:harmonia-store-remote", "dep:harmonia-utils-hash", "dep:tempfile"]
+nix = ["dep:harmonia-file-nar", "dep:harmonia-store-path", "dep:harmonia-store-remote", "dep:harmonia-utils-hash", "dep:tempfile", "dep:zstd"]
 # `gradient eval` (nix-eval-jobs-like). Pulls the shared evaluator crate and
 # thus libnix; off by default so the lean CLI builds without Nix dev libraries.
 eval = ["dep:gradient-eval"]
@@ -49,6 +49,11 @@ optional = true
 
 [dependencies.tempfile]
 version = "3"
+optional = true
+
+[dependencies.zstd]
+version = "0.13"
+default-features = false
 optional = true
 
 [dependencies.harmonia-file-nar]

--- a/cli/src/commands/cache_upload.rs
+++ b/cli/src/commands/cache_upload.rs
@@ -25,9 +25,10 @@ pub struct UploadArgs {
     /// Narinfo metadata file describing --nar-file.
     #[arg(long)]
     pub narinfo: Option<PathBuf>,
-    /// Upload the full runtime closure of each store path (nix feature only).
+    /// Upload only the given store paths, skipping their runtime closure
+    /// (nix feature only). By default the full runtime closure is uploaded.
     #[arg(long)]
-    pub full_closure: bool,
+    pub no_closure: bool,
 }
 
 pub async fn handle(args: UploadArgs, out: Output) {
@@ -46,7 +47,10 @@ pub async fn handle(args: UploadArgs, out: Output) {
     }
 
     if args.paths.is_empty() {
-        out.err(ExitKind::Usage, "provide store path(s) or --nar-file/--narinfo");
+        out.err(
+            ExitKind::Usage,
+            "provide store path(s) or --nar-file/--narinfo",
+        );
     }
 
     #[cfg(not(feature = "nix"))]
@@ -72,6 +76,15 @@ fn store_hash_of(store_path: &str) -> &str {
 }
 
 pub(crate) async fn upload_one_owned(cache: &str, ni: Narinfo, bytes: Vec<u8>, out: Output) {
+    let store_path = ni.store_path.clone();
+    upload_bytes(cache, ni, bytes, out).await;
+    out.human(format!("Uploaded {store_path}"));
+}
+
+/// Chunk-upload `bytes` and finalize against `ni`, emitting the machine-readable
+/// success line but no human summary - the caller owns human progress output so
+/// closure uploads can render one updating line per path.
+pub(crate) async fn upload_bytes(cache: &str, ni: Narinfo, bytes: Vec<u8>, out: Output) {
     let client = client_from_config(out);
     let store_path = ni.store_path.clone();
     let store_hash = store_hash_of(&store_path).to_string();
@@ -90,7 +103,11 @@ pub(crate) async fn upload_one_owned(cache: &str, ni: Narinfo, bytes: Vec<u8>, o
     while offset < total {
         let end = (offset as usize + UPLOAD_CHUNK_SIZE).min(bytes.len());
         let chunk = bytes[offset as usize..end].to_vec();
-        match client.caches().nar_upload_chunk(cache, &store_hash, offset, chunk).await {
+        match client
+            .caches()
+            .nar_upload_chunk(cache, &store_hash, offset, chunk)
+            .await
+        {
             Ok(received) if received > offset => offset = received,
             Ok(received) => out.err(
                 ExitKind::Api,
@@ -100,11 +117,12 @@ pub(crate) async fn upload_one_owned(cache: &str, ni: Narinfo, bytes: Vec<u8>, o
         }
     }
 
-    match client.caches().nar_upload_finalize(cache, &store_hash, payload).await {
-        Ok(()) => {
-            out.ok(&serde_json::json!({"uploaded": true, "store_path": store_path}));
-            out.human(format!("Uploaded {store_path}"));
-        }
+    match client
+        .caches()
+        .nar_upload_finalize(cache, &store_hash, payload)
+        .await
+    {
+        Ok(()) => out.ok(&serde_json::json!({"uploaded": true, "store_path": store_path})),
         Err(e) => out.err(to_exit_kind(&e), e),
     }
 }
@@ -119,6 +137,9 @@ mod tests {
             store_hash_of("/nix/store/bnq5n76hrfr50l5s2hbbg9vw32fvcrbc-linux-rpi-6.12.75-1+rpt1"),
             "bnq5n76hrfr50l5s2hbbg9vw32fvcrbc"
         );
-        assert_eq!(store_hash_of("bnq5n76hrfr50l5s2hbbg9vw32fvcrbc-hello"), "bnq5n76hrfr50l5s2hbbg9vw32fvcrbc");
+        assert_eq!(
+            store_hash_of("bnq5n76hrfr50l5s2hbbg9vw32fvcrbc-hello"),
+            "bnq5n76hrfr50l5s2hbbg9vw32fvcrbc"
+        );
     }
 }

--- a/cli/src/commands/cache_upload_nix.rs
+++ b/cli/src/commands/cache_upload_nix.rs
@@ -13,11 +13,16 @@ use harmonia_store_path::StorePath;
 use harmonia_store_remote::DaemonStore as _;
 use harmonia_store_remote::UnkeyedValidPathInfo;
 use harmonia_store_remote::pool::{ConnectionPool, PoolConfig};
+use harmonia_utils_hash::Sha256;
 use harmonia_utils_hash::fmt::HashFormat as _;
 
-use crate::commands::cache_upload::{UploadArgs, upload_one_owned};
+use crate::commands::cache_upload::{UploadArgs, upload_bytes};
 use crate::narinfo::Narinfo;
 use crate::output::{ExitKind, Output};
+
+/// zstd level for uploaded NARs; matches the server's source NAR and the
+/// worker's `NarPush`, so every object under `nars/` decompresses identically.
+const NAR_ZSTD_LEVEL: i32 = 6;
 
 const DEFAULT_SOCKET: &str = "/nix/var/nix/daemon-socket/socket";
 
@@ -116,49 +121,97 @@ async fn runtime_closure(pool: &ConnectionPool, seeds: &[String]) -> HashSet<Str
     visited
 }
 
+/// zstd-compress a raw NAR into the `.nar.zst` bytes the cache stores, returning
+/// the compressed bytes and their `sha256:` SRI file hash (the narinfo
+/// `FileHash`/`FileSize`). Uploading the raw NAR instead makes the worker's zstd
+/// import fail with "Unknown frame descriptor".
+fn compress_nar(nar_bytes: &[u8]) -> anyhow::Result<(Vec<u8>, String)> {
+    let compressed = zstd::encode_all(std::io::Cursor::new(nar_bytes), NAR_ZSTD_LEVEL)?;
+    let file_hash = Sha256::digest(&compressed).as_sri().to_string();
+    Ok((compressed, file_hash))
+}
+
 pub async fn upload_paths(args: &UploadArgs, out: Output) {
     let pool = ConnectionPool::new(DEFAULT_SOCKET, pool_config());
 
-    let targets: Vec<String> = if args.full_closure {
+    let targets: Vec<String> = if args.no_closure {
+        args.paths.iter().map(|p| canonicalize(p)).collect()
+    } else {
         let seeds: Vec<String> = args.paths.iter().map(|p| canonicalize(p)).collect();
         let mut closure: Vec<String> = runtime_closure(&pool, &seeds).await.into_iter().collect();
         closure.sort();
         closure
-    } else {
-        args.paths.iter().map(|p| canonicalize(p)).collect()
     };
 
     for (i, store_path) in targets.iter().enumerate() {
-        out.progress(format!("[{}/{}] uploading {store_path}", i + 1, targets.len()));
+        let label = format!("[{}/{}]", i + 1, targets.len());
+        out.step_start(format!("{label} Uploading {store_path}"));
         let meta = match gather_path_meta(&pool, store_path).await {
             Ok(m) => m,
             Err(e) => out.err(ExitKind::Api, format!("metadata for {store_path}: {e}")),
         };
 
-        let mut nar_stream =
-            harmonia_file_nar::NarByteStream::new(PathBuf::from(store_path));
+        let mut nar_stream = harmonia_file_nar::NarByteStream::new(PathBuf::from(store_path));
         let mut bytes: Vec<u8> = Vec::new();
         while let Some(chunk_result) = nar_stream.next().await {
             match chunk_result {
                 Ok(chunk) => bytes.extend_from_slice(&chunk),
-                Err(e) => out.err(ExitKind::Api, format!("NAR stream error for {store_path}: {e}")),
+                Err(e) => out.err(
+                    ExitKind::Api,
+                    format!("NAR stream error for {store_path}: {e}"),
+                ),
             }
         }
 
-        let file_size = bytes.len() as i64;
         let nar_size = bytes.len() as i64;
+        let (compressed, file_hash) = match compress_nar(&bytes) {
+            Ok(v) => v,
+            Err(e) => out.err(
+                ExitKind::Api,
+                format!("compressing NAR for {store_path}: {e}"),
+            ),
+        };
 
         let ni = Narinfo {
             store_path: store_path.clone(),
             url: None,
-            file_hash: meta.nar_hash_sri.clone(),
-            file_size,
+            file_hash,
+            file_size: compressed.len() as i64,
             nar_hash: meta.nar_hash_sri,
             nar_size,
             references: meta.references,
             deriver: meta.deriver,
         };
 
-        upload_one_owned(&args.cache, ni, bytes, out).await;
+        upload_bytes(&args.cache, ni, compressed, out).await;
+        out.step_done(format!("{label} Uploaded {store_path}"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compress_nar_round_trips_and_hashes_compressed_bytes() {
+        let raw = b"nar-payload-that-compresses-aaaaaaaaaaaaaaaaaaaaaaaa".repeat(8);
+        let (compressed, file_hash) = compress_nar(&raw).expect("compress");
+
+        assert_ne!(
+            compressed, raw,
+            "uploaded bytes must be zstd, not the raw NAR"
+        );
+        let round = zstd::decode_all(std::io::Cursor::new(&compressed)).expect("decode");
+        assert_eq!(
+            round, raw,
+            "compressed bytes must decompress to the raw NAR"
+        );
+
+        let expected = Sha256::digest(&compressed).as_sri().to_string();
+        assert_eq!(
+            file_hash, expected,
+            "FileHash must be sha256 of the compressed bytes"
+        );
+        assert!(file_hash.starts_with("sha256-"));
     }
 }

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -6,7 +6,7 @@
 
 use connector::ConnectorError;
 use serde::Serialize;
-use std::io::{self, Write};
+use std::io::{self, IsTerminal, Write};
 use std::process::exit;
 
 #[derive(Clone, Copy)]
@@ -62,6 +62,35 @@ impl Output {
         if !self.json {
             eprintln!("{}", msg);
         }
+    }
+
+    /// Draw a transient status line that a following `step_done` overwrites in
+    /// place. On a non-TTY (piped/CI) the transient line is skipped entirely so
+    /// logs stay one clean line per step.
+    pub fn step_start(&self, msg: impl std::fmt::Display) {
+        if self.json {
+            return;
+        }
+        let mut err = io::stderr();
+        if err.is_terminal() {
+            let _ = write!(err, "\r\x1b[K{msg}");
+            let _ = err.flush();
+        }
+    }
+
+    /// Finalize the current step: overwrite the transient line on a TTY, or emit
+    /// a plain line otherwise. Either way the step ends on its own newline.
+    pub fn step_done(&self, msg: impl std::fmt::Display) {
+        if self.json {
+            return;
+        }
+        let mut err = io::stderr();
+        if err.is_terminal() {
+            let _ = write!(err, "\r\x1b[K{msg}\n");
+        } else {
+            let _ = writeln!(err, "{msg}");
+        }
+        let _ = err.flush();
     }
 
     pub fn err(&self, kind: ExitKind, msg: impl std::fmt::Display) -> ! {

--- a/docs/src/development/tests.md
+++ b/docs/src/development/tests.md
@@ -1763,6 +1763,12 @@ authentication flow that workers use to connect to the server:
 3. Worker's `peersFile` contains `*:{token}` (wildcard matches any org UUID)
 4. On boot, worker authenticates via challenge-response with the pre-shared token
 5. Test asserts `"handshake successful"` in journalctl before proceeding to builds
+6. **Phase 9 (`gradient cache upload`, regression #509)**: adds a unique leaf path
+   to the server store, uploads it with `gradient cache upload main <path>`
+   (default = runtime closure, zstd-compressed, signed in place), then realizes it
+   on the client whose substituters are locked to the gradient cache. A raw
+   (uncompressed) NAR would fail the client's zstd import and an unsigned narinfo
+   would fail its signature check, so the realize passing proves both fixes.
 
 **`gradient-api`** - Worker registration CRUD:
 - Tests `POST /api/v1/orgs/{org}/workers` returns a valid 64-character base64 token

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -6065,3 +6065,26 @@ commit identity is chosen:
   configured identity is used only when both `GRADIENT_PR_COMMIT_NAME` and
   `GRADIENT_PR_COMMIT_EMAIL` are non-empty; otherwise it falls back to
   forge-default attribution.
+
+## `gradient cache upload`: compression, eager signing, closure default (#506/#507/#509)
+
+`gradient cache upload <store-path>` streamed the raw NAR but recorded it as the
+narinfo `FileHash`/`FileSize` and uploaded it uncompressed, so the worker's zstd
+import failed with "Unknown frame descriptor" (#509). It also never signed the
+path in place, so its narinfo 404'd until the periodic sweep ran. Uploads now
+zstd-compress the NAR (level 6, matching the server source NAR and worker
+`NarPush`), key `FileHash`/`FileSize` off the compressed bytes, and the REST
+upload endpoints sign the path via the shared `gradient_proto::signing`
+(extracted from the worker `NarPush` handler). The closure flag was inverted:
+the full runtime closure now uploads by default and `--no-closure` restricts to
+the listed paths (#506); progress renders one in-place line per path with
+consistent `Uploading`/`Uploaded` casing (#507).
+
+- `gradient-cli` `commands::cache_upload_nix::tests` -
+  `compress_nar_round_trips_and_hashes_compressed_bytes`: the uploaded bytes are
+  zstd (not the raw NAR), decompress back to the NAR, and `FileHash` is the
+  `sha256:` SRI of the compressed bytes.
+- `gradient-cache` NixOS VM test **Phase 9** (see
+  [Integration Tests](development/tests.md#integration-tests)) uploads a unique
+  store path and realizes it on a client locked to the gradient cache, exercising
+  both the compression and eager-signing fixes end-to-end.

--- a/docs/src/usage/cache-nars.md
+++ b/docs/src/usage/cache-nars.md
@@ -13,7 +13,7 @@ gradient cache nar show <cache> <hash>
 gradient cache nar delete <cache> <hash> [-y]
 gradient cache nar stats <cache>
 gradient cache upload --nar-file <file.nar> --narinfo <file.narinfo> <cache>
-gradient cache upload [--full-closure] <store-path>... <cache>   # nix feature only
+gradient cache upload [--no-closure] <store-path>... <cache>   # nix feature only
 ```
 
 `gradient cache nar list` is paginated. Default page size is 50, max 200.
@@ -46,18 +46,19 @@ store path, NAR hash, NAR size, and references before submitting.
 
 When the CLI is built with the `nix` feature, store paths can be uploaded
 directly from the local Nix daemon. Each path is resolved via harmonia,
-NAR-dumped, and uploaded in one step.
+NAR-dumped, zstd-compressed, and uploaded in one step.
 
 ```sh
-# Upload a single store path
+# Upload a store path together with its full runtime closure (default)
 gradient cache upload /nix/store/abc123-hello-2.12.1 my-cache
 
-# Upload the full runtime reference closure of every listed path
-gradient cache upload --full-closure /nix/store/abc123-hello-2.12.1 my-cache
+# Upload only the listed paths, skipping their runtime closure
+gradient cache upload --no-closure /nix/store/abc123-hello-2.12.1 my-cache
 ```
 
-`--full-closure` walks the runtime reference closure of each given path and
-uploads every reachable path in dependency order.
+By default each given path's full runtime reference closure is walked and every
+reachable path is uploaded in dependency order. Pass `--no-closure` to upload
+only the paths named on the command line.
 
 ### Size cap
 

--- a/docs/src/usage/cli.md
+++ b/docs/src/usage/cli.md
@@ -118,8 +118,9 @@ gradient cache nar stats <cache>
 # Upload a pre-dumped NAR (no Nix required)
 gradient cache upload --nar-file <file.nar> --narinfo <file.narinfo> <cache>
 
-# Upload from the local Nix store (nix feature only)
-gradient cache upload [--full-closure] <store-path>... <cache>
+# Upload from the local Nix store, with the full runtime closure (nix feature only).
+# Pass --no-closure to upload only the listed paths.
+gradient cache upload [--no-closure] <store-path>... <cache>
 ```
 
 Deleting a NAR is ref-counted: if the NAR is signed by more than one cache,

--- a/nix/tests/gradient/cache/default.nix
+++ b/nix/tests/gradient/cache/default.nix
@@ -498,6 +498,29 @@ in {
       print(client.succeed(f"nix-store -vvv --realize {store_path}"))
       print(client.succeed(f"ls {store_path}"))
 
+      # ── Phase 9: `gradient cache upload` compresses + signs (regression #509) ─
+      # Add a unique leaf path to the server store and upload it with the CLI:
+      # the default uploads the runtime closure, zstd-compressed, and the server
+      # signs it in place. The client (substituters locked to the gradient cache)
+      # then realizes it. A raw/uncompressed NAR fails the client's zstd import
+      # ("Unknown frame descriptor"); an unsigned narinfo fails its signature
+      # check. Both fixes must hold for realize to succeed.
+      banner("Phase 9: gradient cache upload compresses + signs (#509)")
+      server.succeed("echo gradient-upload-regression-509 > /tmp/upload-probe.txt")
+      upload_path = server.succeed("nix-store --add /tmp/upload-probe.txt").strip()
+      upload_hash = upload_path.split("-")[0].replace("/nix/store/", "")
+      print(f"Uploading probe path: {upload_path}")
+      print(server.succeed(f"{CLI} cache upload main {upload_path}"))
+
+      client.wait_until_succeeds(
+          f"{CURL} -sf {CACHE}/{upload_hash}.narinfo -o /dev/null", timeout=60
+      )
+      print(client.succeed(f"{CURL} {CACHE}/{upload_hash}.narinfo -i --fail"))
+
+      client.fail(f"ls {upload_path}")
+      print(client.succeed(f"nix-store -vvv --realize {upload_path}"))
+      print(client.succeed(f"ls {upload_path}"))
+
       banner("Cache test PASSED")
       '';
   });


### PR DESCRIPTION
Fixes #506, fixes #507, fixes #509.

`gradient cache upload` now zstd-compresses NARs (the worker's import failed on raw bytes with "Unknown frame descriptor"), the REST upload endpoints sign paths in place via a shared `gradient_proto::signing` module, the full runtime closure uploads by default with `--no-closure` to opt out, and progress renders one in-place `[i/n] Uploaded` line per path.