### PR TITLE
Strip nix's repeated log tail; serve cache logs from upstreams

### DIFF
--- a/backend/gradient-scheduler/src/build/lifecycle.rs
+++ b/backend/gradient-scheduler/src/build/lifecycle.rs
@@ -399,13 +399,16 @@ pub async fn handle_build_job_failed(
     // frontend's log viewer renders it. Without this, pre-`nix build`
     // aborts (prefetch-time errors, daemon connection failures, etc.)
     // produce a Failed badge with an empty log - useless for diagnosis.
+    // Strip nix's repeated log tail here too: a worker older than this change
+    // still sends it, and those lines are already in the log above.
+    let banner = gradient_sources::strip_nix_log_tail(error);
     if let Some(attempt_id) = gradient_db::latest_attempt_id(&state.worker_db, anchor.id)
         .await
         .ok()
         .flatten()
         && let Err(e) = state
             .log_storage
-            .append(attempt_id, &format!("\n=== build failed: {error} ===\n"))
+            .append(attempt_id, &format!("\n=== build failed: {banner} ===\n"))
             .await
     {
         warn!(%derivation_build, error = %e, "failed to append worker error to build log");

--- a/backend/gradient-sources/src/build_log.rs
+++ b/backend/gradient-sources/src/build_log.rs
@@ -1,0 +1,134 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Post-processing for nix build-failure messages.
+
+/// Remove nix's post-failure log tail - the `Last N log lines:` header and the
+/// `>`-prefixed lines under it - from a build failure message.
+///
+/// Nix repeats the tail of the build log in the error it returns, so a failure
+/// surfaced in the build log shows those lines twice: once as they were
+/// streamed, once again inside the failure banner. Nix suppresses the tail
+/// itself when `log-lines` is `0`, but the daemon only honours that setting
+/// from a *trusted* client, so gradient cannot rely on it and strips the block
+/// instead.
+///
+/// Everything else is preserved verbatim, including the `Cannot build`/`Reason`
+/// lines above the tail and the `For full logs, run:` hint below it - with the
+/// cache's log endpoint serving `nix log`, that hint now works.
+pub fn strip_nix_log_tail(message: &str) -> String {
+    let mut out: Vec<&str> = Vec::new();
+    let mut in_tail = false;
+
+    for line in message.lines() {
+        if is_log_tail_header(line) {
+            in_tail = true;
+            continue;
+        }
+        if in_tail {
+            if line.trim_start().starts_with('>') {
+                continue;
+            }
+            in_tail = false;
+        }
+        out.push(line);
+    }
+
+    let mut stripped = out.join("\n");
+    if message.ends_with('\n') && !stripped.is_empty() {
+        stripped.push('\n');
+    }
+
+    stripped
+}
+
+/// Matches nix's `Last %d log lines:` header, which arrives indented when the
+/// message is nested inside another error.
+fn is_log_tail_header(line: &str) -> bool {
+    let line = line.trim();
+    let Some(rest) = line.strip_prefix("Last ") else {
+        return false;
+    };
+    let Some(count) = rest.strip_suffix(" log lines:") else {
+        return false;
+    };
+
+    !count.is_empty() && count.chars().all(|c| c.is_ascii_digit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The reported shape (#546): nix appends the tail of a log gradient has
+    /// already streamed line by line, so the failure banner repeats it.
+    #[test]
+    fn strips_the_tail_block_and_keeps_the_diagnosis() {
+        let message = "\
+Cannot build '/nix/store/1mpqffikzpszxw6zzi8s63a3srqd6swx-python3.14-ctranslate2-4.8.1.drv'.
+Reason: builder failed with exit code 1.
+Output paths:
+  /nix/store/d6ynvin99dw364i198n0k0jsfn0z53wh-python3.14-ctranslate2-4.8.1-dist
+Last 25 log lines:
+> running build_ext
+> building 'ctranslate2._ext' extension
+For full logs, run:
+  nix log /nix/store/1mpqffikzpszxw6zzi8s63a3srqd6swx-python3.14-ctranslate2-4.8.1.drv";
+
+        assert_eq!(
+            strip_nix_log_tail(message),
+            "\
+Cannot build '/nix/store/1mpqffikzpszxw6zzi8s63a3srqd6swx-python3.14-ctranslate2-4.8.1.drv'.
+Reason: builder failed with exit code 1.
+Output paths:
+  /nix/store/d6ynvin99dw364i198n0k0jsfn0z53wh-python3.14-ctranslate2-4.8.1-dist
+For full logs, run:
+  nix log /nix/store/1mpqffikzpszxw6zzi8s63a3srqd6swx-python3.14-ctranslate2-4.8.1.drv"
+        );
+    }
+
+    /// Nested errors arrive indented, and any line count is possible since
+    /// `log-lines` is configurable.
+    #[test]
+    fn strips_an_indented_header_with_any_line_count() {
+        let message = "       Last 3 log lines:\n       > one\n       > two\n       done";
+        assert_eq!(strip_nix_log_tail(message), "       done");
+    }
+
+    /// A quoted line that is part of the builder's own output, before any
+    /// header, is diagnosis - not the tail block.
+    #[test]
+    fn keeps_quoted_lines_that_precede_a_header() {
+        let message = "> not a tail line\nerror: build failed";
+        assert_eq!(strip_nix_log_tail(message), message);
+    }
+
+    /// A message without a tail block is passed through untouched, trailing
+    /// newline included.
+    #[test]
+    fn leaves_a_message_without_a_tail_untouched() {
+        let message = "error: hash mismatch in fixed-output derivation\n";
+        assert_eq!(strip_nix_log_tail(message), message);
+    }
+
+    /// A multi-build failure carries one block per failed build.
+    #[test]
+    fn strips_every_block_in_a_multi_build_failure() {
+        let message = "\
+first failure
+Last 2 log lines:
+> a
+> b
+second failure
+Last 1 log lines:
+> c
+tail end";
+        assert_eq!(
+            strip_nix_log_tail(message),
+            "first failure\nsecond failure\ntail end"
+        );
+    }
+}

--- a/backend/gradient-sources/src/lib.rs
+++ b/backend/gradient-sources/src/lib.rs
@@ -4,12 +4,14 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+pub mod build_log;
 pub mod cache_key;
 pub mod git;
 pub mod nar_path;
 pub mod secret;
 pub mod ssh_key;
 
+pub use self::build_log::strip_nix_log_tail;
 pub use self::cache_key::*;
 pub use self::git::{
     Libgit2Prefetcher, accept_cert, check_project_updates, fetch_options_with_ssh, get_commit_info,

--- a/backend/gradient-web/src/endpoints/caches/build_log.rs
+++ b/backend/gradient-web/src/endpoints/caches/build_log.rs
@@ -11,12 +11,18 @@ use axum::extract::{Path, State};
 use axum::http::{HeaderMap, HeaderValue, header};
 use axum::response::Response;
 use gradient_core::ServerState;
-use gradient_entity::build::BuildStatus;
 use gradient_sources::parse_drv_hash_name;
 use gradient_types::*;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use std::sync::Arc;
 
+/// `GET /cache/{cache}/log/{drv}` - the build log `nix log` asks a binary cache
+/// for.
+///
+/// Serves our own log when this cache holds the derivation, and otherwise asks
+/// the cache's upstreams: a pull-through cache substitutes paths it never built,
+/// and reporting those logs as missing is the whole of #547. `X-Cache` reports
+/// which of the two happened.
 pub async fn log(
     state: State<Arc<ServerState>>,
     OptionalPeer(peer): OptionalPeer,
@@ -26,8 +32,27 @@ pub async fn log(
     let client_ip = cache_client_ip(&state, &headers, peer);
     let ctx = CacheContext::load(&state, &headers, client_ip, cache).await?;
 
-    let Ok((drv_hash, drv_name)) = parse_drv_hash_name(&drv) else {
-        return Err(WebError::not_found("Log"));
+    if let Some(body) = local_log(&state, &ctx, &drv).await? {
+        return log_response(body, "HIT");
+    }
+
+    let upstreams = upstream_urls(&state, ctx.cache.id).await;
+    match fetch_log_from_upstreams(&state.http, &upstreams, &drv).await {
+        Some(body) => log_response(body, "MISS"),
+        None => Err(WebError::not_found("Log")),
+    }
+}
+
+/// This cache's own log for `drv`, if it holds the derivation and an attempt
+/// produced any output. Deliberately not restricted to successful builds - a
+/// failed build's log is the one most worth reading.
+async fn local_log(
+    state: &Arc<ServerState>,
+    ctx: &CacheContext,
+    drv: &str,
+) -> WebResult<Option<String>> {
+    let Ok((drv_hash, drv_name)) = parse_drv_hash_name(drv) else {
+        return Ok(None);
     };
 
     let Some(derivation_row) = EDerivation::find()
@@ -36,7 +61,7 @@ pub async fn log(
         .one(&state.web_db)
         .await?
     else {
-        return Err(WebError::not_found("Log"));
+        return Ok(None);
     };
 
     let linked = ECacheDerivation::find()
@@ -46,27 +71,76 @@ pub async fn log(
         .await?
         .is_some();
     if !linked {
-        return Err(WebError::not_found("Log"));
+        return Ok(None);
     }
 
     let Some(anchor) = EDerivationBuild::find()
         .filter(CDerivationBuild::Derivation.eq(derivation_row.id))
-        .filter(CDerivationBuild::Status.eq(BuildStatus::Completed))
         .one(&state.web_db)
         .await?
     else {
-        return Err(WebError::not_found("Log"));
+        return Ok(None);
     };
 
-    let body = match gradient_db::latest_attempt_id(&state.web_db, anchor.id).await? {
-        Some(key) => state.log_storage.read(key).await.unwrap_or_default(),
-        None => String::new(),
+    let Some(key) = gradient_db::latest_attempt_id(&state.web_db, anchor.id).await? else {
+        return Ok(None);
     };
 
+    Ok(state
+        .log_storage
+        .read(key)
+        .await
+        .ok()
+        .filter(|body| !body.is_empty()))
+}
+
+async fn upstream_urls(state: &Arc<ServerState>, cache: CacheId) -> Vec<String> {
+    ECacheUpstream::find()
+        .filter(CCacheUpstream::Cache.eq(cache))
+        .all(&state.web_db)
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|upstream| upstream.url)
+        .collect()
+}
+
+/// Ask each upstream in turn for `drv`'s build log and return the first hit.
+///
+/// Logs are plain text and carry no signature, so - unlike narinfos - there is
+/// nothing to verify; an upstream that 404s or errors is skipped.
+pub async fn fetch_log_from_upstreams(
+    client: &reqwest::Client,
+    upstreams: &[String],
+    drv: &str,
+) -> Option<String> {
+    for base_url in upstreams {
+        let url = format!("{}/log/{}", base_url.trim_end_matches('/'), drv);
+        let Ok(response) = client.get(&url).send().await else {
+            continue;
+        };
+        if !response.status().is_success() {
+            continue;
+        }
+        match response.text().await {
+            Ok(body) if !body.is_empty() => return Some(body),
+            _ => continue,
+        }
+    }
+
+    None
+}
+
+fn log_response(body: String, cache_status: &'static str) -> WebResult<Response> {
     Response::builder()
         .header(
             header::CONTENT_TYPE,
             HeaderValue::from_static("text/plain; charset=utf-8"),
+        )
+        .header("x-cache", HeaderValue::from_static(cache_status))
+        .header(
+            header::ACCESS_CONTROL_ALLOW_ORIGIN,
+            HeaderValue::from_static("*"),
         )
         .body(Body::from(body))
         .map_err(|e| WebError::internal(format!("Failed to build response: {}", e)))

--- a/backend/gradient-web/src/endpoints/caches/mod.rs
+++ b/backend/gradient-web/src/endpoints/caches/mod.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-mod build_log;
+pub mod build_log;
 mod helpers;
 mod keys;
 mod management;
@@ -19,7 +19,7 @@ mod serve;
 mod upload;
 mod upstreams;
 
-pub use self::build_log::log;
+pub use self::build_log::{fetch_log_from_upstreams, log};
 pub use self::keys::{get_cache_key, get_cache_public_key};
 pub use self::management::{
     delete_cache, delete_cache_active, delete_cache_public, get, get_cache,

--- a/backend/gradient-web/tests/cache_log_upstream.rs
+++ b/backend/gradient-web/tests/cache_log_upstream.rs
@@ -1,0 +1,91 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! A pull-through cache must serve build logs it does not hold itself (#547).
+//!
+//! Paths substituted from an upstream have no gradient build behind them, so
+//! `nix log` against such a cache reported the log as missing. The cache now
+//! asks its upstreams, in configured order, and serves the first hit.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use axum::Router;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::routing::get;
+use gradient_web::endpoints::caches::fetch_log_from_upstreams;
+use tokio::net::TcpListener;
+
+/// An upstream that answers `/log/{drv}` with `body`, or 404 when `body` is
+/// `None`, counting the requests it received.
+async fn upstream(body: Option<&'static str>) -> (String, Arc<AtomicUsize>) {
+    let hits = Arc::new(AtomicUsize::new(0));
+    let app = Router::new()
+        .route(
+            "/log/{drv}",
+            get(
+                |State((body, hits)): State<(Option<&'static str>, Arc<AtomicUsize>)>,
+                 Path(_drv): Path<String>| async move {
+                    hits.fetch_add(1, Ordering::SeqCst);
+                    match body {
+                        Some(b) => (StatusCode::OK, b),
+                        None => (StatusCode::NOT_FOUND, ""),
+                    }
+                },
+            ),
+        )
+        .with_state((body, Arc::clone(&hits)));
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    (format!("http://{addr}"), hits)
+}
+
+const DRV: &str = "1mpqffikzpszxw6zzi8s63a3srqd6swx-python3.14-ctranslate2-4.8.1.drv";
+
+#[tokio::test]
+async fn serves_the_log_from_the_first_upstream_that_has_it() {
+    let (without, without_hits) = upstream(None).await;
+    let (with, with_hits) = upstream(Some("@nix { \"action\": \"setPhase\" }\nbuilding\n")).await;
+
+    let log = fetch_log_from_upstreams(&reqwest::Client::new(), &[without, with], DRV).await;
+
+    assert_eq!(
+        log.as_deref(),
+        Some("@nix { \"action\": \"setPhase\" }\nbuilding\n")
+    );
+    assert_eq!(
+        without_hits.load(Ordering::SeqCst),
+        1,
+        "the first upstream must be asked before falling through"
+    );
+    assert_eq!(with_hits.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn reports_no_log_when_no_upstream_has_one() {
+    let (first, _) = upstream(None).await;
+    let (second, _) = upstream(None).await;
+
+    assert_eq!(
+        fetch_log_from_upstreams(&reqwest::Client::new(), &[first, second], DRV).await,
+        None
+    );
+}
+
+/// A trailing slash on a configured upstream must not produce `//log/...`.
+#[tokio::test]
+async fn normalizes_a_trailing_slash_on_the_upstream_url() {
+    let (base, hits) = upstream(Some("log body")).await;
+
+    let log = fetch_log_from_upstreams(&reqwest::Client::new(), &[format!("{base}/")], DRV).await;
+
+    assert_eq!(log.as_deref(), Some("log body"));
+    assert_eq!(hits.load(Ordering::SeqCst), 1);
+}

--- a/backend/gradient-worker/src/executor/build.rs
+++ b/backend/gradient-worker/src/executor/build.rs
@@ -246,9 +246,13 @@ impl ParsedDerivation {
                 let msg = String::from_utf8_lossy(&f.error_msg).to_string();
                 warn!(drv = %drv_path, error = %msg, "build failed");
                 let kind = classify_build_error(&msg);
+                // The daemon repeats the tail of the log we just streamed; drop
+                // it so the failure banner doesn't duplicate those lines. No
+                // "build failed" prefix either - the server's banner already
+                // says so, and the daemon's message opens with "Cannot build".
                 Err(BuildError::new(
                     kind,
-                    anyhow::anyhow!("build failed: {}", msg),
+                    anyhow::anyhow!("{}", gradient_sources::strip_nix_log_tail(&msg)),
                 ))
             }
         }

--- a/backend/gradient-worker/src/executor/eval.rs
+++ b/backend/gradient-worker/src/executor/eval.rs
@@ -58,12 +58,19 @@ impl std::fmt::Display for CorruptEvalCache {
 }
 impl std::error::Error for CorruptEvalCache {}
 
-/// Whether `msg` is the SQLite-corruption signature of a poisoned eval-cache
-/// blob. The evaluator opens no other SQLite, so these phrases unambiguously
-/// mean "discard and re-evaluate", never a real flake error.
+/// Whether `msg` is the SQLite signature of a poisoned eval-cache blob.
+///
+/// Corruption has two shapes. A damaged file reports "malformed" or "not a
+/// database"; a file that was truncated or never finished being written is a
+/// perfectly valid, *empty* database whose tables simply do not exist, and
+/// reports a missing table instead. Both are unreadable and both must be
+/// discarded - the caller additionally requires the message to name our own
+/// blob, so nothing else's SQLite is ever swept up.
 fn is_corrupt_eval_cache_error(msg: &str) -> bool {
     let m = msg.to_ascii_lowercase();
-    m.contains("database disk image is malformed") || m.contains("file is not a database")
+    m.contains("database disk image is malformed")
+        || m.contains("file is not a database")
+        || m.contains("no such table")
 }
 
 /// The eval-cache blob fingerprint embedded in a corruption error, extracted
@@ -1034,6 +1041,39 @@ mod tests {
         assert!(
             corrupt_eval_cache("database disk image is malformed (in '/tmp/other.sqlite')")
                 .is_none()
+        );
+    }
+
+    /// A blob that is structurally empty - a valid SQLite file that never got
+    /// its schema, from a truncated write or an interrupted pull - fails with
+    /// a missing-table error rather than a corruption phrase. It is just as
+    /// poisonous: every evaluation sharing the blob dies on it, and until it
+    /// is classified as corrupt nothing purges it, so re-evaluating (including
+    /// `.drv` recovery) hits the identical wall forever.
+    #[test]
+    fn corrupt_eval_cache_detects_a_blob_with_no_schema() {
+        let fp = "fcafabf48d74fdfcd38e0c9d903fe9caa423e4ba9404fe07f5a1a8a5d2ab0253";
+        let msg = format!(
+            "failed to evaluate 'packages': Evaluation error: [nix::SQLiteError] executing SQLite \
+             query 'select rowid, type, value, context from Attributes where parent = 0 and name \
+             = '': SQL logic error, no such table: Attributes \
+             (in '/var/lib/gradient-worker/eval-cache/eval-cache-v6/{fp}.sqlite')"
+        );
+
+        assert!(is_corrupt_eval_cache_error(&msg));
+        assert_eq!(corrupt_eval_cache(&msg).unwrap().fingerprint, fp);
+    }
+
+    /// The same missing-table error against any other SQLite file is somebody
+    /// else's problem - the path is what makes it ours to heal.
+    #[test]
+    fn a_missing_table_outside_the_eval_cache_is_not_healed() {
+        assert!(
+            corrupt_eval_cache(
+                "[nix::SQLiteError] ...: SQL logic error, no such table: Attributes \
+                 (in '/nix/var/nix/db/db.sqlite')"
+            )
+            .is_none()
         );
     }
 

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -6172,7 +6172,7 @@ paths:
       |---|---|
       | `GET /cache/{cache}/ls/{hash}` | JSON tree listing of the NAR (nix-serve `.ls` v1 schema). Rate-limited at 60 req/min. |
       | `GET /cache/{cache}/serve/{hash}/{path}` | Extract a single file (bytes, Content-Type sniffed) or directory (tar.zst) from a NAR. Rate-limited at 60 req/min. |
-      | `GET /cache/{cache}/log/{drv}` | Build log for `<drv>.drv`, from either locally-built or upstream-substituted builds (substituter compat - `nix log`). Rate-limited at ~300 req/min. |
+      | `GET /cache/{cache}/log/{drv}` | Build log for `<drv>.drv` (substituter compat - `nix log`). Serves this cache's own log for any build that produced one, successful or failed; otherwise asks the cache's upstreams in order and proxies the first hit, so a pull-through cache exposes logs for paths it substituted rather than built. `X-Cache: HIT` (ours) or `MISS` (upstream). Rate-limited at ~300 req/min. |
 
   /metrics/catalog:
     get:

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -2,6 +2,37 @@
 
 This page tracks notable tests added to Gradient and where they live.
 
+## Nix's repeated log tail is stripped from failures (#546)
+
+On failure nix appends the last `log-lines` (25 by default) lines of the build
+log to its error message, which gradient then wrote into the build log - so the
+UI showed those lines twice, once as streamed and once inside the failure
+banner. Nix omits the block when `log-lines` is `0`, but the daemon only honours
+that setting from a trusted client, so gradient strips it instead.
+
+`backend/gradient-sources/src/build_log.rs`: `strip_nix_log_tail` is covered by
+`strips_the_tail_block_and_keeps_the_diagnosis` (the reported message, keeping
+`Cannot build` / `Reason` / `Output paths` and the `For full logs, run:` hint),
+`strips_an_indented_header_with_any_line_count` (nested errors arrive indented
+and the count is configurable), `keeps_quoted_lines_that_precede_a_header` (a
+`>` line that is the builder's own output is diagnosis, not the tail),
+`leaves_a_message_without_a_tail_untouched`, and
+`strips_every_block_in_a_multi_build_failure`.
+
+## A pull-through cache exposes build logs (#547)
+
+`nix log` against a gradient cache reported the log as missing for any path the
+cache had substituted rather than built, because the endpoint only served
+locally-built derivations.
+
+`backend/gradient-web/tests/cache_log_upstream.rs`:
+`serves_the_log_from_the_first_upstream_that_has_it` runs two real upstream HTTP
+servers - the first 404s, the second holds the log - and asserts both are asked
+in order and the second's body is returned;
+`reports_no_log_when_no_upstream_has_one` keeps the 404 path honest; and
+`normalizes_a_trailing_slash_on_the_upstream_url` guards the `//log/...` URL
+that a trailing slash in an upstream's configured URL would otherwise produce.
+
 ## Cache RPCs are chunked so a big eval cannot wedge the connection
 
 An evaluation of a large flake asked the server about its whole path set in one

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -2,6 +2,23 @@
 
 This page tracks notable tests added to Gradient and where they live.
 
+## An empty eval-cache blob is corrupt too
+
+The self-heal recognised a *damaged* blob ("malformed", "not a database") but
+not an empty one: a truncated or never-finished write leaves a valid SQLite
+file with no schema (4096 bytes - one page, header only), which fails as `SQL
+logic error, no such table: Attributes`. Unclassified, it was never purged, so
+every evaluation sharing the blob died on it and `.drv` recovery re-evaluated
+straight back into the same wall - the evaluation looked like it was recovering
+while nothing was repaired.
+
+`backend/gradient-worker/src/executor/eval.rs`:
+`corrupt_eval_cache_detects_a_blob_with_no_schema` uses the production error
+verbatim and requires both the classification and the fingerprint extraction,
+while `a_missing_table_outside_the_eval_cache_is_not_healed` keeps the path
+requirement honest - the same SQLite error against `/nix/var/nix/db/db.sqlite`
+is not ours to purge.
+
 ## Nix's repeated log tail is stripped from failures (#546)
 
 On failure nix appends the last `log-lines` (25 by default) lines of the build

--- a/docs/src/usage/api.md
+++ b/docs/src/usage/api.md
@@ -347,6 +347,8 @@ Private caches require HTTP Basic Auth (any username, JWT or API key as password
 
 The inspection endpoints (`/ls`, `/serve`) are rate-limited at 60 req/min. The `/log` endpoint is rate-limited at ~300 req/min on its own tier. All endpoints return `404` when the hash or derivation is unknown.
 
+`/log` serves this cache's own log whenever a build produced one - a failed build's log included, since that is the one worth reading. When the cache has no log of its own, which is the normal case for a path it substituted rather than built, it asks its upstreams in configured order and proxies the first that answers. The response carries `X-Cache: HIT` for our own log and `MISS` for an upstream's, so `nix log` works against a pull-through cache.
+
 ## Example: Trigger an Evaluation
 
 ```sh


### PR DESCRIPTION
Closes #546, closes #547.

Nix repeats the last 25 log lines in its failure message, so the build log showed them twice - `log-lines = 0` only works for trusted daemon clients, so gradient strips the block instead. The cache's `/log/{drv}` now also serves failed builds and falls back to the cache's upstreams, so `nix log` works for paths a pull-through cache substituted rather than built.