### PR TITLE
web: create projects at the server keep_evaluations maximum

### DIFF
--- a/backend/gradient-core/src/lib.rs
+++ b/backend/gradient-core/src/lib.rs
@@ -85,8 +85,7 @@ pub async fn init_state(cli: Cli) -> Result<Arc<ServerState>, InitError> {
     let oidc_group_roles = Arc::new(state_result.oidc_group_roles);
     let scim_group_roles = Arc::new(state_result.scim_group_roles);
 
-    if cli.storage.keep_evaluations > 0 {
-        let max = cli.storage.keep_evaluations as i32;
+    if let Some(max) = cli.storage.keep_evaluations_max() {
         let over_limit = EProject::find()
             .filter(CProject::KeepEvaluations.gt(max))
             .all(&db)

--- a/backend/gradient-types/src/cli/mod.rs
+++ b/backend/gradient-types/src/cli/mod.rs
@@ -43,4 +43,4 @@ pub use s3::S3Args;
 pub use scim::ScimArgs;
 pub use secrets::SecretsArgs;
 pub use server::{CreatePermission, ServerArgs};
-pub use storage::StorageArgs;
+pub use storage::{DEFAULT_KEEP_EVALUATIONS, StorageArgs};

--- a/backend/gradient-types/src/cli/storage.rs
+++ b/backend/gradient-types/src/cli/storage.rs
@@ -6,6 +6,10 @@
 
 use clap::Args;
 
+/// Evaluations a freshly created project keeps, before the instance-wide
+/// maximum is applied. Also the default for that maximum.
+pub const DEFAULT_KEEP_EVALUATIONS: i32 = 30;
+
 #[derive(Args, Debug, Clone)]
 pub struct StorageArgs {
     #[arg(long, env = "GRADIENT_STORE_PATH")]
@@ -22,7 +26,14 @@ pub struct StorageArgs {
     pub validate_state: bool,
     #[arg(long, env = "GRADIENT_DELETE_STATE", default_value = "true")]
     pub delete_state: bool,
-    #[arg(long, env = "GRADIENT_KEEP_EVALUATIONS", default_value = "30")]
+    /// Instance-wide maximum for a project's `keep_evaluations`. New projects
+    /// start at the lower of [`DEFAULT_KEEP_EVALUATIONS`] and this. `0` disables
+    /// the cap.
+    #[arg(
+        long,
+        env = "GRADIENT_KEEP_EVALUATIONS",
+        default_value_t = DEFAULT_KEEP_EVALUATIONS as usize
+    )]
     pub keep_evaluations: usize,
     /// TTL in hours for cached NAR files that have not been fetched recently.
     /// When expired the NAR is removed from storage and its GC root is deleted.
@@ -125,7 +136,7 @@ impl Default for StorageArgs {
             state_file: None,
             validate_state: false,
             delete_state: true,
-            keep_evaluations: 30,
+            keep_evaluations: DEFAULT_KEEP_EVALUATIONS as usize,
             nar_ttl_hours: 336,
             keep_orphan_derivations_hours: 24,
             nar_upload_grace_hours: 24,
@@ -140,5 +151,76 @@ impl Default for StorageArgs {
             debug_index_interval_secs: 300,
             nar_verify_digest: false,
         }
+    }
+}
+
+impl StorageArgs {
+    /// The ceiling on a project's `keep_evaluations`, or `None` when the cap is
+    /// disabled. Saturates rather than wrapping: a configured value past
+    /// `i32::MAX` would otherwise become a negative ceiling that rejects
+    /// everything.
+    pub fn keep_evaluations_max(&self) -> Option<i32> {
+        match self.keep_evaluations {
+            0 => None,
+            max => Some(i32::try_from(max).unwrap_or(i32::MAX)),
+        }
+    }
+
+    /// `keep_evaluations` for a freshly created project. Creating a project
+    /// above the ceiling would leave it unsaveable: the frontend sends the whole
+    /// form back and the value it was handed fails validation (#561).
+    pub fn default_keep_evaluations(&self) -> i32 {
+        match self.keep_evaluations_max() {
+            Some(max) => DEFAULT_KEEP_EVALUATIONS.min(max),
+            None => DEFAULT_KEEP_EVALUATIONS,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(keep_evaluations: usize) -> StorageArgs {
+        StorageArgs {
+            keep_evaluations,
+            ..Default::default()
+        }
+    }
+
+    /// The reported bug: with a maximum below the default, a new project was
+    /// still handed the default and every subsequent save was rejected.
+    #[test]
+    fn a_new_project_never_starts_above_the_maximum() {
+        assert_eq!(args(3).default_keep_evaluations(), 3);
+        assert_eq!(args(1).default_keep_evaluations(), 1);
+    }
+
+    /// A maximum above the default raises the ceiling, not the starting point -
+    /// the setting is documented as a cap, not a target.
+    #[test]
+    fn a_higher_maximum_leaves_the_default_alone() {
+        assert_eq!(
+            args(100).default_keep_evaluations(),
+            DEFAULT_KEEP_EVALUATIONS
+        );
+        assert_eq!(args(100).keep_evaluations_max(), Some(100));
+    }
+
+    #[test]
+    fn zero_disables_the_cap() {
+        assert_eq!(args(0).keep_evaluations_max(), None);
+        assert_eq!(args(0).default_keep_evaluations(), DEFAULT_KEEP_EVALUATIONS);
+    }
+
+    /// A maximum past `i32::MAX` must saturate: `as i32` would wrap negative and
+    /// the cap check would then reject every value.
+    #[test]
+    fn an_out_of_range_maximum_saturates() {
+        assert_eq!(args(usize::MAX).keep_evaluations_max(), Some(i32::MAX));
+        assert_eq!(
+            args(usize::MAX).default_keep_evaluations(),
+            DEFAULT_KEEP_EVALUATIONS
+        );
     }
 }

--- a/backend/gradient-web/src/endpoints/build_requests/dispatch.rs
+++ b/backend/gradient-web/src/endpoints/build_requests/dispatch.rs
@@ -217,7 +217,13 @@ pub(super) async fn finalize_build_request(
 
     let cached_path = ensure_cached_path(&tx, nar).await?;
     queue_signature_placeholders(&tx, &cached_path, &organization).await?;
-    let project = ensure_build_request_project(&tx, organization, user.id).await?;
+    let project = ensure_build_request_project(
+        &tx,
+        organization,
+        user.id,
+        state.config.storage.default_keep_evaluations(),
+    )
+    .await?;
 
     let target = target
         .map(|t| t.trim().to_string())
@@ -419,6 +425,7 @@ async fn ensure_build_request_project<C: ConnectionTrait>(
     tx: &C,
     org_id: gradient_types::ids::OrganizationId,
     user_id: gradient_types::ids::UserId,
+    keep_evaluations: i32,
 ) -> WebResult<gradient_entity::project::Model> {
     if let Some(existing) = EProject::find()
         .filter(
@@ -445,7 +452,7 @@ async fn ensure_build_request_project<C: ConnectionTrait>(
         created_by: user_id,
         created_at: now(),
         managed: true,
-        keep_evaluations: 30,
+        keep_evaluations,
         concurrency: ConcurrencyPolicy::SoftAbort,
         sign_cache: true,
         ..Default::default()

--- a/backend/gradient-web/src/endpoints/projects/management.rs
+++ b/backend/gradient-web/src/endpoints/projects/management.rs
@@ -248,7 +248,7 @@ pub async fn put(
         last_check_at: *NULL_TIME,
         created_by: user.id,
         created_at: gradient_types::now(),
-        keep_evaluations: 30,
+        keep_evaluations: state.config.storage.default_keep_evaluations(),
         concurrency: body.concurrency.unwrap_or(ConcurrencyPolicy::SoftAbort),
         sign_cache: body.sign_cache.unwrap_or(true),
         ..Default::default()
@@ -487,8 +487,9 @@ impl<'a> ProjectPatcher<'a> {
                 "keep_evaluations must be at least 1".to_string(),
             ));
         }
-        let global_max = self.state.config.storage.keep_evaluations as i32;
-        if global_max > 0 && keep > global_max {
+        if let Some(global_max) = self.state.config.storage.keep_evaluations_max()
+            && keep > global_max
+        {
             return Err(WebError::bad_request(format!(
                 "keep_evaluations cannot exceed the server maximum of {}",
                 global_max

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -8078,7 +8078,10 @@ components:
         keep_evaluations:
           type: integer
           minimum: 1
-          description: Number of completed evaluations to retain for metrics and history
+          description: >-
+            Number of completed evaluations to retain for metrics and history.
+            Rejected with `400` when it exceeds `GRADIENT_KEEP_EVALUATIONS`, the
+            instance-wide maximum.
         concurrency:
           $ref: '#/components/schemas/ConcurrencyPolicy'
         sign_cache:
@@ -8111,7 +8114,10 @@ components:
           type: boolean
         keep_evaluations:
           type: integer
-          description: Number of completed evaluations retained for metrics and history
+          description: >-
+            Number of completed evaluations retained for metrics and history. A
+            new project starts at the lower of 30 and the instance-wide maximum
+            (`GRADIENT_KEEP_EVALUATIONS`).
         concurrency:
           $ref: '#/components/schemas/ConcurrencyPolicy'
         sign_cache:

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -55,7 +55,7 @@ openssl rand -base64 48 > /run/secrets/gradient-crypt
 | `settings.sentryDsn` | `null` | Override the Sentry DSN used when `reportErrors` is true. `null` ships reports to the upstream Wavelens instance at `reports.wavelens.io`; set your own DSN to keep reports in-house. (`GRADIENT_SENTRY_DSN`) |
 | `discoverable` | `true` | Accept incoming `/proto` WebSocket connections from workers |
 | `settings.maxProtoConnections` | `256` | Max simultaneous worker WebSocket connections; further upgrades return `503 Service Unavailable` with `Retry-After: 10` until a slot frees |
-| `settings.keepEvaluations` | `30` | Global maximum of evaluations kept per project (caps the per-project setting) |
+| `settings.keepEvaluations` | `30` | Global maximum of evaluations kept per project. Caps the per-project setting, and a new project starts at the lower of `30` and this. `0` disables the cap. (`GRADIENT_KEEP_EVALUATIONS`) |
 | `settings.logChunkBytes` | `262144` (256 KiB) | Target uncompressed size for each zstd build-log chunk written on finalize. Chunks split on line boundaries, so an over-long line may exceed this. (`GRADIENT_LOG_CHUNK_BYTES`) |
 | `settings.maxStorageGb` | `0` | Instance-wide cap on total cached NAR storage, in GB. When all writable caches for an org have less than 10 MiB headroom, new evaluations park in `Waiting`. `0` = unlimited; per-cache `max_storage_gb` limits still apply. (`GRADIENT_MAX_STORAGE_GB`) |
 | `settings.evalCacheMaxTotalBytes` | `10737418240` (10 GiB) | Total byte cap for fleet-shared eval-cache blobs. The eviction sweep drops oldest-`updated_at` rows until the surviving total is at or under this. (`GRADIENT_EVAL_CACHE_MAX_TOTAL_BYTES`) |

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -6917,3 +6917,26 @@ store path carrying `lib/debug/.build-id/<xx>/<yy>.debug`, poll until the index
 lands, assert the JSON names the member and an `../nar/...` archive that is
 actually fetchable, and assert `404` for an unknown build id, a malformed one,
 and the exact `/cache/debuginfo/<build-id>.debug` request from the issue.
+
+## A new project never starts above the evaluation cap (#561)
+
+`PUT /projects/{org}` hard-coded `keep_evaluations: 30` and ignored
+`GRADIENT_KEEP_EVALUATIONS`. On an instance with a lower maximum every new
+project was created above it, so the first save - the settings form sends the
+whole form back - was rejected with `keep_evaluations cannot exceed the server
+maximum`, using the value the server itself had handed out. The startup sweep
+that caps existing projects only masked it until the next restart.
+
+`backend/gradient-types/src/cli/storage.rs`:
+`a_new_project_never_starts_above_the_maximum` is the reported case;
+`a_higher_maximum_leaves_the_default_alone` pins that the setting is a cap and
+not a target, so raising it does not raise what new projects get;
+`zero_disables_the_cap` covers the documented opt-out; and
+`an_out_of_range_maximum_saturates` guards the `usize as i32` that would
+otherwise wrap a huge configured maximum into a negative ceiling rejecting every
+value.
+
+`nix/tests/gradient/api` runs with `keepEvaluations = 5`, below the per-project
+default, and phase 4 asserts a freshly created project reports `5`, that echoing
+that value straight back in a `PATCH` succeeds, and that `6` (over the maximum)
+and `0` (under the floor) are still refused.

--- a/nix/modules/gradient.nix
+++ b/nix/modules/gradient.nix
@@ -443,8 +443,8 @@ in {
         };
 
         keepEvaluations = lib.mkOption {
-          description = "Amount of evaluations to keep in the database and cache";
-          type = lib.types.ints.positive;
+          description = "Global maximum of evaluations kept per project. Caps the per-project setting, and a new project starts at the lower of 30 and this. 0 disables the cap.";
+          type = lib.types.ints.unsigned;
           default = 30;
         };
 

--- a/nix/tests/gradient/api/default.nix
+++ b/nix/tests/gradient/api/default.nix
@@ -48,7 +48,12 @@ in {
             domain = "gradient.local";
             jwtSecretFile = toString (pkgs.writeText "jwtSecret" "b68a8eaa8ebcff23ebaba1bd74ecb8a2eb7ba959570ff8842f148207524c7b8d731d7a1998584105e951599221f9dcd20e41223be17275ca70ab6f7e6ecafa8d4f8905623866edb2b344bd15de52ccece395b3546e2f00644eb2679cf7bdaa156fd75cc5f47c34448cba19d903e68015b1ad3c8e9d04862de0a2c525b6676779012919fa9551c4746f9323ab207aedae86c28ada67c901cae821eef97b69ca4ebe1260de31add34d8265f17d9c547e3bbabe284d9cadcc22063ee625b104592403368090642a41967f8ada5791cb09703d0762a3175d0fe06ec37822e9e41d0a623a6349901749673735fdb94f2c268ac08a24216efb058feced6e785f34185a");
             cryptSecretFile = toString (pkgs.writeText "cryptSecret" "aW52YWxpZC1pbnZhbGlkLWludmFsaWQK");
-            settings.logLevel.default = "debug";
+            settings = {
+              logLevel.default = "debug";
+              # Below the per-project default, so a freshly created project is
+              # forced to start at the maximum rather than above it (#561).
+              keepEvaluations = 5;
+            };
 
             state = {
               users = {

--- a/nix/tests/gradient/api/test.py
+++ b/nix/tests/gradient/api/test.py
@@ -196,6 +196,18 @@ api("PUT", "projects/myorg", token=token, expect_error=True, body=json.dumps({
     "repository": "git@github.com:Wavelens/Gradient.git", "wildcard": "packages.*"}))  # reserved name
 assert api("GET", "projects/myorg/myproject", token=token)["id"] == proj_id
 assert any(p["id"] == proj_id for p in api("GET", "projects/myorg", token=token)["items"])
+
+# A new project must not start above GRADIENT_KEEP_EVALUATIONS (5 here). It used
+# to be created at the hardcoded 30, so the very first save - the frontend sends
+# the whole form back - was rejected by the server's own value (#561).
+fresh = api("GET", "projects/myorg/myproject", token=token)
+assert fresh["keep_evaluations"] == 5, fresh
+api("PATCH", "projects/myorg/myproject", token=token,
+    body=json.dumps({"keep_evaluations": fresh["keep_evaluations"]}))
+api("PATCH", "projects/myorg/myproject", token=token, expect_error=True,
+    body=json.dumps({"keep_evaluations": 6}))  # above the server maximum
+api("PATCH", "projects/myorg/myproject", token=token, expect_error=True,
+    body=json.dumps({"keep_evaluations": 0}))  # below the floor
 api("GET", "projects/myorg/available", token=token)
 api("GET", "projects/myorg/myproject/details", token=token)
 api("PATCH", "projects/myorg/myproject", token=token, body=json.dumps({"display_name": "MP2"}))


### PR DESCRIPTION
`PUT /projects/{org}` hard-coded `keep_evaluations: 30`, so on an instance with a lower `GRADIENT_KEEP_EVALUATIONS` every new project was created above the maximum and the first save was rejected with the server's own value.

Existing over-limit projects are already capped by the startup sweep, so they fix themselves on the next restart.

Closes #561