### PR TITLE
Chunk cache RPCs to fix the WebSocket deadlock that looped evals forever

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2421,6 +2421,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-test",
+ "tokio-tungstenite",
  "tokio-util",
  "tower",
  "tower-http",

--- a/backend/gradient-proto/src/messages/mod.rs
+++ b/backend/gradient-proto/src/messages/mod.rs
@@ -41,6 +41,15 @@ pub const CACHE_QUERY_BUDGET: std::time::Duration = std::time::Duration::from_se
 /// Worker-side wait for `CacheStatus`/`CacheError` and `KnownDerivations`.
 pub const CACHE_QUERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(75);
 
+/// Upper bound on the store paths one `CacheQuery` / `QueryKnownDerivations`
+/// may carry. A whole eval's path set (tens of thousands) serialises into a
+/// multi-MB request whose reply is larger still; with both peers holding a
+/// write the socket can't absorb, neither gets back to reading and the
+/// connection deadlocks until a send timeout tears it down. Chunking keeps
+/// every request and its reply inside
+/// [`crate::handler::SAFE_INFLIGHT_MESSAGE_SIZE`].
+pub const CACHE_QUERY_MAX_PATHS: usize = 1_000;
+
 // The server must give up (and reply CacheError) before the worker stops
 // listening, otherwise a slow query reads as a silent miss.
 const _: () = assert!(CACHE_QUERY_BUDGET.as_secs() < CACHE_QUERY_TIMEOUT.as_secs());

--- a/backend/gradient-proto/src/session/frame.rs
+++ b/backend/gradient-proto/src/session/frame.rs
@@ -40,6 +40,17 @@ pub const NAR_PUSH_CHUNK_SIZE: usize = 4 * 1024 * 1024;
 /// connect.
 pub const MAX_PROTO_MESSAGE_SIZE: usize = 8 * 1024 * 1024;
 
+/// Size a *bidirectional* RPC (a request whose reply travels the other way
+/// while the peer may itself be writing) must stay under.
+///
+/// [`MAX_PROTO_MESSAGE_SIZE`] bounds memory, not liveness: a message far
+/// larger than the socket's send buffer leaves its sender blocked mid-write,
+/// and a peer that is itself blocked mid-write never returns to reading. Both
+/// ends then sit on unflushable writes until a send timeout kills the
+/// connection - and the job retries into the same wall. Bulk transfers
+/// (`NarPush`) are exempt: they flow one way against small acks.
+pub const SAFE_INFLIGHT_MESSAGE_SIZE: usize = 2 * 1024 * 1024;
+
 /// Maximum time the server will wait for a peer to complete the handshake
 /// (Discoverable check → InitConnection → AuthChallenge → AuthResponse →
 /// InitAck). A peer that opens the WebSocket and then stalls is dropped after
@@ -472,6 +483,61 @@ mod tests {
     #[test]
     fn nar_push_chunk_size_is_four_mib() {
         assert_eq!(NAR_PUSH_CHUNK_SIZE, 4 * 1024 * 1024);
+    }
+
+    /// The knob that keeps the cache RPC deadlock-free: a full-size
+    /// `CacheQuery` and the worst-case `CacheStatus` it can provoke - every
+    /// path uncached, each carrying a presigned upload URL and path info -
+    /// must both fit inside [`SAFE_INFLIGHT_MESSAGE_SIZE`]. Raising
+    /// `CACHE_QUERY_MAX_PATHS` past that point re-arms the deadlock that
+    /// wedged evals into an endless dispatch loop.
+    #[test]
+    fn a_full_cache_query_and_its_worst_case_reply_stay_inflight_safe() {
+        use crate::messages::{CACHE_QUERY_MAX_PATHS, CachedPath};
+
+        let paths: Vec<String> = (0..CACHE_QUERY_MAX_PATHS)
+            .map(|i| format!("/nix/store/{:0>32}-some-package-name-1.2.3-{i}", i))
+            .collect();
+
+        let query = ClientMessage::CacheQuery {
+            job_id: "eval:019fcd73-aa63-7a41-b51c-05ed673c6d1f".to_owned(),
+            query_id: "6c1a5e2c-0f52-4f9e-9a0e-2f1b7c4d8e90".to_owned(),
+            paths: paths.clone(),
+            mode: gradient_types::proto::QueryMode::Push,
+        };
+
+        let cached: Vec<CachedPath> = paths
+            .iter()
+            .map(|p| CachedPath {
+                path: p.clone(),
+                cached: false,
+                file_size: Some(1),
+                nar_size: Some(1),
+                // Presigned PUT URLs are the largest field a reply can carry.
+                url: Some(format!("https://s3.example.com{p}?{}", "x".repeat(512))),
+                nar_hash: Some(format!("sha256:{}", "y".repeat(52))),
+                file_hash: Some(format!("sha256:{}", "z".repeat(52))),
+                references: None,
+                signatures: None,
+                deriver: None,
+                ca: None,
+            })
+            .collect();
+        let reply = ServerMessage::CacheStatus {
+            query_id: "6c1a5e2c-0f52-4f9e-9a0e-2f1b7c4d8e90".to_owned(),
+            cached,
+        };
+
+        let query_bytes = query.encode().expect("query encodes").len();
+        let reply_bytes = reply.encode().expect("reply encodes").len();
+        assert!(
+            query_bytes <= SAFE_INFLIGHT_MESSAGE_SIZE,
+            "CacheQuery of {CACHE_QUERY_MAX_PATHS} paths encodes to {query_bytes} bytes"
+        );
+        assert!(
+            reply_bytes <= SAFE_INFLIGHT_MESSAGE_SIZE,
+            "worst-case CacheStatus encodes to {reply_bytes} bytes"
+        );
     }
 }
 

--- a/backend/gradient-scheduler/src/build/lifecycle.rs
+++ b/backend/gradient-scheduler/src/build/lifecycle.rs
@@ -13,7 +13,7 @@ use anyhow::{Context, Result};
 use gradient_core::ServerState;
 use gradient_db::{
     cascade_dependency_failed, fail_latest_attempt, update_derivation_build_status,
-    update_evaluation_status,
+    update_evaluation_status, update_evaluation_status_with_error,
 };
 use gradient_entity::build::BuildStatus;
 use gradient_entity::build_attempt::{AttemptFailureReason, AttemptOutcome};
@@ -31,6 +31,33 @@ use gradient_types::BuildOutputMetadata;
 use gradient_types::proto::BuildFailureKind;
 use gradient_types::proto::BuildMetrics;
 use gradient_types::proto::BuildOutput;
+
+/// How many times an evaluation may be handed to a worker before the
+/// scheduler stops re-queuing it. A healthy eval spends exactly one; each
+/// dispatch that ends in a disconnect rather than a result costs another.
+/// Without this ceiling an eval whose worker keeps dying mid-evaluation is
+/// re-dispatched forever, taking the fleet's eval capacity with it every
+/// round.
+pub(crate) const MAX_EVAL_DISPATCH_ATTEMPTS: u64 = 10;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OrphanedEval {
+    /// Budget remains: park the eval so a worker can pick it up again.
+    Requeue,
+    /// Budget spent: fail the eval instead of looping.
+    Exhausted,
+}
+
+/// Decide what to do with an evaluation orphaned by a worker disconnect,
+/// given how many times it has already been dispatched (this dispatch
+/// included).
+pub(crate) fn orphaned_eval_outcome(dispatches: u64, budget: u64) -> OrphanedEval {
+    if dispatches >= budget {
+        OrphanedEval::Exhausted
+    } else {
+        OrphanedEval::Requeue
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum FailureOutcome {
@@ -494,6 +521,26 @@ async fn check_referencing_evals_done(
 /// `Building -> Queued`; evaluations (which the state machine only lets reach
 /// `Queued` via `Waiting`) park to `Waiting` so the reconciler that runs right
 /// after recovers them to `Queued` once an eval-capable worker is free.
+/// How many times this evaluation has been handed to a worker, from the
+/// dispatch telemetry. A load failure counts as zero so a DB hiccup can never
+/// fail an otherwise healthy evaluation.
+async fn eval_dispatch_count(state: &Arc<ServerState>, evaluation_id: EvaluationId) -> u64 {
+    use gradient_entity::dispatched_job::{
+        Column as CDispatchedJob, DispatchedJobKind, Entity as EDispatchedJob,
+    };
+    use sea_orm::PaginatorTrait;
+
+    EDispatchedJob::find()
+        .filter(CDispatchedJob::EvaluationId.eq(evaluation_id))
+        .filter(CDispatchedJob::Kind.eq(DispatchedJobKind::Eval))
+        .count(&state.worker_db)
+        .await
+        .unwrap_or_else(|e| {
+            warn!(%evaluation_id, error = %e, "eval dispatch count failed; treating as first attempt");
+            0
+        })
+}
+
 pub async fn requeue_orphaned_jobs(state: &Arc<ServerState>, orphaned: &[PendingJob]) {
     for job in orphaned {
         if let Some(derivation_build) = job.derivation_build() {
@@ -526,18 +573,74 @@ pub async fn requeue_orphaned_jobs(state: &Arc<ServerState>, orphaned: &[Pending
                         | EvaluationStatus::EvaluatingDerivation
                 ) =>
             {
-                persist_waiting_reason(
-                    state,
-                    eval.id,
-                    &eval.waiting_reason,
-                    Some(&WaitingReason::eval_workers(EvalCapability::Eval, 0)),
-                )
-                .await;
-                update_evaluation_status(&state.db(), eval, EvaluationStatus::Waiting).await;
+                let dispatches = eval_dispatch_count(state, eval.id).await;
+                match orphaned_eval_outcome(dispatches, MAX_EVAL_DISPATCH_ATTEMPTS) {
+                    OrphanedEval::Requeue => {
+                        persist_waiting_reason(
+                            state,
+                            eval.id,
+                            &eval.waiting_reason,
+                            Some(&WaitingReason::eval_workers(EvalCapability::Eval, 0)),
+                        )
+                        .await;
+                        update_evaluation_status(&state.db(), eval, EvaluationStatus::Waiting)
+                            .await;
+                    }
+                    OrphanedEval::Exhausted => {
+                        warn!(
+                            evaluation_id = %eval.id,
+                            dispatches,
+                            "evaluation orphaned on every dispatch; failing instead of re-queuing"
+                        );
+                        update_evaluation_status_with_error(
+                            &state.db(),
+                            eval,
+                            EvaluationStatus::Failed,
+                            format!(
+                                "evaluation was dispatched {dispatches} times and each worker \
+                                 disconnected before reporting a result; giving up"
+                            ),
+                            Some("scheduler".to_string()),
+                        )
+                        .await;
+                    }
+                }
             }
             Ok(_) => {}
             Err(e) => warn!(error = %e, %evaluation_id, "requeue orphaned eval: load failed"),
         }
+    }
+}
+
+#[cfg(test)]
+mod orphaned_eval_tests {
+    use super::{MAX_EVAL_DISPATCH_ATTEMPTS, OrphanedEval, orphaned_eval_outcome};
+
+    /// The common case: a worker drops once, the eval goes back on the queue.
+    #[test]
+    fn an_eval_under_budget_is_requeued() {
+        for dispatches in 1..MAX_EVAL_DISPATCH_ATTEMPTS {
+            assert_eq!(
+                orphaned_eval_outcome(dispatches, MAX_EVAL_DISPATCH_ATTEMPTS),
+                OrphanedEval::Requeue,
+                "dispatch {dispatches} of {MAX_EVAL_DISPATCH_ATTEMPTS}"
+            );
+        }
+    }
+
+    /// An eval that wedges every worker it touches must terminate: without
+    /// this it is re-dispatched forever, parking to `Waiting` between rounds
+    /// and starving the fleet each time it runs.
+    #[test]
+    fn an_eval_that_spends_its_budget_stops_being_requeued() {
+        assert_eq!(
+            orphaned_eval_outcome(MAX_EVAL_DISPATCH_ATTEMPTS, MAX_EVAL_DISPATCH_ATTEMPTS),
+            OrphanedEval::Exhausted
+        );
+        assert_eq!(
+            orphaned_eval_outcome(MAX_EVAL_DISPATCH_ATTEMPTS + 20, MAX_EVAL_DISPATCH_ATTEMPTS),
+            OrphanedEval::Exhausted
+        );
     }
 }
 

--- a/backend/gradient-web/Cargo.toml
+++ b/backend/gradient-web/Cargo.toml
@@ -83,5 +83,6 @@ harmonia-file-nar = { workspace = true, features = ["test"] }
 hmac              = { workspace = true }
 gradient-test-support = { workspace = true }
 tokio-test   = { workspace = true }
+tokio-tungstenite = { workspace = true }
 tower        = { workspace = true }
 zstd         = { workspace = true }

--- a/backend/gradient-web/src/endpoints/live.rs
+++ b/backend/gradient-web/src/endpoints/live.rs
@@ -27,26 +27,40 @@ use super::evals::EvalAccessContext;
 
 /// Forward events selected by `select` to the socket until either side closes.
 /// A lagged receiver skips missed frames (the client refetches on the next one).
-async fn live_stream<F>(mut socket: WebSocket, mut rx: BoardEventRx, mut select: F)
+///
+/// The inbound half is polled purely to notice the client leaving: a loop that
+/// only writes learns of a closed tab at the next event that fails to send, so
+/// a quiet channel would hold its task and socket open indefinitely.
+pub async fn live_stream<F>(socket: WebSocket, mut rx: BoardEventRx, mut select: F)
 where
     F: FnMut(&BoardEvent) -> Option<String> + Send + 'static,
 {
+    use futures::{SinkExt, StreamExt};
+
+    let (mut sink, mut stream) = socket.split();
     loop {
-        match rx.recv().await {
-            Ok(ev) => {
-                if let Some(text) = select(&ev)
-                    && socket.send(Message::Text(text.into())).await.is_err()
-                {
-                    break;
+        tokio::select! {
+            incoming = stream.next() => match incoming {
+                // Close frame, transport error, or the peer simply went away.
+                None | Some(Err(_)) | Some(Ok(Message::Close(_))) => break,
+                Some(Ok(_)) => continue,
+            },
+            event = rx.recv() => match event {
+                Ok(ev) => {
+                    if let Some(text) = select(&ev)
+                        && sink.send(Message::Text(text.into())).await.is_err()
+                    {
+                        break;
+                    }
                 }
-            }
-            Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
-            Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            },
         }
     }
 }
 
-type BoardEventRx = tokio::sync::broadcast::Receiver<BoardEvent>;
+pub type BoardEventRx = tokio::sync::broadcast::Receiver<BoardEvent>;
 
 fn frame(ev: &BoardEvent) -> Option<String> {
     serde_json::to_string(ev).ok()

--- a/backend/gradient-web/tests/live_stream_disconnect.rs
+++ b/backend/gradient-web/tests/live_stream_disconnect.rs
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! A `/live` channel must let go of a client that walked away.
+//!
+//! The stream only ever wrote to its socket, so a closed browser tab was
+//! noticed only if some later event happened to fail the send. A channel that
+//! stays quiet - a finished project, an idle cache - therefore kept its task
+//! and its file descriptor forever, and the server accumulated CLOSE-WAIT
+//! sockets (258 of them over a few hours in production) until it would have
+//! run out of descriptors.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::Router;
+use axum::extract::State;
+use axum::extract::ws::WebSocketUpgrade;
+use axum::response::Response;
+use axum::routing::get;
+use gradient_types::BoardEvent;
+use tokio::net::TcpListener;
+use tokio::sync::broadcast;
+
+/// Signals when the server-side stream task has returned.
+type Done = Arc<tokio::sync::Notify>;
+
+async fn live_route(
+    State((tx, done)): State<(broadcast::Sender<BoardEvent>, Done)>,
+    ws: WebSocketUpgrade,
+) -> Response {
+    let rx = tx.subscribe();
+    ws.on_upgrade(move |socket| async move {
+        gradient_web::endpoints::live::live_stream(socket, rx, |ev| serde_json::to_string(ev).ok())
+            .await;
+        done.notify_one();
+    })
+}
+
+#[tokio::test]
+async fn live_stream_ends_when_the_client_disconnects() {
+    let (tx, _rx) = broadcast::channel(16);
+    let done: Done = Arc::new(tokio::sync::Notify::new());
+
+    let app = Router::new()
+        .route("/live", get(live_route))
+        .with_state((tx, Arc::clone(&done)));
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let (client, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/live"))
+        .await
+        .expect("client connects");
+
+    // The client goes away without the channel ever publishing an event -
+    // exactly the case a write-only loop cannot detect.
+    drop(client);
+
+    tokio::time::timeout(Duration::from_secs(5), done.notified())
+        .await
+        .expect("stream task must end when the client disconnects");
+}

--- a/backend/gradient-worker/src/connection_state.rs
+++ b/backend/gradient-worker/src/connection_state.rs
@@ -36,4 +36,7 @@ pub enum RunOutcome {
     CleanDisconnect,
     /// Server sent `Draining` - the worker should shut down gracefully.
     Drained,
+    /// Server refused the session (post-handshake `Reject`), so nothing was
+    /// served. Reconnecting is appropriate but must back off.
+    Refused,
 }

--- a/backend/gradient-worker/src/main.rs
+++ b/backend/gradient-worker/src/main.rs
@@ -26,7 +26,7 @@ use tracing::{error, info, warn};
 
 use config::WorkerConfig;
 use connection_state::RunOutcome;
-use reconnect::retry_reconnect;
+use reconnect::{SessionEnd, backoff_after_session, retry_reconnect};
 use tracing_subscriber::EnvFilter;
 use worker::Worker;
 
@@ -172,20 +172,29 @@ fn main() -> Result<()> {
                 return Ok(());
             }
 
-            match outcome {
+            let session_end = match outcome {
                 Ok(RunOutcome::Drained) => {
                     info!("server requested drain; shutting down");
                     drop(disconnected);
                     executor_handle.shutdown().await;
                     return Ok(());
                 }
+                Ok(RunOutcome::Refused) => {
+                    warn!(
+                        delay_secs = backoff.as_secs(),
+                        "server refused the session; backing off"
+                    );
+                    SessionEnd::Refused
+                }
                 Ok(RunOutcome::CleanDisconnect) => {
                     warn!(delay_secs = backoff.as_secs(), "connection closed; reconnecting");
+                    SessionEnd::Served
                 }
                 Err(e) => {
                     error!(error = %e, delay_secs = backoff.as_secs(), "dispatch loop error; reconnecting");
+                    SessionEnd::Served
                 }
-            }
+            };
 
             // Reconnect with exponential backoff, but bail out if shutdown
             // fires while we're waiting. Never give up otherwise - a transient
@@ -207,7 +216,11 @@ fn main() -> Result<()> {
                 Some(w) => {
                     info!("reconnected successfully");
                     worker = w;
-                    backoff = INITIAL_BACKOFF;
+                    // Reconnecting only proves the transport works. A session
+                    // the server refuses is not a served one, so its delay
+                    // keeps escalating instead of dropping back to the floor.
+                    backoff =
+                        backoff_after_session(backoff, session_end, INITIAL_BACKOFF, MAX_BACKOFF);
                 }
                 None => {
                     info!("shutdown requested during reconnect");

--- a/backend/gradient-worker/src/proto/job.rs
+++ b/backend/gradient-worker/src/proto/job.rs
@@ -15,8 +15,8 @@ use std::sync::{Arc, Mutex};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use gradient_proto::messages::{
-    BuildMetrics, BuildOutput, CACHE_QUERY_TIMEOUT, CachedPath, ClientMessage,
-    DiscoveredDerivation, EvalCachePullOutcome, EvalCachePushMode, EvalMessageLevel,
+    BuildMetrics, BuildOutput, CACHE_QUERY_MAX_PATHS, CACHE_QUERY_TIMEOUT, CachedPath,
+    ClientMessage, DiscoveredDerivation, EvalCachePullOutcome, EvalCachePushMode, EvalMessageLevel,
     EvalStatsReport, JobUpdateKind, QueryMode,
 };
 use tokio::sync::oneshot;
@@ -415,9 +415,28 @@ impl JobUpdater {
     }
 }
 
-/// Send a `QueryKnownDerivations` and wait for the matching `KnownDerivations`,
-/// with a hard timeout so a stalled dispatch loop can't hang the eval task.
+/// Query the server's known-derivation set in [`CACHE_QUERY_MAX_PATHS`]-sized
+/// batches, one at a time, and concatenate the answers. See
+/// [`cache_query_with_timeout`] for why a whole eval's set must never ride in
+/// a single message.
 async fn known_derivations_with_timeout(
+    job_id: &str,
+    writer: &ProtoWriter,
+    waiters: &KnownDerivationWaiters,
+    drv_paths: Vec<String>,
+) -> Result<Vec<String>> {
+    let mut known = Vec::new();
+    for chunk in drv_paths.chunks(CACHE_QUERY_MAX_PATHS) {
+        known.extend(known_derivations_chunk(job_id, writer, waiters, chunk.to_vec()).await?);
+    }
+
+    Ok(known)
+}
+
+/// Send one `QueryKnownDerivations` and wait for the matching
+/// `KnownDerivations`, with a hard timeout so a stalled dispatch loop can't
+/// hang the eval task.
+async fn known_derivations_chunk(
     job_id: &str,
     writer: &ProtoWriter,
     waiters: &KnownDerivationWaiters,
@@ -449,9 +468,35 @@ async fn known_derivations_with_timeout(
     }
 }
 
-/// Send a `CacheQuery` and wait for the matching `CacheStatus`, with a hard
-/// timeout so a stalled dispatch loop can't hang the eval task forever.
+/// Query cache state for `paths` in [`CACHE_QUERY_MAX_PATHS`]-sized batches,
+/// one at a time, and concatenate the answers in request order.
+///
+/// An eval's full path set (tens of thousands) would otherwise serialise into
+/// a multi-MB request whose `CacheStatus` reply is larger still. With both
+/// peers mid-write the socket buffers fill in both directions and neither
+/// dispatch loop gets back to reading - the connection wedges until the
+/// worker's send timeout tears it down, and the job is retried forever. One
+/// bounded query in flight keeps both sides drainable.
 async fn cache_query_with_timeout(
+    job_id: &str,
+    writer: &ProtoWriter,
+    cache_waiters: &CacheWaiters,
+    paths: Vec<String>,
+    mode: QueryMode,
+) -> Result<Vec<CachedPath>> {
+    let mut cached = Vec::with_capacity(paths.len());
+    for chunk in paths.chunks(CACHE_QUERY_MAX_PATHS) {
+        cached.extend(
+            cache_query_chunk(job_id, writer, cache_waiters, chunk.to_vec(), mode.clone()).await?,
+        );
+    }
+
+    Ok(cached)
+}
+
+/// Send one `CacheQuery` and wait for the matching `CacheStatus`, with a hard
+/// timeout so a stalled dispatch loop can't hang the eval task forever.
+async fn cache_query_chunk(
     job_id: &str,
     writer: &ProtoWriter,
     cache_waiters: &CacheWaiters,
@@ -825,5 +870,146 @@ mod tests {
             .await
             .unwrap();
         server_task.await.unwrap();
+    }
+
+    fn cached(path: &str) -> CachedPath {
+        CachedPath {
+            path: path.to_owned(),
+            cached: true,
+            file_size: None,
+            nar_size: None,
+            url: None,
+            nar_hash: None,
+            file_hash: None,
+            references: None,
+            signatures: None,
+            deriver: None,
+            ca: None,
+        }
+    }
+
+    /// Stand in for the dispatch loop: route every inbound reply to its waiter.
+    fn pump_replies(
+        mut reader: crate::connection::ProtoReader,
+        cache_waiters: CacheWaiters,
+        known_waiters: KnownDerivationWaiters,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            while let Some(msg) = reader.recv().await {
+                match msg {
+                    gradient_proto::messages::ServerMessage::CacheStatus { query_id, cached } => {
+                        deliver_cache_reply(&cache_waiters, &query_id, Ok(cached));
+                    }
+                    gradient_proto::messages::ServerMessage::KnownDerivations { job_id, known } => {
+                        let waiter = known_waiters.lock().unwrap().remove(&job_id);
+                        if let Some(tx) = waiter {
+                            let _ = tx.send(known);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        })
+    }
+
+    /// A whole eval's path set must go out as several bounded `CacheQuery`
+    /// messages - one multi-MB request plus its larger reply deadlocks the
+    /// socket - and the replies must merge back into one answer covering
+    /// every path, in order.
+    #[tokio::test]
+    async fn cache_query_splits_oversized_path_list_into_bounded_chunks() {
+        let total = CACHE_QUERY_MAX_PATHS * 2 + 5;
+        let (conn, server_task, job_id) = server_then_client!("job-chunk", |sc| {
+            let mut seen: Vec<String> = Vec::new();
+            while seen.len() < total {
+                let msg = sc.recv().await.unwrap();
+                let ClientMessage::CacheQuery {
+                    query_id, paths, ..
+                } = msg
+                else {
+                    panic!("expected CacheQuery, got {msg:?}");
+                };
+                assert!(
+                    paths.len() <= CACHE_QUERY_MAX_PATHS,
+                    "CacheQuery carried {} paths, over the {CACHE_QUERY_MAX_PATHS} bound",
+                    paths.len()
+                );
+                let cached: Vec<CachedPath> = paths.iter().map(|p| cached(p)).collect();
+                seen.extend(paths);
+                sc.send(gradient_proto::messages::ServerMessage::CacheStatus { query_id, cached })
+                    .await
+                    .unwrap();
+            }
+            seen
+        });
+
+        let (mut updater, reader) = make_updater(job_id, conn);
+        let pump = pump_replies(
+            reader,
+            updater.cache_waiters.clone(),
+            updater.known_derivation_waiters.clone(),
+        );
+
+        let paths: Vec<String> = (0..total).map(|i| format!("/nix/store/path-{i}")).collect();
+        let got = updater
+            .query_cache(paths.clone(), QueryMode::Push)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            got.into_iter().map(|c| c.path).collect::<Vec<_>>(),
+            paths,
+            "merged reply must cover every queried path in order"
+        );
+        assert_eq!(server_task.await.unwrap(), paths);
+        pump.abort();
+    }
+
+    /// Same bound for the BFS-prune query: a full `.drv` set must not ride in
+    /// one message.
+    #[tokio::test]
+    async fn known_derivations_splits_oversized_path_list_into_bounded_chunks() {
+        let total = CACHE_QUERY_MAX_PATHS + 7;
+        let (conn, server_task, job_id) = server_then_client!("job-known", |sc| {
+            let mut seen: Vec<String> = Vec::new();
+            while seen.len() < total {
+                let msg = sc.recv().await.unwrap();
+                let ClientMessage::QueryKnownDerivations { job_id, drv_paths } = msg else {
+                    panic!("expected QueryKnownDerivations, got {msg:?}");
+                };
+                assert!(
+                    drv_paths.len() <= CACHE_QUERY_MAX_PATHS,
+                    "QueryKnownDerivations carried {} paths, over the {CACHE_QUERY_MAX_PATHS} bound",
+                    drv_paths.len()
+                );
+                let known = drv_paths.clone();
+                seen.extend(drv_paths);
+                sc.send(gradient_proto::messages::ServerMessage::KnownDerivations {
+                    job_id,
+                    known,
+                })
+                .await
+                .unwrap();
+            }
+            seen
+        });
+
+        let (mut updater, reader) = make_updater(job_id, conn);
+        let pump = pump_replies(
+            reader,
+            updater.cache_waiters.clone(),
+            updater.known_derivation_waiters.clone(),
+        );
+
+        let drvs: Vec<String> = (0..total)
+            .map(|i| format!("/nix/store/d-{i}.drv"))
+            .collect();
+        let got = JobReporter::query_known_derivations(&mut updater, drvs.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(got, drvs, "merged reply must cover every queried .drv");
+        assert_eq!(server_task.await.unwrap(), drvs);
+        pump.abort();
     }
 }

--- a/backend/gradient-worker/src/reconnect.rs
+++ b/backend/gradient-worker/src/reconnect.rs
@@ -16,6 +16,36 @@ use std::time::Duration;
 
 use tracing::error;
 
+/// How the previous session ended, as far as reconnect pacing cares.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionEnd {
+    /// The connection was established and served (jobs, heartbeats, a clean
+    /// close, or an error mid-work).
+    Served,
+    /// The server refused the session outright - e.g. `Reject` 496 while a
+    /// zombie session still owns this worker's slot. Nothing was served.
+    Refused,
+}
+
+/// Delay before the next reconnect attempt.
+///
+/// Reconnecting is only "successful" in the transport sense: the worker can
+/// complete a handshake and still be refused at registration. Treating that as
+/// a healthy connection resets the backoff to its floor, so the worker
+/// hammers the server about once a second until the stale session is reaped.
+/// A refused session therefore escalates instead.
+pub fn backoff_after_session(
+    previous: Duration,
+    end: SessionEnd,
+    initial: Duration,
+    max: Duration,
+) -> Duration {
+    match end {
+        SessionEnd::Served => initial,
+        SessionEnd::Refused => (previous * 2).min(max),
+    }
+}
+
 /// Retry `attempt` indefinitely with exponential backoff.
 ///
 /// `attempt` consumes the current state and returns either the next state on
@@ -59,6 +89,38 @@ where
 mod tests {
     use super::*;
     use std::cell::RefCell;
+
+    /// A session the server refused did no work, so the next attempt must
+    /// wait longer - resetting to the floor turns a server-side zombie
+    /// session (`Reject` 496, "worker already connected") into a ~1/s
+    /// reconnect storm that lasts until the liveness watchdog reaps it.
+    #[test]
+    fn refused_sessions_escalate_the_backoff() {
+        let initial = Duration::from_secs(1);
+        let max = Duration::from_secs(60);
+
+        let mut delay = initial;
+        for expected in [2, 4, 8, 16, 32, 60, 60] {
+            delay = backoff_after_session(delay, SessionEnd::Refused, initial, max);
+            assert_eq!(delay, Duration::from_secs(expected));
+        }
+    }
+
+    /// A session that actually ran restarts from the floor: a genuine network
+    /// blip must not inherit a long delay from an earlier refusal.
+    #[test]
+    fn served_sessions_reset_the_backoff() {
+        let initial = Duration::from_secs(1);
+        assert_eq!(
+            backoff_after_session(
+                Duration::from_secs(32),
+                SessionEnd::Served,
+                initial,
+                Duration::from_secs(60)
+            ),
+            initial
+        );
+    }
 
     /// Regression for #99: the loop must keep retrying after a single failure
     /// instead of breaking out and shutting the worker down.

--- a/backend/gradient-worker/src/worker/dispatch.rs
+++ b/backend/gradient-worker/src/worker/dispatch.rs
@@ -32,13 +32,20 @@ use super::scoring::{send_score_chunks, spawn_scoring_task};
 
 // ── Dispatch loop ─────────────────────────────────────────────────────────────
 
-/// Returns the draining flag: `true` if the server sent `Draining` before
-/// closing the connection.
+/// How the dispatch loop ended, for the caller's reconnect decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct LoopEnd {
+    /// The server sent `Draining` before closing.
+    pub(super) draining: bool,
+    /// The server refused the session (post-handshake `Reject`).
+    pub(super) refused: bool,
+}
+
 pub(super) async fn run_dispatch_loop(
     mut state: DispatchState,
     mut reader: ProtoReader,
     shutdown: CancellationToken,
-) -> Result<bool> {
+) -> Result<LoopEnd> {
     let mut done_rx = state
         .done_rx
         .take()
@@ -91,7 +98,10 @@ pub(super) async fn run_dispatch_loop(
         let _ = abort_tx.send(true);
     }
 
-    Ok(state.draining)
+    Ok(LoopEnd {
+        draining: state.draining,
+        refused: state.refused,
+    })
 }
 
 // ── Per-job bookkeeping ───────────────────────────────────────────────────────
@@ -133,6 +143,7 @@ pub(super) struct DispatchState {
     executor: JobExecutor,
     config: WorkerConfig,
     draining: bool,
+    refused: bool,
 }
 
 impl DispatchState {
@@ -177,6 +188,7 @@ impl DispatchState {
             executor,
             config,
             draining: false,
+            refused: false,
         }
     }
 
@@ -261,7 +273,16 @@ impl DispatchState {
             ServerMessage::Error { code, message } => {
                 error!(code, %message, "protocol error from server");
             }
-            ServerMessage::InitAck { .. } | ServerMessage::Reject { .. } => {
+            // A post-handshake `Reject` is the server refusing this session -
+            // typically 496 while a zombie session still holds this worker's
+            // slot. The server closes right after, so end the loop and mark
+            // the session refused: the reconnect path must back off rather
+            // than retry at its floor delay.
+            ServerMessage::Reject { code, reason } => {
+                warn!(code, %reason, "server refused the session");
+                self.refused = true;
+            }
+            ServerMessage::InitAck { .. } => {
                 warn!("unexpected handshake message in dispatch loop - ignoring");
             }
             ServerMessage::AuthChallenge { peers } => {

--- a/backend/gradient-worker/src/worker/mod.rs
+++ b/backend/gradient-worker/src/worker/mod.rs
@@ -219,12 +219,10 @@ impl Worker<Connected> {
             _marker: PhantomData,
         };
 
-        let result = outcome.map(|drained| {
-            if drained {
-                RunOutcome::Drained
-            } else {
-                RunOutcome::CleanDisconnect
-            }
+        let result = outcome.map(|end| match end {
+            _ if end.draining => RunOutcome::Drained,
+            _ if end.refused => RunOutcome::Refused,
+            _ => RunOutcome::CleanDisconnect,
         });
 
         (disconnected, result)

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -2,6 +2,63 @@
 
 This page tracks notable tests added to Gradient and where they live.
 
+## Cache RPCs are chunked so a big eval cannot wedge the connection
+
+An evaluation of a large flake asked the server about its whole path set in one
+`CacheQuery` (37,640 paths, ~3 MB) whose `CacheStatus` reply was ~5.7 MB. A
+message that far exceeds the socket buffers leaves its sender blocked mid-write,
+and a peer that is itself blocked mid-write never returns to reading, so the
+connection wedged until a send timeout tore it down - and the evaluation was
+dispatched again, forever.
+
+`backend/gradient-worker/src/proto/job.rs`:
+`cache_query_splits_oversized_path_list_into_bounded_chunks` and
+`known_derivations_splits_oversized_path_list_into_bounded_chunks` drive a real
+WebSocket against `MockProtoServer`, assert every request stays within
+`CACHE_QUERY_MAX_PATHS`, and assert the per-chunk replies merge back into one
+answer covering each queried path in order.
+
+`backend/gradient-proto/src/session/frame.rs`:
+`a_full_cache_query_and_its_worst_case_reply_stay_inflight_safe` encodes a
+full-size query plus the largest reply it can provoke (every path uncached, each
+with a presigned upload URL) and holds both under `SAFE_INFLIGHT_MESSAGE_SIZE`,
+so raising the chunk bound cannot silently re-arm the deadlock.
+
+## A refused session backs off instead of storming
+
+After the wedge the server still held the worker's slot, so every reconnect was
+answered with `Reject` 496 ("worker already connected"). The worker logged it as
+an unexpected handshake message and retried about once a second, because
+completing a handshake reset the backoff to its floor.
+
+`backend/gradient-worker/src/reconnect.rs`:
+`refused_sessions_escalate_the_backoff` walks the delay from 1 s to the 60 s cap
+across repeated refusals, and `served_sessions_reset_the_backoff` confirms a
+session that actually ran starts the next attempt from the floor, so a plain
+network blip does not inherit a long delay.
+
+## An evaluation stops being re-dispatched forever
+
+Builds have an attempt budget; evaluations had none, so an evaluation whose
+worker vanished mid-run was re-queued indefinitely.
+
+`backend/gradient-scheduler/src/build/lifecycle.rs`:
+`an_eval_under_budget_is_requeued` keeps the ordinary single-disconnect case
+retrying, and `an_eval_that_spends_its_budget_stops_being_requeued` fails the
+evaluation once `MAX_EVAL_DISPATCH_ATTEMPTS` dispatches have each ended in a
+disconnect rather than a result.
+
+## `/live` channels release a client that walked away
+
+The live-update stream only wrote to its socket, so a closed browser tab was
+noticed only at the next event that failed to send. A quiet channel kept its
+task and file descriptor forever; production accumulated 258 CLOSE-WAIT sockets.
+
+`backend/gradient-web/tests/live_stream_disconnect.rs`:
+`live_stream_ends_when_the_client_disconnects` serves the real `live_stream`,
+connects a WebSocket client, drops it without ever publishing an event, and
+requires the server-side task to finish.
+
 ## NAR content is verified on commit (#482)
 
 `backend/gradient-storage/src/digest.rs`: `verify_nar_bytes` recomputes the


### PR DESCRIPTION
One `CacheQuery` carrying a whole eval's path set (37,640 paths, ~3 MB) and its ~5.7 MB reply exceeded the socket buffers, wedging both peers mid-write until a send timeout, after which the worker hammered the server's zombie-session `Reject` once a second and the eval was re-dispatched forever.

Chunks both cache RPCs, backs off refused sessions, caps eval dispatch attempts, and ends `/live` streams when the client disconnects (the CLOSE-WAIT fd leak).