### PR TITLE
Serve CA: narinfo field for content-addressed paths

### DIFF
--- a/backend/gradient-proto/examples/probe_narpush.rs
+++ b/backend/gradient-proto/examples/probe_narpush.rs
@@ -142,6 +142,7 @@ async fn main() {
             nar_hash: "sha256:deadbeef".into(),
             references: vec![],
             deriver: None,
+            ca: None,
         },
     )
     .await;

--- a/backend/gradient-proto/src/handler/dispatch.rs
+++ b/backend/gradient-proto/src/handler/dispatch.rs
@@ -199,10 +199,11 @@ impl<'a> DispatchContext<'a> {
                 nar_hash,
                 references,
                 deriver,
+                ca,
             } => {
                 self.on_nar_uploaded(
                     job_id, store_path, file_hash, file_size, nar_size, nar_hash, references,
-                    deriver, nar,
+                    deriver, ca, nar,
                 )
                 .await;
                 true

--- a/backend/gradient-proto/src/handler/nar.rs
+++ b/backend/gradient-proto/src/handler/nar.rs
@@ -24,6 +24,8 @@ pub(super) struct NarUploadRecord<'a> {
     pub references: &'a [String],
     /// Full deriver `.drv` path, if the worker reported one.
     pub deriver: Option<&'a str>,
+    /// Content address of the path in narinfo form, if content-addressed.
+    pub ca: Option<&'a str>,
 }
 
 /// Resolves the org's cache and increments the traffic counter. `org_id` is
@@ -109,6 +111,7 @@ pub(super) async fn mark_nar_stored(
         nar_hash: record.nar_hash,
         references: record.references,
         deriver: record.deriver,
+        ca: record.ca,
     };
 
     let cached_path_id = ingest_metadata_only(&state.worker_db, input, targets)

--- a/backend/gradient-proto/src/handler/nar_transfer.rs
+++ b/backend/gradient-proto/src/handler/nar_transfer.rs
@@ -336,7 +336,7 @@ impl<'a> DispatchContext<'a> {
         ca: Option<String>,
         nar: &mut NarReceiveStore,
     ) {
-        debug!(peer_id = %self.peer_id, %job_id, %store_path, %file_hash, file_size, nar_size, %nar_hash, ?deriver, "NarUploaded");
+        debug!(peer_id = %self.peer_id, %job_id, %store_path, %file_hash, file_size, nar_size, %nar_hash, ?deriver, ?ca, "NarUploaded");
 
         // Reject any NarUploaded for a path whose chunked transfer was rejected
         // mid-stream. Without this guard `mark_nar_stored` would record a

--- a/backend/gradient-proto/src/handler/nar_transfer.rs
+++ b/backend/gradient-proto/src/handler/nar_transfer.rs
@@ -333,6 +333,7 @@ impl<'a> DispatchContext<'a> {
         nar_hash: String,
         references: Vec<String>,
         deriver: Option<String>,
+        ca: Option<String>,
         nar: &mut NarReceiveStore,
     ) {
         debug!(peer_id = %self.peer_id, %job_id, %store_path, %file_hash, file_size, nar_size, %nar_hash, ?deriver, "NarUploaded");
@@ -400,6 +401,7 @@ impl<'a> DispatchContext<'a> {
                 nar_hash,
                 references,
                 deriver,
+                ca,
                 staged,
             })
             .await;
@@ -431,6 +433,7 @@ struct CommitUploadedNar {
     nar_hash: String,
     references: Vec<String>,
     deriver: Option<String>,
+    ca: Option<String>,
     staged: Option<StagedNar>,
 }
 
@@ -479,6 +482,7 @@ async fn commit_uploaded_nar(c: CommitUploadedNar) {
         nar_hash: &c.nar_hash,
         references: &c.references,
         deriver: c.deriver.as_deref(),
+        ca: c.ca.as_deref(),
     };
     if let Err(e) = mark_nar_stored(&c.state, c.org_id, &c.store_path, &nar_record).await {
         warn!(store_path = %c.store_path, error = %e, "failed to mark NAR as stored");

--- a/backend/gradient-proto/src/ingest.rs
+++ b/backend/gradient-proto/src/ingest.rs
@@ -25,6 +25,9 @@ pub struct IngestInput<'a> {
     /// References in hash-name format (no `/nix/store/` prefix).
     pub references: &'a [String],
     pub deriver: Option<&'a str>,
+    /// Content address in narinfo form (`text:sha256:<b32>` /
+    /// `fixed:[r:]sha256:<b32>`), if the path is content-addressed.
+    pub ca: Option<&'a str>,
 }
 
 pub enum SignTargets {
@@ -166,6 +169,9 @@ async fn upsert_and_sign<C: ConnectionTrait>(
             if input.deriver.is_some() {
                 active.deriver = Set(input.deriver.map(str::to_owned));
             }
+            if input.ca.is_some() {
+                active.ca = Set(input.ca.map(str::to_owned));
+            }
             active.update(db).await?;
             (id, false)
         }
@@ -179,6 +185,7 @@ async fn upsert_and_sign<C: ConnectionTrait>(
                 nar_size: Some(input.nar_size),
                 nar_hash: Some(normalize_nar_hash(input.nar_hash)),
                 deriver: input.deriver.map(str::to_owned),
+                ca: input.ca.map(str::to_owned),
                 created_at: ts,
                 ..Default::default()
             }
@@ -277,6 +284,7 @@ mod tests {
             nar_hash: "sha256:def",
             references: &[],
             deriver: None,
+            ca: None,
         }
     }
     fn returned_cached_path(hash: &str) -> gradient_entity::cached_path::Model {
@@ -479,6 +487,28 @@ mod tests {
             log_has_signature_insert(db),
             "OrgCaches target must insert a cached_path_signature placeholder"
         );
+    }
+
+    #[tokio::test]
+    async fn ingest_records_content_address() {
+        let hash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let ca = "text:sha256:006vc8gixyrcynsx4lz1qxingl0mdja3l0xw1nl0j73isg37x944";
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([Vec::<gradient_entity::cached_path::Model>::new()])
+            .append_query_results([vec![returned_cached_path(hash)]])
+            .into_connection();
+
+        let mut inp = input(SP);
+        inp.ca = Some(ca);
+        ingest_metadata_only(&db, inp, SignTargets::None)
+            .await
+            .expect("ingest");
+
+        let logged = db
+            .into_transaction_log()
+            .iter()
+            .any(|t| format!("{t:?}").contains(ca));
+        assert!(logged, "the content address must be written to cached_path");
     }
 
     /// No resolvable org (the exact state the pre-fix race produced) records the

--- a/backend/gradient-proto/src/messages/client.rs
+++ b/backend/gradient-proto/src/messages/client.rs
@@ -152,6 +152,10 @@ pub enum ClientMessage {
         /// `None` when the worker could not query local path info or when the
         /// path has no deriver (e.g. sources, `.drv` files themselves).
         deriver: Option<String>,
+        /// Content address of the path in narinfo form
+        /// (`text:sha256:<b32>` / `fixed:[r:]sha256:<b32>`), when the path is
+        /// content-addressed. `None` for input-addressed paths.
+        ca: Option<String>,
     },
 
     /// Opens a push stream for `store_path`; sent before the first `NarPush`.

--- a/backend/gradient-proto/src/messages/mod.rs
+++ b/backend/gradient-proto/src/messages/mod.rs
@@ -24,7 +24,8 @@ pub use wire::{decode_client_message, decode_server_message};
 
 /// Wire protocol version implemented by this build.
 /// v5: dropped `PresignedUpload`/`PresignedDownload` and `AssignJob.timeout_secs`.
-/// v7: `CacheQuery`/`CacheStatus`/`CacheError` carry a per-query `query_id`.
+/// v7: `CacheQuery`/`CacheStatus`/`CacheError` carry a per-query `query_id`;
+///     `NarUploaded` carries the path's content address (`ca`).
 pub const PROTO_VERSION: u16 = 7;
 
 pub use gradient_types::constants::{NAR_ZSTD_LEVEL, PRESIGN_TTL};

--- a/backend/gradient-proto/src/messages/wire.rs
+++ b/backend/gradient-proto/src/messages/wire.rs
@@ -108,4 +108,22 @@ mod tests {
         let decoded = decode_server_message(unaligned).expect("misaligned decode must succeed");
         assert_eq!(decoded, original);
     }
+
+    #[test]
+    fn nar_uploaded_round_trips_content_address() {
+        let original = ClientMessage::NarUploaded {
+            job_id: "job-1".into(),
+            store_path: "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello-2.12".into(),
+            file_hash: "sha256:abc".into(),
+            file_size: 10,
+            nar_size: 20,
+            nar_hash: "sha256:def".into(),
+            references: vec![],
+            deriver: None,
+            ca: Some("text:sha256:006vc8gixyrcynsx4lz1qxingl0mdja3l0xw1nl0j73isg37x944".into()),
+        };
+        let bytes = rkyv::to_bytes::<RkyvError>(&original).unwrap();
+        let decoded = decode_client_message(&bytes).expect("decode");
+        assert_eq!(decoded, original);
+    }
 }

--- a/backend/gradient-types/src/nix_cache.rs
+++ b/backend/gradient-types/src/nix_cache.rs
@@ -290,9 +290,7 @@ mod tests {
         pi.ca = Some("text:sha256:006vc8gixyrcynsx4lz1qxingl0mdja3l0xw1nl0j73isg37x944".into());
         let s = pi.to_nix_string();
         assert!(
-            s.contains(
-                "CA: text:sha256:006vc8gixyrcynsx4lz1qxingl0mdja3l0xw1nl0j73isg37x944\n"
-            ),
+            s.contains("CA: text:sha256:006vc8gixyrcynsx4lz1qxingl0mdja3l0xw1nl0j73isg37x944\n"),
             "content-addressed path must emit the CA line:\n{s}"
         );
     }

--- a/backend/gradient-types/src/nix_cache.rs
+++ b/backend/gradient-types/src/nix_cache.rs
@@ -283,10 +283,18 @@ mod tests {
     #[test]
     fn nix_path_info_ca_appears_only_when_set() {
         let mut pi = path_info();
-        assert!(!pi.to_nix_string().contains("CA:"));
-        pi.ca = Some("fixed:r:sha256:deadbeef".into());
+        assert!(
+            !pi.to_nix_string().contains("CA:"),
+            "no ca must omit the CA line"
+        );
+        pi.ca = Some("text:sha256:006vc8gixyrcynsx4lz1qxingl0mdja3l0xw1nl0j73isg37x944".into());
         let s = pi.to_nix_string();
-        assert!(s.contains("CA: fixed:r:sha256:deadbeef"));
+        assert!(
+            s.contains(
+                "CA: text:sha256:006vc8gixyrcynsx4lz1qxingl0mdja3l0xw1nl0j73isg37x944\n"
+            ),
+            "content-addressed path must emit the CA line:\n{s}"
+        );
     }
 
     #[test]

--- a/backend/gradient-web/src/endpoints/caches/upload.rs
+++ b/backend/gradient-web/src/endpoints/caches/upload.rs
@@ -125,6 +125,7 @@ pub async fn nars_upload(
             nar_hash: &narinfo.nar_hash,
             references: &narinfo.references,
             deriver: narinfo.deriver.as_deref(),
+            ca: None,
         },
         SignTargets::Cache(cache.id),
     )
@@ -318,6 +319,7 @@ pub async fn nar_finalize(
             nar_hash: &narinfo.nar_hash,
             references: &narinfo.references,
             deriver: narinfo.deriver.as_deref(),
+            ca: None,
         },
         SignTargets::Cache(cache.id),
     )

--- a/backend/gradient-worker/src/proto/nar.rs
+++ b/backend/gradient-worker/src/proto/nar.rs
@@ -86,6 +86,7 @@ pub enum NarSource<'a> {
         meta: CompressedNarMeta,
         references: Vec<String>,
         deriver: Option<String>,
+        ca: Option<String>,
     },
 }
 
@@ -169,6 +170,7 @@ pub async fn upload_nar(
                 meta,
                 path_meta.references,
                 path_meta.deriver,
+                path_meta.ca,
             )
             .await
         }
@@ -177,6 +179,7 @@ pub async fn upload_nar(
             meta,
             references,
             deriver,
+            ca,
         } => {
             match sink {
                 NarSink::Relay { nar_recv } => {
@@ -207,7 +210,7 @@ pub async fn upload_nar(
                     http_put(url, method, headers, bytes.to_vec()).await?;
                 }
             }
-            send_nar_uploaded(writer, job_id, store_path, meta, references, deriver).await
+            send_nar_uploaded(writer, job_id, store_path, meta, references, deriver, ca).await
         }
     }
 }
@@ -418,6 +421,7 @@ async fn send_nar_uploaded(
     meta: CompressedNarMeta,
     references: Vec<String>,
     deriver: Option<String>,
+    ca: Option<String>,
 ) -> Result<()> {
     debug!(
         store_path,
@@ -436,7 +440,7 @@ async fn send_nar_uploaded(
             nar_hash: meta.nar_hash,
             references,
             deriver,
-            ca: None, // Task 3 wires this from PathMeta / relay metadata.
+            ca,
         })
         .await
 }
@@ -477,6 +481,8 @@ struct PathMeta {
     references: Vec<String>,
     /// Full deriver `.drv` path, if the daemon reports one.
     deriver: Option<String>,
+    /// Content address in narinfo form, if the daemon reports one.
+    ca: Option<String>,
 }
 
 /// Resolve the metadata an upload should attach to a NAR push.
@@ -560,10 +566,12 @@ async fn gather_path_meta(store: &LocalNixStore, store_path: &str) -> Option<Pat
         .collect();
 
     let deriver = path_info.deriver.as_ref().map(|d| d.to_string());
+    let ca = path_info.ca.as_ref().map(|c| c.to_string());
 
     Some(PathMeta {
         references,
         deriver,
+        ca,
     })
 }
 
@@ -979,6 +987,7 @@ mod tests {
                     meta,
                     references: vec!["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-dep".to_owned()],
                     deriver: None,
+                    ca: None,
                 },
                 NarSink::Relay { nar_recv: &recv2 },
                 &writer,
@@ -988,6 +997,59 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
         recv.resolve_push("job-relay", store_path, 0);
         push.await.unwrap().unwrap();
+        server_task.await.unwrap();
+    }
+
+    /// The upstream content address must thread through the relay's
+    /// `NarSource::Compressed` into the `NarUploaded` the server receives.
+    #[tokio::test]
+    async fn compressed_source_threads_content_address() {
+        let ca = "text:sha256:006vc8gixyrcynsx4lz1qxingl0mdja3l0xw1nl0j73isg37x944";
+        let server = MockProtoServer::bind().await;
+        let url = server.url().to_owned();
+        let expected_ca = ca.to_string();
+
+        let server_task = tokio::spawn(async move {
+            let mut sc = server.accept().await;
+            let msg = sc.recv().await.unwrap();
+            match msg {
+                ClientMessage::NarUploaded { ca, .. } => {
+                    assert_eq!(ca.as_deref(), Some(expected_ca.as_str()));
+                }
+                other => panic!("expected NarUploaded, got {other:?}"),
+            }
+        });
+
+        let (http_url, _http_task) = one_shot_http_server().await;
+        let conn = crate::connection::ProtoConnection::open(&url)
+            .await
+            .unwrap();
+        let (writer, _reader) = conn.split();
+        let meta = CompressedNarMeta {
+            file_hash: "sha256:abc".into(),
+            file_size: 3,
+            nar_hash: "sha256:def".into(),
+            nar_size: 3,
+        };
+        upload_nar(
+            "job-ca",
+            "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello-2.12",
+            NarSource::Compressed {
+                bytes: b"abc",
+                meta,
+                references: vec![],
+                deriver: None,
+                ca: Some(ca.to_string()),
+            },
+            NarSink::Presigned {
+                url: &http_url,
+                method: "PUT",
+                headers: &[],
+            },
+            &writer,
+        )
+        .await
+        .unwrap();
         server_task.await.unwrap();
     }
 
@@ -1025,6 +1087,7 @@ mod tests {
                 meta,
                 references: vec![],
                 deriver: None,
+                ca: None,
             },
             NarSink::Presigned {
                 url: &http_url,

--- a/backend/gradient-worker/src/proto/nar.rs
+++ b/backend/gradient-worker/src/proto/nar.rs
@@ -436,6 +436,7 @@ async fn send_nar_uploaded(
             nar_hash: meta.nar_hash,
             references,
             deriver,
+            ca: None, // Task 3 wires this from PathMeta / relay metadata.
         })
         .await
 }

--- a/backend/gradient-worker/src/proto/substitute_relay.rs
+++ b/backend/gradient-worker/src/proto/substitute_relay.rs
@@ -164,6 +164,7 @@ pub async fn relay_external_cached_outputs(
                 meta: cmeta,
                 references,
                 deriver: meta.deriver.clone(),
+                ca: upstream.ca.clone(),
             },
             crate::proto::nar::NarSink::from_upload_url(
                 push.get(path).and_then(|c| c.url.as_deref()),

--- a/docs/src/development/internals.md
+++ b/docs/src/development/internals.md
@@ -110,7 +110,7 @@ Each cache has a dedicated Ed25519 signing key encrypted in the database (using 
 
 **Narinfo** (`GET /cache/{cache}/{hash}.narinfo`)
 
-Constructs a `NixPathInfo` response from `derivation_output` + `cached_path` + `cached_path_signature`. Sizes, hashes, and references are read directly from the DB row the worker populated when it uploaded the NAR - the server never re-packs or re-hashes a NAR.
+Constructs a `NixPathInfo` response from `derivation_output` + `cached_path` + `cached_path_signature`. Sizes, hashes, and references are read directly from the DB row the worker populated when it uploaded the NAR - the server never re-packs or re-hashes a NAR. For content-addressed paths (those with `cached_path.ca` set), the `CA:` field is emitted in the narinfo response.
 
 When the hash doesn't match any `derivation_output`, narinfo falls back to the `cached_path` table. This covers `.drv` files and any other standalone store path the worker pushed.
 

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -6477,7 +6477,7 @@ replies via `NixPathInfo.ca`.
   without `ca` set, verifies that narinfo emission includes `CA:` line only when
   `ca: Some(...)` is present, and the emitted line contains the exact
   content-address string.
-- `backend/gradient-proto/src/wire.rs` `tests`:
+- `backend/gradient-proto/src/messages/wire.rs` `tests`:
   `nar_uploaded_round_trips_content_address` encodes a `NarUploaded` with
   `ca: Some(...)` via rkyv, decodes it, and asserts `ca` field matches
   byte-for-byte.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -6465,3 +6465,23 @@ comes from `query_path_info`'s `UnkeyedValidPathInfo.ca` (harmonia
   server-received `NarUploaded.ca` matches. Daemon-sourced `ca` (the
   `NarSource::Path` branch through `gather_path_meta`) needs a live nix daemon
   and is covered by E2E CI.
+
+## Narinfo emission and protocol round-tripping of content address
+
+The `ca` field is persisted end-to-end: from worker `PathMeta` through
+`NarUploaded.ca` to the server's `cached_path.ca` column, and served in narinfo
+replies via `NixPathInfo.ca`.
+
+- `backend/gradient-types/src/nix_cache.rs` `tests`:
+  `nix_path_info_ca_appears_only_when_set` constructs `NixPathInfo` with and
+  without `ca` set, verifies that narinfo emission includes `CA:` line only when
+  `ca: Some(...)` is present, and the emitted line contains the exact
+  content-address string.
+- `backend/gradient-proto/src/wire.rs` `tests`:
+  `nar_uploaded_round_trips_content_address` encodes a `NarUploaded` with
+  `ca: Some(...)` via rkyv, decodes it, and asserts `ca` field matches
+  byte-for-byte.
+- `backend/gradient-proto/src/ingest.rs` `tests`:
+  `ingest_records_content_address` drives the ingest pipeline with a
+  `NarUploadRecord` holding `ca: Some(...)`, asserts the resulting `cached_path`
+  row has `ca` populated with the exact input string.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -6449,3 +6449,19 @@ auth-gated.
   `GET /api/v1/caches/main/upstreams` against a public cache and asserts the
   upstream `public_key` is returned; `anonymous_cannot_list_private_cache_upstreams`
   asserts a private cache still `404`s for anonymous callers.
+
+## Worker sources `NarUploaded.ca` from the daemon and the substitute relay
+
+`NarUploaded.ca` was a `None` bridge left after the wire field and DB column
+were added. The worker now populates it: on the direct-upload path, `PathMeta.ca`
+comes from `query_path_info`'s `UnkeyedValidPathInfo.ca` (harmonia
+`ContentAddress::to_string()`, narinfo form); on the substitute-relay path,
+`NarSource::Compressed.ca` carries the upstream `CachedPath.ca` from the
+`QueryMode::Pull` reply straight through to `NarUploaded`.
+
+- `backend/gradient-worker/src/proto/nar.rs` `proto::nar::tests`:
+  `compressed_source_threads_content_address` drives a `NarSource::Compressed`
+  upload with `ca: Some(...)` through `MockProtoServer` and asserts the
+  server-received `NarUploaded.ca` matches. Daemon-sourced `ca` (the
+  `NarSource::Path` branch through `gather_path_meta`) needs a live nix daemon
+  and is covered by E2E CI.


### PR DESCRIPTION
Fixes #526. Threads each path's content address from the worker daemon (and upstream relay) through NarUploaded into cached_path.ca, so the binary cache serves the CA: narinfo line for content-addressed paths.