### PR TITLE
worker,scheduler: fix: best-effort flake input prefetch and graph-stuck eval recovery

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -198,39 +198,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-attributes"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,65 +207,6 @@ dependencies = [
  "compression-core",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.5.0",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
- "tokio",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix 1.1.4",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
-dependencies = [
- "event-listener 5.4.1",
- "event-listener-strategy",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -312,33 +220,6 @@ dependencies = [
  "libssh2-sys",
  "ssh2",
  "tokio",
-]
-
-[[package]]
-name = "async-std"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
-dependencies = [
- "async-attributes",
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io",
- "async-lock",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -360,14 +241,8 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -377,7 +252,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -553,7 +428,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
  "ubyte",
 ]
 
@@ -620,7 +495,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex 1.3.0",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -683,19 +558,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel 2.5.0",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
-]
-
-[[package]]
 name = "brotli"
 version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,7 +615,7 @@ checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -896,7 +758,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1052,6 +914,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
+name = "crc-fast"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
+dependencies = [
+ "digest 0.10.7",
+ "spin 0.10.1",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1173,7 +1045,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1206,7 +1078,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1219,7 +1091,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1230,7 +1102,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1241,7 +1113,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1331,7 +1203,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.118",
+ "syn",
  "unicode-xid",
 ]
 
@@ -1377,7 +1249,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1550,28 +1422,12 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener 5.4.1",
  "pin-project-lite",
 ]
 
@@ -1601,7 +1457,7 @@ checksum = "c0637949cd816934f3b7aab44ff98e7ec1fb903c379e07dcb9eac943ec33499e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1672,7 +1528,7 @@ checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -1787,19 +1643,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1807,7 +1650,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1905,7 +1748,7 @@ checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1946,18 +1789,6 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "governor"
@@ -2038,7 +1869,7 @@ dependencies = [
  "hex",
  "num_enum",
  "rand 0.10.2",
- "reqwest 0.13.4",
+ "reqwest",
  "sea-orm",
  "serde",
  "serde_json",
@@ -2100,7 +1931,7 @@ dependencies = [
  "password-auth",
  "rand 0.10.2",
  "rand_core 0.10.1",
- "reqwest 0.13.4",
+ "reqwest",
  "ring",
  "rkyv",
  "rustls",
@@ -2204,7 +2035,7 @@ dependencies = [
  "gradient-sources",
  "gradient-util",
  "harmonia-file-nar",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -2228,7 +2059,7 @@ dependencies = [
  "gradient-util",
  "hex",
  "hmac 0.13.0",
- "reqwest 0.13.4",
+ "reqwest",
  "ring",
  "serde",
  "serde_json",
@@ -2244,10 +2075,10 @@ dependencies = [
 name = "gradient-migration"
 version = "1.3.0"
 dependencies = [
- "async-std",
  "async-trait",
  "sea-orm-migration",
  "sha2 0.11.0",
+ "tokio",
  "uuid",
 ]
 
@@ -2300,7 +2131,7 @@ dependencies = [
  "gradient-util",
  "hex",
  "password-auth",
- "reqwest 0.13.4",
+ "reqwest",
  "rkyv",
  "sea-orm",
  "serde",
@@ -2333,7 +2164,7 @@ dependencies = [
  "gradient-storage",
  "gradient-test-support",
  "gradient-types",
- "reqwest 0.13.4",
+ "reqwest",
  "sea-orm",
  "serde",
  "serde_json",
@@ -2440,7 +2271,7 @@ dependencies = [
  "harmonia-utils-hash",
  "hex",
  "object_store",
- "reqwest 0.13.4",
+ "reqwest",
  "tar",
  "tempfile",
  "thiserror 2.0.18",
@@ -2520,7 +2351,7 @@ version = "1.3.0"
 dependencies = [
  "base64",
  "hex",
- "reqwest 0.13.4",
+ "reqwest",
  "rustls",
  "rustls-native-certs",
  "thiserror 2.0.18",
@@ -2580,7 +2411,7 @@ dependencies = [
  "password-auth",
  "prometheus",
  "rand 0.10.2",
- "reqwest 0.13.4",
+ "reqwest",
  "sea-orm",
  "serde",
  "serde_json",
@@ -2636,7 +2467,7 @@ dependencies = [
  "hex",
  "libc",
  "nix-bindings",
- "reqwest 0.13.4",
+ "reqwest",
  "rkyv",
  "serde",
  "serde_json",
@@ -2758,7 +2589,7 @@ source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -3126,7 +2957,6 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -3306,7 +3136,7 @@ checksum = "c727f80bfa4a6c6e2508d2f05b6f4bfce242030bd88ed15ae5331c5b5d30fba7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -3358,6 +3188,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3390,7 +3229,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -3409,7 +3248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -3450,21 +3289,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -3616,9 +3446,6 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "lru-slab"
@@ -3671,6 +3498,16 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3760,7 +3597,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -3776,7 +3613,7 @@ dependencies = [
  "httparse",
  "memchr",
  "mime",
- "spin",
+ "spin 0.9.9",
  "version_check",
 ]
 
@@ -3797,7 +3634,7 @@ checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -4018,7 +3855,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -4201,14 +4038,16 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.13.2"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
+checksum = "d354792e39fa5f0009e47623cf8b15b099bf9a652fa55c6f817fe28ac84fea50"
 dependencies = [
  "async-trait",
+ "aws-lc-rs",
  "base64",
  "bytes",
  "chrono",
+ "crc-fast",
  "form_urlencoded",
  "futures-channel",
  "futures-core",
@@ -4217,14 +4056,15 @@ dependencies = [
  "http-body-util",
  "humantime",
  "hyper",
- "itertools 0.14.0",
- "md-5",
+ "itertools 0.15.0",
+ "md-5 0.11.0",
+ "nix 0.31.3",
  "parking_lot",
  "percent-encoding",
  "quick-xml",
  "rand 0.10.2",
- "reqwest 0.12.28",
- "ring",
+ "reqwest",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -4235,6 +4075,7 @@ dependencies = [
  "walkdir",
  "wasm-bindgen-futures",
  "web-time",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4302,7 +4143,7 @@ dependencies = [
  "bytes",
  "http",
  "opentelemetry",
- "reqwest 0.13.4",
+ "reqwest",
 ]
 
 [[package]]
@@ -4317,7 +4158,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.13.4",
+ "reqwest",
  "thiserror 2.0.18",
 ]
 
@@ -4394,7 +4235,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -4541,7 +4382,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -4570,7 +4411,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -4578,23 +4419,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "piper"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
 
 [[package]]
 name = "pkcs1"
@@ -4628,20 +4452,6 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix 1.1.4",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "polyval"
@@ -4748,7 +4558,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -4768,7 +4578,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
  "version_check",
  "yansi",
 ]
@@ -4831,7 +4641,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -4851,7 +4661,7 @@ checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -4871,9 +4681,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",
@@ -5124,48 +4934,6 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-native-certs",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams 0.4.2",
- "web-sys",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -5206,7 +4974,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.5.0",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -5267,7 +5035,7 @@ checksum = "c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -5488,7 +5256,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -5551,7 +5319,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn 2.0.118",
+ "syn",
  "unicode-ident",
 ]
 
@@ -5608,7 +5376,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
  "thiserror 2.0.18",
 ]
 
@@ -5634,7 +5402,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -5688,7 +5456,7 @@ checksum = "82719d9cd9d2686541dc49875f7944ab71348edfcc6a5686414b22ea0b6d9b29"
 dependencies = [
  "cfg_aliases",
  "httpdate",
- "reqwest 0.13.4",
+ "reqwest",
  "rustls",
  "sentry-backtrace",
  "sentry-contexts",
@@ -5815,7 +5583,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -5994,12 +5762,18 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "spin"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spinning_top"
@@ -6045,7 +5819,7 @@ dependencies = [
  "crc",
  "crossbeam-queue",
  "either",
- "event-listener 5.4.1",
+ "event-listener",
  "futures-core",
  "futures-intrusive",
  "futures-io",
@@ -6081,7 +5855,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -6104,7 +5878,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.118",
+ "syn",
  "tokio",
  "url",
 ]
@@ -6135,7 +5909,7 @@ dependencies = [
  "hmac 0.12.1",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "once_cell",
  "percent-encoding",
@@ -6176,7 +5950,7 @@ dependencies = [
  "home",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "once_cell",
  "rand 0.8.6",
@@ -6315,17 +6089,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
@@ -6352,7 +6115,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -6386,7 +6149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -6424,7 +6187,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -6435,7 +6198,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -6526,7 +6289,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -6710,7 +6473,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -6822,7 +6585,7 @@ checksum = "cf808357c6ed7e13ba0f3277ec8d8f21b2d501274895104263985330c726c1c5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -6986,12 +6749,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "value-bag"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7086,7 +6843,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -7097,19 +6854,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
@@ -7266,7 +7010,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -7277,7 +7021,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -7573,7 +7317,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
  "synstructure",
 ]
 
@@ -7594,7 +7338,7 @@ checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -7614,7 +7358,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
  "synstructure",
 ]
 
@@ -7635,7 +7379,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -7668,7 +7412,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -47,7 +47,6 @@ gradient-web          = { path = "gradient-web" }
 gradient-worker       = { path = "gradient-worker" }
 
 # Async / runtime
-async-std    = { version = "1", features = ["attributes", "tokio1"] } # defaults: provides the task executor
 async-stream = { version = "0.3", default-features = false }
 async-trait  = { version = "0.1", default-features = false }
 futures      = { version = "0.3", default-features = false, features = ["std", "async-await"] }
@@ -129,7 +128,7 @@ tower_governor       = { version = "0.8", default-features = false, features = [
 # Object store / git
 git2         = { version = "0.21", default-features = false, features = ["https", "ssh"] }
 libc         = { version = "0.2", default-features = false }
-object_store = { version = "0.13", default-features = false, features = ["aws", "fs"] }
+object_store = { version = "0.14", default-features = false, features = ["aws", "fs"] }
 
 # Harmonia (git deps)
 harmonia-file-nar              = { git = "https://github.com/nix-community/harmonia.git", default-features = false }

--- a/backend/gradient-ci/src/reactor.rs
+++ b/backend/gradient-ci/src/reactor.rs
@@ -21,6 +21,7 @@ fn eval_kind_str(kind: EvaluationKind) -> &'static str {
     match kind {
         EvaluationKind::Normal => "normal",
         EvaluationKind::InputUpdate => "input_update",
+        EvaluationKind::DrvRecovery => "drv_recovery",
     }
 }
 

--- a/backend/gradient-ci/src/trigger/drv_recovery.rs
+++ b/backend/gradient-ci/src/trigger/drv_recovery.rs
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use super::TriggerError;
+use super::flake_snapshot::snapshot_flake_input_overrides;
+use crate::abort::{AbortKind, abort_evaluation};
+use gradient_entity::evaluation::{EvaluationKind, EvaluationStatus};
+use gradient_types::*;
+use sea_orm::ActiveValue::Set;
+use sea_orm::{ActiveModelTrait, ConnectionTrait, IntoActiveModel};
+
+/// Auto-recover an evaluation wedged in `graph_stuck` because an anchor's own
+/// `.drv` NAR is missing from our cache and has no producer: only evaluation
+/// emits a `.drv`, and the daemon-free server cannot reproduce one. Aborts the
+/// stuck run (freeing the single-active-per-project slot) and queues a fresh
+/// full evaluation of the **same commit** - re-instantiating the flake
+/// re-materialises the `.drv` in the worker store, which re-uploads it.
+///
+/// The new run is [`EvaluationKind::DrvRecovery`] so the caller can make the
+/// recovery one-shot: a `.drv` a cold re-eval still fails to persist is not a
+/// transient miss, and re-triggering again would loop.
+pub async fn trigger_drv_recovery<C: ConnectionTrait>(
+    db: &C,
+    project: &MProject,
+    stuck: &MEvaluation,
+) -> Result<MEvaluation, TriggerError> {
+    // Abort before insert: the single-active-per-project unique index rejects a
+    // second active row, so the stuck eval must leave the active set first.
+    abort_evaluation(db, stuck.id, AbortKind::Soft).await?;
+
+    let now = gradient_types::now();
+    let new_eval_id = EvaluationId::now_v7();
+    let aevaluation = MEvaluation {
+        id: new_eval_id,
+        project: Some(project.id),
+        repository: stuck.repository.clone(),
+        commit: stuck.commit,
+        wildcard: stuck.wildcard.clone(),
+        status: EvaluationStatus::Queued,
+        previous: Some(stuck.id),
+        kind: EvaluationKind::DrvRecovery,
+        created_at: now,
+        updated_at: now,
+        flake_source: stuck.flake_source.clone(),
+        ..Default::default()
+    }
+    .into_active_model();
+
+    let new_eval = aevaluation.insert(db).await?;
+
+    snapshot_flake_input_overrides(db, project.id, new_eval.id).await?;
+
+    let mut aproject: AProject = project.clone().into();
+    aproject.last_evaluation = Set(Some(new_eval_id));
+    aproject.update(db).await?;
+
+    Ok(new_eval)
+}

--- a/backend/gradient-ci/src/trigger/mod.rs
+++ b/backend/gradient-ci/src/trigger/mod.rs
@@ -8,6 +8,7 @@
 //! (API endpoint, incoming forge webhook, …) and for restarting the failed
 //! builds of a previous evaluation.
 
+mod drv_recovery;
 mod flake_snapshot;
 mod input_update;
 mod new_evaluation;
@@ -15,6 +16,7 @@ mod restart;
 
 use thiserror::Error;
 
+pub use drv_recovery::trigger_drv_recovery;
 pub use input_update::{fan_out_expansion, maybe_trigger_input_update};
 pub use new_evaluation::trigger_evaluation;
 pub use restart::trigger_restart_builds;

--- a/backend/gradient-db/src/graph_sql.rs
+++ b/backend/gradient-db/src/graph_sql.rs
@@ -24,6 +24,20 @@ pub fn dependency_closure_cte(
     seed_select: &str,
     direction: ClosureDirection,
 ) -> String {
+    format!(
+        "WITH RECURSIVE {}",
+        dependency_closure_cte_body(name, seed_select, direction)
+    )
+}
+
+/// The bare `{name}(derivation) AS (...)` CTE body, without the `WITH RECURSIVE`
+/// prefix, so a statement can bind several closures under one `WITH RECURSIVE`
+/// (e.g. an eval closure plus the deterministic-blocked set it constrains).
+pub fn dependency_closure_cte_body(
+    name: &str,
+    seed_select: &str,
+    direction: ClosureDirection,
+) -> String {
     let step = match direction {
         ClosureDirection::Dependencies => format!(
             "SELECT e.dependency FROM derivation_dependency e JOIN {name} c ON e.derivation = c.derivation"
@@ -32,7 +46,7 @@ pub fn dependency_closure_cte(
             "SELECT e.derivation FROM derivation_dependency e JOIN {name} c ON e.dependency = c.derivation"
         ),
     };
-    format!("WITH RECURSIVE {name}(derivation) AS ({seed_select} UNION {step})")
+    format!("{name}(derivation) AS ({seed_select} UNION {step})")
 }
 
 /// Dependency-readiness of anchor `{alias}`: every build dependency is
@@ -84,7 +98,13 @@ pub fn drv_nar_closure_complete_predicate(alias: &str) -> String {
 /// `build_job` rows), walking toward dependencies. Binds the evaluation id as
 /// `$1`. Shared by every per-eval sweep so they all see the same closure.
 pub fn eval_closure_cte() -> String {
-    dependency_closure_cte(
+    format!("WITH RECURSIVE {}", eval_closure_cte_body())
+}
+
+/// The eval-closure CTE body (no `WITH RECURSIVE` prefix), for statements that
+/// bind it alongside a second closure under one `WITH RECURSIVE`.
+pub fn eval_closure_cte_body() -> String {
+    dependency_closure_cte_body(
         "closure",
         "SELECT bj.derivation FROM build_job bj WHERE bj.evaluation = $1",
         ClosureDirection::Dependencies,

--- a/backend/gradient-db/src/promotion.rs
+++ b/backend/gradient-db/src/promotion.rs
@@ -520,7 +520,9 @@ fn dependency_failed_reconcile_sql(scope: Option<gradient_types::EvaluationId>) 
         None => (
             dependency_closure_cte(
                 "dependents",
-                &format!("SELECT derivation FROM derivation_build WHERE status IN ({terminal_failure})"),
+                &format!(
+                    "SELECT derivation FROM derivation_build WHERE status IN ({terminal_failure})"
+                ),
                 ClosureDirection::Dependents,
             ),
             String::new(),
@@ -1023,7 +1025,10 @@ mod tests {
             "scoped seed must be the closure's terminal-failed anchors: {scoped}"
         );
         assert!(
-            scoped.matches("IN (SELECT derivation FROM closure)").count() >= 3,
+            scoped
+                .matches("IN (SELECT derivation FROM closure)")
+                .count()
+                >= 3,
             "scoped seed, walk, and UPDATE must all be bounded to the closure: {scoped}"
         );
     }

--- a/backend/gradient-db/src/promotion.rs
+++ b/backend/gradient-db/src/promotion.rs
@@ -42,7 +42,9 @@
 //! `flush_deferred_deps` could not record) is held off promotion by the
 //! separate `edges_unresolved` flag instead of a clear.
 
-use crate::graph_sql::{ClosureDirection, dependency_closure_cte, eval_closure_cte};
+use crate::graph_sql::{
+    ClosureDirection, dependency_closure_cte, eval_closure_cte, eval_closure_cte_body,
+};
 use crate::status::TransitionChange;
 use crate::status_sql;
 use gradient_entity::build::BuildStatus;
@@ -488,11 +490,13 @@ pub async fn cascade_dependency_failed<C: ConnectionTrait>(
 /// finalize the now-settled evaluations.
 pub async fn reconcile_dependency_failed<C: ConnectionTrait>(
     db: &C,
+    scope: Option<gradient_types::EvaluationId>,
 ) -> Result<Vec<TransitionChange>, DbErr> {
     let rows = db
-        .query_all(Statement::from_string(
+        .query_all(Statement::from_sql_and_values(
             DatabaseBackend::Postgres,
-            dependency_failed_reconcile_sql(),
+            dependency_failed_reconcile_sql(scope),
+            fixpoint_params(scope),
         ))
         .await?;
 
@@ -503,29 +507,49 @@ pub async fn reconcile_dependency_failed<C: ConnectionTrait>(
 /// reachable non-terminal anchor. Mirrors the reactive
 /// [`cascade_dependency_failed`] terminal-failed set (it excludes `Aborted`,
 /// which is retried, not permanent). The failed roots are excluded from the
-/// UPDATE by the cascade-target predicate, so the sweep is idempotent.
-fn dependency_failed_reconcile_sql() -> String {
-    let cte = dependency_closure_cte(
-        "dependents",
-        &format!(
-            "SELECT derivation FROM derivation_build WHERE status IN ({})",
-            status_sql::build_in(&BuildStatus::TERMINAL_FAILURE)
+/// UPDATE by the cascade-target predicate, so the sweep is idempotent. `None`
+/// is the global full-table backstop; `Some(eval)` bounds the seed, the walk,
+/// and the UPDATE to that eval's dependency closure ($1) so the per-worker-event
+/// `Eval`/`Unstick` heal - which runs right after the requeue thaw - re-fails
+/// that eval's thawed victims without scanning the whole table.
+fn dependency_failed_reconcile_sql(scope: Option<gradient_types::EvaluationId>) -> String {
+    let dependency_failed = status_sql::build(BuildStatus::DependencyFailed);
+    let cascade_target = status_sql::build_in(&CASCADE_TARGET);
+    let terminal_failure = status_sql::build_in(&BuildStatus::TERMINAL_FAILURE);
+    let (prelude, update_bound) = match scope {
+        None => (
+            dependency_closure_cte(
+                "dependents",
+                &format!("SELECT derivation FROM derivation_build WHERE status IN ({terminal_failure})"),
+                ClosureDirection::Dependents,
+            ),
+            String::new(),
         ),
-        ClosureDirection::Dependents,
-    );
+        Some(_) => (
+            format!(
+                r#"WITH RECURSIVE {closure},
+    dependents(derivation) AS (
+        SELECT derivation FROM derivation_build
+        WHERE status IN ({terminal_failure}) AND derivation IN (SELECT derivation FROM closure)
+        UNION
+        SELECT e.derivation FROM derivation_dependency e JOIN dependents c ON e.dependency = c.derivation
+        WHERE e.derivation IN (SELECT derivation FROM closure))"#,
+                closure = eval_closure_cte_body(),
+            ),
+            " AND db.derivation IN (SELECT derivation FROM closure)".to_string(),
+        ),
+    };
     format!(
         r#"
-    {cte}
+    {prelude}
     UPDATE derivation_build AS db
     SET status = {dependency_failed}, updated_at = (now() AT TIME ZONE 'UTC')
     FROM derivation_build old
     WHERE old.id = db.id
       AND db.status IN ({cascade_target})
-      AND db.derivation IN (SELECT derivation FROM dependents)
+      AND db.derivation IN (SELECT derivation FROM dependents){update_bound}
     RETURNING db.derivation, old.status AS from_status, db.status AS to_status
-    "#,
-        dependency_failed = status_sql::build(BuildStatus::DependencyFailed),
-        cascade_target = status_sql::build_in(&CASCADE_TARGET),
+    "#
     )
 }
 
@@ -689,24 +713,14 @@ pub async fn requeue_failed_anchors<C: ConnectionTrait>(
     db: &C,
     derivations: &[DerivationId],
 ) -> Result<u64, DbErr> {
+    let sql = requeue_failed_anchors_sql();
     let mut total = 0;
     for chunk in derivations.chunks(crate::IN_CHUNK_SIZE) {
         let ids: Vec<uuid::Uuid> = chunk.iter().map(|d| d.into_inner()).collect();
         total += db
             .execute(Statement::from_sql_and_values(
                 DatabaseBackend::Postgres,
-                format!(
-                    r#"
-                UPDATE derivation_build db
-                SET status = {created}, attempt = 0, closure_complete = false,
-                    updated_at = (now() AT TIME ZONE 'UTC')
-                WHERE db.derivation = ANY($1) AND db.status IN ({requeueable})
-                  AND NOT {deterministic}
-                "#,
-                    created = status_sql::build(BuildStatus::Created),
-                    requeueable = status_sql::build_in(&BuildStatus::REQUEUEABLE),
-                    deterministic = deterministic_build_failure("db"),
-                ),
+                &sql,
                 [ids.into()],
             ))
             .await?
@@ -714,6 +728,49 @@ pub async fn requeue_failed_anchors<C: ConnectionTrait>(
     }
 
     Ok(total)
+}
+
+/// `WITH RECURSIVE` prelude binding a requeue candidate `closure` (the downward
+/// build closure of the candidates) and the `deterministic_blocked` subset a
+/// reproducible build failure permanently poisons. `deterministic_blocked` seeds
+/// from every anchor in the closure with a [`deterministic_build_failure`] and
+/// closes upward over `derivation_dependency` (bounded to the closure), so a
+/// `DependencyFailed` dependent of such a failure is caught even though it never
+/// ran a build of its own. A thaw must exclude this whole set: its members can
+/// never build, and thawing one back to `Created` only re-enters the demote<->
+/// thaw oscillation with [`reconcile_dependency_failed`] that hangs the eval in
+/// `graph_stuck` forever.
+fn requeue_ctes(closure_seed: &str) -> String {
+    let deterministic = deterministic_build_failure("dbf");
+    format!(
+        r#"WITH RECURSIVE closure(derivation) AS (
+        {closure_seed}
+        UNION
+        SELECT e.dependency FROM derivation_dependency e JOIN closure c ON e.derivation = c.derivation),
+    deterministic_blocked(derivation) AS (
+        SELECT dbf.derivation FROM derivation_build dbf
+        WHERE dbf.derivation IN (SELECT derivation FROM closure) AND {deterministic}
+        UNION
+        SELECT e.derivation FROM derivation_dependency e
+        JOIN deterministic_blocked c ON e.dependency = c.derivation
+        WHERE e.derivation IN (SELECT derivation FROM closure))"#
+    )
+}
+
+fn requeue_failed_anchors_sql() -> String {
+    let ctes = requeue_ctes("SELECT unnest($1::uuid[])");
+    format!(
+        r#"
+        {ctes}
+        UPDATE derivation_build db
+        SET status = {created}, attempt = 0, closure_complete = false,
+            updated_at = (now() AT TIME ZONE 'UTC')
+        WHERE db.derivation = ANY($1) AND db.status IN ({requeueable})
+          AND db.derivation NOT IN (SELECT derivation FROM deterministic_blocked)
+        "#,
+        created = status_sql::build(BuildStatus::Created),
+        requeueable = status_sql::build_in(&BuildStatus::REQUEUEABLE),
+    )
 }
 
 /// Re-queue terminal-failed anchors across the full build-dependency **closure**
@@ -732,30 +789,33 @@ pub async fn requeue_failed_closure_for_eval<C: ConnectionTrait>(
     db: &C,
     evaluation: gradient_types::EvaluationId,
 ) -> Result<u64, DbErr> {
-    let cte = eval_closure_cte();
     let affected = db
         .execute(Statement::from_sql_and_values(
             DatabaseBackend::Postgres,
-            format!(
-                r#"
-            {cte}
-            UPDATE derivation_build db
-            SET status = {created}, attempt = 0, closure_complete = false,
-                updated_at = (now() AT TIME ZONE 'UTC')
-            WHERE db.derivation IN (SELECT derivation FROM closure)
-              AND db.status IN ({requeueable})
-              AND NOT {deterministic}
-            "#,
-                created = status_sql::build(BuildStatus::Created),
-                requeueable = status_sql::build_in(&BuildStatus::REQUEUEABLE),
-                deterministic = deterministic_build_failure("db"),
-            ),
+            requeue_failed_closure_for_eval_sql(),
             [Value::Uuid(Some(Box::new(evaluation.into_inner())))],
         ))
         .await?
         .rows_affected();
 
     Ok(affected)
+}
+
+fn requeue_failed_closure_for_eval_sql() -> String {
+    let ctes = requeue_ctes("SELECT bj.derivation FROM build_job bj WHERE bj.evaluation = $1");
+    format!(
+        r#"
+        {ctes}
+        UPDATE derivation_build db
+        SET status = {created}, attempt = 0, closure_complete = false,
+            updated_at = (now() AT TIME ZONE 'UTC')
+        WHERE db.derivation IN (SELECT derivation FROM closure)
+          AND db.status IN ({requeueable})
+          AND db.derivation NOT IN (SELECT derivation FROM deterministic_blocked)
+        "#,
+        created = status_sql::build(BuildStatus::Created),
+        requeueable = status_sql::build_in(&BuildStatus::REQUEUEABLE),
+    )
 }
 
 /// Reconcile anchor state from cache state across an evaluation's dependency
@@ -847,6 +907,46 @@ mod tests {
         }
     }
 
+    /// A thaw must exclude not just a derivation's own reproducible failure but
+    /// the whole subtree a deterministic failure poisons: a `DependencyFailed`
+    /// dependent never ran a build of its own, so keying the exclusion on the
+    /// anchor's own attempts alone re-thaws it forever (the demote<->thaw
+    /// oscillation that hangs the eval). Pin that both requeue SQLs build the
+    /// closure + `deterministic_blocked` walk and exclude that set (no live DB).
+    #[test]
+    fn requeue_excludes_the_deterministic_blocked_subtree() {
+        let norm = |s: String| s.split_whitespace().collect::<Vec<_>>().join(" ");
+        let deterministic = norm(deterministic_build_failure("dbf"));
+        for sql in [
+            norm(requeue_failed_anchors_sql()),
+            norm(requeue_failed_closure_for_eval_sql()),
+        ] {
+            assert!(
+                sql.contains("deterministic_blocked(derivation) AS"),
+                "must build the deterministic-blocked closure: {sql}"
+            );
+            assert!(
+                sql.contains(&deterministic),
+                "blocked set must seed from a reproducible builder-nonzero exit: {sql}"
+            );
+            assert!(
+                sql.contains("JOIN deterministic_blocked c ON e.dependency = c.derivation"),
+                "must close upward over dependents so DependencyFailed victims are caught: {sql}"
+            );
+            assert!(
+                sql.contains("db.derivation NOT IN (SELECT derivation FROM deterministic_blocked)"),
+                "the thaw must skip the whole poisoned subtree: {sql}"
+            );
+            assert!(
+                sql.contains(&format!(
+                    "db.status IN ({})",
+                    status_sql::build_in(&BuildStatus::REQUEUEABLE)
+                )),
+                "still thaws the requeueable states for transient causes: {sql}"
+            );
+        }
+    }
+
     /// The proactive dependency-failed sweep must mirror the reactive cascade:
     /// seed the recursive walk from the terminal-failed set the cascade reacts
     /// to (NOT `Aborted`), fail only non-terminal anchors to `DependencyFailed`,
@@ -855,7 +955,7 @@ mod tests {
     /// anchors, so pin the SQL shape (no live DB in unit tests).
     #[test]
     fn dependency_failed_reconcile_sql_mirrors_the_cascade() {
-        let sql = dependency_failed_reconcile_sql()
+        let sql = dependency_failed_reconcile_sql(None)
             .split_whitespace()
             .collect::<Vec<_>>()
             .join(" ");
@@ -894,6 +994,37 @@ mod tests {
         assert!(
             sql.contains("RETURNING db.derivation"),
             "must return failed derivations so the caller can finalize their evals: {sql}"
+        );
+    }
+
+    /// Scoped to an eval (`Eval`/`Unstick`), the sweep must bound the seed, the
+    /// walk, and the UPDATE to that eval's dependency closure ($1) so the inline
+    /// per-worker-event heal re-fails its own thawed victims without a full-table
+    /// scan. The global (`None`) pass must not carry any closure walk.
+    #[test]
+    fn dependency_failed_reconcile_sql_bounds_to_eval_closure_when_scoped() {
+        let norm = |s: String| s.split_whitespace().collect::<Vec<_>>().join(" ");
+        let global = norm(dependency_failed_reconcile_sql(None));
+        assert!(
+            !global.contains("FROM closure"),
+            "global pass scans the whole table, no closure walk: {global}"
+        );
+        let scoped = norm(dependency_failed_reconcile_sql(Some(
+            gradient_types::EvaluationId::now_v7(),
+        )));
+        assert!(
+            scoped.contains("WITH RECURSIVE closure(derivation) AS"),
+            "scoped pass must walk the eval closure: {scoped}"
+        );
+        assert!(
+            scoped.contains(
+                "WHERE status IN (4, 6, 9) AND derivation IN (SELECT derivation FROM closure)"
+            ),
+            "scoped seed must be the closure's terminal-failed anchors: {scoped}"
+        );
+        assert!(
+            scoped.matches("IN (SELECT derivation FROM closure)").count() >= 3,
+            "scoped seed, walk, and UPDATE must all be bounded to the closure: {scoped}"
         );
     }
 

--- a/backend/gradient-db/src/reconcile.rs
+++ b/backend/gradient-db/src/reconcile.rs
@@ -199,11 +199,14 @@ pub async fn reconcile_build_graph(ctx: &DbContext, scope: ReconcileScope) -> Re
         }
     }
 
-    if matches!(scope, ReconcileScope::Global | ReconcileScope::Deep) {
-        // Failure-side backstop: fail every non-terminal anchor reachable from a
-        // terminal failure (the reactive cascade misses anchors thawed after
-        // their dependency already failed).
-        match crate::promotion::reconcile_dependency_failed(db).await {
+    if scope.runs_anchor_fixpoints() {
+        // Failure-side backstop, paired with the requeue thaw above: fail every
+        // non-terminal anchor reachable from a terminal failure (the reactive
+        // cascade misses anchors thawed after their dependency already failed).
+        // `Eval`/`Unstick` bound it to the eval closure so the graph-stuck heal
+        // re-fails its own thawed victims inline; `Global`/`Deep` sweep the whole
+        // table. `Tick` skips it, as with the other anchor fixpoints.
+        match crate::promotion::reconcile_dependency_failed(db, scope.evaluation()).await {
             Ok(changes) => {
                 emit_transition_effects(ctx, &changes).await;
                 report.dependency_failed = changes;

--- a/backend/gradient-entity/src/evaluation.rs
+++ b/backend/gradient-entity/src/evaluation.rs
@@ -99,6 +99,20 @@ mod status_tests {
         assert_eq!(EvaluationStatus::iter().count(), 9);
     }
 
+    /// `kind` is persisted as a raw integer; a renumber silently reinterprets
+    /// existing rows (an `input_update` run becoming `drv_recovery`, etc.).
+    #[test]
+    fn kind_numbering_is_pinned() {
+        for (kind, n) in [
+            (EvaluationKind::Normal, 0),
+            (EvaluationKind::InputUpdate, 1),
+            (EvaluationKind::DrvRecovery, 2),
+        ] {
+            assert_eq!(i32::from(kind), n);
+        }
+        assert_eq!(EvaluationKind::iter().count(), 3);
+    }
+
     #[test]
     fn active_and_terminal_partition_every_status() {
         for status in EvaluationStatus::iter() {
@@ -137,6 +151,12 @@ pub enum EvaluationKind {
     Normal = 0,
     #[sea_orm(num_value = 1)]
     InputUpdate = 1,
+    /// A re-evaluation the scheduler auto-triggered to regenerate a `.drv` whose
+    /// NAR our cache lost (or never received): the daemon-free server cannot
+    /// reproduce a `.drv`, so it re-evaluates the same commit. A `DrvRecovery`
+    /// run that stalls the same way again is not retried (one-shot).
+    #[sea_orm(num_value = 2)]
+    DrvRecovery = 2,
 }
 
 #[repr(i32)]

--- a/backend/gradient-migration/Cargo.toml
+++ b/backend/gradient-migration/Cargo.toml
@@ -18,6 +18,5 @@ workspace = true
 async-trait       = { workspace = true }
 sea-orm-migration = { workspace = true }
 sha2              = { workspace = true }
+tokio             = { workspace = true, features = ["macros"] }
 uuid              = { workspace = true }
-
-async-std = { workspace = true }

--- a/backend/gradient-migration/src/main.rs
+++ b/backend/gradient-migration/src/main.rs
@@ -6,7 +6,7 @@
 
 use sea_orm_migration::prelude::*;
 
-#[async_std::main]
+#[tokio::main]
 async fn main() {
     cli::run_cli(gradient_migration::Migrator).await;
 }

--- a/backend/gradient-scheduler/src/dispatch/build.rs
+++ b/backend/gradient-scheduler/src/dispatch/build.rs
@@ -82,6 +82,12 @@ pub(super) async fn build_dispatch_loop(scheduler: Arc<Scheduler>) {
         if let Err(e) = scheduler.reconcile_waiting_state().await {
             error!(error = %e, "reconcile_waiting_state in dispatch loop failed");
         }
+        // A `.drv` our cache lost has no producer; the only recovery is a fresh
+        // evaluation of the same commit. Runs after the waiting-state reconcile
+        // has settled `graph_stuck`.
+        if let Err(e) = crate::waiting_state::recover_drv_stuck_evals(&scheduler.state).await {
+            error!(error = %e, "recover_drv_stuck_evals in dispatch loop failed");
+        }
 
         // Re-offer still-pending jobs to all sessions each pass. A build
         // re-queued after a failed/rejected dispatch had its sent-flag cleared,

--- a/backend/gradient-scheduler/src/waiting_state.rs
+++ b/backend/gradient-scheduler/src/waiting_state.rs
@@ -342,7 +342,9 @@ pub async fn recover_drv_stuck_evals(state: &Arc<ServerState>) -> Result<()> {
                 info!(stuck = %eval.id, recovery = %new_eval.id, "auto-triggered .drv-recovery re-evaluation");
                 gradient_ci::actions::dispatch_evaluation_created(&state.ci(), &new_eval).await;
             }
-            Err(e) => warn!(evaluation_id = %eval.id, error = %e, "failed to trigger .drv recovery"),
+            Err(e) => {
+                warn!(evaluation_id = %eval.id, error = %e, "failed to trigger .drv recovery")
+            }
         }
     }
 
@@ -566,7 +568,9 @@ mod tests {
             assert!(sql.contains(frag), "missing `{frag}`: {sql}");
         }
         assert!(
-            sql.contains(&gradient_db::graph_sql::drv_nar_closure_complete_predicate("db")),
+            sql.contains(&gradient_db::graph_sql::drv_nar_closure_complete_predicate(
+                "db"
+            )),
             "must require the .drv's own NAR closure to be absent: {sql}"
         );
         assert!(

--- a/backend/gradient-scheduler/src/waiting_state.rs
+++ b/backend/gradient-scheduler/src/waiting_state.rs
@@ -15,10 +15,18 @@ use anyhow::{Context, Result};
 use gradient_core::ServerState;
 use gradient_db::update_evaluation_status;
 use gradient_entity::build::BuildStatus;
-use gradient_entity::evaluation::EvaluationStatus;
+use gradient_entity::evaluation::{EvaluationKind, EvaluationStatus};
 use gradient_types::*;
-use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+use sea_orm::{
+    ColumnTrait, ConnectionTrait, DatabaseBackend, EntityTrait, QueryFilter, Statement, Value,
+};
 use tracing::{info, warn};
+
+/// How long an evaluation must have sat `graph_stuck` before `.drv`-recovery
+/// re-evaluates it, so a still-in-flight `.drv` upload isn't raced into a
+/// needless re-eval. The graph-stuck reason is only rewritten on change, so a
+/// stably-stuck eval's `updated_at` ages past this quickly.
+const DRV_RECOVERY_GRACE_SECS: i64 = 120;
 
 use crate::buildability::BuildabilityChecker;
 
@@ -276,6 +284,120 @@ async fn attempt_graph_unstick(
     ))
 }
 
+/// Re-evaluate evaluations wedged in `graph_stuck` on a `.drv` our cache lost.
+/// A build target's own `.drv` has no producer - only evaluation emits a `.drv`,
+/// and the daemon-free server cannot reproduce one - so an anchor whose `.drv`
+/// NAR is absent (never uploaded, or GC-reclaimed) can never dispatch and no
+/// reconcile heals it. The sole recovery is a fresh evaluation of the same
+/// commit ([`gradient_ci::trigger_drv_recovery`]), which re-materialises and
+/// re-uploads the `.drv`. Runs after [`reconcile_waiting_state`] has persisted
+/// the `graph_stuck` reason; the abort inside the trigger drops the stuck eval
+/// out of `Waiting`, so each is handled once.
+///
+/// One-shot: a run already marked [`EvaluationKind::DrvRecovery`] that stalls
+/// the same way is failed, not retried - a `.drv` a cold re-eval still cannot
+/// persist is a real defect, not a transient upload miss, and re-triggering
+/// would loop.
+pub async fn recover_drv_stuck_evals(state: &Arc<ServerState>) -> Result<()> {
+    let waiting = EEvaluation::find()
+        .filter(CEvaluation::Status.eq(EvaluationStatus::Waiting))
+        .all(&state.worker_db)
+        .await
+        .context("fetch waiting evaluations")?;
+
+    let now = gradient_types::now();
+    for eval in waiting {
+        let graph_stuck = eval
+            .waiting_reason
+            .as_ref()
+            .and_then(WaitingReason::from_json)
+            .is_some_and(|r| matches!(r, WaitingReason::GraphStuck { .. }));
+        if !graph_stuck || (now - eval.updated_at).num_seconds() < DRV_RECOVERY_GRACE_SECS {
+            continue;
+        }
+        if !eval_blocked_on_unproducible_drv(state, eval.id).await? {
+            continue;
+        }
+
+        if eval.kind == EvaluationKind::DrvRecovery {
+            warn!(evaluation_id = %eval.id, "drv-recovery re-eval still blocked on its own missing .drv; failing (unrecoverable)");
+            update_evaluation_status(&state.db(), eval, EvaluationStatus::Failed).await;
+            continue;
+        }
+
+        let Some(project_id) = eval.project else {
+            continue;
+        };
+        let project = match EProject::find_by_id(project_id).one(&state.worker_db).await {
+            Ok(Some(p)) => p,
+            Ok(None) => continue,
+            Err(e) => {
+                warn!(evaluation_id = %eval.id, error = %e, "drv recovery: project lookup failed");
+                continue;
+            }
+        };
+
+        match gradient_ci::trigger_drv_recovery(state.worker_db.inner(), &project, &eval).await {
+            Ok(new_eval) => {
+                info!(stuck = %eval.id, recovery = %new_eval.id, "auto-triggered .drv-recovery re-evaluation");
+                gradient_ci::actions::dispatch_evaluation_created(&state.ci(), &new_eval).await;
+            }
+            Err(e) => warn!(evaluation_id = %eval.id, error = %e, "failed to trigger .drv recovery"),
+        }
+    }
+
+    Ok(())
+}
+
+/// True when a pending anchor of `evaluation_id` is dispatch-blocked solely by
+/// its own missing `.drv`: its build dependencies are all satisfied and it is
+/// not substitutable, yet neither the build-graph `drv_closure_cached` flag nor
+/// the `.drv`'s own NAR-closure holds. That is the zone-B signature - a `.drv`
+/// our cache never received or lost - distinct from a failed-dependency block,
+/// whose anchors the dependency-failed cascade has already demoted.
+async fn eval_blocked_on_unproducible_drv(
+    state: &Arc<ServerState>,
+    evaluation_id: EvaluationId,
+) -> Result<bool> {
+    let row = state
+        .worker_db
+        .inner()
+        .query_one(Statement::from_sql_and_values(
+            DatabaseBackend::Postgres,
+            unproducible_drv_block_sql(),
+            [Value::Uuid(Some(Box::new(evaluation_id.into_inner())))],
+        ))
+        .await
+        .context("detect unproducible-drv block")?;
+
+    Ok(row
+        .and_then(|r| r.try_get::<bool>("", "blocked").ok())
+        .unwrap_or(false))
+}
+
+fn unproducible_drv_block_sql() -> String {
+    let deps_ready = gradient_db::graph_sql::deps_ready_predicate("db");
+    let drv_nar_closure = gradient_db::graph_sql::drv_nar_closure_complete_predicate("db");
+    format!(
+        r#"
+        SELECT EXISTS (
+            SELECT 1
+            FROM build_job bj
+            JOIN derivation_build db ON db.id = bj.derivation_build
+            WHERE bj.evaluation = $1
+              AND db.status IN ({created}, {queued})
+              AND db.edges_complete
+              AND NOT db.substitutable
+              AND NOT db.drv_closure_cached
+              AND NOT {drv_nar_closure}
+              AND ({deps_ready})
+        ) AS blocked
+        "#,
+        created = BuildStatus::Created as i32,
+        queued = BuildStatus::Queued as i32,
+    )
+}
+
 /// The non-terminal `derivation_build` anchors an evaluation still needs:
 /// the anchors of its `build_job`s in Created/Queued/Building/FailedTransient.
 async fn eval_pending_anchors(
@@ -416,6 +538,42 @@ pub(crate) async fn persist_waiting_reason(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The zone-B detection must fire only on an anchor blocked *solely* by its
+    /// own unimportable `.drv`: pending, edges complete, deps satisfied, not
+    /// substitutable, and neither `.drv` signal true. Mis-shaping it would either
+    /// re-eval healthy evals or miss the lost-`.drv` stall (no live DB in unit
+    /// tests, so pin the SQL shape).
+    #[test]
+    fn unproducible_drv_block_sql_shape() {
+        let sql = unproducible_drv_block_sql()
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(
+            sql.contains(&format!(
+                "db.status IN ({}, {})",
+                BuildStatus::Created as i32,
+                BuildStatus::Queued as i32
+            )),
+            "only pending anchors: {sql}"
+        );
+        for frag in [
+            "db.edges_complete",
+            "NOT db.substitutable",
+            "NOT db.drv_closure_cached",
+        ] {
+            assert!(sql.contains(frag), "missing `{frag}`: {sql}");
+        }
+        assert!(
+            sql.contains(&gradient_db::graph_sql::drv_nar_closure_complete_predicate("db")),
+            "must require the .drv's own NAR closure to be absent: {sql}"
+        );
+        assert!(
+            sql.contains("cached_path cp") && sql.contains("derivation_input_source"),
+            "must embed the deps-ready predicate (all build deps and sources cached): {sql}"
+        );
+    }
 
     fn eval_workers_view(r: &WaitingReason) -> (EvalCapability, u32) {
         match r {

--- a/backend/gradient-worker/src/executor/fetch.rs
+++ b/backend/gradient-worker/src/executor/fetch.rs
@@ -1233,7 +1233,10 @@ mod tests {
             super::percent_encode_hash("sha256:A+b/C="),
             "sha256:A%2Bb%2FC%3D"
         );
-        assert_eq!(super::percent_encode_hash("plain-hash_123"), "plain-hash_123");
+        assert_eq!(
+            super::percent_encode_hash("plain-hash_123"),
+            "plain-hash_123"
+        );
     }
 
     #[test]

--- a/backend/gradient-worker/src/executor/fetch.rs
+++ b/backend/gradient-worker/src/executor/fetch.rs
@@ -19,7 +19,7 @@ use gradient_proto::messages::{FlakeJob, FlakeSource};
 use gradient_proto::traits::JobReporter;
 use tempfile::NamedTempFile;
 use tokio::sync::watch;
-use tracing::{debug, info, trace};
+use tracing::{debug, info, trace, warn};
 
 use crate::proto::credentials::CredentialStore;
 
@@ -46,16 +46,15 @@ async fn abort_true(abort: &mut watch::Receiver<bool>) {
 
 /// Outcome of a successful `fetch_repository` call.
 ///
-/// `local_flake_path` is the path eval tasks should point at (either the
-/// archived nix-store source, or the temporary git checkout on fallback).
-/// `flake_source` is `Some(store_path)` when `nix flake archive` succeeded
-/// and the source now lives in the cache - this is the value reported back
-/// to the server so subsequent eval-only jobs can use
-/// `FlakeSource::Cached { store_path }`. On archive fallback it is `None`
-/// (worker is on a tmp checkout; no eval-only follow-up possible).
-/// `archived_paths` lists every store path produced by the archive (source
-/// + transitive inputs) - the caller pushes and optionally signs these.
-///   Empty on fallback.
+/// `local_flake_path` is the path eval tasks should point at (the nix-store
+/// source produced by `nix flake archive` or the per-input prefetch fallback).
+/// `flake_source` is `Some(store_path)` whenever the source landed in the
+/// cache - either `nix flake archive` succeeded or the fallback prefetched at
+/// least the source - and is reported back so subsequent eval-only jobs can use
+/// `FlakeSource::Cached { store_path }`. `archived_paths` lists every store path
+/// pushed to the cache (source plus every input the archive or fallback managed
+/// to fetch) - the caller pushes and optionally signs these. The fallback may
+/// legitimately omit inputs the org has no credentials for.
 pub struct FetchOutcome {
     pub local_flake_path: String,
     pub flake_source: Option<String>,
@@ -173,7 +172,7 @@ pub async fn fetch_repository(
         &binpath_ssh,
         ssh_key.as_deref(),
         &applied_overrides,
-        abort,
+        &mut abort,
     )
     .await
     {
@@ -185,7 +184,56 @@ pub async fn fetch_repository(
                 archived_paths,
             })
         }
-        Err(e) => Err(e),
+        // `nix flake archive` is all-or-nothing: one unfetchable input (e.g. a
+        // private `git+ssh` input the org has no key for) fails the whole
+        // command even though eval targets never reference it. Nix evaluation is
+        // lazy, so fall back to prefetching the source and each locked input
+        // independently as best-effort cache population.
+        Err(archive_err) => {
+            let archive_msg = archive_err.to_string();
+            warn!(error = %archive_msg, "nix flake archive failed; falling back to per-input prefetch");
+            match prefetch_flake_best_effort(
+                &flake_ref,
+                &flake_root,
+                &binpath_nix,
+                &binpath_ssh,
+                ssh_key.as_deref(),
+                &applied_overrides,
+                &mut abort,
+            )
+            .await
+            {
+                Ok((source_path, archived_paths, input_warnings)) => {
+                    updater
+                        .send_eval_message(
+                            gradient_types::proto::EvalMessageLevel::Warning,
+                            "fetch",
+                            &format!(
+                                "nix flake archive failed, continued with best-effort per-input fetch: {}",
+                                archive_msg.trim()
+                            ),
+                        )
+                        .await?;
+                    for msg in &input_warnings {
+                        updater
+                            .send_eval_message(
+                                gradient_types::proto::EvalMessageLevel::Warning,
+                                "fetch",
+                                msg,
+                            )
+                            .await?;
+                    }
+                    info!(%source_path, inputs = archived_paths.len(), "flake prefetched to nix store after archive fallback");
+                    Ok(FetchOutcome {
+                        local_flake_path: source_path.clone(),
+                        flake_source: Some(source_path),
+                        archived_paths,
+                    })
+                }
+                Err(prefetch_err) => Err(prefetch_err
+                    .context(format!("nix flake archive failed: {}", archive_msg.trim()))),
+            }
+        }
     }
 }
 
@@ -282,98 +330,198 @@ fn build_archive_argv(flake_ref: &str, overrides: &[(String, String)]) -> Vec<St
 }
 
 /// Run `nix flake archive --json` and collect all store paths (source + all
-/// transitive flake inputs).  Returns the source store path and metadata for
-/// every archived path obtained from `nix path-info`.
-///
-/// When `ssh_key` is `Some`, the key is written to a mode-600 temp file and
-/// `GIT_SSH_COMMAND` is set on the subprocess so libfetchers can clone private
-/// `git+ssh` inputs.  The temp file is deleted when this function returns.
+/// transitive flake inputs). Returns the source store path and every archived
+/// path, verified present via `nix path-info`.
 async fn archive_flake(
     flake_ref: &str,
     binpath_nix: &str,
     binpath_ssh: &str,
     ssh_key: Option<&str>,
     overrides: &[(String, String)],
-    mut abort: watch::Receiver<bool>,
+    abort: &mut watch::Receiver<bool>,
 ) -> Result<(String, Vec<String>)> {
-    use std::os::unix::fs::PermissionsExt;
-
     trace!(binpath_nix, flake_ref, "executing nix flake archive");
+    let key_env = ssh_key_env(ssh_key, binpath_ssh).await?;
     let mut cmd = tokio::process::Command::new(binpath_nix);
     cmd.args(build_archive_argv(flake_ref, overrides));
-    cmd.stdout(std::process::Stdio::piped());
-    cmd.stderr(std::process::Stdio::piped());
-    cmd.kill_on_drop(true);
-
-    // Write the SSH key to a temp file (mode 0600) and set GIT_SSH_COMMAND so
-    // that nix's libfetchers picks it up when cloning git+ssh inputs.  The
-    // _key_file guard ensures the file is deleted when this scope exits.
-    let _key_file: Option<NamedTempFile> = if let Some(key) = ssh_key {
-        let kf =
-            NamedTempFile::with_suffix(".key").context("failed to create SSH key temp file")?;
-        tokio::fs::set_permissions(kf.path(), std::fs::Permissions::from_mode(0o600))
-            .await
-            .context("failed to chmod SSH key file")?;
-        tokio::fs::write(kf.path(), key.as_bytes())
-            .await
-            .context("failed to write SSH key file")?;
-        let ssh_command = format!(
-            "{} -i {} -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null",
-            binpath_ssh,
-            kf.path().display()
-        );
+    if let Some((_guard, ssh_command)) = &key_env {
         cmd.env("GIT_SSH_COMMAND", ssh_command);
-        Some(kf)
-    } else {
-        None
-    };
-
-    let child = cmd.spawn().context("failed to spawn nix flake archive")?;
-
-    // Spawn into a separate task so abort_handle can cancel it (dropping child,
-    // which triggers kill_on_drop) independently of the await future.
-    let archive_task = tokio::spawn(async move { child.wait_with_output().await });
-    let abort_handle = archive_task.abort_handle();
-
-    let output = tokio::select! {
-        biased;
-        _ = abort_true(&mut abort) => {
-            abort_handle.abort();
-            anyhow::bail!("job aborted during nix flake archive");
-        }
-        result = archive_task => {
-            result
-                .context("nix flake archive task panicked")?
-                .context("failed to run nix flake archive")?
-        }
-    };
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("nix flake archive failed: {}", stderr.trim());
     }
+    let output = run_nix_subprocess(cmd, "nix flake archive", abort).await?;
 
     let json: serde_json::Value = parse_nix_json(&output.stdout, "nix flake archive")?;
-
     let source_path = json["path"]
         .as_str()
         .context("nix flake archive JSON missing 'path' field")?
         .to_owned();
 
-    // Collect every store path referenced by the archive output (deduplicated).
     let mut all_paths: HashSet<String> = HashSet::new();
     all_paths.insert(source_path.clone());
     collect_input_paths(&json, &mut all_paths);
 
     let all_paths: Vec<String> = all_paths.into_iter().collect();
-    // Path metadata is no longer surfaced via FetchResult - the server
-    // records cached_path rows from the NarUploaded stream instead. We
-    // still run `nix path-info` here to verify every archived path is
-    // actually present in the local store before the caller tries to push
-    // it, which surfaces a misbehaving archive step early.
     let _ = query_path_info(&all_paths, binpath_nix, abort).await?;
 
     Ok((source_path, all_paths))
+}
+
+/// Spawn a `nix` subprocess, honoring `abort` (killing the child via
+/// `kill_on_drop` on abort), and return its captured output, failing on a
+/// non-zero exit with the trimmed stderr. Shared by archive, prefetch and
+/// path-info so the spawn/select/status plumbing lives in one place.
+async fn run_nix_subprocess(
+    mut cmd: tokio::process::Command,
+    label: &str,
+    abort: &mut watch::Receiver<bool>,
+) -> Result<std::process::Output> {
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+    cmd.kill_on_drop(true);
+
+    let child = cmd
+        .spawn()
+        .with_context(|| format!("failed to spawn {label}"))?;
+
+    let task = tokio::spawn(async move { child.wait_with_output().await });
+    let abort_handle = task.abort_handle();
+
+    let output = tokio::select! {
+        biased;
+        _ = abort_true(abort) => {
+            abort_handle.abort();
+            anyhow::bail!("job aborted during {label}");
+        }
+        result = task => {
+            result
+                .with_context(|| format!("{label} task panicked"))?
+                .with_context(|| format!("failed to run {label}"))?
+        }
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("{label} failed: {}", stderr.trim());
+    }
+
+    Ok(output)
+}
+
+/// Write `ssh_key` to a mode-0600 temp file and build the matching
+/// `GIT_SSH_COMMAND` value so nix's libfetchers can clone private `git+ssh`
+/// inputs. The returned guard deletes the file on drop and MUST outlive every
+/// subprocess that reads the env.
+async fn ssh_key_env(
+    ssh_key: Option<&str>,
+    binpath_ssh: &str,
+) -> Result<Option<(NamedTempFile, String)>> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let Some(key) = ssh_key else {
+        return Ok(None);
+    };
+    let kf = NamedTempFile::with_suffix(".key").context("failed to create SSH key temp file")?;
+    tokio::fs::set_permissions(kf.path(), std::fs::Permissions::from_mode(0o600))
+        .await
+        .context("failed to chmod SSH key file")?;
+    tokio::fs::write(kf.path(), key.as_bytes())
+        .await
+        .context("failed to write SSH key file")?;
+    let ssh_command = format!(
+        "{} -i {} -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null",
+        binpath_ssh,
+        kf.path().display()
+    );
+    Ok(Some((kf, ssh_command)))
+}
+
+fn build_prefetch_argv(flake_ref: &str) -> Vec<String> {
+    vec![
+        "flake".to_owned(),
+        "prefetch".to_owned(),
+        "--json".to_owned(),
+        flake_ref.to_owned(),
+    ]
+}
+
+/// Prefetch a single flake ref via `nix flake prefetch --json` and return its
+/// `storePath`.
+async fn prefetch_one(
+    flake_ref: &str,
+    binpath_nix: &str,
+    ssh_command: Option<&str>,
+    abort: &mut watch::Receiver<bool>,
+) -> Result<String> {
+    trace!(binpath_nix, flake_ref, "executing nix flake prefetch");
+    let mut cmd = tokio::process::Command::new(binpath_nix);
+    cmd.args(build_prefetch_argv(flake_ref));
+    if let Some(sc) = ssh_command {
+        cmd.env("GIT_SSH_COMMAND", sc);
+    }
+    let output = run_nix_subprocess(cmd, "nix flake prefetch", abort).await?;
+    let json = parse_nix_json(&output.stdout, "nix flake prefetch")?;
+    json["storePath"]
+        .as_str()
+        .context("nix flake prefetch JSON missing 'storePath' field")
+        .map(str::to_owned)
+}
+
+/// Best-effort fallback for when `nix flake archive` fails: prefetch the flake
+/// source itself (a hard error if that fails) then every locked input from
+/// `flake.lock` independently, collecting the successes and turning per-input
+/// failures into warnings. Returns `(source_path, collected_paths, warnings)`.
+async fn prefetch_flake_best_effort(
+    flake_ref: &str,
+    flake_root: &str,
+    binpath_nix: &str,
+    binpath_ssh: &str,
+    ssh_key: Option<&str>,
+    overrides: &[(String, String)],
+    abort: &mut watch::Receiver<bool>,
+) -> Result<(String, Vec<String>, Vec<String>)> {
+    // The key-file guard must outlive every prefetch invocation below.
+    let key_env = ssh_key_env(ssh_key, binpath_ssh).await?;
+    let ssh_command = key_env.as_ref().map(|(_, c)| c.as_str());
+
+    let source_path = prefetch_one(flake_ref, binpath_nix, ssh_command, abort)
+        .await
+        .context("nix flake prefetch of source failed")?;
+
+    let mut all_paths: HashSet<String> = HashSet::new();
+    all_paths.insert(source_path.clone());
+    let mut warnings: Vec<String> = Vec::new();
+
+    let lock_path = std::path::Path::new(flake_root).join("flake.lock");
+    match tokio::fs::read(&lock_path).await {
+        Ok(bytes) => {
+            let lock: serde_json::Value =
+                serde_json::from_slice(&bytes).context("failed to parse flake.lock")?;
+            let (refs, walk_warnings) = prefetch_refs_from_lock(&lock, overrides);
+            warnings.extend(walk_warnings);
+            for (name, input_ref) in refs {
+                if *abort.borrow() {
+                    anyhow::bail!("job aborted during flake input prefetch");
+                }
+                match prefetch_one(&input_ref, binpath_nix, ssh_command, abort).await {
+                    Ok(path) => {
+                        all_paths.insert(path);
+                    }
+                    Err(e) => warnings.push(format!(
+                        "skipping flake input '{name}': {}",
+                        e.to_string().trim()
+                    )),
+                }
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            return Err(e).with_context(|| format!("failed to read {}", lock_path.display()));
+        }
+    }
+
+    let all_paths: Vec<String> = all_paths.into_iter().collect();
+    let _ = query_path_info(&all_paths, binpath_nix, abort).await?;
+
+    Ok((source_path, all_paths, warnings))
 }
 
 /// Recursively walk the `inputs` tree from `nix flake archive --json` output
@@ -389,15 +537,15 @@ fn collect_input_paths(node: &serde_json::Value, paths: &mut HashSet<String>) {
     }
 }
 
-/// Query `narHash` and `narSize` for each store path via `nix path-info --json`.
+/// Verify every store path is present locally via `nix path-info --json`.
 ///
-/// Supports both the legacy object output (`{"/nix/store/xxx": {...}}`) and the
-/// modern array output (`[{"path": "/nix/store/xxx", ...}]`) from newer Nix
-/// versions.
+/// Metadata is no longer surfaced here (the server records it from the
+/// NarUploaded stream); this only confirms the archive/prefetch step actually
+/// populated the store before the caller pushes.
 async fn query_path_info(
     paths: &[String],
     binpath_nix: &str,
-    mut abort: watch::Receiver<bool>,
+    abort: &mut watch::Receiver<bool>,
 ) -> Result<Vec<()>> {
     if paths.is_empty() {
         return Ok(vec![]);
@@ -406,39 +554,11 @@ async fn query_path_info(
     trace!(binpath_nix, count = paths.len(), "executing nix path-info");
     let mut cmd = tokio::process::Command::new(binpath_nix);
     cmd.arg("path-info").arg("--json");
-    cmd.stdout(std::process::Stdio::piped());
-    cmd.stderr(std::process::Stdio::piped());
-    cmd.kill_on_drop(true);
     for path in paths {
         cmd.arg(path);
     }
+    let output = run_nix_subprocess(cmd, "nix path-info", abort).await?;
 
-    let child = cmd.spawn().context("failed to spawn nix path-info")?;
-
-    let path_info_task = tokio::spawn(async move { child.wait_with_output().await });
-    let abort_handle = path_info_task.abort_handle();
-
-    let output = tokio::select! {
-        biased;
-        _ = abort_true(&mut abort) => {
-            abort_handle.abort();
-            anyhow::bail!("job aborted during nix path-info");
-        }
-        result = path_info_task => {
-            result
-                .context("nix path-info task panicked")?
-                .context("failed to run nix path-info")?
-        }
-    };
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("nix path-info failed: {}", stderr.trim());
-    }
-
-    // Just parse enough to confirm nix path-info ran successfully; we no
-    // longer surface narHash/narSize from here because the server receives
-    // that metadata via the NarUploaded stream.
     let _json: serde_json::Value = parse_nix_json(&output.stdout, "nix path-info")?;
 
     Ok(Vec::new())
@@ -538,6 +658,137 @@ fn flake_ref_from_lock_original(original: &serde_json::Value) -> anyhow::Result<
         }
         other => anyhow::bail!("unsupported flake.lock input type '{other}'"),
     })
+}
+
+/// Percent-encode the base64/SRI characters a `narHash` can contain so it
+/// survives inside a flake-ref query string. SRI hashes only use these three.
+fn percent_encode_hash(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '+' => out.push_str("%2B"),
+            '/' => out.push_str("%2F"),
+            '=' => out.push_str("%3D"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+fn nar_hash_param(locked: &serde_json::Value, sep: char) -> String {
+    match locked.get("narHash").and_then(|v| v.as_str()) {
+        Some(h) => format!("{sep}narHash={}", percent_encode_hash(h)),
+        None => String::new(),
+    }
+}
+
+/// Reconstruct a pinned flake-ref from a `flake.lock` node's `locked` field,
+/// used by the per-input prefetch fallback. Appends the percent-encoded
+/// `narHash` so nix prefetches exactly the pinned revision.
+fn flake_ref_from_lock_locked(locked: &serde_json::Value) -> anyhow::Result<String> {
+    use anyhow::Context;
+    let ty = locked
+        .get("type")
+        .and_then(|v| v.as_str())
+        .context("flake.lock node.locked missing 'type'")?;
+
+    let s = |k: &str| -> Option<&str> { locked.get(k).and_then(|v| v.as_str()) };
+
+    Ok(match ty {
+        "github" | "gitlab" | "sourcehut" => {
+            let owner = s("owner").with_context(|| format!("{ty} node missing 'owner'"))?;
+            let repo = s("repo").with_context(|| format!("{ty} node missing 'repo'"))?;
+            let rev = s("rev").with_context(|| format!("{ty} node missing 'rev'"))?;
+            format!("{ty}:{owner}/{repo}/{rev}{}", nar_hash_param(locked, '?'))
+        }
+        "git" => {
+            let url = s("url").context("git node missing 'url'")?;
+            let mut params: Vec<String> = Vec::new();
+            if let Some(r) = s("ref") {
+                params.push(format!("ref={r}"));
+            }
+            if let Some(rev) = s("rev") {
+                params.push(format!("rev={rev}"));
+            }
+            if let Some(h) = s("narHash") {
+                params.push(format!("narHash={}", percent_encode_hash(h)));
+            }
+            if params.is_empty() {
+                format!("git+{url}")
+            } else {
+                let sep = if url.contains('?') { '&' } else { '?' };
+                format!("git+{url}{sep}{}", params.join("&"))
+            }
+        }
+        "tarball" => {
+            let url = s("url").context("tarball node missing 'url'")?;
+            let sep = if url.contains('?') { '&' } else { '?' };
+            format!("{url}{}", nar_hash_param(locked, sep))
+        }
+        "path" => {
+            let path = s("path").context("path node missing 'path'")?;
+            format!("path:{path}")
+        }
+        other => anyhow::bail!("unsupported flake.lock locked type '{other}'"),
+    })
+}
+
+/// Walk every non-root node in a `flake.lock` (a flat graph, so this covers
+/// transitive inputs) and build the pinned flake ref to prefetch for each. Root
+/// inputs carrying an override prefetch the override ref instead of the locked
+/// one. Returns `(refs, warnings)` where each unsupported node becomes a warning
+/// rather than aborting the walk. `refs` items are `(display_name, flake_ref)`.
+fn prefetch_refs_from_lock(
+    lock: &serde_json::Value,
+    overrides: &[(String, String)],
+) -> (Vec<(String, String)>, Vec<String>) {
+    let root_key = lock.get("root").and_then(|v| v.as_str()).unwrap_or("root");
+    let override_map: std::collections::HashMap<&str, &str> = overrides
+        .iter()
+        .map(|(n, r)| (n.as_str(), r.as_str()))
+        .collect();
+
+    // node key -> root input name, for the override lookup and warning names.
+    let root_input_of: std::collections::HashMap<&str, &str> = lock
+        .get("nodes")
+        .and_then(|n| n.get(root_key))
+        .and_then(|r| r.get("inputs"))
+        .and_then(|i| i.as_object())
+        .map(|inputs| {
+            inputs
+                .iter()
+                .filter_map(|(name, key)| key.as_str().map(|k| (k, name.as_str())))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let Some(nodes) = lock.get("nodes").and_then(|n| n.as_object()) else {
+        return (Vec::new(), Vec::new());
+    };
+
+    let mut refs = Vec::new();
+    let mut warnings = Vec::new();
+    for (node_key, node) in nodes {
+        if node_key == root_key {
+            continue;
+        }
+        let root_name = root_input_of.get(node_key.as_str()).copied();
+        let display_name = root_name.unwrap_or(node_key.as_str());
+
+        if let Some(override_ref) = root_name.and_then(|name| override_map.get(name)) {
+            refs.push((display_name.to_owned(), (*override_ref).to_owned()));
+            continue;
+        }
+
+        let Some(locked) = node.get("locked") else {
+            continue;
+        };
+        match flake_ref_from_lock_locked(locked) {
+            Ok(r) => refs.push((display_name.to_owned(), r)),
+            Err(e) => warnings.push(format!("skipping flake input '{display_name}': {e}")),
+        }
+    }
+    (refs, warnings)
 }
 
 /// Worker-side mirror of the proto `FlakeInputOverride`.
@@ -974,5 +1225,127 @@ mod tests {
         assert!(applied.is_empty());
         assert_eq!(warnings.len(), 1);
         assert!(warnings[0].contains("missing"));
+    }
+
+    #[test]
+    fn percent_encode_hash_encodes_base64_specials() {
+        assert_eq!(
+            super::percent_encode_hash("sha256:A+b/C="),
+            "sha256:A%2Bb%2FC%3D"
+        );
+        assert_eq!(super::percent_encode_hash("plain-hash_123"), "plain-hash_123");
+    }
+
+    #[test]
+    fn flake_ref_from_lock_locked_github_rev_narhash() {
+        let locked = serde_json::json!({
+            "type": "github",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "deadbeef",
+            "narHash": "sha256:x+y/z=",
+        });
+        assert_eq!(
+            super::flake_ref_from_lock_locked(&locked).unwrap(),
+            "github:NixOS/nixpkgs/deadbeef?narHash=sha256:x%2By%2Fz%3D",
+        );
+    }
+
+    #[test]
+    fn flake_ref_from_lock_locked_git_ref_rev() {
+        let locked = serde_json::json!({
+            "type": "git",
+            "url": "ssh://git@example.test/r.git",
+            "ref": "main",
+            "rev": "abc123",
+        });
+        assert_eq!(
+            super::flake_ref_from_lock_locked(&locked).unwrap(),
+            "git+ssh://git@example.test/r.git?ref=main&rev=abc123",
+        );
+    }
+
+    #[test]
+    fn flake_ref_from_lock_locked_tarball_narhash() {
+        let locked = serde_json::json!({
+            "type": "tarball",
+            "url": "https://example.test/x.tar.gz",
+            "narHash": "sha256:a/b=",
+        });
+        assert_eq!(
+            super::flake_ref_from_lock_locked(&locked).unwrap(),
+            "https://example.test/x.tar.gz?narHash=sha256:a%2Fb%3D",
+        );
+    }
+
+    #[test]
+    fn flake_ref_from_lock_locked_path() {
+        let locked = serde_json::json!({
+            "type": "path",
+            "path": "/nix/store/xxx-source",
+        });
+        assert_eq!(
+            super::flake_ref_from_lock_locked(&locked).unwrap(),
+            "path:/nix/store/xxx-source",
+        );
+    }
+
+    #[test]
+    fn build_prefetch_argv_shape() {
+        assert_eq!(
+            super::build_prefetch_argv("github:NixOS/nixpkgs/rev"),
+            vec![
+                "flake".to_owned(),
+                "prefetch".to_owned(),
+                "--json".to_owned(),
+                "github:NixOS/nixpkgs/rev".to_owned(),
+            ],
+        );
+    }
+
+    /// The lock walk covers transitive (non-root-input) nodes, skips the root
+    /// node, prefers an override for a root input, and warns on an unknown type.
+    #[test]
+    fn prefetch_refs_from_lock_walks_all_and_applies_override() {
+        let lock = serde_json::json!({
+            "root": "root",
+            "nodes": {
+                "root": { "inputs": { "nixpkgs": "nixpkgs", "secret": "secret" } },
+                "nixpkgs": {
+                    "locked": { "type": "github", "owner": "NixOS", "repo": "nixpkgs", "rev": "aaa" },
+                    "inputs": { "flake-utils": "flake-utils" }
+                },
+                "flake-utils": {
+                    "locked": { "type": "github", "owner": "numtide", "repo": "flake-utils", "rev": "bbb" }
+                },
+                "secret": {
+                    "locked": { "type": "git", "url": "ssh://git@host/secret.git", "rev": "ccc" }
+                },
+                "weird": {
+                    "locked": { "type": "mercurial", "url": "http://x" }
+                }
+            }
+        });
+        let overrides = [(
+            "nixpkgs".to_owned(),
+            "github:NixOS/nixpkgs/override-rev".to_owned(),
+        )];
+        let (refs, warnings) = super::prefetch_refs_from_lock(&lock, &overrides);
+        let map: std::collections::HashMap<String, String> = refs.into_iter().collect();
+        assert_eq!(
+            map.get("nixpkgs").map(String::as_str),
+            Some("github:NixOS/nixpkgs/override-rev")
+        );
+        assert_eq!(
+            map.get("flake-utils").map(String::as_str),
+            Some("github:numtide/flake-utils/bbb")
+        );
+        assert_eq!(
+            map.get("secret").map(String::as_str),
+            Some("git+ssh://git@host/secret.git?rev=ccc")
+        );
+        assert!(!map.contains_key("root"));
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("weird"));
     }
 }

--- a/docs/src/development/proto.md
+++ b/docs/src/development/proto.md
@@ -528,16 +528,15 @@ Fetch runs on a worker that has the `fetch` capability. The fetch step performs 
  3. **Compress and push every uncached NAR** - the worker sends `CacheQuery { mode: Push }` for every fetched path. For uncached paths, it **zstd-compresses the NAR locally** and uploads via presigned S3 PUT (S3-backed) or chunked `NarPush` (local stores); on completion it emits `NarUploaded` with the full metadata (`file_hash`, `file_size`, `nar_size`, `nar_hash`, `references`, `deriver`). A failed upload fails the evaluation. **NARs are never transmitted uncompressed.**
  4. **Report `FetchResult`** carrying only the archived flake source store path (not the full input list - the server already has every `cached_path` row from the `NarUploaded` stream). The server hands this path to any subsequent eval-only job via `FlakeSource::Cached { store_path }`.
 
-If `nix flake archive` fails (e.g. network unavailable), the worker falls back to the temporary git checkout path, skips step 3 (nothing to push), and sets `flake_source` to `None` to signal the fallback - no follow-up eval-only job can then use `FlakeSource::Cached`.
+`nix flake archive` is all-or-nothing: one unfetchable input (e.g. a private `git+ssh` input the org has no key for) fails the whole command even though the eval targets never reference it. Since Nix evaluation is lazy, the archive is only cache population, so on that failure the worker falls back to **best-effort per-input prefetch**: it runs `nix flake prefetch --json` for the flake source (a hard error if even that fails) and then for each locked input from `flake.lock` independently, pushing the successes and turning per-input failures into `Warning` `EvalMessage`s (plus one leading warning naming the archive error). `flake_source` still carries the cached source path, so an eval-only follow-up can proceed against exactly the inputs its targets need.
 
 ```rust
 FetchResult {
     /// Nix store path of the archived flake source (e.g.
-    /// `/nix/store/xxx-source`). `Some` when `nix flake archive`
-    /// succeeded and the source now lives in the cache as a NAR;
-    /// `None` when the worker fell back to a temporary git checkout -
-    /// in that case the server cannot dispatch an eval-only follow-up
-    /// job (no `FlakeSource::Cached` path is available).
+    /// `/nix/store/xxx-source`). `Some` when the source landed in the
+    /// cache - either `nix flake archive` succeeded or the per-input
+    /// prefetch fallback fetched at least the source; only `None` when
+    /// the fetch failed outright (no `FlakeSource::Cached` follow-up).
     flake_source: Option<String>,
 }
 ```

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -204,6 +204,28 @@ exit, close upward over dependents, and exclude that set from the thaw;
 scoped sweep bounds its seed, walk, and UPDATE to the eval closure while the global
 pass carries no closure walk. The demote/thaw convergence stays E2E-CI-covered.
 
+## Re-evaluate to regenerate a lost `.drv` (graph-stuck zone B)
+
+A build target's own `.drv` has no producer - only evaluation emits a `.drv`, and
+the daemon-free server cannot reproduce one - so an anchor whose `.drv` NAR is absent
+from our cache (never uploaded, or GC-reclaimed) can never dispatch and no reconcile
+heals it; the eval hangs `graph_stuck` (prod `019f6661`: entry point
+`testPCB-image_set` had no `cached_path` row for its `.drv` while its sibling's
+survived, a transient upload miss). The scheduler now detects this - a pending anchor
+that is `edges_complete`, deps-ready, not `substitutable`, with neither
+`drv_closure_cached` nor its `.drv`'s own NAR closure - and auto-triggers a fresh
+evaluation of the same commit (`gradient_ci::trigger_drv_recovery`), which
+re-instantiates the flake and re-uploads the `.drv`. The recovery run is
+`EvaluationKind::DrvRecovery`; if it stalls the same way, it is failed rather than
+retried (one-shot), and a 120s grace on the stuck eval's age avoids racing an
+in-flight `.drv` upload. `backend/gradient-scheduler/src/waiting_state.rs`:
+`unproducible_drv_block_sql_shape` pins the detection predicate (pending anchors
+only, edges complete, not substitutable, not `drv_closure_cached`, the `.drv`
+NAR-closure and deps-ready predicates embedded). `backend/gradient-entity/src/evaluation.rs`:
+`kind_numbering_is_pinned` pins `DrvRecovery = 2` so a renumber can't reinterpret
+persisted rows. The abort-and-re-eval convergence is E2E-CI-covered (MockDatabase
+can't drive the multi-step trigger).
+
 ## Corrupt eval-cache blob self-heals (worker detects, server heals)
 
 A poisoned shared eval-cache SQLite blob (fingerprint `ad2ae6ba…`, error `database

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -180,6 +180,30 @@ still thaws `FailedPermanent` but never a build-once success;
 `status_sql.rs`: `renders_the_pinned_numbers` pins `attempt_outcome`/`attempt_reason`.
 The recursive requeue convergence stays E2E-CI-covered (no live DB in unit tests).
 
+## Requeue thaw skips the whole deterministic-blocked subtree (graph-stuck follow-up)
+
+The retry-storm fix kept the deterministic *root* terminal, which then exposed its
+*dependents*: the failure cascade demotes them `DependencyFailed`, but a
+`DependencyFailed` dependent never ran a build of its own, so the own-attempt
+`deterministic_build_failure` guard did not protect it - the next graph-stuck heal
+thawed it back to `Created`, the cascade re-demoted it, and the eval oscillated in
+`graph_stuck` forever, never finalizing (prod: 26 evals wedged since the retry-storm
+fix landed; c3d2/nix-config `019f6cd0` had 27 dependents of `atop`/`tree-sitter`/
+`rustfs` trapped). Both requeue paths now exclude the whole `deterministic_blocked`
+subtree - the closure's deterministic failures plus every dependent reachable upward
+over `derivation_dependency` (bounded to the requeue closure) - so a poisoned
+dependent is never thawed and the eval settles to `Failed`. Paired with this,
+`reconcile_dependency_failed` gained an eval-scoped mode and now also runs in the
+`Eval`/`Unstick` reconcile scopes (right after the requeue thaw), bounded to the
+eval closure, so the graph-stuck heal re-fails its own thawed victims inline instead
+of waiting for the sporadic global backstop. `backend/gradient-db/src/promotion.rs`:
+`requeue_excludes_the_deterministic_blocked_subtree` pins that both requeue SQLs
+build the `deterministic_blocked` closure, seed it from a reproducible builder-nonzero
+exit, close upward over dependents, and exclude that set from the thaw;
+`dependency_failed_reconcile_sql_bounds_to_eval_closure_when_scoped` pins that the
+scoped sweep bounds its seed, walk, and UPDATE to the eval closure while the global
+pass carries no closure walk. The demote/thaw convergence stays E2E-CI-covered.
+
 ## Corrupt eval-cache blob self-heals (worker detects, server heals)
 
 A poisoned shared eval-cache SQLite blob (fingerprint `ad2ae6ba…`, error `database

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -6581,3 +6581,25 @@ content before any object write.
   `put_nar_idempotent_reader` writes the streamed bytes when no row records the
   path and honours the same idempotency skip as the buffered `put_nar_idempotent`
   (leaving stored bytes untouched, reader unread).
+
+## Per-input flake prefetch fallback (#550)
+
+`nix flake archive` fetches every input in `flake.lock`, so one unfetchable
+input (e.g. a private `git+ssh` input the org has no key for) failed the whole
+fetch even when the eval targets never referenced it. On archive failure the
+worker now prefetches the source and each locked input independently
+(`prefetch_flake_best_effort`), collecting successes and emitting per-input
+`Warning` `EvalMessage`s instead of aborting.
+
+`backend/gradient-worker/src/executor/fetch.rs`:
+- `flake_ref_from_lock_locked_github_rev_narhash` - `github` rebuilds
+  `{ty}:{owner}/{repo}/{rev}?narHash=<percent-encoded>`.
+- `flake_ref_from_lock_locked_git_ref_rev` - `git` appends `ref`/`rev` query
+  params; `flake_ref_from_lock_locked_tarball_narhash` / `_path` cover the
+  remaining locked node types.
+- `percent_encode_hash_encodes_base64_specials` - the SRI hash helper encodes
+  `+`/`/`/`=` and leaves other characters untouched.
+- `build_prefetch_argv_shape` - argv is `flake prefetch --json <ref>`.
+- `prefetch_refs_from_lock_walks_all_and_applies_override` - the lock walk
+  covers transitive (non-root-input) nodes, skips the root node, prefers an
+  override for a root input, and warns on an unsupported node type.


### PR DESCRIPTION
Fetch now falls back to best-effort per-input prefetch when nix flake archive fails, so an unfetchable input no eval target needs cannot kill the eval. Closes #550.

Also lands the two graph-stuck dead-zone fixes: dependents of a deterministic build failure finalize instead of re-thawing, and an eval wedged on a lost .drv (e.g. 019f9d29-ecad-7d30-80b1-b929637ac02d) auto-recovers via a one-shot DrvRecovery re-evaluation.