### PR TITLE
Converge .drv closure flags per eval; stop condemning evals over an unconverged flag

### DIFF
--- a/backend/gradient-db/src/cache_storage.rs
+++ b/backend/gradient-db/src/cache_storage.rs
@@ -483,9 +483,13 @@ pub(crate) const CACHED_PATH_CLOSURE_COMPLETE_GATE: &str = r#"
 "#;
 
 /// Prelude CTE and `cp` membership filter bounding the `cached_path` fixpoint to
-/// one eval's output NAR-reference closure. `None` yields empty fragments (the
-/// global full-table `Deep` backstop); `Some` seeds `eval_paths` from the eval's
-/// `build_job` output hashes and walks `cached_path_reference` toward references,
+/// one eval's NAR-reference closure. `None` yields empty fragments (the global
+/// full-table `Deep` backstop); `Some` seeds `eval_paths` from the eval's
+/// `build_job` output hashes **and its targets' own `.drv` hashes** - a `.drv` is
+/// keyed by `derivation.hash` and is never a `derivation_output.hash`, so
+/// seeding from outputs alone put every `.drv` row outside the bound, leaving the
+/// flag the dispatch gate reads settable only by the rare `Deep` pass - and walks
+/// `cached_path_reference` toward references,
 /// so the bound is closed under the reference relation and the SET pass still
 /// converges leaves-first within it. Eval id binds as `$1`.
 fn cached_path_eval_scope_fragments(
@@ -497,6 +501,10 @@ fn cached_path_eval_scope_fragments(
             "WITH RECURSIVE eval_paths(hash) AS ( \
                  SELECT DISTINCT o.hash FROM derivation_output o \
                  JOIN build_job bj ON bj.derivation = o.derivation \
+                 WHERE bj.evaluation = $1 \
+               UNION \
+                 SELECT DISTINCT d.hash FROM derivation d \
+                 JOIN build_job bj ON bj.derivation = d.id \
                  WHERE bj.evaluation = $1 \
                UNION \
                  SELECT r.reference_hash FROM cached_path_reference r \
@@ -1005,6 +1013,29 @@ mod tests {
             assert!(
                 stmt.contains("cp.hash IN (SELECT hash FROM eval_paths)"),
                 "restricts the UPDATE to that closure: {stmt}"
+            );
+        }
+    }
+
+    /// The scope must also seed the eval's own `.drv` paths. A build target's
+    /// `.drv` is keyed by `derivation.hash` and is never a
+    /// `derivation_output.hash`, so seeding from outputs alone left every `.drv`
+    /// row outside the filter - unreachable by `Eval`/`Unstick`, and settable
+    /// only by the rare global `Deep` pass. The dispatch gate
+    /// (`drv_nar_closure_complete_predicate`) reads exactly those rows, so the
+    /// flag it depends on never converged: anchors stayed undispatchable, the
+    /// graph-stuck heal called `Unstick` forever, and `DrvRecovery` eventually
+    /// failed the evaluation outright.
+    #[test]
+    fn cached_path_closure_scope_seeds_the_evals_own_drv_paths() {
+        let eval = gradient_types::EvaluationId::now_v7();
+        let (clear, set) = cached_path_closure_statements(Some(eval));
+        for stmt in [&clear, &set] {
+            assert!(
+                stmt.contains("FROM derivation d")
+                    && stmt.contains("bj.derivation = d.id")
+                    && stmt.contains("SELECT d.hash"),
+                "seeds the eval's .drv hashes alongside its output hashes: {stmt}"
             );
         }
     }

--- a/backend/gradient-db/src/graph_sql.rs
+++ b/backend/gradient-db/src/graph_sql.rs
@@ -94,6 +94,23 @@ pub fn drv_nar_closure_complete_predicate(alias: &str) -> String {
     )
 }
 
+/// The build target `{alias}`'s own `.drv` NAR is not in our cache at all: no
+/// `cached_path` row, or a row with no backing NAR. This is the only `.drv`
+/// state a fresh evaluation repairs - it re-materialises and re-uploads the
+/// `.drv`. Deliberately narrower than
+/// `NOT drv_nar_closure_complete_predicate`, which is also true for a `.drv`
+/// that is present and merely has an unconverged closure flag; re-evaluating
+/// cannot set a flag, so conflating the two burned an evaluation per stall and
+/// then failed it as unrecoverable with the `.drv` cached the whole time.
+pub fn drv_nar_absent_predicate(alias: &str) -> String {
+    format!(
+        r#"NOT EXISTS (
+        SELECT 1 FROM derivation d
+        JOIN cached_path cp ON cp.hash = d.hash
+        WHERE d.id = {alias}.derivation AND cp.file_hash IS NOT NULL)"#
+    )
+}
+
 /// Closure of the derivations an evaluation directly references (its
 /// `build_job` rows), walking toward dependencies. Binds the evaluation id as
 /// `$1`. Shared by every per-eval sweep so they all see the same closure.

--- a/backend/gradient-forge/src/reporter.rs
+++ b/backend/gradient-forge/src/reporter.rs
@@ -1980,11 +1980,10 @@ pub fn parse_owner_repo(repository_url: &str) -> Option<(String, String)> {
     {
         // https://host/owner/repo.git → "host/owner/repo.git" → take after first '/'
         rest.split_once('/')?.1
-    } else if let Some(colon_pos) = url.find(':') {
-        // git@host:owner/repo.git
-        &url[colon_pos + 1..]
     } else {
-        return None;
+        // git@host:owner/repo.git
+        let colon_pos = url.find(':')?;
+        &url[colon_pos + 1..]
     };
 
     let path = path.trim_end_matches(".git");

--- a/backend/gradient-forge/src/webhook.rs
+++ b/backend/gradient-forge/src/webhook.rs
@@ -443,10 +443,9 @@ pub fn decode_push_commit(git_ref: &str, after: &str, forge: &str) -> Option<Pus
     }
     let (ref_name, is_tag) = if let Some(branch) = git_ref.strip_prefix("refs/heads/") {
         (branch.to_string(), false)
-    } else if let Some(tag) = git_ref.strip_prefix("refs/tags/") {
-        (tag.to_string(), true)
     } else {
-        return None;
+        let tag = git_ref.strip_prefix("refs/tags/")?;
+        (tag.to_string(), true)
     };
     match hex::decode(after) {
         Ok(hash) => Some(PushCommit {

--- a/backend/gradient-scheduler/src/waiting_state.rs
+++ b/backend/gradient-scheduler/src/waiting_state.rs
@@ -380,6 +380,7 @@ async fn eval_blocked_on_unproducible_drv(
 fn unproducible_drv_block_sql() -> String {
     let deps_ready = gradient_db::graph_sql::deps_ready_predicate("db");
     let drv_nar_closure = gradient_db::graph_sql::drv_nar_closure_complete_predicate("db");
+    let drv_nar_absent = gradient_db::graph_sql::drv_nar_absent_predicate("db");
     format!(
         r#"
         SELECT EXISTS (
@@ -392,6 +393,7 @@ fn unproducible_drv_block_sql() -> String {
               AND NOT db.substitutable
               AND NOT db.drv_closure_cached
               AND NOT {drv_nar_closure}
+              AND {drv_nar_absent}
               AND ({deps_ready})
         ) AS blocked
         "#,
@@ -574,6 +576,26 @@ mod tests {
         assert!(
             sql.contains("cached_path cp") && sql.contains("derivation_input_source"),
             "must embed the deps-ready predicate (all build deps and sources cached): {sql}"
+        );
+    }
+
+    /// Only a genuinely absent `.drv` NAR justifies condemning an evaluation.
+    ///
+    /// The closure flags are also false while a present `.drv` simply has not
+    /// converged, and re-evaluating cannot fix a flag - so keying on them alone
+    /// burned an eval per stall and then failed it one-shot as "unrecoverable"
+    /// with the `.drv` sitting in the cache the whole time. The block now
+    /// additionally requires that no backed `cached_path` row exists for the
+    /// `.drv`, which is the state a fresh evaluation actually repairs.
+    #[test]
+    fn unproducible_drv_block_requires_the_drv_nar_to_be_absent() {
+        let norm = |s: String| s.split_whitespace().collect::<Vec<_>>().join(" ");
+        let sql = norm(unproducible_drv_block_sql());
+        assert!(
+            sql.contains(&norm(gradient_db::graph_sql::drv_nar_absent_predicate(
+                "db"
+            ))),
+            "must require the .drv's own NAR to be missing, not merely unconverged: {sql}"
         );
     }
 

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -6825,3 +6825,39 @@ before falling back to `Permanent`.
 - `genuine_build_errors_stay_permanent` - a link error, a failing test suite
   and a make failure stay terminal, so broken derivations are not retried until
   their attempt budget runs out.
+
+## `.drv` paths converge inside the per-eval closure fixpoint
+
+`cached_path_eval_scope_fragments` seeded `eval_paths` from `derivation_output`
+hashes only. A build target's own `.drv` is keyed by `derivation.hash` and is
+never a `derivation_output.hash`, so every `.drv` row sat outside the
+`cp.hash IN (SELECT hash FROM eval_paths)` bound and no `Eval`/`Unstick` pass
+could ever set its `closure_complete`. The dispatch gate
+(`drv_nar_closure_complete_predicate`) reads exactly those rows, so anchors
+stayed undispatchable, the graph-stuck heal called `Unstick` every ~30 s
+without effect, and `DrvRecovery` eventually failed the evaluation with the
+`.drv` present in the cache the whole time. Measured against production: for one
+stuck eval the old seed covered 0 `.drv` paths, the new one 36,730.
+
+`backend/gradient-db/src/cache_storage.rs`:
+- `cached_path_closure_scope_seeds_the_evals_own_drv_paths` - the scoped CLEAR
+  and SET both seed the eval's `.drv` hashes alongside its output hashes.
+- `cached_path_closure_fixpoint_scopes_to_one_eval` - unchanged guarantees: the
+  global pass stays full-table, the scoped pass still walks the reference
+  closure and still restricts the `UPDATE` to it. The recursive term stays last
+  in the `UNION` chain, as PostgreSQL requires of a self-referencing CTE.
+
+## Only a genuinely missing `.drv` condemns an evaluation
+
+`eval_blocked_on_unproducible_drv` keyed on the closure flags alone, which are
+equally false while a present `.drv` merely has an unconverged flag.
+Re-evaluation cannot set a flag, so the scheduler burned an evaluation per stall
+and then failed it one-shot as unrecoverable. The block now also requires
+`drv_nar_absent_predicate`: no `cached_path` row for the `.drv`, or one with no
+backing NAR - the only state a fresh evaluation repairs.
+
+`backend/gradient-scheduler/src/waiting_state.rs`:
+- `unproducible_drv_block_requires_the_drv_nar_to_be_absent` - the emitted SQL
+  embeds the absent-NAR predicate.
+- `unproducible_drv_block_sql_shape` - the existing gate fragments are retained
+  alongside it.


### PR DESCRIPTION
The per-eval closure fixpoint seeded only from output hashes, so `.drv` rows were never reachable by Eval/Unstick and the flag the dispatch gate reads could only be set by the rare Deep pass: anchors stayed undispatchable, the graph-stuck heal looped every ~30s, and DrvRecovery failed the eval with the `.drv` cached the whole time. Measured on prod, one stuck eval's scope covered 0 `.drv` paths before and 36,730 after.