### PR TITLE
web: fix: stream NAR serving instead of buffering whole NARs into memory (OOM)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2445,6 +2445,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
  "uuid",
  "zstd",

--- a/backend/gradient-core/tests/nar_extract.rs
+++ b/backend/gradient-core/tests/nar_extract.rs
@@ -9,7 +9,11 @@
 //! Async assertions use sync `#[test]` + `tokio::runtime::Builder::block_on`.
 
 use bytes::Bytes;
-use gradient_storage::nar_extract::{ExtractError, Extracted, extract_path_from_nar_bytes};
+use futures::StreamExt as _;
+use gradient_storage::nar_extract::{
+    ExtractError, Extracted, extract_path_from_nar_bytes, extract_path_from_reader,
+    nar_reader_from_stream,
+};
 use harmonia_file_nar::archive::test_data::{TestNarEvent, TestNarEvents};
 use harmonia_file_nar::archive::write_nar;
 use std::collections::BTreeMap;
@@ -93,6 +97,33 @@ fn extracts_file_at_relative_path() {
     let (contents, executable, _) = unwrap_file(out);
     assert_eq!(contents, b"hi there");
     assert!(!executable);
+}
+
+/// The streaming bridge used by the serve/browse endpoints must decode and
+/// extract identically to the buffered path, even when the compressed input is
+/// delivered as many small chunks that split the zstd frame across boundaries.
+#[test]
+fn streaming_reader_extracts_same_file_as_buffered() {
+    let nar = dir_with_file("hello.txt", b"streamed hi", false);
+    let compressed = zstd_compress(&nar);
+
+    let buffered = block_on(extract_path_from_nar_bytes(compressed.clone(), "hello.txt")).unwrap();
+    let (buffered_contents, _, _) = unwrap_file(buffered);
+
+    let chunks: Vec<anyhow::Result<Bytes>> = compressed
+        .chunks(48)
+        .map(|c| Ok(Bytes::copy_from_slice(c)))
+        .collect();
+    let stream = futures::stream::iter(chunks).boxed();
+    let streamed = block_on(extract_path_from_reader(
+        nar_reader_from_stream(stream),
+        "hello.txt",
+    ))
+    .unwrap();
+    let (streamed_contents, _, _) = unwrap_file(streamed);
+
+    assert_eq!(streamed_contents, b"streamed hi");
+    assert_eq!(streamed_contents, buffered_contents);
 }
 
 #[test]

--- a/backend/gradient-proto/src/handler/nar_transfer.rs
+++ b/backend/gradient-proto/src/handler/nar_transfer.rs
@@ -524,8 +524,12 @@ async fn commit_relayed(
         fail_build_transient(writer, scheduler, peer_id, job_id, reason).await;
         return false;
     }
-    let buf = match staged.store.read_all(&staged.key).await {
-        Ok(b) => b,
+    // Stream-verify then stream-store the staged NAR so a large build output is
+    // never buffered whole in server memory (two sequential reads of the local
+    // `.partial`; verify passes before any object write so a corrupt upload
+    // never commits).
+    let verify_reader = match staged.store.open_read(&staged.key).await {
+        Ok(f) => f,
         Err(e) => {
             let reason = format!("failed to read staged NAR: {e}");
             error!(%peer_id, %job_id, %store_path, error = %e, "read staged NAR failed");
@@ -533,18 +537,27 @@ async fn commit_relayed(
             return false;
         }
     };
-    if let Err(e) = gradient_storage::verify_nar_bytes(&buf, file_hash, file_size) {
+    if let Err(e) = gradient_storage::verify_nar_reader(verify_reader, file_hash, file_size).await {
         let reason = format!("NAR content verification failed: {e}");
         error!(%peer_id, %job_id, %store_path, %reason, "NAR upload integrity check failed");
         fail_build_transient(writer, scheduler, peer_id, job_id, reason).await;
         return false;
     }
-    if let Err(e) = crate::ingest::put_nar_idempotent(
+    let put_reader = match staged.store.open_read(&staged.key).await {
+        Ok(f) => f,
+        Err(e) => {
+            let reason = format!("failed to read staged NAR: {e}");
+            error!(%peer_id, %job_id, %store_path, error = %e, "read staged NAR failed");
+            fail_build_transient(writer, scheduler, peer_id, job_id, reason).await;
+            return false;
+        }
+    };
+    if let Err(e) = crate::ingest::put_nar_idempotent_reader(
         &state.worker_db,
         &state.nar_storage,
         hash,
         file_hash,
-        buf,
+        put_reader,
     )
     .await
     {

--- a/backend/gradient-proto/src/ingest.rs
+++ b/backend/gradient-proto/src/ingest.rs
@@ -13,6 +13,7 @@ use sea_orm::sea_query::OnConflict;
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, IntoActiveModel, QueryFilter, Set,
 };
+use tokio::io::AsyncRead;
 use tracing::{debug, warn};
 
 /// NAR metadata required to record a cached path. Hashes are normalized on write.
@@ -66,6 +67,25 @@ pub async fn ingest_nar<C: ConnectionTrait>(
     upsert_and_sign(db, sp.hash(), sp.name(), input, targets).await
 }
 
+/// Streaming counterpart to [`ingest_nar`]: takes an `AsyncRead` over the
+/// compressed NAR (typically a staged `.partial` file) so the whole object is
+/// never buffered in memory.
+pub async fn ingest_nar_reader<C, R>(
+    db: &C,
+    nar_storage: &NarStore,
+    reader: R,
+    input: IngestInput<'_>,
+    targets: SignTargets,
+) -> anyhow::Result<IngestOutcome>
+where
+    C: ConnectionTrait,
+    R: AsyncRead + Unpin + Send,
+{
+    let sp = parse_store_path(input.store_path)?;
+    put_nar_idempotent_reader(db, nar_storage, sp.hash(), input.file_hash, reader).await?;
+    upsert_and_sign(db, sp.hash(), sp.name(), input, targets).await
+}
+
 /// Store `nar_bytes` for store-path `hash`, skipping the object-store write when
 /// the identical NAR is already present: a `cached_path` row records the same
 /// compressed `file_hash` AND the object is physically there (`HEAD`). A re-push
@@ -80,13 +100,54 @@ pub async fn put_nar_idempotent<C: ConnectionTrait>(
     file_hash: &str,
     nar_bytes: Vec<u8>,
 ) -> anyhow::Result<bool> {
+    if !nar_write_needed(db, nar_storage, hash, file_hash).await? {
+        return Ok(false);
+    }
+    nar_storage.put(hash, nar_bytes).await?;
+    Ok(true)
+}
+
+/// Streaming counterpart to [`put_nar_idempotent`]: same idempotency skip, but
+/// streams `reader` into storage via multipart instead of taking a `Vec<u8>`.
+/// On a skip the reader is dropped unread.
+pub async fn put_nar_idempotent_reader<C, R>(
+    db: &C,
+    nar_storage: &NarStore,
+    hash: &str,
+    file_hash: &str,
+    reader: R,
+) -> anyhow::Result<bool>
+where
+    C: ConnectionTrait,
+    R: AsyncRead + Unpin + Send,
+{
+    if !nar_write_needed(db, nar_storage, hash, file_hash).await? {
+        return Ok(false);
+    }
+    nar_storage.put_reader(hash, reader).await?;
+    Ok(true)
+}
+
+/// Whether `hash`'s NAR must be (re)written, or can be skipped because an
+/// identical one is already stored: a `cached_path` row records the same
+/// compressed `file_hash` AND the object is physically present (`HEAD`). A
+/// re-push of unchanged content is then a metadata-only no-op instead of a
+/// fresh write, which on a versioning-enabled bucket would otherwise pile up
+/// retained versions that no S3-API GC can reclaim. `file_hash` is the incoming
+/// compressed-NAR hash (`sha256:<nix32>`).
+///
+/// The lookup is a best-effort optimization. A transient DB error here (e.g. a
+/// worker_db pool timeout under an eval's input-.drv push storm) must NOT
+/// propagate: it would abort the commit and terminally fail an eval whose
+/// evaluation actually succeeded. Degrade to "must write", which is always safe
+/// (re-storing identical bytes is a no-op on the store side).
+async fn nar_write_needed<C: ConnectionTrait>(
+    db: &C,
+    nar_storage: &NarStore,
+    hash: &str,
+    file_hash: &str,
+) -> anyhow::Result<bool> {
     let incoming = normalize_nar_hash(file_hash);
-    // The idempotency lookup is a best-effort optimization that skips a
-    // redundant write. A transient DB error here (e.g. a worker_db pool timeout
-    // under an eval's input-.drv push storm) must NOT propagate: it would abort
-    // the commit and terminally fail an eval whose evaluation actually
-    // succeeded. Degrade to "not recorded" and fall through to the write, which
-    // is always safe (re-storing identical bytes is a no-op on the store side).
     let recorded_match = match ECachedPath::find()
         .filter(CCachedPath::Hash.eq(hash))
         .one(db)
@@ -106,7 +167,6 @@ pub async fn put_nar_idempotent<C: ConnectionTrait>(
         return Ok(false);
     }
 
-    nar_storage.put(hash, nar_bytes).await?;
     Ok(true)
 }
 
@@ -439,6 +499,40 @@ mod tests {
             "must write the NAR when the idempotency lookup errors"
         );
         assert_eq!(store.get(IDEM_HASH).await.unwrap().unwrap(), b"NEW");
+    }
+
+    /// The streaming put writes through when no row records the path, storing
+    /// exactly the bytes read from the reader.
+    #[tokio::test]
+    async fn idempotent_reader_writes_when_no_row() {
+        let store = temp_store();
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([Vec::<gradient_entity::cached_path::Model>::new()])
+            .into_connection();
+
+        let wrote = put_nar_idempotent_reader(&db, &store, IDEM_HASH, "sha256:abc", &b"NEW"[..])
+            .await
+            .unwrap();
+        assert!(wrote);
+        assert_eq!(store.get(IDEM_HASH).await.unwrap().unwrap(), b"NEW");
+    }
+
+    /// The streaming put honours the same idempotency skip as the buffered one:
+    /// identical content already present leaves the stored bytes untouched and
+    /// never consumes/streams the reader.
+    #[tokio::test]
+    async fn idempotent_reader_skips_when_present_and_hash_matches() {
+        let store = temp_store();
+        store.put(IDEM_HASH, b"OLD".to_vec()).await.unwrap();
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![row_with_file_hash("sha256:abc")]])
+            .into_connection();
+
+        let wrote = put_nar_idempotent_reader(&db, &store, IDEM_HASH, "sha256:abc", &b"NEW"[..])
+            .await
+            .unwrap();
+        assert!(!wrote, "must skip when an identical NAR is already stored");
+        assert_eq!(store.get(IDEM_HASH).await.unwrap().unwrap(), b"OLD");
     }
 
     const SP: &str = "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello-2.12";

--- a/backend/gradient-storage/Cargo.toml
+++ b/backend/gradient-storage/Cargo.toml
@@ -35,6 +35,7 @@ reqwest                        = { workspace = true }
 tempfile                       = { workspace = true }
 thiserror                      = { workspace = true }
 tokio                          = { workspace = true, features = ["fs", "io-util", "macros", "rt", "sync"] }
+tokio-util                     = { workspace = true, features = ["io"] }
 tracing                        = { workspace = true }
 uuid                           = { workspace = true }
 zstd                           = { workspace = true }

--- a/backend/gradient-storage/src/digest.rs
+++ b/backend/gradient-storage/src/digest.rs
@@ -9,7 +9,8 @@
 //! worker or client reported at upload time.
 
 use gradient_util::nix_hash::normalize_nar_hash;
-use harmonia_utils_hash::{HashFormat as _, Sha256};
+use harmonia_utils_hash::{Algorithm, Context, HashFormat as _, Sha256};
+use tokio::io::{AsyncRead, AsyncReadExt as _};
 
 /// SHA-256 of `bytes` as a narinfo `file_hash` SRI string (`sha256-<base64>`),
 /// matching how uploads compute the value they report.
@@ -60,6 +61,60 @@ pub fn verify_nar_bytes(
     Ok(())
 }
 
+/// Streaming counterpart to [`verify_nar_bytes`]: reads `reader` to end while
+/// hashing incrementally, so a large NAR is never held whole in memory. The
+/// incremental SHA-256 uses harmonia's `Context`, which is documented to match
+/// the one-shot `Sha256::digest` used by [`file_hash_sri`] exactly, so the
+/// computed `file_hash` SRI is identical to the buffered path.
+pub async fn verify_nar_reader<R: AsyncRead + Unpin>(
+    mut reader: R,
+    expected_file_hash: &str,
+    expected_size: u64,
+) -> Result<(), VerifyError> {
+    let expected_norm = normalize_nar_hash(expected_file_hash);
+    let mut ctx = expected_norm
+        .starts_with("sha256:")
+        .then(|| Context::new(Algorithm::SHA256));
+
+    let mut total: u64 = 0;
+    let mut buf = vec![0u8; 256 * 1024];
+    loop {
+        let n = reader
+            .read(&mut buf)
+            .await
+            .map_err(|e| VerifyError::Store(e.into()))?;
+        if n == 0 {
+            break;
+        }
+        total += n as u64;
+        if let Some(ctx) = ctx.as_mut() {
+            ctx.update(&buf[..n]);
+        }
+    }
+
+    if total != expected_size {
+        return Err(VerifyError::Size {
+            expected: expected_size,
+            actual: total,
+        });
+    }
+
+    if let Some(ctx) = ctx {
+        let computed = Sha256::try_from(ctx.finish()).map_err(|_| {
+            VerifyError::Store(anyhow::anyhow!("sha256 finalize produced non-sha256"))
+        })?;
+        let computed_norm = normalize_nar_hash(&computed.as_sri().to_string());
+        if computed_norm != expected_norm {
+            return Err(VerifyError::Hash {
+                expected: expected_norm,
+                computed: computed_norm,
+            });
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -92,5 +147,37 @@ mod tests {
     fn non_sha256_hash_takes_size_only_path() {
         let blake3 = "blake3:11cxppanr71mzl1xnyax8rccaj5milx2fx9vnvzk6la672nb6dv4";
         assert!(verify_nar_bytes(BYTES, blake3, BYTES.len() as u64).is_ok());
+    }
+
+    /// The streaming verifier's incremental SHA-256 must produce the exact
+    /// `file_hash` SRI the one-shot path reports, so a valid NAR passes.
+    #[tokio::test]
+    async fn reader_verify_matches_one_shot_hash() {
+        let expected = file_hash_sri(BYTES);
+        assert!(
+            verify_nar_reader(BYTES, &expected, BYTES.len() as u64)
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn reader_verify_rejects_size_mismatch() {
+        let expected = file_hash_sri(BYTES);
+        let err = verify_nar_reader(BYTES, &expected, BYTES.len() as u64 + 1)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, VerifyError::Size { .. }));
+    }
+
+    #[tokio::test]
+    async fn reader_verify_rejects_tampered_content() {
+        let mut tampered = BYTES.to_vec();
+        let expected = file_hash_sri(&tampered);
+        *tampered.last_mut().unwrap() ^= 0xff;
+        let err = verify_nar_reader(&tampered[..], &expected, tampered.len() as u64)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, VerifyError::Hash { .. }));
     }
 }

--- a/backend/gradient-storage/src/lib.rs
+++ b/backend/gradient-storage/src/lib.rs
@@ -16,7 +16,7 @@ pub mod sgr;
 pub mod source_nar;
 
 pub use self::context::StorageCtx;
-pub use self::digest::{VerifyError, file_hash_sri, verify_nar_bytes};
+pub use self::digest::{VerifyError, file_hash_sri, verify_nar_bytes, verify_nar_reader};
 pub use self::log::*;
 pub use self::nar::*;
 pub use self::partial::PartialStore;

--- a/backend/gradient-storage/src/nar.rs
+++ b/backend/gradient-storage/src/nar.rs
@@ -11,6 +11,7 @@ use futures::stream::BoxStream;
 use object_store::{ClientOptions, ObjectStore, ObjectStoreExt as _, PutPayload, path::Path};
 pub use object_store::{MultipartUpload, WriteMultipart};
 use std::sync::Arc;
+use tokio::io::{AsyncRead, AsyncReadExt as _};
 
 /// Unified NAR file storage abstraction over local disk or an S3-compatible backend.
 ///
@@ -312,6 +313,41 @@ impl NarStore {
         Ok(WriteMultipart::new_with_chunk_size(upload, chunk_size))
     }
 
+    /// Stream `reader` into object storage under `hash` via a multipart upload,
+    /// so a large NAR is never held whole in memory: bytes flow reader -> part
+    /// buffer -> object store with at most `MAX_INFLIGHT_PARTS` uploads pending.
+    pub async fn put_reader<R: AsyncRead + Unpin + Send>(
+        &self,
+        hash: &str,
+        mut reader: R,
+    ) -> Result<()> {
+        const PART_SIZE: usize = 8 * 1024 * 1024;
+        const MAX_INFLIGHT_PARTS: usize = 2;
+        const READ_CHUNK: usize = 256 * 1024;
+
+        let mut upload = self.put_streaming(hash, PART_SIZE).await?;
+        let mut buf = vec![0u8; READ_CHUNK];
+        loop {
+            let n = reader
+                .read(&mut buf)
+                .await
+                .context("read NAR while streaming to storage")?;
+            if n == 0 {
+                break;
+            }
+            upload.write(&buf[..n]);
+            upload
+                .wait_for_capacity(MAX_INFLIGHT_PARTS)
+                .await
+                .context("multipart upload backpressure")?;
+        }
+        upload
+            .finish()
+            .await
+            .context("finish multipart NAR upload")?;
+        Ok(())
+    }
+
     pub async fn get(&self, hash: &str) -> Result<Option<Vec<u8>>> {
         self.get_object(&self.object_path(hash)).await
     }
@@ -587,6 +623,22 @@ mod tests {
             assembled.extend_from_slice(&chunk.expect("chunk"));
         }
         assert_eq!(assembled, payload);
+    }
+
+    #[tokio::test]
+    async fn put_reader_round_trips_multipart_payload() {
+        let (_d, store) = local_store();
+        // Larger than the 8 MiB part size so the multipart path spans >1 part.
+        let mut payload = Vec::with_capacity(20 * 1024 * 1024);
+        for i in 0..(20 * 1024 * 1024 / 4) {
+            payload.extend_from_slice(&(i as u32).to_le_bytes());
+        }
+        store
+            .put_reader("streamed", &payload[..])
+            .await
+            .expect("put_reader");
+        let got = store.get("streamed").await.expect("get").expect("present");
+        assert_eq!(got, payload);
     }
 
     #[tokio::test]

--- a/backend/gradient-storage/src/nar_extract.rs
+++ b/backend/gradient-storage/src/nar_extract.rs
@@ -16,7 +16,9 @@
 //! arbitrarily large outputs.
 
 use async_compression::tokio::bufread::ZstdDecoder;
+use bytes::Bytes;
 use futures::StreamExt as _;
+use futures::stream::BoxStream;
 use gradient_types::constants::{NAR_EXTRACT_MAX_PREALLOC, TAR_ZSTD_LEVEL};
 use harmonia_file_nar::{NarEvent, parse_nar};
 use std::io;
@@ -52,6 +54,17 @@ pub async fn extract_path_from_nar_bytes(
     let reader = BufReader::new(io::Cursor::new(compressed));
     let decoder = ZstdDecoder::new(reader);
     extract_path_from_reader(decoder, relative_path).await
+}
+
+/// Wraps a compressed `.nar.zst` byte stream (as returned by
+/// `NarStore::get_stream`) into an `AsyncRead` over the *decompressed* NAR, so a
+/// caller can extract or enumerate a single path without ever buffering the
+/// whole compressed object in memory.
+pub fn nar_reader_from_stream(
+    stream: BoxStream<'static, anyhow::Result<Bytes>>,
+) -> impl tokio::io::AsyncRead + Unpin {
+    let byte_stream = stream.map(|chunk| chunk.map_err(io::Error::other));
+    ZstdDecoder::new(tokio_util::io::StreamReader::new(byte_stream))
 }
 
 pub async fn extract_path_from_reader<R>(

--- a/backend/gradient-storage/src/partial.rs
+++ b/backend/gradient-storage/src/partial.rs
@@ -61,6 +61,15 @@ impl PartialStore {
         self.partial_path(key)
     }
 
+    /// Open the staged `.partial` for streaming reads, so a large NAR can be
+    /// verified and uploaded without `read_all` buffering it whole in memory.
+    pub async fn open_read(&self, key: &str) -> Result<tokio::fs::File> {
+        let path = self.partial_path(key);
+        tokio::fs::File::open(&path)
+            .await
+            .with_context(|| format!("open staged partial {}", path.display()))
+    }
+
     /// Ensure any parent directory implied by a `{peer}/{hash}` key exists.
     async fn ensure_parent(&self, key: &str) -> Result<()> {
         if let Some(parent) = self.partial_path(key).parent()

--- a/backend/gradient-web/src/endpoints/builds/downloads.rs
+++ b/backend/gradient-web/src/endpoints/builds/downloads.rs
@@ -13,7 +13,9 @@ use axum::response::{IntoResponse, Response};
 use axum::{Extension, Json};
 use gradient_core::ServerState;
 use gradient_sources::get_path_from_derivation_output;
-use gradient_storage::nar_extract::{ExtractError, Extracted, extract_path_from_nar_bytes};
+use gradient_storage::nar_extract::{
+    ExtractError, Extracted, extract_path_from_reader, nar_reader_from_stream,
+};
 use gradient_types::*;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use serde::{Deserialize, Serialize};
@@ -132,8 +134,8 @@ async fn find_and_serve_file(
         let hash = store_path_hash(&output_root);
         let rel = relative_in_output(&product.path, &output_root);
 
-        let compressed = match state.nar_storage.get(hash).await {
-            Ok(Some(b)) => b,
+        let (_size, stream) = match state.nar_storage.get_stream(hash).await {
+            Ok(Some(s)) => s,
             Ok(None) => {
                 tracing::warn!(%build_id, %filename, hash, "NAR not found in nar_storage");
                 continue;
@@ -150,7 +152,7 @@ async fn find_and_serve_file(
             format!("attachment; filename=\"{}\"", filename)
         };
 
-        match extract_path_from_nar_bytes(compressed, &rel).await {
+        match extract_path_from_reader(nar_reader_from_stream(stream), &rel).await {
             Ok(Extracted::File { contents, .. }) => {
                 tracing::info!(%build_id, %filename, file_size = contents.len(), "Successfully extracted file for download");
                 return Ok(Some(

--- a/backend/gradient-web/src/endpoints/caches/helpers.rs
+++ b/backend/gradient-web/src/endpoints/caches/helpers.rs
@@ -12,6 +12,8 @@ use crate::ip_allowlist::is_allowed as ip_allowed;
 use axum::extract::State;
 use axum::http::HeaderMap;
 use base64::Engine;
+use bytes::Bytes;
+use futures::stream::BoxStream;
 use gradient_core::ServerState;
 use gradient_sources::get_path_from_derivation_output;
 use gradient_types::*;
@@ -378,6 +380,25 @@ pub async fn fetch_nar_bytes(state: &Arc<ServerState>, path_hash: &str) -> WebRe
         .await
         .map_err(|e| WebError::internal(format!("Failed to read NAR: {}", e)))?
         .or_not_found("Path")
+}
+
+/// Streaming counterpart to [`fetch_nar_bytes`]: resolves the store hash once
+/// and opens a byte stream over the stored `.nar.zst` so the substitution path
+/// never pins a whole NAR (which can be hundreds of MB) in the server heap.
+/// Returns the resolved `(effective_hash, object_size, byte_stream)`.
+pub async fn fetch_nar_stream(
+    state: &Arc<ServerState>,
+    path_hash: &str,
+) -> WebResult<(String, u64, BoxStream<'static, anyhow::Result<Bytes>>)> {
+    let effective_hash =
+        crate::endpoints::caches::nar::resolve_effective_hash_db(&state.web_db, path_hash).await?;
+    let (size, stream) = state
+        .nar_storage
+        .get_stream(&effective_hash)
+        .await
+        .map_err(|e| WebError::internal(format!("Failed to read NAR: {}", e)))?
+        .or_not_found("Path")?;
+    Ok((effective_hash, size, stream))
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/backend/gradient-web/src/endpoints/caches/helpers.rs
+++ b/backend/gradient-web/src/endpoints/caches/helpers.rs
@@ -371,21 +371,9 @@ impl JsonFlag {
     }
 }
 
-pub async fn fetch_nar_bytes(state: &Arc<ServerState>, path_hash: &str) -> WebResult<Vec<u8>> {
-    let effective_hash =
-        crate::endpoints::caches::nar::resolve_effective_hash_db(&state.web_db, path_hash).await?;
-    state
-        .nar_storage
-        .get(&effective_hash)
-        .await
-        .map_err(|e| WebError::internal(format!("Failed to read NAR: {}", e)))?
-        .or_not_found("Path")
-}
-
-/// Streaming counterpart to [`fetch_nar_bytes`]: resolves the store hash once
-/// and opens a byte stream over the stored `.nar.zst` so the substitution path
-/// never pins a whole NAR (which can be hundreds of MB) in the server heap.
-/// Returns the resolved `(effective_hash, object_size, byte_stream)`.
+/// Resolves the store hash once and opens a byte stream over the stored
+/// `.nar.zst` so the serve paths never pin a whole NAR (which can be hundreds of
+/// MB) in the server heap. Returns `(effective_hash, object_size, byte_stream)`.
 pub async fn fetch_nar_stream(
     state: &Arc<ServerState>,
     path_hash: &str,

--- a/backend/gradient-web/src/endpoints/caches/nar.rs
+++ b/backend/gradient-web/src/endpoints/caches/nar.rs
@@ -35,10 +35,10 @@ pub async fn nar(
     let client_ip = cache_client_ip(&state, &headers, peer);
     let ctx = CacheContext::load(&state, &headers, client_ip, cache).await?;
 
-    let compressed = super::helpers::fetch_nar_bytes(&state, &path_hash).await?;
-    let effective_hash = resolve_effective_hash_db(&state.web_db, &path_hash).await?;
+    let (effective_hash, size, stream) =
+        super::helpers::fetch_nar_stream(&state, &path_hash).await?;
 
-    spawn_nar_traffic_metric(Arc::clone(&state), ctx.cache.id, compressed.len() as i64);
+    spawn_nar_traffic_metric(Arc::clone(&state), ctx.cache.id, size as i64);
     spawn_cache_derivation_fetch_update(Arc::clone(&state), ctx.cache.id, effective_hash);
 
     Response::builder()
@@ -46,7 +46,8 @@ pub async fn nar(
             header::CONTENT_TYPE,
             HeaderValue::from_static("application/x-nix-nar"),
         )
-        .body(Body::from(compressed))
+        .header(header::CONTENT_LENGTH, size)
+        .body(Body::from_stream(stream))
         .map_err(|e| WebError::internal(format!("Failed to build response: {}", e)))
 }
 
@@ -70,14 +71,27 @@ pub async fn upstream_nar(
         .url
         .ok_or_else(|| WebError::bad_request("Not an external upstream"))?;
 
-    let bytes = fetch_upstream_nar(&state.http, &base_url, &path, query.as_deref()).await?;
+    let nar_url = build_upstream_nar_url(&base_url, &path, query.as_deref());
+    let resp = state
+        .http
+        .get(&nar_url)
+        .send()
+        .await
+        .map_err(|e| WebError::internal(format!("Upstream request failed: {}", e)))?;
 
-    Response::builder()
-        .header(
-            header::CONTENT_TYPE,
-            HeaderValue::from_static("application/x-nix-nar"),
-        )
-        .body(Body::from(bytes))
+    if !resp.status().is_success() {
+        return Err(WebError::not_found("NAR in upstream"));
+    }
+
+    let mut builder = Response::builder().header(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/x-nix-nar"),
+    );
+    if let Some(len) = resp.content_length() {
+        builder = builder.header(header::CONTENT_LENGTH, len);
+    }
+    builder
+        .body(Body::from_stream(resp.bytes_stream()))
         .map_err(|e| WebError::internal(format!("Failed to build response: {}", e)))
 }
 
@@ -157,28 +171,6 @@ fn build_upstream_nar_url(base_url: &str, path: &str, query: Option<&str>) -> St
         Some(q) if !q.is_empty() => format!("{url}?{q}"),
         _ => url,
     }
-}
-
-async fn fetch_upstream_nar(
-    http: &reqwest::Client,
-    base_url: &str,
-    path: &str,
-    query: Option<&str>,
-) -> WebResult<bytes::Bytes> {
-    let nar_url = build_upstream_nar_url(base_url, path, query);
-    let resp = http
-        .get(&nar_url)
-        .send()
-        .await
-        .map_err(|e| WebError::internal(format!("Upstream request failed: {}", e)))?;
-
-    if !resp.status().is_success() {
-        return Err(WebError::not_found("NAR in upstream"));
-    }
-
-    resp.bytes()
-        .await
-        .map_err(|e| WebError::internal(format!("Failed to read upstream response: {}", e)))
 }
 
 #[cfg(test)]

--- a/backend/gradient-web/src/endpoints/caches/narlist.rs
+++ b/backend/gradient-web/src/endpoints/caches/narlist.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-use super::helpers::{CacheContext, cache_client_ip, fetch_nar_bytes};
+use super::helpers::{CacheContext, cache_client_ip, fetch_nar_stream};
 use crate::client_ip::OptionalPeer;
 use crate::error::{WebError, WebResult};
 use axum::Json;
@@ -12,12 +12,12 @@ use axum::http::HeaderMap;
 use axum::response::{IntoResponse, Response};
 use futures::StreamExt as _;
 use gradient_core::ServerState;
+use gradient_storage::nar_extract::nar_reader_from_stream;
 use harmonia_file_nar::parse_nar;
 use serde::Serialize;
 use std::collections::BTreeMap;
 use std::io;
 use std::sync::Arc;
-use tokio::io::BufReader;
 
 type DirFrame = (Option<String>, BTreeMap<String, Box<FileTree>>);
 
@@ -53,12 +53,10 @@ pub async fn ls(
 ) -> WebResult<Response> {
     let client_ip = cache_client_ip(&state, &headers, peer);
     let _ctx = CacheContext::load(&state, &headers, client_ip, cache).await?;
-    let compressed = fetch_nar_bytes(&state, &hash).await?;
+    let (_effective_hash, _size, stream) = fetch_nar_stream(&state, &hash).await?;
+    let reader = nar_reader_from_stream(stream);
 
-    let decompressed = zstd::decode_all(io::Cursor::new(&compressed))
-        .map_err(|e| WebError::internal(format!("NAR decompression failed: {}", e)))?;
-
-    let root = walk_nar(BufReader::new(io::Cursor::new(decompressed)))
+    let root = walk_nar(reader)
         .await
         .map_err(|e| WebError::internal(format!("NAR walk failed: {}", e)))?;
 

--- a/backend/gradient-web/src/endpoints/caches/serve.rs
+++ b/backend/gradient-web/src/endpoints/caches/serve.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-use super::helpers::{CacheContext, cache_client_ip, fetch_nar_bytes};
+use super::helpers::{CacheContext, cache_client_ip, fetch_nar_stream};
 use crate::client_ip::OptionalPeer;
 use crate::error::{WebError, WebResult};
 use axum::body::Body;
@@ -11,7 +11,9 @@ use axum::extract::{Path, State};
 use axum::http::{HeaderMap, HeaderValue, header};
 use axum::response::Response;
 use gradient_core::ServerState;
-use gradient_storage::nar_extract::{ExtractError, Extracted, extract_path_from_nar_bytes};
+use gradient_storage::nar_extract::{
+    ExtractError, Extracted, extract_path_from_reader, nar_reader_from_stream,
+};
 use std::sync::Arc;
 
 pub async fn serve(
@@ -22,9 +24,10 @@ pub async fn serve(
 ) -> WebResult<Response> {
     let client_ip = cache_client_ip(&state, &headers, peer);
     let _ctx = CacheContext::load(&state, &headers, client_ip, cache).await?;
-    let compressed = fetch_nar_bytes(&state, &hash).await?;
+    let (_effective_hash, _size, stream) = fetch_nar_stream(&state, &hash).await?;
+    let reader = nar_reader_from_stream(stream);
 
-    match extract_path_from_nar_bytes(compressed, &rel_path).await {
+    match extract_path_from_reader(reader, &rel_path).await {
         Ok(Extracted::File { contents, size, .. }) => {
             let ct = mime_guess::from_path(&rel_path).first_or_octet_stream();
             Response::builder()

--- a/backend/gradient-web/src/endpoints/caches/upload.rs
+++ b/backend/gradient-web/src/endpoints/caches/upload.rs
@@ -15,7 +15,7 @@ use axum::extract::{Multipart, Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use gradient_core::ServerState;
-use gradient_proto::ingest::{IngestInput, SignTargets, ingest_nar};
+use gradient_proto::ingest::{IngestInput, SignTargets, ingest_nar_reader};
 use gradient_storage::PartialStore;
 use gradient_types::*;
 use serde::Deserialize;
@@ -56,15 +56,20 @@ pub async fn nars_upload(
     )
     .await?;
 
+    let upload_store = upload_partial_store(&state)?;
+    let stage_key = format!("{}/oneshot-{}", cache.id, uuid::Uuid::now_v7());
+    let max = state.config.limits.max_nar_upload_size as u64;
+
     let mut narinfo: Option<NarinfoPart> = None;
-    let mut nar_bytes: Option<Vec<u8>> = None;
+    let mut staged_size: Option<u64> = None;
 
     while let Some(field) = multipart
         .next_field()
         .await
         .map_err(|e| WebError::BadRequest(ErrorCode::INPUT_VALIDATION, e.to_string()))?
     {
-        match field.name() {
+        let name = field.name().map(str::to_owned);
+        match name.as_deref() {
             Some("narinfo") => {
                 let text = field.text().await.map_err(|e| {
                     WebError::BadRequest(ErrorCode::INPUT_VALIDATION, e.to_string())
@@ -78,45 +83,63 @@ pub async fn nars_upload(
                 narinfo = Some(parsed);
             }
             Some("nar") => {
-                let bytes = field.bytes().await.map_err(|e| {
-                    WebError::BadRequest(ErrorCode::INPUT_VALIDATION, e.to_string())
-                })?;
-                nar_bytes = Some(bytes.to_vec());
+                staged_size = Some(stage_nar_field(&upload_store, &stage_key, field, max).await?);
             }
             _ => {}
         }
     }
 
-    let narinfo = narinfo.ok_or_else(|| {
-        WebError::BadRequest(ErrorCode::INPUT_VALIDATION, "missing narinfo part".into())
-    })?;
-    let nar_bytes = nar_bytes.ok_or_else(|| {
+    let narinfo = match narinfo {
+        Some(n) => n,
+        None => {
+            let _ = upload_store.discard(&stage_key).await;
+            return Err(WebError::BadRequest(
+                ErrorCode::INPUT_VALIDATION,
+                "missing narinfo part".into(),
+            ));
+        }
+    };
+    let staged_size = staged_size.ok_or_else(|| {
         WebError::BadRequest(ErrorCode::INPUT_VALIDATION, "missing nar part".into())
     })?;
 
-    if nar_bytes.len() as i64 != narinfo.file_size {
+    if staged_size as i64 != narinfo.file_size {
+        let _ = upload_store.discard(&stage_key).await;
         return Err(WebError::BadRequest(
             ErrorCode::INPUT_VALIDATION,
             format!(
-                "nar size mismatch: declared {} bytes, got {}",
-                narinfo.file_size,
-                nar_bytes.len()
+                "nar size mismatch: declared {} bytes, got {staged_size}",
+                narinfo.file_size
             ),
         ));
     }
-    if let Err(e) =
-        gradient_storage::verify_nar_bytes(&nar_bytes, &narinfo.file_hash, narinfo.file_size as u64)
+
+    let verify_reader = upload_store
+        .open_read(&stage_key)
+        .await
+        .map_err(|e| WebError::internal(format!("failed to read staged NAR: {e}")))?;
+    if let Err(e) = gradient_storage::verify_nar_reader(
+        verify_reader,
+        &narinfo.file_hash,
+        narinfo.file_size as u64,
+    )
+    .await
     {
+        let _ = upload_store.discard(&stage_key).await;
         return Err(WebError::BadRequest(
             ErrorCode::INPUT_VALIDATION,
             format!("nar content verification failed: {e}"),
         ));
     }
 
-    let outcome = ingest_nar(
+    let nar_reader = upload_store
+        .open_read(&stage_key)
+        .await
+        .map_err(|e| WebError::internal(format!("failed to read staged NAR: {e}")))?;
+    let outcome = ingest_nar_reader(
         &state.web_db,
         &state.nar_storage,
-        nar_bytes,
+        nar_reader,
         IngestInput {
             store_path: &narinfo.store_path,
             file_hash: &narinfo.file_hash,
@@ -131,6 +154,7 @@ pub async fn nars_upload(
     )
     .await
     .map_err(WebError::from)?;
+    let _ = upload_store.discard(&stage_key).await;
 
     sign_uploaded_path(&state, &narinfo, outcome.cached_path).await;
 
@@ -191,6 +215,38 @@ fn upload_partial_store(state: &ServerState) -> WebResult<PartialStore> {
     let root = format!("{}/nar-upload-partial", state.config.storage.base_path);
     let ttl = Duration::from_secs(state.config.proto.nar_partial_ttl_secs);
     Ok(PartialStore::new(root, ttl)?)
+}
+
+/// Stream one multipart `nar` field to a staged `.partial` so a single-shot
+/// upload never buffers the whole NAR in memory. Returns the staged byte count;
+/// discards the partial and errors if it would exceed `max`.
+async fn stage_nar_field(
+    store: &PartialStore,
+    key: &str,
+    mut field: axum::extract::multipart::Field<'_>,
+    max: u64,
+) -> WebResult<u64> {
+    let token = "oneshot";
+    let mut offset = 0u64;
+    while let Some(chunk) = field
+        .chunk()
+        .await
+        .map_err(|e| WebError::BadRequest(ErrorCode::INPUT_VALIDATION, e.to_string()))?
+    {
+        if offset + chunk.len() as u64 > max {
+            let _ = store.discard(key).await;
+            return Err(WebError::PayloadTooLarge(
+                ErrorCode::PAYLOAD_TOO_LARGE,
+                format!("nar exceeds max upload size of {max} bytes"),
+            ));
+        }
+        store
+            .append(key, token, offset, &chunk)
+            .await
+            .map_err(|e| WebError::internal(format!("failed to stage NAR: {e}")))?;
+        offset += chunk.len() as u64;
+    }
+    Ok(offset)
 }
 
 /// A store path's base name (`<hash>-<name>`) used as the staging key. Rejected
@@ -298,19 +354,30 @@ pub async fn nar_finalize(
         ));
     }
 
-    let nar_bytes = store.read_all(&key).await?;
-    if let Err(e) =
-        gradient_storage::verify_nar_bytes(&nar_bytes, &narinfo.file_hash, narinfo.file_size as u64)
+    let verify_reader = store
+        .open_read(&key)
+        .await
+        .map_err(|e| WebError::internal(format!("failed to read staged NAR: {e}")))?;
+    if let Err(e) = gradient_storage::verify_nar_reader(
+        verify_reader,
+        &narinfo.file_hash,
+        narinfo.file_size as u64,
+    )
+    .await
     {
         return Err(WebError::BadRequest(
             ErrorCode::INPUT_VALIDATION,
             format!("nar content verification failed: {e}"),
         ));
     }
-    let outcome = ingest_nar(
+    let nar_reader = store
+        .open_read(&key)
+        .await
+        .map_err(|e| WebError::internal(format!("failed to read staged NAR: {e}")))?;
+    let outcome = ingest_nar_reader(
         &state.web_db,
         &state.nar_storage,
-        nar_bytes,
+        nar_reader,
         IngestInput {
             store_path: &narinfo.store_path,
             file_hash: &narinfo.file_hash,

--- a/backend/gradient-web/src/endpoints/projects/evaluations.rs
+++ b/backend/gradient-web/src/endpoints/projects/evaluations.rs
@@ -23,7 +23,9 @@ use gradient_db::get_any_organization_by_name;
 use gradient_entity::build::BuildStatus;
 use gradient_entity::evaluation_message::MessageLevel;
 use gradient_sources::{check_project_updates, get_commit_info, get_path_from_derivation_output};
-use gradient_storage::nar_extract::{ExtractError, Extracted, extract_path_from_nar_bytes};
+use gradient_storage::nar_extract::{
+    ExtractError, Extracted, extract_path_from_reader, nar_reader_from_stream,
+};
 use gradient_types::input::vec_to_hex;
 use gradient_types::*;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect};
@@ -735,8 +737,8 @@ async fn serve_hydra_artifact(
             .map(str::to_owned)
             .unwrap_or_else(|| product.path.trim_start_matches('/').to_owned());
 
-        let compressed = match state.nar_storage.get(hash).await {
-            Ok(Some(b)) => b,
+        let (_size, stream) = match state.nar_storage.get_stream(hash).await {
+            Ok(Some(s)) => s,
             Ok(None) => continue,
             Err(e) => {
                 tracing::warn!(output_path = %output_root, error = %e, "Failed to fetch NAR from nar_storage");
@@ -750,7 +752,7 @@ async fn serve_hydra_artifact(
             format!("attachment; filename=\"{}\"", filename)
         };
 
-        match extract_path_from_nar_bytes(compressed, &rel).await {
+        match extract_path_from_reader(nar_reader_from_stream(stream), &rel).await {
             Ok(Extracted::File { contents, .. }) => {
                 return Ok(Some(
                     (

--- a/backend/gradient-web/tests/nar_serve.rs
+++ b/backend/gradient-web/tests/nar_serve.rs
@@ -1,0 +1,165 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Integration test: `GET /cache/{cache}/nar/{path}` streams the stored NAR
+//! blob straight from `nar_storage` without buffering the whole object in the
+//! server heap. The response must be byte-identical to the stored blob and
+//! carry an accurate `Content-Length` (the streamed body has no implicit
+//! length, so the handler sets it from the storage object size).
+
+use axum::extract::connect_info::MockConnectInfo;
+use axum_test::TestServer;
+use gradient_core::ServerState;
+use gradient_db::{WebDb, WorkerDb};
+use gradient_notify::EmailSender;
+use gradient_storage::NarStore;
+use gradient_test_support::fakes::email::InMemoryEmailSender;
+use gradient_test_support::log_storage::NoopLogStorage;
+use gradient_test_support::prelude::test_cli;
+use gradient_types::ids::*;
+use sea_orm::{DatabaseBackend, MockDatabase};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use uuid::Uuid;
+
+/// 32-char nix-base32 store hash the blob is written under.
+const STORE_HASH: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+/// 52-char nix-base32 file hash carried in the `.nar.zst` URL slug.
+const FILE_HASH_NIX32: &str = "0mdqa9w1p6cmli6976v4wi0sw9r4p5prkj7lzfd1877wk11c9c73";
+
+fn cache_id() -> CacheId {
+    CacheId::new(Uuid::parse_str("30000000-0000-0000-0000-000000000001").unwrap())
+}
+fn user_id() -> UserId {
+    UserId::new(Uuid::parse_str("30000000-0000-0000-0000-000000000002").unwrap())
+}
+fn cached_path_id() -> CachedPathId {
+    CachedPathId::new(Uuid::parse_str("30000000-0000-0000-0000-000000000003").unwrap())
+}
+fn test_date() -> chrono::NaiveDateTime {
+    chrono::NaiveDate::from_ymd_opt(2026, 1, 1)
+        .unwrap()
+        .and_hms_opt(0, 0, 0)
+        .unwrap()
+}
+
+fn cache_row() -> gradient_entity::cache::Model {
+    gradient_entity::cache::Model {
+        id: cache_id(),
+        name: "test-cache".into(),
+        display_name: "Test Cache".into(),
+        active: true,
+        priority: 40,
+        public_key: "test-pub-key".into(),
+        private_key: "test-priv-key".into(),
+        public: true,
+        created_by: user_id(),
+        created_at: test_date(),
+        ..Default::default()
+    }
+}
+
+fn cached_path_row() -> gradient_entity::cached_path::Model {
+    gradient_entity::cached_path::Model {
+        id: cached_path_id(),
+        hash: STORE_HASH.into(),
+        package: "hello".into(),
+        file_hash: Some(format!("sha256:{FILE_HASH_NIX32}")),
+        file_size: Some(12345),
+        nar_size: Some(67890),
+        nar_hash: Some(format!("sha256:{FILE_HASH_NIX32}")),
+        created_at: test_date(),
+        ..Default::default()
+    }
+}
+
+/// A blob large enough to span several storage stream chunks, so the test
+/// exercises reassembly rather than a single-chunk read.
+fn blob() -> Vec<u8> {
+    (0..256 * 1024).map(|i| (i * 31 + 7) as u8).collect()
+}
+
+fn run<F: std::future::Future<Output = ()>>(f: F) {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(f);
+}
+
+#[test]
+fn nar_serve_streams_stored_blob_byte_for_byte() {
+    run(async {
+        let cli = test_cli();
+
+        // Query order: CacheContext::load (ECache by name) → fetch_nar_stream's
+        // single resolve_effective_hash_db (ECachedPath by file_hash).
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![cache_row()]])
+            .append_query_results([vec![cached_path_row()]])
+            .into_connection();
+
+        let nar_storage = NarStore::local(&cli.storage.base_path).expect("create test NarStore");
+        let data = blob();
+        nar_storage
+            .put(STORE_HASH, data.clone())
+            .await
+            .expect("seed NAR blob");
+
+        let state = Arc::new(ServerState {
+            web_db: WebDb::new(db),
+            cache_db: gradient_db::CacheDb::new(
+                MockDatabase::new(DatabaseBackend::Postgres).into_connection(),
+            ),
+            worker_db: WorkerDb::new(
+                MockDatabase::new(DatabaseBackend::Postgres).into_connection(),
+            ),
+            config: Arc::new(gradient_types::RuntimeConfig::from_cli(&cli).expect("valid config")),
+            log_storage: Arc::new(NoopLogStorage),
+            email: Arc::new(InMemoryEmailSender::new()) as Arc<dyn EmailSender>,
+            nar_storage,
+            manifest_state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            pending_credentials: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            http: gradient_util::http::build_client().expect("http client"),
+            shutdown: gradient_util::shutdown::Shutdown::new(),
+            jwt_secret: gradient_types::SecretString::new("test-jwt-secret".to_string()),
+            started_at: chrono::Utc::now(),
+            pending_org_memberships: Arc::new(std::collections::HashMap::new()),
+            oidc_group_roles: Arc::new(std::collections::HashMap::new()),
+            scim_group_roles: Arc::new(Default::default()),
+            board_events: tokio::sync::broadcast::channel(256).0,
+            forge: gradient_forge::ForgeRegistry::with_builtin(),
+            upstream_query: Arc::new(tokio::sync::Semaphore::new(32)),
+            reactor: Arc::new(gradient_db::NoReactor),
+        });
+
+        let peer: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let router = gradient_web::create_router(state)
+            .expect("router")
+            .layer(MockConnectInfo(peer));
+        let server = TestServer::new(router);
+
+        let resp = server
+            .get(&format!("/cache/test-cache/nar/{FILE_HASH_NIX32}.nar.zst"))
+            .await;
+
+        resp.assert_status_ok();
+        assert_eq!(
+            resp.header("content-type").to_str().unwrap(),
+            "application/x-nix-nar",
+        );
+        assert_eq!(
+            resp.header("content-length").to_str().unwrap(),
+            data.len().to_string(),
+            "streamed NAR must carry an explicit Content-Length equal to the object size",
+        );
+        assert_eq!(
+            resp.as_bytes().as_ref(),
+            data.as_slice(),
+            "served body must be byte-identical to the stored blob",
+        );
+    });
+}

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -6519,3 +6519,21 @@ replies via `NixPathInfo.ca`.
   `ingest_records_content_address` drives the ingest pipeline with a
   `NarUploadRecord` holding `ca: Some(...)`, asserts the resulting `cached_path`
   row has `ca` populated with the exact input string.
+
+## HTTP NAR serving streams instead of buffering the whole object
+
+The daemon-free serve path read the entire compressed NAR into a `Vec<u8>`
+before responding (`fetch_nar_bytes` -> `Body::from(compressed)`), so heap grew
+with `concurrent downloads x NAR size` and OOM-killed the server under
+substitution load. `caches::nar` now opens `NarStore::get_stream` and returns
+`Body::from_stream`, setting an explicit `Content-Length` from the object size
+(a streamed body has no implicit length); `upstream_nar` streams the upstream
+response via `bytes_stream()` instead of `resp.bytes()`.
+
+- `backend/gradient-web/tests/nar_serve.rs`:
+  `nar_serve_streams_stored_blob_byte_for_byte` seeds a multi-chunk blob in a
+  local `NarStore`, drives `GET /cache/{cache}/nar/{hash}.nar.zst`, and asserts
+  the response is byte-identical to the stored blob with `Content-Type:
+  application/x-nix-nar` and a `Content-Length` equal to the object size. The
+  streaming/no-buffering property itself is covered by the storage-level
+  `get_stream` tests in `backend/gradient-storage/src/nar.rs`.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -6530,6 +6530,14 @@ substitution load. `caches::nar` now opens `NarStore::get_stream` and returns
 (a streamed body has no implicit length); `upstream_nar` streams the upstream
 response via `bytes_stream()` instead of `resp.bytes()`.
 
+The single-path browse/download endpoints that extract one file or subtree out
+of a NAR (`caches::serve`, `caches::ls`, `builds` product download,
+`evaluations` product download) had the same problem: they read the whole
+compressed NAR into a `Vec<u8>` before extracting. They now feed
+`NarStore::get_stream` through the new `nar_extract::nar_reader_from_stream`
+(a `StreamReader` + async `ZstdDecoder` bridge) into the already-streaming
+`extract_path_from_reader`, so the compressed NAR is never fully buffered.
+
 - `backend/gradient-web/tests/nar_serve.rs`:
   `nar_serve_streams_stored_blob_byte_for_byte` seeds a multi-chunk blob in a
   local `NarStore`, drives `GET /cache/{cache}/nar/{hash}.nar.zst`, and asserts
@@ -6537,3 +6545,9 @@ response via `bytes_stream()` instead of `resp.bytes()`.
   application/x-nix-nar` and a `Content-Length` equal to the object size. The
   streaming/no-buffering property itself is covered by the storage-level
   `get_stream` tests in `backend/gradient-storage/src/nar.rs`.
+- `backend/gradient-core/tests/nar_extract.rs`:
+  `streaming_reader_extracts_same_file_as_buffered` feeds a compressed NAR as
+  many small chunks (splitting the zstd frame across boundaries) through
+  `nar_reader_from_stream` + `extract_path_from_reader` and asserts the
+  extracted file is identical to the buffered `extract_path_from_nar_bytes`
+  result.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -6551,3 +6551,33 @@ compressed NAR into a `Vec<u8>` before extracting. They now feed
   `nar_reader_from_stream` + `extract_path_from_reader` and asserts the
   extracted file is identical to the buffered `extract_path_from_nar_bytes`
   result.
+
+## Inbound NAR upload streaming keeps the #482 integrity guarantee
+
+The inbound paths that receive a NAR (worker WS commit `commit_relayed`, chunked
+`nar_finalize`, single-shot `nars_upload`) previously `read_all`/`field.bytes()`
+the whole NAR into a `Vec<u8>` to verify (`verify_nar_bytes`) and store
+(`nar_storage.put`). They now stream from the staged `.partial`: `verify_nar_reader`
+hashes incrementally and `put_reader` uploads via multipart, so the object is
+never held whole in memory. `nars_upload` streams its multipart `nar` field to a
+staged file first (`stage_nar_field`). The single-source-of-truth for the skip
+decision is `nar_write_needed`, shared by the buffered and streaming puts. The
+integrity guarantee (#482) is preserved: verification passes over the full
+content before any object write.
+
+- `backend/gradient-storage/src/digest.rs`:
+  `reader_verify_matches_one_shot_hash` asserts the incremental SHA-256 in
+  `verify_nar_reader` produces the exact `file_hash` SRI the one-shot
+  `file_hash_sri` reports (so a valid NAR passes);
+  `reader_verify_rejects_size_mismatch` / `reader_verify_rejects_tampered_content`
+  assert a wrong length or altered byte is rejected with the matching error.
+- `backend/gradient-storage/src/nar.rs`:
+  `put_reader_round_trips_multipart_payload` streams a 20 MiB payload (spanning
+  multiple 8 MiB parts) through `put_reader` and asserts `get` returns it
+  byte-for-byte.
+- `backend/gradient-proto/src/ingest.rs`:
+  `idempotent_reader_writes_when_no_row` /
+  `idempotent_reader_skips_when_present_and_hash_matches` assert
+  `put_nar_idempotent_reader` writes the streamed bytes when no row records the
+  path and honours the same idempotency skip as the buffered `put_nar_idempotent`
+  (leaving stored bytes untouched, reader unread).


### PR DESCRIPTION
`caches::nar` buffered each entire compressed NAR into a `Vec<u8>` before responding, with no concurrency cap, so server heap scaled with `concurrent downloads x NAR size` and OOM-killed `gradient-server` (6.1 GB anon RSS on a swapless box). Regression from the daemon-free refactor: streaming existed (#109) and `NarStore::get_stream` was only wired to the worker WS path. This streams every NAR path, in and out.

**Outbound (serve):**
- `caches::nar` / `upstream_nar` return `Body::from_stream` with an explicit `Content-Length`.
- Browse/download endpoints (`serve`, `ls`, build/eval product downloads) feed `get_stream` through `nar_reader_from_stream` into the already-streaming extractor.

**Inbound (upload):**
- Worker WS commit, chunked `nar_finalize`, and single-shot `nars_upload` stream from the staged `.partial`: `verify_nar_reader` hashes incrementally and `NarStore::put_reader` uploads via multipart. `nars_upload` streams its multipart field to disk first.
- The #482 integrity guarantee is preserved: the incremental SHA-256 uses harmonia's `Context` (documented equal to the one-shot `Sha256::digest`), verified before any object write; a test asserts the streamed `file_hash` SRI matches the one-shot path byte-for-byte.

Peak per-transfer heap drops from the whole NAR to a fixed chunk/part budget in both directions.

Deferred: source uploads (`post_source`/`source_finalize`) are content-addressed by hashing the whole NAR to derive the store path, so they are inherently whole-buffer; bounded by the 512 MiB source limit.