### PR TITLE
frontend: feat: replace PrimeNG with a CDK component layer, upgrade to Angular 22

### DIFF
--- a/docs/src/development/architecture.md
+++ b/docs/src/development/architecture.md
@@ -150,9 +150,9 @@ All timestamps are `NaiveDateTime` (UTC, stored without timezone). The `NULL_TIM
 
 ## Frontend
 
-Standalone Angular 21 SPA in `frontend/`. Communicates exclusively with the backend REST API. Built as static files, served by NGINX in production.
+Standalone Angular 22 SPA in `frontend/`. Communicates exclusively with the backend REST API. Built as static files, served by NGINX in production.
 
-Key patterns: standalone components, Angular signals (`signal()`, `computed()`), PrimeNG for UI, Apache ECharts for metric charts, SCSS variables from `_variables.scss`.
+Key patterns: standalone components, Angular signals (`signal()`, `computed()`), the in-repo `gr-ui` component layer on `@angular/cdk` for UI, Apache ECharts for metric charts, SCSS variables from `_variables.scss`.
 
 ## CLI
 

--- a/docs/src/development/contributing.md
+++ b/docs/src/development/contributing.md
@@ -106,7 +106,8 @@ CI (`.github/workflows/rust.yml`) runs fmt, the grep-gate and cargo-deny; clippy
 
 - Standalone components with Angular signals (`signal()`, `computed()`).
 - Feature-based structure under `frontend/src/app/features/`.
-- PrimeNG for UI components; Apache ECharts (via `<app-metric-chart>`) for every chart; SCSS variables from `src/app/styles/_variables.scss` for colours and spacing.
+- `gr-ui` (`src/app/shared/ui/`, built on `@angular/cdk`) for UI components; Apache ECharts (via `<app-metric-chart>`) for every chart; SCSS variables from `src/app/styles/_variables.scss` for colours and spacing.
+- No third-party UI or charting dependency may impose a field-of-use restriction: the bundle ships under AGPL-3.0, so anything beyond MIT / BSD / Apache-2.0 cannot be conveyed downstream.
 
 ### Nix
 

--- a/docs/src/development/frontend-style-guide.md
+++ b/docs/src/development/frontend-style-guide.md
@@ -24,13 +24,13 @@ left):
    inline code.
 3. **Spacing & Radius** - visual chips for every `$spacing-*` and
    `$border-radius-*` token.
-4. **Icons** - Material Symbols and PrimeIcons sample grids.
-5. **Buttons** - PrimeNG `pButton` severities, variants (icon, text, outlined,
+4. **Icons** - Material Symbols sample grid.
+5. **Buttons** - `grButton` severities, variants (icon, text, outlined,
    rounded), and states (default, disabled, loading).
 6. **Form Primitives** - live demo of `<gr-form-field>`,
    `<gr-password-input>`, `<gr-message-banner>`, and the `FormFieldsBuilder`
    service.
-7. **Popups & Overlays** - `<gr-form-dialog>`, PrimeNG confirm dialog,
+7. **Popups & Overlays** - `<gr-form-dialog>`, `<gr-confirm-dialog>`,
    toast notifications, and tooltips.
 8. **Feedback** - `<app-loading-spinner>`, `<app-empty-state>`,
    `<app-stat-card>`, status chips, and badges.
@@ -52,7 +52,7 @@ Located at `frontend/src/app/shared/components/form/`.
 | `<gr-form-error>` | Renders a validation message for a control once touched/dirty. Built-in messages for `required`, `email`, `minlength`, `maxlength`, `min`, `max`, `pattern`, `passwordStrength`, `passwordMatch`, `usernameTaken`. Overridable per-instance via `[messages]`. |
 | `<gr-password-input>` | Password input with a built-in show/hide toggle. Bind to a `FormControl` via `[control]`. |
 | `<gr-message-banner>` | Page-level message with `error / success / warning / info` types. Default icon per type, overridable. |
-| `<gr-form-dialog>` | PrimeNG `p-dialog` wrapper with standardized Cancel / Submit footer, loading state, and disabled state. |
+| `<gr-form-dialog>` | `<gr-dialog>` wrapper with standardized Cancel / Submit footer, loading state, and disabled state. |
 | `FormFieldsBuilder` | Typed convenience wrapper around `FormBuilder`: `text`, `email`, `password`, `confirm`, `number`, `checkbox`. Inject and call instead of repeating `[Validators.required, ...]` everywhere. Also exports `passwordStrengthValidator` and `passwordMatchValidator` as standalone helpers. |
 
 Import from the barrel:

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -4125,10 +4125,10 @@ The primitives:
   when `managed || !canEdit`. Tests cover all four flag combinations,
   tooltip text, and that the directive correctly clears its own state when
   access becomes writable. The directive also propagates the disabled state
-  through `NgControl.valueAccessor.setDisabledState`, so PrimeNG controls
+  through `NgControl.valueAccessor.setDisabledState`, so `gr-ui` controls
   (`p-select`, `p-checkbox`, `p-autoComplete`, …) - which only honor the
   ControlValueAccessor hook, not raw DOM `disabled` - actually become
-  read-only when the user has no write access. A `FakePrimeNgInputDirective`
+  read-only when the user has no write access. A `FakeInputDirective`
   in the spec stands in for any `ControlValueAccessor` host and asserts the
   propagation (issue #229).
 - `frontend/src/app/core/resolvers/task-access.resolver.ts` and
@@ -6977,3 +6977,54 @@ actually created (the SVG renderer is used rather than canvas so this is
 verifiable under jsdom), that `bare` drops the card chrome and heading for
 callers supplying their own panel, that changing the `series` input re-renders,
 and that destroying the component disposes the chart instead of leaking it.
+
+## The gr-ui component layer replaces PrimeNG
+
+PrimeNG v22 is closed source: compiled-only, with a no-reverse-engineering
+clause and an offline-verified licence key. That cannot ship inside an
+AGPL-3.0 distribution at any price, because there is no corresponding source
+for downstream to rebuild. v21 is the last MIT line and it pins the app to
+Angular 21, so the ten components actually in use were rebuilt in
+`frontend/src/app/shared/ui/` on `@angular/cdk`. The upstream source for those
+components runs to roughly 11,900 lines; sized to the API the call sites
+actually use it is closer to 1,500, because the overlay positioning, focus
+trap and keyboard handling are delegated to the CDK.
+
+Each component has its own spec under `frontend/src/app/shared/ui/`.
+
+`button.component.spec.ts` covers the attribute component that sits on a native
+`<button>`: that the severity class tracks the input, that the icon renders as a
+Material Symbol on the correct side of the label, that `loading` swaps the icon
+for a spinner and sets `aria-busy`, and that a caller passing content instead of
+`label` still renders. One case pins the deliberate design decision that the
+component never touches the native `disabled` property, so the existing
+`appManagedDisable` directive stays the only writer and the two cannot fight.
+
+`dialog.component.spec.ts` covers the modal on the CDK overlay: that it is
+absent from the DOM until visible, that the header, body and the
+`[grDialogFooter]` slot all render, that closing reports back through the
+two-way `visible` binding and emits `hide`. The re-open case is the important
+one: the panel lives in an `<ng-template>` projected into an overlay, and
+content projected into a template that is stamped more than once is exactly the
+pattern that silently renders empty on the second open. `popover.component.spec.ts`
+pins the same property for the popover.
+
+`select.component.spec.ts` covers the dropdown against a real `ngModel`: that it
+writes the option *value* rather than the option object, that a value pushed in
+from the model resolves back to its label, that a disabled option cannot be
+picked, and that Escape and the arrow keys work, since a `<div>`-based dropdown
+loses everything a native `<select>` gave us for free.
+`checkbox.component.spec.ts` and `select-button.component.spec.ts` cover the
+other two `ControlValueAccessor` implementations, including `setDisabledState`,
+which is the hook `appManagedDisable` reaches through.
+
+`autocomplete.component.spec.ts` covers the suggestion flow: the component asks
+the caller to complete on every keystroke, shows the panel only once there are
+suggestions, and writes a picked suggestion into both the model and the field.
+`menu.component.spec.ts` covers item commands, separators, disabled items and
+that router-link items render as anchors. `tooltip.directive.spec.ts` covers
+hover and focus, and pins that a doubled `mouseenter` does not stack a second
+overlay. `toast.component.spec.ts` covers the `MessageService` queue including
+`life` expiry and `life: 0` meaning sticky, and `confirm-dialog.component.spec.ts`
+covers accept, reject and the default button labels.
+

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -7028,3 +7028,23 @@ overlay. `toast.component.spec.ts` covers the `MessageService` queue including
 `life` expiry and `life: 0` meaning sticky, and `confirm-dialog.component.spec.ts`
 covers accept, reject and the default button labels.
 
+## Live Jobs decision-score fixture drifted from the API (#419)
+
+`live-jobs.component.spec.ts` "surfaces rejected/negative candidate scores when
+scope is 'incl. rejected'" had been failing since `16756b1e`. That commit moved
+the component off deriving the winner in the browser
+(`won: d.winner === c.job_id`) and onto the per-candidate `id` and `won` fields
+the server had started sending, matching `DecisionCandidateView` in
+`backend/gradient-web/src/endpoints/board.rs`. The spec's mock was never
+updated, so every row came back with `won: undefined` and `id: undefined`: the
+assertion on the winning row failed, and the `@for` track expression collapsed
+both rows onto the same empty key, which Angular reported as `NG0955`.
+
+The mock is now declared `const DECISIONS: DispatchDecisionView[]`. That is the
+actual fix, not just the added fields: the mock was previously an untyped object
+literal inside `useValue`, so nothing checked it against the interface it was
+standing in for and the drift stayed silent. With the annotation, dropping
+`won` from a candidate fails the build with `TS2741: Property 'won' is missing
+in type ... but required in type 'DecisionCandidateView'`, which is what should
+have caught this when the server contract changed.
+

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -31,6 +31,7 @@
               }
             ],
             "styles": [
+              "node_modules/@angular/cdk/overlay-prebuilt.css",
               "src/styles.scss"
             ]
           },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,26 +23,26 @@
   "private": true,
   "packageManager": "pnpm@10.26.1",
   "dependencies": {
-    "@angular/animations": "^21.2.16",
-    "@angular/cdk": "^21.2.14",
-    "@angular/common": "^21.2.16",
-    "@angular/compiler": "^21.2.16",
-    "@angular/core": "^21.2.16",
-    "@angular/forms": "^21.2.16",
-    "@angular/platform-browser": "^21.2.16",
-    "@angular/router": "^21.2.16",
+    "@angular/animations": "^22.1.3",
+    "@angular/cdk": "^22.1.3",
+    "@angular/common": "^22.1.3",
+    "@angular/compiler": "^22.1.3",
+    "@angular/core": "^22.1.3",
+    "@angular/forms": "^22.1.3",
+    "@angular/platform-browser": "^22.1.3",
+    "@angular/router": "^22.1.3",
     "d3-sankey": "^0.12.3",
     "echarts": "^6.1.0",
     "rxjs": "~7.8.2",
     "tslib": "^2.8.1"
   },
   "devDependencies": {
-    "@angular/build": "^21.2.14",
-    "@angular/cli": "^21.2.14",
-    "@angular/compiler-cli": "^21.2.16",
+    "@angular/build": "^22.1.5",
+    "@angular/cli": "^22.1.5",
+    "@angular/compiler-cli": "^22.1.3",
     "@types/d3-sankey": "^0.12.5",
-    "jsdom": "^29.1.1",
-    "typescript": "~5.9.3",
-    "vitest": "^4.1.8"
+    "jsdom": "^30.0.1",
+    "typescript": "~6.0.3",
+    "vitest": "^4.1.11"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,11 +31,8 @@
     "@angular/forms": "^21.2.16",
     "@angular/platform-browser": "^21.2.16",
     "@angular/router": "^21.2.16",
-    "@primeuix/themes": "2.0.3",
     "d3-sankey": "^0.12.3",
     "echarts": "^6.1.0",
-    "primeicons": "7.0.0",
-    "primeng": "21.1.9",
     "rxjs": "~7.8.2",
     "tslib": "^2.8.1"
   },

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -36,29 +36,29 @@ importers:
   .:
     dependencies:
       '@angular/animations':
-        specifier: ^21.2.16
-        version: 21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))
+        specifier: ^22.1.3
+        version: 22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))
       '@angular/cdk':
-        specifier: ^21.2.14
-        version: 21.2.14(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(@angular/platform-browser@21.2.16(@angular/animations@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(rxjs@7.8.2)
+        specifier: ^22.1.3
+        version: 22.1.3(@angular/common@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(@angular/platform-browser@22.1.3(@angular/animations@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)))(@angular/common@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@angular/common':
-        specifier: ^21.2.16
-        version: 21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2)
+        specifier: ^22.1.3
+        version: 22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(rxjs@7.8.2)
       '@angular/compiler':
-        specifier: ^21.2.16
-        version: 21.2.16
+        specifier: ^22.1.3
+        version: 22.1.3
       '@angular/core':
-        specifier: ^21.2.16
-        version: 21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)
+        specifier: ^22.1.3
+        version: 22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)
       '@angular/forms':
-        specifier: ^21.2.16
-        version: 21.2.16(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(@angular/platform-browser@21.2.16(@angular/animations@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(rxjs@7.8.2)
+        specifier: ^22.1.3
+        version: 22.1.3(@angular/common@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(@angular/platform-browser@22.1.3(@angular/animations@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)))(@angular/common@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@angular/platform-browser':
-        specifier: ^21.2.16
-        version: 21.2.16(@angular/animations@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))
+        specifier: ^22.1.3
+        version: 22.1.3(@angular/animations@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)))(@angular/common@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))
       '@angular/router':
-        specifier: ^21.2.16
-        version: 21.2.16(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(@angular/platform-browser@21.2.16(@angular/animations@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(rxjs@7.8.2)
+        specifier: ^22.1.3
+        version: 22.1.3(@angular/common@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(@angular/platform-browser@22.1.3(@angular/animations@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)))(@angular/common@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)))(rxjs@7.8.2)
       d3-sankey:
         specifier: ^0.12.3
         version: 0.12.3
@@ -73,132 +73,79 @@ importers:
         version: 2.8.1
     devDependencies:
       '@angular/build':
-        specifier: ^21.2.14
-        version: 21.2.14(@angular/compiler-cli@21.2.16(@angular/compiler@21.2.16)(typescript@5.9.3))(@angular/compiler@21.2.16)(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(@angular/platform-browser@21.2.16(@angular/animations@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(chokidar@5.0.0)(postcss@8.5.15)(tslib@2.8.1)(typescript@5.9.3)(vitest@4.1.8(jsdom@29.1.1)(vite@7.3.2(sass@1.97.3)))
+        specifier: ^22.1.5
+        version: 22.1.5(@angular/compiler-cli@22.1.3(@angular/compiler@22.1.3)(typescript@6.0.3))(@angular/compiler@22.1.3)(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(@angular/platform-browser@22.1.3(@angular/animations@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)))(@angular/common@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)))(chokidar@5.0.0)(istanbul-lib-instrument@6.0.3)(postcss@8.5.15)(rollup@4.61.0)(tslib@2.8.1)(typescript@6.0.3)(vitest@4.1.11(jsdom@30.0.1)(vite@8.1.5(esbuild@0.28.2)(sass@1.101.0)))
       '@angular/cli':
-        specifier: ^21.2.14
-        version: 21.2.14(chokidar@5.0.0)
+        specifier: ^22.1.5
+        version: 22.1.5(chokidar@5.0.0)
       '@angular/compiler-cli':
-        specifier: ^21.2.16
-        version: 21.2.16(@angular/compiler@21.2.16)(typescript@5.9.3)
+        specifier: ^22.1.3
+        version: 22.1.3(@angular/compiler@22.1.3)(typescript@6.0.3)
       '@types/d3-sankey':
         specifier: ^0.12.5
         version: 0.12.5
       jsdom:
-        specifier: ^29.1.1
-        version: 29.1.1
+        specifier: ^30.0.1
+        version: 30.0.1
       typescript:
-        specifier: ~5.9.3
-        version: 5.9.3
+        specifier: ~6.0.3
+        version: 6.0.3
       vitest:
-        specifier: ^4.1.8
-        version: 4.1.8(jsdom@29.1.1)(vite@7.3.2(sass@1.97.3))
+        specifier: ^4.1.11
+        version: 4.1.11(jsdom@30.0.1)(vite@8.1.5(esbuild@0.28.2)(sass@1.101.0))
 
 packages:
-
-  '@algolia/abtesting@1.14.1':
-    resolution: {integrity: sha512-Dkj0BgPiLAaim9sbQ97UKDFHJE/880wgStAM18U++NaJ/2Cws34J5731ovJifr6E3Pv4T2CqvMXf8qLCC417Ew==}
-    engines: {node: '>= 14.0.0'}
-
-  '@algolia/client-abtesting@5.48.1':
-    resolution: {integrity: sha512-LV5qCJdj+/m9I+Aj91o+glYszrzd7CX6NgKaYdTOj4+tUYfbS62pwYgUfZprYNayhkQpVFcrW8x8ZlIHpS23Vw==}
-    engines: {node: '>= 14.0.0'}
-
-  '@algolia/client-analytics@5.48.1':
-    resolution: {integrity: sha512-/AVoMqHhPm14CcHq7mwB+bUJbfCv+jrxlNvRjXAuO+TQa+V37N8k1b0ijaRBPdmSjULMd8KtJbQyUyabXOu6Kg==}
-    engines: {node: '>= 14.0.0'}
-
-  '@algolia/client-common@5.48.1':
-    resolution: {integrity: sha512-VXO+qu2Ep6ota28ktvBm3sG53wUHS2n7bgLWmce5jTskdlCD0/JrV4tnBm1l7qpla1CeoQb8D7ShFhad+UoSOw==}
-    engines: {node: '>= 14.0.0'}
-
-  '@algolia/client-insights@5.48.1':
-    resolution: {integrity: sha512-zl+Qyb0nLg+Y5YvKp1Ij+u9OaPaKg2/EPzTwKNiVyOHnQJlFxmXyUZL1EInczAZsEY8hVpPCLtNfhMhfxluXKQ==}
-    engines: {node: '>= 14.0.0'}
-
-  '@algolia/client-personalization@5.48.1':
-    resolution: {integrity: sha512-r89Qf9Oo9mKWQXumRu/1LtvVJAmEDpn8mHZMc485pRfQUMAwSSrsnaw1tQ3sszqzEgAr1c7rw6fjBI+zrAXTOw==}
-    engines: {node: '>= 14.0.0'}
-
-  '@algolia/client-query-suggestions@5.48.1':
-    resolution: {integrity: sha512-TPKNPKfghKG/bMSc7mQYD9HxHRUkBZA4q1PEmHgICaSeHQscGqL4wBrKkhfPlDV1uYBKW02pbFMUhsOt7p4ZpA==}
-    engines: {node: '>= 14.0.0'}
-
-  '@algolia/client-search@5.48.1':
-    resolution: {integrity: sha512-4Fu7dnzQyQmMFknYwTiN/HxPbH4DyxvQ1m+IxpPp5oslOgz8m6PG5qhiGbqJzH4HiT1I58ecDiCAC716UyVA8Q==}
-    engines: {node: '>= 14.0.0'}
-
-  '@algolia/ingestion@1.48.1':
-    resolution: {integrity: sha512-/RFq3TqtXDUUawwic/A9xylA2P3LDMO8dNhphHAUOU51b1ZLHrmZ6YYJm3df1APz7xLY1aht6okCQf+/vmrV9w==}
-    engines: {node: '>= 14.0.0'}
-
-  '@algolia/monitoring@1.48.1':
-    resolution: {integrity: sha512-Of0jTeAZRyRhC7XzDSjJef0aBkgRcvRAaw0ooYRlOw57APii7lZdq+layuNdeL72BRq1snaJhoMMwkmLIpJScw==}
-    engines: {node: '>= 14.0.0'}
-
-  '@algolia/recommend@5.48.1':
-    resolution: {integrity: sha512-bE7JcpFXzxF5zHwj/vkl2eiCBvyR1zQ7aoUdO+GDXxGp0DGw7nI0p8Xj6u8VmRQ+RDuPcICFQcCwRIJT5tDJFw==}
-    engines: {node: '>= 14.0.0'}
-
-  '@algolia/requester-browser-xhr@5.48.1':
-    resolution: {integrity: sha512-MK3wZ2koLDnvH/AmqIF1EKbJlhRS5j74OZGkLpxI4rYvNi9Jn/C7vb5DytBnQ4KUWts7QsmbdwHkxY5txQHXVw==}
-    engines: {node: '>= 14.0.0'}
-
-  '@algolia/requester-fetch@5.48.1':
-    resolution: {integrity: sha512-2oDT43Y5HWRSIQMPQI4tA/W+TN/N2tjggZCUsqQV440kxzzoPGsvv9QP1GhQ4CoDa+yn6ygUsGp6Dr+a9sPPSg==}
-    engines: {node: '>= 14.0.0'}
-
-  '@algolia/requester-node-http@5.48.1':
-    resolution: {integrity: sha512-xcaCqbhupVWhuBP1nwbk1XNvwrGljozutEiLx06mvqDf3o8cHyEgQSHS4fKJM+UAggaWVnnFW+Nne5aQ8SUJXg==}
-    engines: {node: '>= 14.0.0'}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@angular-devkit/architect@0.2102.14':
-    resolution: {integrity: sha512-0+vjVsCkMyJdVjz5XkPW+Bdf/9TI8V2voomx/+o0o+oOaqqiEhptQWFnaIlLr7HasjB0LxXK5P9L0oQ61vxj8Q==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
+  '@angular-devkit/architect@0.2201.5':
+    resolution: {integrity: sha512-DAticcJ2tw3M+D1CH4HhlCgMK5tAb0CwSsnczNMJB9QgQsBC/JhOozQTvgnyCvagitX9u+408YcwEW/Wo2pnzA==}
+    engines: {node: ^22.22.3 || ^24.15.0 || >=26.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
     hasBin: true
 
-  '@angular-devkit/core@21.2.14':
-    resolution: {integrity: sha512-RSOWXB9bFc2nwRWMxbIT0RbSNFUrwfBo4N5MNxbyQ69Ndc0gVm3h+3ArHv0qotH4d+pJYbm5ttXu8YqR2kc0CA==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
+  '@angular-devkit/core@22.1.5':
+    resolution: {integrity: sha512-HiY6d5dkIdJs5grP9OHvgkf14QOcDIo+hbuT7YKuLItQ++ZxCwUabJMLCCJ5R0KrstE5NqED0dNcyk5WD01t5Q==}
+    engines: {node: ^22.22.3 || ^24.15.0 || >=26.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
     peerDependencies:
       chokidar: ^5.0.0
     peerDependenciesMeta:
       chokidar:
         optional: true
 
-  '@angular-devkit/schematics@21.2.14':
-    resolution: {integrity: sha512-KMJlQSBEzI4+Cy1Zh72gmGQNN2I1vY+nj9CoRcZPBIi1si+0ZAc49XT85eYl+eQumNTVQviUG7LQqgLDAHml+g==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
+  '@angular-devkit/schematics@22.1.5':
+    resolution: {integrity: sha512-HTmo9y8wjXKtJGVTYomTjZsjWzhirpu1pPRAzsVob3eiYOuxv1qDRAgWiHXNGp5CpnbHunZweXY/WffNGOFRyA==}
+    engines: {node: ^22.22.3 || ^24.15.0 || >=26.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
 
-  '@angular/animations@21.2.16':
-    resolution: {integrity: sha512-YPhph/OC1A0vkT95XZW6lXMNmi5ly91JeXi+5yeG8CCxfqscVfRNPsYbRWjSueO0cQT2HJ8U1CLteQ5a1OaoHA==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+  '@angular/animations@22.1.3':
+    resolution: {integrity: sha512-EgL1BrPcn3yaRamr/R9NlYlV6hZzzKRGxVp/cnfkYzzWKG4Wcno7lkGEo6eA2Vry66AJuXUu4M1BMyhHJ96zzg==}
+    engines: {node: ^22.22.3 || ^24.15.0 || >=26.0.0}
+    deprecated: '@angular/animations is deprecated. Use `animate.enter` and `animate.leave` instead. For more information see: https://v22.angular.dev/guide/animations.'
     peerDependencies:
-      '@angular/core': 21.2.16
+      '@angular/core': 22.1.3
 
-  '@angular/build@21.2.14':
-    resolution: {integrity: sha512-l8JB326iIwum2WmbopUUFdiuYsbHchix6MH8o6F6FA7LJr8QLTvipwwbw+Jx31/RE50WkGmzsZ1fBDw/cMbmUw==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
+  '@angular/build@22.1.5':
+    resolution: {integrity: sha512-YqsbHZK3/HFmLLhwxa5SpN+3ABoVo5GFLV0fiEXCQg2KC7gw2pL15x692jxrq8gEGzT7O27bnjWkvFZ0bBHCnw==}
+    engines: {node: ^22.22.3 || ^24.15.0 || >=26.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
     peerDependencies:
-      '@angular/compiler': '>=21.2.4'
-      '@angular/compiler-cli': ^21.0.0
-      '@angular/core': '>=21.1.6'
-      '@angular/localize': ^21.0.0
-      '@angular/platform-browser': ^21.0.0
-      '@angular/platform-server': ^21.0.0
-      '@angular/service-worker': ^21.0.0
-      '@angular/ssr': ^21.2.14
+      '@angular/compiler': ^22.0.0
+      '@angular/compiler-cli': ^22.0.0
+      '@angular/core': ^22.0.0
+      '@angular/localize': ^22.0.0
+      '@angular/platform-browser': ^22.0.0
+      '@angular/platform-server': ^22.0.0
+      '@angular/service-worker': ^22.0.0
+      '@angular/ssr': ^22.1.5
+      istanbul-lib-instrument: ^6.0.0
       karma: ^6.4.0
       less: ^4.2.0
-      ng-packagr: ^21.0.0
+      ng-packagr: ^22.0.0
       postcss: ^8.4.0
+      rollup: '>=4.59.0'
       tailwindcss: ^2.0.0 || ^3.0.0 || ^4.0.0
       tslib: ^2.3.0
-      typescript: '>=5.9 <6.0'
+      typescript: '>=6.0 <6.1'
       vitest: ^4.0.8
     peerDependenciesMeta:
       '@angular/core':
@@ -213,6 +160,8 @@ packages:
         optional: true
       '@angular/ssr':
         optional: true
+      istanbul-lib-instrument:
+        optional: true
       karma:
         optional: true
       less:
@@ -221,51 +170,53 @@ packages:
         optional: true
       postcss:
         optional: true
+      rollup:
+        optional: true
       tailwindcss:
         optional: true
       vitest:
         optional: true
 
-  '@angular/cdk@21.2.14':
-    resolution: {integrity: sha512-806REq/CLf37nEhmmd8Q+ILN8z/RVG2vk2n8YZ/4TdHpcBCi5ux4AxLbpMmduLwGPOzPagJ6ggRzE5fnX0rmcQ==}
+  '@angular/cdk@22.1.3':
+    resolution: {integrity: sha512-6N3S71J877j9zGpCqU0PDIP4AGQf+SjJrA1Pouy+xfC8GE8sfCyIVr0Y6qnpxr5D2k2lROykAMbQekZtKEiEeA==}
     peerDependencies:
-      '@angular/common': ^21.0.0 || ^22.0.0
-      '@angular/core': '>=21.1.6'
-      '@angular/platform-browser': ^21.0.0 || ^22.0.0
+      '@angular/common': ^22.0.0 || ^23.0.0
+      '@angular/core': ^22.0.0 || ^23.0.0
+      '@angular/platform-browser': ^22.0.0 || ^23.0.0
       rxjs: ^6.5.3 || ^7.4.0
 
-  '@angular/cli@21.2.14':
-    resolution: {integrity: sha512-S8jExTjxPJILwpg2lu3DohSASVZ8DLhSNCmOe7z0qF9VskRSjC7SIQv1rq36tsJkenxuA72gjVOHZv+uSRT8HA==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
+  '@angular/cli@22.1.5':
+    resolution: {integrity: sha512-YZkhI64INQHJkZ13h2n0/0PBrQ5ZZvFGiprrDiCOLAD0y1fehguL0PGp9HxF3ZWf+xWRyP//tIte2gmyAaiWLw==}
+    engines: {node: ^22.22.3 || ^24.15.0 || >=26.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
     hasBin: true
 
-  '@angular/common@21.2.16':
-    resolution: {integrity: sha512-htHNepKzjIjkc5BQ7MKDN0bVDOfQpFr/fGUxa6irC0kFLfWt7idUTdNcxypRvjCCTuBYHkjr74fH4QKu+qvPXg==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+  '@angular/common@22.1.3':
+    resolution: {integrity: sha512-QtMkjhiRd0EnmKR50bw3WbCWYTi6CmA72nnSz1BLQPpaLSi2goloCrPPniHz8fP+w2ESrmmlOWxs1Da3COgnQg==}
+    engines: {node: ^22.22.3 || ^24.15.0 || >=26.0.0}
     peerDependencies:
-      '@angular/core': 21.2.16
+      '@angular/core': 22.1.3
       rxjs: ^6.5.3 || ^7.4.0
 
-  '@angular/compiler-cli@21.2.16':
-    resolution: {integrity: sha512-w2ck3o+uw29AZEGK3HvOsF/ZRiPcfoq2TaDtiNjdH+svhwawt9PfMXrDbbIKF30prWzKLpT3UsCqTz1awv7Ubw==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+  '@angular/compiler-cli@22.1.3':
+    resolution: {integrity: sha512-37lLaDp0RHWZ/lmJqCmIEr0HOM2D5ulHy61gqTBm7KRj3Y6ZaxR8B/JqZmeIpPzKFILVsga+NQ4A8apBUkmezw==}
+    engines: {node: ^22.22.3 || ^24.15.0 || >=26.0.0}
     hasBin: true
     peerDependencies:
-      '@angular/compiler': 21.2.16
-      typescript: '>=5.9 <6.1'
+      '@angular/compiler': 22.1.3
+      typescript: '>=6.0 <6.1'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@angular/compiler@21.2.16':
-    resolution: {integrity: sha512-hVjp93gYgNj5aRbCQUK7L+pOfdqk96lCtmSL2hOL725Pmib9NyNIrA3ISfAQHN+Qo70763WUZahOiqBBOzfAcg==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+  '@angular/compiler@22.1.3':
+    resolution: {integrity: sha512-L8Mw2r7bGG/obqgQC+RU3mdFJ3NtLgO5gWhEC1ylcHpLCMPIAXYsMKJIL8dnS78S1wXo/omXwmJ4FiIlCwWahg==}
+    engines: {node: ^22.22.3 || ^24.15.0 || >=26.0.0}
 
-  '@angular/core@21.2.16':
-    resolution: {integrity: sha512-uufKORlB0jeYdqOvjAfMYgqIqmJentOj8XvTUxsFP5k85xxzXsDarSpP199YQz6jhJJQYNOWIloDkUTQJi5rNA==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+  '@angular/core@22.1.3':
+    resolution: {integrity: sha512-313+Xkf970AmStJE0E/zNJW/9xvDExQG+6TNltBBl+KJsW0q5dffK2w2PQfV4mtTquBqYoeHSRsms4WgjBKL8g==}
+    engines: {node: ^22.22.3 || ^24.15.0 || >=26.0.0}
     peerDependencies:
-      '@angular/compiler': 21.2.16
+      '@angular/compiler': 22.1.3
       rxjs: ^6.5.3 || ^7.4.0
       zone.js: ~0.15.0 || ~0.16.0
     peerDependenciesMeta:
@@ -274,77 +225,94 @@ packages:
       zone.js:
         optional: true
 
-  '@angular/forms@21.2.16':
-    resolution: {integrity: sha512-2djTJmTpg/MkQ2kdCI9k0LT4RL9/Hg03fDUNN2eN5c04FIk99D3yHXUJYLwiaErLuLQNkU8HaijluKHdH93cWQ==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+  '@angular/forms@22.1.3':
+    resolution: {integrity: sha512-b4ual9pgfNqcnEHord50w960DDFIytG3Qb3bu2aCgzmagvRlg9wrtwQNqY+oqY2FVq7c9McNUN7MZRcWl9HNdQ==}
+    engines: {node: ^22.22.3 || ^24.15.0 || >=26.0.0}
     peerDependencies:
-      '@angular/common': 21.2.16
-      '@angular/core': 21.2.16
-      '@angular/platform-browser': 21.2.16
+      '@angular/common': 22.1.3
+      '@angular/core': 22.1.3
+      '@angular/platform-browser': 22.1.3
       rxjs: ^6.5.3 || ^7.4.0
 
-  '@angular/platform-browser@21.2.16':
-    resolution: {integrity: sha512-59ToWYDb+O3fS0+Y4ubQqV0zY6sf2esLZ19AT7JKXN7Akqbz7aQ2/3k3PKmfhwKWek5o3lkuNz8YhxKQruNh8Q==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+  '@angular/platform-browser@22.1.3':
+    resolution: {integrity: sha512-A8McE6AclwZa2ese4jMfZZu+qZfBFQ4Hl6CaMpzJ1C6Vv6+sXkLu9pouTosJEsUE+etVdepDsqau90lhzgw3Eg==}
+    engines: {node: ^22.22.3 || ^24.15.0 || >=26.0.0}
     peerDependencies:
-      '@angular/animations': 21.2.16
-      '@angular/common': 21.2.16
-      '@angular/core': 21.2.16
+      '@angular/animations': 22.1.3
+      '@angular/common': 22.1.3
+      '@angular/core': 22.1.3
     peerDependenciesMeta:
       '@angular/animations':
         optional: true
 
-  '@angular/router@21.2.16':
-    resolution: {integrity: sha512-0+Pyh0uT4vCLabKoGCARYWlwpz4DgZI9AE01n8s9u/nKAZuEMnJtLLnaUtHEMI8nJSqpgnS/5AthuJZdDEfkYw==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+  '@angular/router@22.1.3':
+    resolution: {integrity: sha512-23owvZKCpdL7Yh3EzBj4OLf3x0z+jT9b57Qk96wdwI8Lsyf9L78/RJPYCutJ5r+zq3pFM/BHVKyd+2hkfH7N6Q==}
+    engines: {node: ^22.22.3 || ^24.15.0 || >=26.0.0}
     peerDependencies:
-      '@angular/common': 21.2.16
-      '@angular/core': 21.2.16
-      '@angular/platform-browser': 21.2.16
+      '@angular/common': 22.1.3
+      '@angular/core': 22.1.3
+      '@angular/platform-browser': 22.1.3
       rxjs: ^6.5.3 || ^7.4.0
 
-  '@asamuzakjp/css-color@5.1.11':
-    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+  '@asamuzakjp/css-color@6.0.7':
+    resolution: {integrity: sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==}
+    engines: {node: ^22.13.0 || >=24.0.0}
 
-  '@asamuzakjp/dom-selector@7.1.1':
-    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-
-  '@asamuzakjp/generational-cache@1.0.1':
-    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-
-  '@asamuzakjp/nwsapi@2.3.9':
-    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+  '@asamuzakjp/dom-selector@8.3.2':
+    resolution: {integrity: sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==}
+    engines: {node: ^22.13.0 || >=24.0.0}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@8.0.0':
+    resolution: {integrity: sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/compat-data@7.29.7':
     resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@8.0.0':
+    resolution: {integrity: sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/core@7.29.0':
     resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/core@8.0.1':
+    resolution: {integrity: sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/generator@7.29.7':
     resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-annotate-as-pure@7.27.3':
-    resolution: {integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==}
-    engines: {node: '>=6.9.0'}
+  '@babel/generator@8.0.0':
+    resolution: {integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-annotate-as-pure@8.0.0':
+    resolution: {integrity: sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-compilation-targets@7.29.7':
     resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-compilation-targets@8.0.0':
+    resolution: {integrity: sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-globals@7.29.7':
     resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@8.0.0':
+    resolution: {integrity: sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-module-imports@7.29.7':
     resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
@@ -364,52 +332,85 @@ packages:
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@8.0.0':
+    resolution: {integrity: sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-validator-identifier@7.29.7':
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@8.0.4':
+    resolution: {integrity: sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-validator-option@7.29.7':
     resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-option@8.0.0':
+    resolution: {integrity: sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helpers@7.29.7':
     resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@8.0.0':
+    resolution: {integrity: sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@8.0.4':
+    resolution: {integrity: sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    hasBin: true
+
   '@babel/template@7.29.7':
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/template@8.0.0':
+    resolution: {integrity: sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/traverse@7.29.7':
     resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@8.0.4':
+    resolution: {integrity: sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@8.0.4':
+    resolution: {integrity: sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@csstools/color-helpers@6.0.2':
-    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+  '@csstools/color-helpers@6.1.1':
+    resolution: {integrity: sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==}
     engines: {node: '>=20.19.0'}
 
-  '@csstools/css-calc@3.2.1':
-    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^4.0.0
       '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/css-color-parser@4.1.1':
-    resolution: {integrity: sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==}
+  '@csstools/css-color-parser@4.2.0':
+    resolution: {integrity: sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^4.0.0
@@ -421,8 +422,8 @@ packages:
     peerDependencies:
       '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/css-syntax-patches-for-csstree@1.1.5':
-    resolution: {integrity: sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==}
+  '@csstools/css-syntax-patches-for-csstree@1.1.8':
+    resolution: {integrity: sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==}
     peerDependencies:
       css-tree: ^3.2.1
     peerDependenciesMeta:
@@ -433,167 +434,173 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
-  '@emnapi/core@1.9.1':
-    resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
-  '@emnapi/runtime@1.9.1':
-    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
+  '@emnapi/core@1.11.2':
+    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
 
-  '@emnapi/wasi-threads@1.2.0':
-    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
-  '@esbuild/aix-ppc64@0.27.3':
-    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.3':
-    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.27.3':
-    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.3':
-    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.3':
-    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.3':
-    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.3':
-    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.3':
-    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.3':
-    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.3':
-    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.3':
-    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.3':
-    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.3':
-    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.3':
-    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.3':
-    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.3':
-    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.3':
-    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.3':
-    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.3':
-    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.3':
-    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.3':
-    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.3':
-    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.27.3':
-    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.3':
-    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.3':
-    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.3':
-    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -607,10 +614,6 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@gar/promise-retry@1.0.3':
-    resolution: {integrity: sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
   '@harperfast/extended-iterable@1.0.3':
     resolution: {integrity: sha512-sSAYhQca3rDWtQUHSAPeO7axFIUJOI6hn1gjRC5APVE1a90tuyT8f5WIgRsFhhWA7htNkju2veB9eWL6YHi/Lw==}
 
@@ -620,143 +623,157 @@ packages:
     peerDependencies:
       hono: '>=4.12.7'
 
-  '@inquirer/ansi@1.0.2':
-    resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
-    engines: {node: '>=18'}
+  '@inquirer/ansi@2.0.7':
+    resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
 
-  '@inquirer/checkbox@4.3.2':
-    resolution: {integrity: sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==}
-    engines: {node: '>=18'}
+  '@inquirer/checkbox@5.2.2':
+    resolution: {integrity: sha512-Y5/bAScMy5Y+9isCx0SKbyJebMCaXXX5em0kxkj115eZNscgV9srOHrgyfS0e5xAVymIfOh9piYBKDILktsMMg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/confirm@5.1.21':
-    resolution: {integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==}
-    engines: {node: '>=18'}
+  '@inquirer/confirm@6.1.1':
+    resolution: {integrity: sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/core@10.3.2':
-    resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
-    engines: {node: '>=18'}
+  '@inquirer/confirm@6.2.0':
+    resolution: {integrity: sha512-SKXarWrYhtpqOEctf9XGCGy29QjsvJAM0Aq9ZR9z4Ns94OmpqudOly+aSEfNqUf9SwsQaUgY9+Z8hyzG0xX8fw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/editor@4.2.23':
-    resolution: {integrity: sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==}
-    engines: {node: '>=18'}
+  '@inquirer/core@11.2.1':
+    resolution: {integrity: sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/expand@4.0.23':
-    resolution: {integrity: sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==}
-    engines: {node: '>=18'}
+  '@inquirer/core@12.0.0':
+    resolution: {integrity: sha512-+nnvFEXIB08CZNVXpvW3B+zHW96QXvGUjNKJ8NJIPqAZi5Kd4WhYt2S3C234ReepG1qw2HOlEUbjYVHBowXObA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/external-editor@1.0.3':
-    resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
-    engines: {node: '>=18'}
+  '@inquirer/editor@5.3.0':
+    resolution: {integrity: sha512-nnsP/IdJ8s83q7ZuObmgn12QM+uLCkab9E0Oordojbn62WUg1c+v9Ou/F/057pgh0ppX0W+Hj5bO/Dp5hsxQtA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/figures@1.0.15':
-    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
-    engines: {node: '>=18'}
-
-  '@inquirer/input@4.3.1':
-    resolution: {integrity: sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==}
-    engines: {node: '>=18'}
+  '@inquirer/expand@5.1.2':
+    resolution: {integrity: sha512-OWIH1IyyWqEKIyqC9Xy+Bnga7NkGMovFdo4atYZMUOTRqf6rO2WCv9E/1MyzvOErDBCxs+9UFliRUDc50xs/jw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/number@3.0.23':
-    resolution: {integrity: sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==}
-    engines: {node: '>=18'}
+  '@inquirer/external-editor@3.0.4':
+    resolution: {integrity: sha512-tZbbaK2ovq6vlrRBNQvjrypmrED/p5x2ncIHQ79cD55tei3dD96v5glMMA+6tiq7K104i/25DVYKWVPJuV6ptA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/password@4.0.23':
-    resolution: {integrity: sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==}
-    engines: {node: '>=18'}
+  '@inquirer/figures@2.0.8':
+    resolution: {integrity: sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
+  '@inquirer/input@5.1.3':
+    resolution: {integrity: sha512-F/BZHtyEzP+HO+IGVd4AjBRgvX/ywm42bx8S0+dENk2YclzE9tJ3X/15THwtT6ehApmKvdYDMsVTuyyDod0gOQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/prompts@7.10.1':
-    resolution: {integrity: sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==}
-    engines: {node: '>=18'}
+  '@inquirer/number@4.2.0':
+    resolution: {integrity: sha512-ew+fSDijsQ/WhD4TV3XLb+if400cDuzTzHfGR8sTNBXkK9CYDWoGE8fhaO8GbT312pNv1AJEOsDxy/z/HVettA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/rawlist@4.1.11':
-    resolution: {integrity: sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==}
-    engines: {node: '>=18'}
+  '@inquirer/password@5.1.2':
+    resolution: {integrity: sha512-nSdufycW8xynEVssFkNQEYIzTySilog0UlfOVRwh3pXzPSk4frXUT2jZWjHnKae6RU9PaoF9wfy1pGwewQuqGw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/search@3.2.2':
-    resolution: {integrity: sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==}
-    engines: {node: '>=18'}
+  '@inquirer/prompts@8.5.2':
+    resolution: {integrity: sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/select@4.4.2':
-    resolution: {integrity: sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==}
-    engines: {node: '>=18'}
+  '@inquirer/rawlist@5.3.2':
+    resolution: {integrity: sha512-oPSKrYK1X1bMkjXDzIKHUkJp195LFSfgbnVtXnjSKGFjrCbS6I+wyvfAZTwKE9BSt3HwWgfD7JfsXALBgCogzQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/type@3.0.10':
-    resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
-    engines: {node: '>=18'}
+  '@inquirer/search@4.3.0':
+    resolution: {integrity: sha512-HFxXE5w727ctSUcAwrDquftJGjMgu36OeV5SHEXMlr2j/ahzmRX9xSEeVolV8tzYnTf45cg6vGkdMMRdm3RPhQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@isaacs/fs-minipass@4.0.1':
-    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
-    engines: {node: '>=18.0.0'}
+  '@inquirer/select@5.2.2':
+    resolution: {integrity: sha512-RkI8dRHWt+bh04oLixvF1kFzKC7e5rqJoHKkzcqSHATebBXFC6GmrT8ddbVkgSzLV0HnHs2cPFuBINr8otij8Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@4.0.7':
+    resolution: {integrity: sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   '@istanbuljs/schema@0.1.6':
     resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
@@ -778,50 +795,50 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@listr2/prompt-adapter-inquirer@3.0.5':
-    resolution: {integrity: sha512-WELs+hj6xcilkloBXYf9XXK8tYEnKsgLj01Xl5ONUJpKjmT5hGVUzNUS5tooUxs7pGMrw+jFD/41WpqW4V3LDA==}
-    engines: {node: '>=20.0.0'}
+  '@listr2/prompt-adapter-inquirer@4.2.5':
+    resolution: {integrity: sha512-pYGy9dTdTwXdasPgyohkr0HoQ4FrkAzFnsUZl/gcnadDArbpZ8e+fgr+F9WBdNEl2y00mb9bCM4WgmoBkZJ27A==}
+    engines: {node: '>=22.13.0'}
     peerDependencies:
-      '@inquirer/prompts': '>= 3 < 8'
-      listr2: 9.0.5
+      '@inquirer/prompts': '>= 3 < 9'
+      listr2: 11.0.0
 
-  '@lmdb/lmdb-darwin-arm64@3.5.1':
-    resolution: {integrity: sha512-tpfN4kKrrMpQ+If1l8bhmoNkECJi0iOu6AEdrTJvWVC+32sLxTARX5Rsu579mPImRP9YFWfWgeRQ5oav7zApQQ==}
+  '@lmdb/lmdb-darwin-arm64@3.5.6':
+    resolution: {integrity: sha512-mY5FG4TjPAkY4P0w+OhHaUka5mDh2TX2WKYIwuKzJ1zeW3VvRgxdam/lGJTquI+bthTx5CSHDW+BAQCnNAzkEA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@lmdb/lmdb-darwin-x64@3.5.1':
-    resolution: {integrity: sha512-+a2tTfc3rmWhLAolFUWRgJtpSuu+Fw/yjn4rF406NMxhfjbMuiOUTDRvRlMFV+DzyjkwnokisskHbCWkS3Ly5w==}
+  '@lmdb/lmdb-darwin-x64@3.5.6':
+    resolution: {integrity: sha512-foa+pwitysO8k+xhs7psBFfTKnVgR69NlZRRTHaFVDqphh7AdGpLeyRzKw/ofatr/sN6TiHRRW6mmop0ZrrppQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@lmdb/lmdb-linux-arm64@3.5.1':
-    resolution: {integrity: sha512-aoERa5B6ywXdyFeYGQ1gbQpkMkDbEo45qVoXE5QpIRavqjnyPwjOulMkmkypkmsbJ5z4Wi0TBztON8agCTG0Vg==}
+  '@lmdb/lmdb-linux-arm64@3.5.6':
+    resolution: {integrity: sha512-HmiyFFdJa38s1heCMSooSPaBSFTHJ3C+ERPp28xAPlDX1YiALJVOgbry065nXd8Y7KISWjnw05zpG1RX8IfftA==}
     cpu: [arm64]
     os: [linux]
 
-  '@lmdb/lmdb-linux-arm@3.5.1':
-    resolution: {integrity: sha512-0EgcE6reYr8InjD7V37EgXcYrloqpxVPINy3ig1MwDSbl6LF/vXTYRH9OE1Ti1D8YZnB35ZH9aTcdfSb5lql2A==}
+  '@lmdb/lmdb-linux-arm@3.5.6':
+    resolution: {integrity: sha512-QR4YRyR5h5Z8eGXrNQjiyo2NNDfqi3tCc9dQG5Is1blCt+qWw1ZoBWhlWAr5d+jshkifMIJjVHzHGKbkKzF8Tw==}
     cpu: [arm]
     os: [linux]
 
-  '@lmdb/lmdb-linux-x64@3.5.1':
-    resolution: {integrity: sha512-SqNDY1+vpji7bh0sFH5wlWyFTOzjbDOl0/kB5RLLYDAFyd/uw3n7wyrmas3rYPpAW7z18lMOi1yKlTPv967E3g==}
+  '@lmdb/lmdb-linux-x64@3.5.6':
+    resolution: {integrity: sha512-ADzCuCF2cTNiX9kDScqcz1fjnAkxPpQNneV3KFTdV3wWtVlI2sTGzySoMTgDpinkMMFj1NTJlxA6XR8fwc4hlA==}
     cpu: [x64]
     os: [linux]
 
-  '@lmdb/lmdb-win32-arm64@3.5.1':
-    resolution: {integrity: sha512-50v0O1Lt37cwrmR9vWZK5hRW0Aw+KEmxJJ75fge/zIYdvNKB/0bSMSVR5Uc2OV9JhosIUyklOmrEvavwNJ8D6w==}
+  '@lmdb/lmdb-win32-arm64@3.5.6':
+    resolution: {integrity: sha512-J7A9aEQsQiv0TYtBGL7NDIPp2lOS8nnl+zm4sWZm1xlsTTaQ4PgD096Adzdrk27rw3UxCkDXdCUa4ax41oztBQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@lmdb/lmdb-win32-x64@3.5.1':
-    resolution: {integrity: sha512-qwosvPyl+zpUlp3gRb7UcJ3H8S28XHCzkv0Y0EgQToXjQP91ZD67EHSCDmaLjtKhe+GVIW5om1KUpzVLA0l6pg==}
+  '@lmdb/lmdb-win32-x64@3.5.6':
+    resolution: {integrity: sha512-1g7G0knRX2iV/voDu54yxrGqw5Dk0w2oIYb7dgJq8IkOi+m7wbD8Q3QpPFjh0C01G58S88dqGn03len6UPCXsg==}
     cpu: [x64]
     os: [win32]
 
-  '@modelcontextprotocol/sdk@1.26.0':
-    resolution: {integrity: sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==}
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -966,51 +983,140 @@ packages:
     resolution: {integrity: sha512-xJIPs+bYuc9ASBl+cvGsKbGrJmS6fAKaSZCnT0lhahT5rhA2VVy9/EcIgd2JhtEuFOJNx7UHNn/qiTPTY4nrQw==}
     engines: {node: '>= 10'}
 
-  '@napi-rs/wasm-runtime@1.1.4':
-    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+  '@napi-rs/wasm-runtime@1.2.3':
+    resolution: {integrity: sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
     peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
+      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.4
+      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.4
 
-  '@npmcli/agent@4.0.2':
-    resolution: {integrity: sha512-EUEuWAxnL07Sp5/iC/1X6Xj+XThUvnbei9zfRWZdEXa7lss9RTHMhAHBeg+MZ5To9s/gGaSI+UwZTPdYMvKSeg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  '@oxc-parser/binding-android-arm-eabi@0.142.0':
+    resolution: {integrity: sha512-ZiRGDutGsv1G6bL/ozy/koC0Sv39T1DqyoC4KD1DOy9ZoACm1O5UWhEK2c02Qdk+4lfLVkvFa/mQ0fm/4h1BtQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
 
-  '@npmcli/fs@5.0.0':
-    resolution: {integrity: sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  '@oxc-parser/binding-android-arm64@0.142.0':
+    resolution: {integrity: sha512-WZkvGRLNQTz8lR9zP5nLjUdlroRCopBu3g9zF1p/laE6DzT1UbQo8Rdz5MWhaJUPYg/6gp+jo7HUgsyKaN1FtQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
 
-  '@npmcli/git@7.0.2':
-    resolution: {integrity: sha512-oeolHDjExNAJAnlYP2qzNjMX/Xi9bmu78C9dIGr4xjobrSKbuMYCph8lTzn4vnW3NjIqVmw/f8BCfouqyJXlRg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  '@oxc-parser/binding-darwin-arm64@0.142.0':
+    resolution: {integrity: sha512-l4khS8LQOOVYsGRVARo1gSaCT/aBSceUVXgtovWc2+drnxVuDr082WA3OCHVdVzIz5JIrP/y9CWsSKxBDNmYGg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
 
-  '@npmcli/installed-package-contents@4.0.0':
-    resolution: {integrity: sha512-yNyAdkBxB72gtZ4GrwXCM0ZUedo9nIbOMKfGjt6Cu6DXf0p8y1PViZAKDC8q8kv/fufx0WTjRBdSlyrvnP7hmA==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-    hasBin: true
+  '@oxc-parser/binding-darwin-x64@0.142.0':
+    resolution: {integrity: sha512-QBsNF3nqlXmcH2B1YOPqQYmCJoy4HuIjUxGbBO/k5JAJUl68ghU2psRY2zPk+RyBaWqKP/qfL4oaFgEMCdwskA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
 
-  '@npmcli/node-gyp@5.0.0':
-    resolution: {integrity: sha512-uuG5HZFXLfyFKqg8QypsmgLQW7smiRjVc45bqD/ofZZcR/uxEjgQU8qDPv0s9TEeMUiAAU/GC5bR6++UdTirIQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  '@oxc-parser/binding-freebsd-x64@0.142.0':
+    resolution: {integrity: sha512-b7Q7m4Cqc6XqNhri3R+QhU+GVy646Pn+bkdhrDdWym/Fdi0ZUa+d73H9dm5H91JtbtAQ/z1d8XKMW3oOV8a4tQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
 
-  '@npmcli/package-json@7.0.5':
-    resolution: {integrity: sha512-iVuTlG3ORq2iaVa1IWUxAO/jIp77tUKBhoMjuzYW2kL4MLN1bi/ofqkZ7D7OOwh8coAx1/S2ge0rMdGv8sLSOQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.142.0':
+    resolution: {integrity: sha512-3riVS5IhdH3uCZj1Y9ftDQlR0dvLsIlw/edrRqk8JhgNd5K0XSs+UBtgh50N13CAlW9/TXj6sVGXaKNBocd0Yg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
 
-  '@npmcli/promise-spawn@9.0.1':
-    resolution: {integrity: sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  '@oxc-parser/binding-linux-arm-musleabihf@0.142.0':
+    resolution: {integrity: sha512-NmXUOpgpTSkhl795TiXmWppTwmSJ92RC1qvD6e4XOF+slgmo3e6Ah+kEu+6AN8s7NAOEwqGmir58MgSQSWmBSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
 
-  '@npmcli/redact@4.0.0':
-    resolution: {integrity: sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  '@oxc-parser/binding-linux-arm64-gnu@0.142.0':
+    resolution: {integrity: sha512-gc0EXsKtXgerujmU2Bql3u1L1HsSQ2774R83idq/FoNMPVV/RY/1ErFsvnit7KoiP/sLvzQixeUo4Ut0ic0wmw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
 
-  '@npmcli/run-script@10.0.4':
-    resolution: {integrity: sha512-mGUWr1uMnf0le2TwfOZY4SFxZGXGfm4Jtay/nwAa2FLNAKXUoUwaGwBMNH36UHPtinWfTSJ3nqFQr0091CxVGg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  '@oxc-parser/binding-linux-arm64-musl@0.142.0':
+    resolution: {integrity: sha512-F2XvmWSE0uWpie+jHKKIFgdVOe9ypGhkEZxKx5DuW215K6cbAC274yYaPkcM7EqY4Df3Weyhpcz3lsURyH2LVg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
 
-  '@oxc-project/types@0.113.0':
-    resolution: {integrity: sha512-Tp3XmgxwNQ9pEN9vxgJBAqdRamHibi76iowQ38O2I4PMpcvNRQNVsU2n1x1nv9yh0XoTrGFzf7cZSGxmixxrhA==}
+  '@oxc-parser/binding-linux-ppc64-gnu@0.142.0':
+    resolution: {integrity: sha512-wLMbT21U/QxknQsk+VvNF0b9D2/aGWhcaQQQ+VYlE8FwD5+GoWZIPPXNzyHmkYyhm0KB3itL+TBavjMatqNnYA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.142.0':
+    resolution: {integrity: sha512-+G8F/4ckwT7FCJV4H2bt09xEzJbjNCfuL4Sp1AYNaFtFMVtgIGMuJlteT82U+K0UIZ/DzAR/LDlMFnEuajG7Kw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.142.0':
+    resolution: {integrity: sha512-hTsHtTLxMAfCo+rpF5K3qZJKW2NpPN/CHd4mYB3y7XlSdspHkd2gehDIofP64AacA9nWQw2tY3O7wR6UY8IVOA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.142.0':
+    resolution: {integrity: sha512-6y7qYY3TCUDYjqswImdTGl92y+KA/80twALegQPN27kfY+bG7Ib1+L3jbmrCZQx6wrVnai9IPsEZp07I0hx7JQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.142.0':
+    resolution: {integrity: sha512-i69kAWU+2LgoH5bR+zWiiu+UzAw7Oxkwv7COeJTeY19pn4e70nKQcr9Pm6cL2Z0Z54d+gl9qADlK/0yyuCPiBA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-x64-musl@0.142.0':
+    resolution: {integrity: sha512-4SQs678MmjYVrmhAgCWD4o0vpaFszXw9xLX5p2Z9MMFcltxiLkA88wQjh80YHjPrXtpyZ2CWI5m+1yNKM0m2Pw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-parser/binding-openharmony-arm64@0.142.0':
+    resolution: {integrity: sha512-YHpx9N7Ln3a++Tc8rv+H7mrK1zyJQOAwCFg8LZ3lTs1T5afGWeZrLPhPT9HLnIwSjCyJqPWVMIrMxbjcmBr2oQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-wasm32-wasi@0.142.0':
+    resolution: {integrity: sha512-3pLDyY3+oogW73RM5uehNgAiR/Xfb7fvO2Q1Z1gIqZ2+50XDVQmBVlRkHXZTU4gKnQHpwETNsYQVsJ3joVB2iA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.142.0':
+    resolution: {integrity: sha512-Had/VeVY28Oyb0K+Q4FV8KCzoBycIh93oDK6pCbya9lkzdq+ikMHMgBubsdqqlybjJmQRawCQRrnBRHyQwYvcQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.142.0':
+    resolution: {integrity: sha512-GGi3+YphVHavvgs6gum2UXoNCqzHAmPt/nXkn8ZQZstV2Q1qZD1Mn8fz/nWrDkefHQtrG/+1/XrbMxsBTo6Svw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.142.0':
+    resolution: {integrity: sha512-Ny/Wv4Us1LGC/ljwNTp+Hx3r/pH15EFfeDF0p+n898gt+TtRd6C9SccHcuUhDiNTb8s5tt7jdeAMDRQZ4Vq6hg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-project/types@0.139.0':
+    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
+  '@oxc-project/types@0.140.0':
+    resolution: {integrity: sha512-h5LUOzGArYemnW1NMz/DuuQhBi96J6JL2Bk8zE4kvqxB5Sg3jxmCiH4uyOWHDkiKSt5vWlG4FIwCR/DbstcNRQ==}
+
+  '@oxc-project/types@0.142.0':
+    resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
 
   '@parcel/watcher-android-arm64@2.5.6':
     resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
@@ -1094,85 +1200,186 @@ packages:
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.4':
-    resolution: {integrity: sha512-vRq9f4NzvbdZavhQbjkJBx7rRebDKYR9zHfO/Wg486+I7bSecdUapzCm5cyXoK+LHokTxgSq7A5baAXUZkIz0w==}
+  '@rolldown/binding-android-arm64@1.1.5':
+    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.4':
-    resolution: {integrity: sha512-kFgEvkWLqt3YCgKB5re9RlIrx9bRsvyVUnaTakEpOPuLGzLpLapYxE9BufJNvPg8GjT6mB1alN4yN1NjzoeM8Q==}
+  '@rolldown/binding-android-arm64@1.2.0':
+    resolution: {integrity: sha512-9yB1l95IrJuNGDFdOYe79vdApdz6WWBCObE+rQ2LUliYUlcyFwSYIb2xb5/Ifw7dAtMy2ZqNyd8QTSOc7duAKw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.4':
-    resolution: {integrity: sha512-JXmaOJGsL/+rsmMfutcDjxWM2fTaVgCHGoXS7nE8Z3c9NAYjGqHvXrAhMUZvMpHS/k7Mg+X7n/MVKb7NYWKKww==}
+  '@rolldown/binding-darwin-arm64@1.2.0':
+    resolution: {integrity: sha512-pexNaW9ACLUOaBITOpU6qVu4VrsOFIjTv6bzgu0YUATo4eUJx0V605PxwZfndpPOn0ilqGqvGQ0M8UW0IE24jg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.4':
-    resolution: {integrity: sha512-ep3Catd6sPnHTM0P4hNEvIv5arnDvk01PfyJIJ+J3wVCG1eEaPo09tvFqdtcaTrkwQy0VWR24uz+cb4IsK53Qw==}
+  '@rolldown/binding-darwin-x64@1.2.0':
+    resolution: {integrity: sha512-NqKYaq0355ZmNMG4QGpxtEDxsc7tGDhjhCm4PpE0cwnBW+5Il95LJyq414niEiaKLVjnVHBEjSo1wngKxJNiFw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.4':
-    resolution: {integrity: sha512-LwA5ayKIpnsgXJEwWc3h8wPiS33NMIHd9BhsV92T8VetVAbGe2qXlJwNVDGHN5cOQ22R9uYvbrQir2AB+ntT2w==}
+  '@rolldown/binding-freebsd-x64@1.2.0':
+    resolution: {integrity: sha512-3vPoHzh6eBTz9IbB0/qZdSr0Qeks2echn+I4cHu2joV74VriPDdldswksEDzrl1mBB+oPRi+67+3Ib59paxIPQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.4':
-    resolution: {integrity: sha512-AC1WsGdlV1MtGay/OQ4J9T7GRadVnpYRzTcygV1hKnypbYN20Yh4t6O1Sa2qRBMqv1etulUknqXjc3CTIsBu6A==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.0':
+    resolution: {integrity: sha512-E6NNefZ1bUVmKJq2tJkf45J4Zyczj7qm9rUT7NY+Xo2474Y13qWAwc2tvBt0BAVbmtXR1llkxXg0Ou1jbDf2SQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.4':
-    resolution: {integrity: sha512-lU+6rgXXViO61B4EudxtVMXSOfiZONR29Sys5VGSetUY7X8mg9FCKIIjcPPj8xNDeYzKl+H8F/qSKOBVFJChCQ==}
+  '@rolldown/binding-linux-arm64-gnu@1.2.0':
+    resolution: {integrity: sha512-D+TgkdgM1vu+7/Fpf8+v0ARW+RXEP9Ccazgm8zQ4JFFd9Q7SrYQ2TakU5S5ihazQDgpKyAgZDOcIFsvoHmTZ8w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.4':
-    resolution: {integrity: sha512-DZaN1f0PGp/bSvKhtw50pPsnln4T13ycDq1FrDWRiHmWt1JeW+UtYg9touPFf8yt993p8tS2QjybpzKNTxYEwg==}
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.2.0':
+    resolution: {integrity: sha512-wUqdwJBbAv0APN87GecstdMUtLjjNTs0hBALpxETD73mccFxdmt/XeizXDtN5RAlBwNKmI+Tg+blect2G+8IeQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.0':
+    resolution: {integrity: sha512-9DtF35qR9/NrfhM4oxLplCzVVjE+KKm8Pjemi0i/sdhAWkUasjmSo8WTTubNJClhSHCfyk2yeyoXDQEDPtDAAw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.0':
+    resolution: {integrity: sha512-RzuHrBh8X8Hntd2N4VR02QGEciq/9JhcZoTpR/Cee6otRrlILGCf3cg2ygHuih+ZebUnWmMrDX6ITI85btO6rQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.4':
-    resolution: {integrity: sha512-RnGxwZLN7fhMMAItnD6dZ7lvy+TI7ba+2V54UF4dhaWa/p8I/ys1E73KO6HmPmgz92ZkfD8TXS1IMV8+uhbR9g==}
+  '@rolldown/binding-linux-x64-gnu@1.2.0':
+    resolution: {integrity: sha512-MK7L0018jjh1jR3mh21G2j1zAVcpscJBlPo2z19pRjv2XOYGRhaV4LyiD8HO6nCDdZln9IFgCMIV5yt4E3klGQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.4':
-    resolution: {integrity: sha512-6lcI79+X8klGiGd8yHuTgQRjuuJYNggmEml+RsyN596P23l/zf9FVmJ7K0KVKkFAeYEdg0iMUKyIxiV5vebDNQ==}
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.2.0':
+    resolution: {integrity: sha512-gyrxLQ9NfGb/9LoVnC4kb9miUghw1mghnkfYvNHSnVIXriabnfgGPUP4RLcJm87q3KgYz4FYUG8IDiWUT+CpSw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.4':
-    resolution: {integrity: sha512-wz7ohsKCAIWy91blZ/1FlpPdqrsm1xpcEOQVveWoL6+aSPKL4VUcoYmmzuLTssyZxRpEwzuIxL/GDsvpjaBtOw==}
-    engines: {node: '>=14.0.0'}
+  '@rolldown/binding-openharmony-arm64@1.2.0':
+    resolution: {integrity: sha512-/6VFMQGRmrhP77KXDC+StIxGzcNp5JOIyYtw0CQ8gPlzhpiIRucYfoM5FaFamHd5BJYIdH86yfP46l1p3WdrFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.4':
-    resolution: {integrity: sha512-cfiMrfuWCIgsFmcVG0IPuO6qTRHvF7NuG3wngX1RZzc6dU8FuBFb+J3MIR5WrdTNozlumfgL4cvz+R4ozBCvsQ==}
+  '@rolldown/binding-wasm32-wasi@1.2.0':
+    resolution: {integrity: sha512-rwdbUL465kisF24WEJLvP3JrEG6E5GRuIHt5wpMwHGERtHe4Wm2CIvtf5gTBgr2tGOHKh5NdKEAFS2VkOPE91g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.4':
-    resolution: {integrity: sha512-p6UeR9y7ht82AH57qwGuFYn69S6CZ7LLKdCKy/8T3zS9VTrJei2/CGsTUV45Da4Z9Rbhc7G4gyWQ/Ioamqn09g==}
+  '@rolldown/binding-win32-arm64-msvc@1.2.0':
+    resolution: {integrity: sha512-+5suHwRiKGmhwyUaNT8a5QbrBvLFh2DbO910TEmGRH1aSxwrCezodvGQnulv4uiWEIv1Kq4ypRsJ5+O+ry1DiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-rc.4':
-    resolution: {integrity: sha512-1BrrmTu0TWfOP1riA8uakjFc9bpIUGzVKETsOtzY39pPga8zELGDl8eu1Dx7/gjM5CAz14UknsUMpBO8L+YntQ==}
+  '@rolldown/binding-win32-x64-msvc@1.2.0':
+    resolution: {integrity: sha512-WfFv6/qGufotqBSBzBYwgpCkJBk8Nj7697LL9vTz/XWc67e0r3oewu8iMRwQj3AUL45GVD7wVsPjCsAAtW66Wg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@rollup/rollup-android-arm-eabi@4.61.0':
     resolution: {integrity: sha512-dnxczajOqt0gesZlN5pGQ1s1imQVrsmCw5G2Ci4oM+0WvNz3pyRnlWrT7McoZIb8VlFwCawdmbWRmxRn7HI+VQ==}
@@ -1299,47 +1506,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@schematics/angular@21.2.14':
-    resolution: {integrity: sha512-rIEdtNTdCCTwuo7B4tMoq5qmbLXdBgmW6Ays1hyno//4OE+HFtvlWZd+hl6KceEyN00IcZ2HRaPnfd71E1JnoA==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
-
-  '@sigstore/bundle@4.0.0':
-    resolution: {integrity: sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  '@sigstore/core@3.2.1':
-    resolution: {integrity: sha512-qRsxPnCrbC/puegGxKuynfnxgLiHqWStrSjxkoB4YKqq3Z3s4cyZyj42ZdWFAEblNP65C+rBH8EuREHIXoi83g==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  '@sigstore/protobuf-specs@0.5.1':
-    resolution: {integrity: sha512-/ScWUhhoFasJsSRGTVBwId1loQjjnjAfE4djL6ZhrXRpNCmPTnUKF5Jokd58ILseOMjzET3UrMOtJPS9sYeI0g==}
-    engines: {node: ^18.17.0 || >=20.5.0}
-
-  '@sigstore/sign@4.1.1':
-    resolution: {integrity: sha512-Hf4xglukg0XXQ2RiD5vSoLjdPe8OBUPA8XeVjUObheuDcWdYWrnH/BNmxZCzkAy68MzmNCxXLeurJvs6hcP2OQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  '@sigstore/tuf@4.0.2':
-    resolution: {integrity: sha512-TCAzTy0xzdP79EnxSjq9KQ3eaR7+FmudLC6eRKknVKZbV7ZNlGLClAAQb/HMNJ5n2OBNk2GT1tEmU0xuPr+SLQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  '@sigstore/verify@3.1.1':
-    resolution: {integrity: sha512-qv7+G3J2cc6wwFj3yKvXOamzqhMwSk1ogPGmhpS8iXllcPrJaIIBA+4HbttlHVu1pqWTdmaCH/WE7UOC51kdoA==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  '@schematics/angular@22.1.5':
+    resolution: {integrity: sha512-3UXlO4YoGgQ6nEBbCTGRRHTfQuDcKgHbRaiivzSinHzOYigsskwvloMsa0LCBCO/3uJpDIjJIyTW0XKhDti0iA==}
+    engines: {node: ^22.22.3 || ^24.15.0 || >=26.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@tufjs/canonical-json@2.0.0':
-    resolution: {integrity: sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==}
-    engines: {node: ^16.14.0 || >=18.0.0}
-
-  '@tufjs/models@4.1.0':
-    resolution: {integrity: sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  '@tybys/wasm-util@0.10.2':
-    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -1359,17 +1534,23 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
-  '@vitejs/plugin-basic-ssl@2.1.4':
-    resolution: {integrity: sha512-HXciTXN/sDBYWgeAD4V4s0DN0g72x5mlxQhHxtYu3Tt8BLa6MzcJZUyDVFCdtjNs3bfENVHVzOsmooTVuNgAAw==}
+  '@types/gensync@1.0.5':
+    resolution: {integrity: sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg==}
+
+  '@types/jsesc@2.5.1':
+    resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
+
+  '@vitejs/plugin-basic-ssl@2.3.0':
+    resolution: {integrity: sha512-bdyo8rB3NnQbikdMpHaML9Z1OZPBu6fFOBo+OtxsBlvMJtysWskmBcnbIDhUqgC8tcxNv/a+BcV5U+2nQMm1OQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     peerDependencies:
-      vite: ^6.0.0 || ^7.0.0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@vitest/expect@4.1.8':
-    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+  '@vitest/expect@4.1.11':
+    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
 
-  '@vitest/mocker@4.1.8':
-    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
+  '@vitest/mocker@4.1.11':
+    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1379,35 +1560,28 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.8':
-    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
+  '@vitest/pretty-format@4.1.11':
+    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
 
-  '@vitest/runner@4.1.8':
-    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
+  '@vitest/runner@4.1.11':
+    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
 
-  '@vitest/snapshot@4.1.8':
-    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
+  '@vitest/snapshot@4.1.11':
+    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
 
-  '@vitest/spy@4.1.8':
-    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
+  '@vitest/spy@4.1.11':
+    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
 
-  '@vitest/utils@4.1.8':
-    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
-
-  '@yarnpkg/lockfile@1.1.0':
-    resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
-
-  abbrev@4.0.0:
-    resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  '@vitest/utils@4.1.11':
+    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
-  agent-base@7.1.4:
-    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
-    engines: {node: '>= 14'}
+  agent-base@9.0.0:
+    resolution: {integrity: sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==}
+    engines: {node: '>= 20'}
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -1417,31 +1591,16 @@ packages:
       ajv:
         optional: true
 
-  ajv@8.18.0:
-    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
-
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
-
-  algoliasearch@5.48.1:
-    resolution: {integrity: sha512-Rf7xmeuIo7nb6S4mp4abW2faW8DauZyE2faBIKFaUfP3wnpOvNSbiI5AwVhqBNj0jPgBWEvhyCu0sLjN2q77Rg==}
-    engines: {node: '>= 14.0.0'}
 
   ansi-escapes@7.3.0:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
 
-  ansi-regex@5.0.1:
-    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
-    engines: {node: '>=8'}
-
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
-
-  ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
 
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
@@ -1451,17 +1610,13 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  balanced-match@4.0.4:
-    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
-    engines: {node: 18 || 20 || >=22}
-
   baseline-browser-mapping@2.10.33:
     resolution: {integrity: sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  beasties@0.4.1:
-    resolution: {integrity: sha512-2Imdcw3LznDuxAbJM26RHniOLAzE6WgrK8OuvVXCQtNBS8rsnD9zsSEa3fHl4hHpUY7BYTlrpvtPVbvu9G6neg==}
+  beasties@0.4.3:
+    resolution: {integrity: sha512-fIIeLOcbAB/K1kb1HBVJoiq1alHL4RCYBSo5e7HzrNkkgMggXR1Vqt/Z9JWnkfe/qdCo66Ux3QRwZioAIBdWRA==}
     engines: {node: '>=18.0.0'}
 
   bidi-js@1.0.3:
@@ -1474,10 +1629,6 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
-
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -1489,10 +1640,6 @@ packages:
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
-
-  cacache@20.0.4:
-    resolution: {integrity: sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==}
-    engines: {node: ^20.17.0 || >=22.9.0}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -1516,17 +1663,9 @@ packages:
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
-  chokidar@4.0.3:
-    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
-    engines: {node: '>= 14.16.0'}
-
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
-
-  chownr@3.0.0:
-    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
-    engines: {node: '>=18'}
 
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
@@ -1536,9 +1675,9 @@ packages:
     resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
     engines: {node: '>=18.20'}
 
-  cli-truncate@5.2.0:
-    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
-    engines: {node: '>=20'}
+  cli-truncate@6.1.1:
+    resolution: {integrity: sha512-06p9vyLahLa4zkGcgsGxU6iEkSOiuI4fhCH6Emhe2lPAcoUv73n72DnODsnHA+5wwXGnV0n9M9/qOQJSjYhFhw==}
+    engines: {node: '>=22'}
 
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
@@ -1547,16 +1686,6 @@ packages:
   cliui@9.0.1:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
     engines: {node: '>=20'}
-
-  color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
-
-  color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
-  colorette@2.0.20:
-    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
@@ -1668,8 +1797,9 @@ packages:
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
-  emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+  empathic@2.0.1:
+    resolution: {integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==}
+    engines: {node: '>=14'}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -1677,10 +1807,6 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
-    engines: {node: '>=0.12'}
-
-  entities@6.0.1:
-    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
   entities@7.0.1:
@@ -1691,16 +1817,9 @@ packages:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
 
-  env-paths@2.2.1:
-    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
-    engines: {node: '>=6'}
-
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
-
-  err-code@2.0.3:
-    resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -1717,8 +1836,8 @@ packages:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
 
-  esbuild@0.27.3:
-    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1736,9 +1855,6 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
-  eventemitter3@5.0.4:
-    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
-
   eventsource-parser@3.1.0:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
@@ -1750,9 +1866,6 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
-
-  exponential-backoff@3.1.3:
-    resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
   express-rate-limit@8.5.2:
     resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
@@ -1767,8 +1880,17 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1790,10 +1912,6 @@ packages:
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
-
-  fs-minipass@3.0.3:
-    resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1823,13 +1941,6 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
-  glob-to-regexp@0.4.1:
-    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
-
-  glob@13.0.6:
-    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
-    engines: {node: 18 || 20 || >=22}
-
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -1849,9 +1960,9 @@ packages:
     resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
     engines: {node: '>=16.9.0'}
 
-  hosted-git-info@9.0.3:
-    resolution: {integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  hosted-git-info@10.1.1:
+    resolution: {integrity: sha512-DeOnSPAvOndYKfw075gt8yZzQ7S2hNztw34zBTfhIzLhmBTswIBg5/y+pqu/VD5cYWm5goAFTusDmUEmKZ0PEQ==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
@@ -1860,38 +1971,26 @@ packages:
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
-  http-cache-semantics@4.2.0:
-    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
-
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
-  http-proxy-agent@7.0.2:
-    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
-    engines: {node: '>= 14'}
-
-  https-proxy-agent@7.0.6:
-    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
-    engines: {node: '>= 14'}
+  https-proxy-agent@9.1.0:
+    resolution: {integrity: sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==}
+    engines: {node: '>= 20'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
-  ignore-walk@8.0.0:
-    resolution: {integrity: sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
   immutable@5.1.6:
     resolution: {integrity: sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==}
 
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
-  ini@6.0.0:
-    resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
 
   internmap@1.0.1:
     resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
@@ -1907,10 +2006,6 @@ packages:
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
-
-  is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
 
   is-fullwidth-code-point@5.1.0:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
@@ -1937,10 +2032,6 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  isexe@4.0.0:
-    resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
-    engines: {node: '>=20'}
-
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -1952,14 +2043,17 @@ packages:
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  jsdom@29.1.1:
-    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+  jsdom@30.0.1:
+    resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
     peerDependencies:
-      canvas: ^3.0.0
+      canvas: ^3.2.3
     peerDependenciesMeta:
       canvas:
         optional: true
@@ -1968,10 +2062,6 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
-
-  json-parse-even-better-errors@5.0.0:
-    resolution: {integrity: sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -1987,28 +2077,98 @@ packages:
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
-  jsonparse@1.3.1:
-    resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
-    engines: {'0': node >= 0.2.0}
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
 
-  listr2@9.0.5:
-    resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
-    engines: {node: '>=20.0.0'}
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
 
-  lmdb@3.5.1:
-    resolution: {integrity: sha512-NYHA0MRPjvNX+vSw8Xxg6FLKxzAG+e7Pt8RqAQA/EehzHVXq9SxDqJIN3JL1hK0dweb884y8kIh6rkWvPyg9Wg==}
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
+    engines: {node: '>= 12.0.0'}
+
+  listr2@11.0.0:
+    resolution: {integrity: sha512-8K88S0aSrcSXdJfiZtEy5BQMnR+TyjrCGLcgAvQs6ta0NEnIm0RJ72/Pv67Jvg07cfBhDbuN74V81lSSVYEFEw==}
+    engines: {node: '>=22.13.0'}
+
+  lmdb@3.5.6:
+    resolution: {integrity: sha512-j3uE8ReKNyUWDjhfEFSJqE/1DLtfTR5Z8yFzVHvBjAk37wNg7HdScjcv8ttPHRvrdgPQMPWxFFI0SsdBzI5lBw==}
     hasBin: true
 
   log-symbols@7.0.1:
     resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
     engines: {node: '>=18'}
 
-  log-update@6.1.0:
-    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
-    engines: {node: '>=18'}
+  log-update@8.0.0:
+    resolution: {integrity: sha512-lddSgOt3bPASrylL54ZSpy8nBHns+vBVSoILlVOx+dei300pnLRN958rj/EdlVLKuWlSESU3qdnDZdAI7FXYGg==}
+    engines: {node: '>=22'}
 
   lru-cache@11.5.1:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
+
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
@@ -2017,9 +2177,8 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  make-fetch-happen@15.0.6:
-    resolution: {integrity: sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  magic-string@1.0.0:
+    resolution: {integrity: sha512-CGvjzMN08iv6w1mm4/x3Gh1hLb4VnyRUA15FFpl6CsCIGGoe36k7kY5KNz9QDbSBN5I/fWHM6ZlIkUTa5xdUEA==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2048,42 +2207,6 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
-  minimatch@10.2.5:
-    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
-    engines: {node: 18 || 20 || >=22}
-
-  minipass-collect@2.0.1:
-    resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
-  minipass-fetch@5.0.2:
-    resolution: {integrity: sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  minipass-flush@1.0.7:
-    resolution: {integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==}
-    engines: {node: '>= 8'}
-
-  minipass-pipeline@1.2.4:
-    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
-    engines: {node: '>=8'}
-
-  minipass-sized@2.0.0:
-    resolution: {integrity: sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==}
-    engines: {node: '>=8'}
-
-  minipass@3.3.6:
-    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
-    engines: {node: '>=8'}
-
-  minipass@7.1.3:
-    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
-  minizlib@3.1.0:
-    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
-    engines: {node: '>= 18'}
-
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -2098,12 +2221,17 @@ packages:
   msgpackr@1.11.12:
     resolution: {integrity: sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg==}
 
-  mute-stream@2.0.0:
-    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
-    engines: {node: ^18.17.0 || >=20.5.0}
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2121,47 +2249,13 @@ packages:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
     hasBin: true
 
-  node-gyp@12.3.0:
-    resolution: {integrity: sha512-QNcUWM+HgJplcPzBvFBZ9VXacyGZ4+VTOb80PwWR+TlVzoHbRKULNEzpRsnaoxG3Wzr7Qh7BYxGDU3CbKib2Yg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-    hasBin: true
-
   node-releases@2.0.47:
     resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
     engines: {node: '>=18'}
 
-  nopt@9.0.0:
-    resolution: {integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-    hasBin: true
-
-  npm-bundled@5.0.0:
-    resolution: {integrity: sha512-JLSpbzh6UUXIEoqPsYBvVNVmyrjVZ1fzEFbqxKkTJQkWBO3xFzFT+KDnSKQWwOQNbuWRwt5LSD6HOTLGIWzfrw==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  npm-install-checks@8.0.0:
-    resolution: {integrity: sha512-ScAUdMpyzkbpxoNekQ3tNRdFI8SJ86wgKZSQZdUxT+bj0wVFpsEMWnkXP0twVe1gJyNF5apBWDJhhIbgrIViRA==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  npm-normalize-package-bin@5.0.0:
-    resolution: {integrity: sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  npm-package-arg@13.0.2:
-    resolution: {integrity: sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  npm-packlist@10.0.4:
-    resolution: {integrity: sha512-uMW73iajD8hiH4ZBxEV3HC+eTnppIqwakjOYuvgddnalIw2lJguKviK1pcUJDlIWm1wSJkchpDZDSVVsZEYRng==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  npm-pick-manifest@11.0.3:
-    resolution: {integrity: sha512-buzyCfeoGY/PxKqmBqn1IUJrZnUi1VVJTdSSRPGI60tJdUhUoSQFhs0zycJokDdOznQentgrpf8LayEHyyYlqQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  npm-registry-fetch@19.1.1:
-    resolution: {integrity: sha512-TakBap6OM1w0H73VZVDf44iFXsOS3h+L4wVMXmbWOQroZgFhMch0juN6XSzBNlD965yIKvWg2dfu7NSiaYLxtw==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  npm-package-arg@14.0.0:
+    resolution: {integrity: sha512-69XQh3k+dtGa1p+7RaR57IuG3rCko96xr/nUfN4yDYBXbTYICiWcOpsFKLN2GtGE9cyIljE+f1exnaYt9MvM+Q==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
@@ -2188,24 +2282,19 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
-  ora@9.3.0:
-    resolution: {integrity: sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==}
+  ora@9.4.1:
+    resolution: {integrity: sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw==}
     engines: {node: '>=20'}
 
   ordered-binary@1.6.1:
     resolution: {integrity: sha512-QkCdPooczexPLiXIrbVOPYkR3VO3T6v2OyKRkR1Xbhpy7/LAVXwahnRCgRp78Oe/Ehf0C/HATAxfSr6eA1oX+w==}
 
-  p-map@7.0.4:
-    resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
-    engines: {node: '>=18'}
+  oxc-parser@0.142.0:
+    resolution: {integrity: sha512-kKR+jPiRJYJDexVoziIg/FVGvr1fT1FZSSJOk6tVoMKKSlsf1Cso+cgGCJkOEDWOP174vRntCPFKg+AS7InWvw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
-  pacote@21.3.1:
-    resolution: {integrity: sha512-O0EDXi85LF4AzdjG74GUwEArhdvawi/YOHcsW6IijKNj7wm8IvEWNF5GnfuxNpQ/ZpO3L37+v8hqdVh8GgWYhg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-    hasBin: true
-
-  parse5-html-rewriting-stream@8.0.0:
-    resolution: {integrity: sha512-wzh11mj8KKkno1pZEu+l2EVeWsuKDfR5KNWZOTsslfUX8lPDZx77m9T0kIoAVkFtD1nx6YF8oh4BnPHvxMtNMw==}
+  parse5-html-rewriting-stream@8.0.1:
+    resolution: {integrity: sha512-NaRku2aMpUN1Sh1Gyk1KWUh2A7EJx2c6qYzvwsPtqhoHoaURshdrceYK3LunVCm3WHhm6FS7Vcczbvdh3/UIVw==}
 
   parse5-sax-parser@8.0.0:
     resolution: {integrity: sha512-/dQ8UzHZwnrzs3EvDj6IkKrD/jIZyTlB+8XrHJvcjNgRdmWruNdN9i9RK/JtxakmlUdPwKubKPTCqvbTgzGhrw==}
@@ -2221,10 +2310,6 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
-  path-scurry@2.0.2:
-    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
-    engines: {node: 18 || 20 || >=22}
-
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
@@ -2238,8 +2323,12 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  piscina@5.1.4:
-    resolution: {integrity: sha512-7uU4ZnKeQq22t9AsmHGD2w4OYQGonwFnTypDypaWi7Qr2EvQIFVtG8J5D/3bE7W123Wdc9+v4CZDu5hJXVCtBg==}
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  piscina@5.2.0:
+    resolution: {integrity: sha512-DszUCKeVN/5G5QKo6jAVHL8fmKnkJvQ0ACiVgY7YGCq3TUB2oznAOayvZPIAdEThvhczkXR+qm3IHsNXpFCYfA==}
     engines: {node: '>=20.x'}
 
   pkce-challenge@5.0.1:
@@ -2259,17 +2348,26 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
-  proc-log@6.1.0:
-    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
 
-  promise-retry@2.0.1:
-    resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
-    engines: {node: '>=10'}
+  proc-log@7.0.0:
+    resolution: {integrity: sha512-FYgfaA69XZ93zaXLoMNQ+ViDXGGBgR8aLh03txzcFhV+9xOXx7+8DLCULrKKpR9+GsH9ZfHm82aSUPpozX0Ztg==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  proxy-agent-negotiate@1.1.0:
+    resolution: {integrity: sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      kerberos: ^2.0.0
+    peerDependenciesMeta:
+      kerberos:
+        optional: true
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2287,10 +2385,6 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
-  readdirp@4.1.2:
-    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
-    engines: {node: '>= 14.18.0'}
-
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
@@ -2306,15 +2400,13 @@ packages:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
 
-  retry@0.12.0:
-    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
-    engines: {node: '>= 4'}
+  rolldown@1.1.5:
+    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
 
-  rfdc@1.4.1:
-    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
-
-  rolldown@1.0.0-rc.4:
-    resolution: {integrity: sha512-V2tPDUrY3WSevrvU2E41ijZlpF+5PbZu4giH+VpNraaadsJGHa4fR6IFwsocVwEXDoAdIv5qgPPxgrvKAOIPtA==}
+  rolldown@1.2.0:
+    resolution: {integrity: sha512-u7tgm5l4Yw1iTqUL4EcYOAt7fFvCgQMLeidrnD4GALlC6aOznCjezYajgxeyKw27u0Q5N7fwgCzjVyPIWzwuBA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -2333,9 +2425,9 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  sass@1.97.3:
-    resolution: {integrity: sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==}
-    engines: {node: '>=14.0.0'}
+  sass@1.101.0:
+    resolution: {integrity: sha512-OL3GoQyoUdDt843DpVmDO6y2k1sc5IhUDSpu8XucEI+35neq5QivZ1iuegnpraEVTJXlQGK1gl27zKcTLEPbQw==}
+    engines: {node: '>=20.19.0'}
     hasBin: true
 
   saxes@6.0.0:
@@ -2346,13 +2438,8 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  semver@7.8.1:
-    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -2398,29 +2485,9 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  sigstore@4.1.1:
-    resolution: {integrity: sha512-endqECJkfhozrXMK5ngu/UAA0xVcVEFdnHJCElGaExypjW+HK5i6zu3NteLoaX/iFbRUbC3+DjttQs0GARr+5w==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  slice-ansi@7.1.2:
-    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
-    engines: {node: '>=18'}
-
-  slice-ansi@8.0.0:
-    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
-    engines: {node: '>=20'}
-
-  smart-buffer@4.2.0:
-    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
-    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
-
-  socks-proxy-agent@8.0.5:
-    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
-    engines: {node: '>= 14'}
-
-  socks@2.8.9:
-    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
-    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+  slice-ansi@9.0.0:
+    resolution: {integrity: sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==}
+    engines: {node: '>=22'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2437,19 +2504,6 @@ packages:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
 
-  spdx-exceptions@2.5.0:
-    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
-
-  spdx-expression-parse@4.0.0:
-    resolution: {integrity: sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==}
-
-  spdx-license-ids@3.0.23:
-    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
-
-  ssri@13.0.1:
-    resolution: {integrity: sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -2464,10 +2518,6 @@ packages:
     resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
     engines: {node: '>=18'}
 
-  string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
-    engines: {node: '>=8'}
-
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
@@ -2476,10 +2526,6 @@ packages:
     resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
     engines: {node: '>=20'}
 
-  strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
-
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
@@ -2487,20 +2533,12 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
-  tar@7.5.16:
-    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
-    engines: {node: '>=18'}
-
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
-
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
@@ -2521,8 +2559,8 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
-  tough-cookie@6.0.1:
-    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
     engines: {node: '>=16'}
 
   tr46@6.0.0:
@@ -2535,30 +2573,18 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tuf-js@4.1.0:
-    resolution: {integrity: sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici@6.26.0:
-    resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
-    engines: {node: '>=18.17'}
-
-  undici@7.24.4:
-    resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
-    engines: {node: '>=20.18.1'}
-
-  undici@7.27.0:
-    resolution: {integrity: sha512-+t2Z/GwkZQDtu00813aP66ygViGtPHKhhoFZpQKpKrE+9jIgES+Zw+mFNaDWOVRKiuJjuqKHzD3B1sfGg8+ZOQ==}
-    engines: {node: '>=20.18.1'}
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -2570,23 +2596,24 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
-  validate-npm-package-name@7.0.2:
-    resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  validate-npm-package-name@8.0.0:
+    resolution: {integrity: sha512-SCv6OOV6Xj2/3cXy3dGmADluJTNcL3o7hZAglNPTe+WYuEuvxgJzxPrSDLZhF+CwyQOubqgecjMmTJGMVLWjYQ==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  vite@7.3.2:
-    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+  vite@8.1.5:
+    resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.3.0
+      esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
-      lightningcss: ^1.21.0
       sass: ^1.70.0
       sass-embedded: ^1.70.0
       stylus: '>=0.54.8'
@@ -2597,11 +2624,13 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
       jiti:
         optional: true
       less:
-        optional: true
-      lightningcss:
         optional: true
       sass:
         optional: true
@@ -2618,20 +2647,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.8:
-    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+  vitest@4.1.11:
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.8
-      '@vitest/browser-preview': 4.1.8
-      '@vitest/browser-webdriverio': 4.1.8
-      '@vitest/coverage-istanbul': 4.1.8
-      '@vitest/coverage-v8': 4.1.8
-      '@vitest/ui': 4.1.8
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -2663,8 +2692,8 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
-  watchpack@2.5.1:
-    resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
+  watchpack@2.5.2:
+    resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
     engines: {node: '>=10.13.0'}
 
   weak-lru-cache@1.2.2:
@@ -2682,14 +2711,13 @@ packages:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  whatwg-url@17.1.0:
+    resolution: {integrity: sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==}
+    engines: {node: ^22.14.0 || >=24.0.0}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
-    hasBin: true
-
-  which@6.0.1:
-    resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
   why-is-node-running@2.3.0:
@@ -2697,9 +2725,9 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  wrap-ansi@6.2.0:
-    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
-    engines: {node: '>=8'}
+  wrap-ansi@10.0.1:
+    resolution: {integrity: sha512-M0N4xzyzosiIok3svYlEo1sdLZts/8FPgYH/GPC3wvlmPoRvnoManGMrE54waYj3tISA8w6lsdesfVv67qSr8Q==}
+    engines: {node: '>=20'}
 
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
@@ -2722,24 +2750,13 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
-  yallist@4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-
-  yallist@5.0.0:
-    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
-    engines: {node: '>=18'}
-
   yargs-parser@22.0.0:
     resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
-  yargs@18.0.0:
-    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
+  yargs@18.1.0:
+    resolution: {integrity: sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
-
-  yoctocolors-cjs@2.1.3:
-    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
-    engines: {node: '>=18'}
 
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
@@ -2750,182 +2767,98 @@ packages:
     peerDependencies:
       zod: ^3.25.28 || ^4
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zrender@6.1.0:
     resolution: {integrity: sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==}
 
 snapshots:
 
-  '@algolia/abtesting@1.14.1':
-    dependencies:
-      '@algolia/client-common': 5.48.1
-      '@algolia/requester-browser-xhr': 5.48.1
-      '@algolia/requester-fetch': 5.48.1
-      '@algolia/requester-node-http': 5.48.1
-
-  '@algolia/client-abtesting@5.48.1':
-    dependencies:
-      '@algolia/client-common': 5.48.1
-      '@algolia/requester-browser-xhr': 5.48.1
-      '@algolia/requester-fetch': 5.48.1
-      '@algolia/requester-node-http': 5.48.1
-
-  '@algolia/client-analytics@5.48.1':
-    dependencies:
-      '@algolia/client-common': 5.48.1
-      '@algolia/requester-browser-xhr': 5.48.1
-      '@algolia/requester-fetch': 5.48.1
-      '@algolia/requester-node-http': 5.48.1
-
-  '@algolia/client-common@5.48.1': {}
-
-  '@algolia/client-insights@5.48.1':
-    dependencies:
-      '@algolia/client-common': 5.48.1
-      '@algolia/requester-browser-xhr': 5.48.1
-      '@algolia/requester-fetch': 5.48.1
-      '@algolia/requester-node-http': 5.48.1
-
-  '@algolia/client-personalization@5.48.1':
-    dependencies:
-      '@algolia/client-common': 5.48.1
-      '@algolia/requester-browser-xhr': 5.48.1
-      '@algolia/requester-fetch': 5.48.1
-      '@algolia/requester-node-http': 5.48.1
-
-  '@algolia/client-query-suggestions@5.48.1':
-    dependencies:
-      '@algolia/client-common': 5.48.1
-      '@algolia/requester-browser-xhr': 5.48.1
-      '@algolia/requester-fetch': 5.48.1
-      '@algolia/requester-node-http': 5.48.1
-
-  '@algolia/client-search@5.48.1':
-    dependencies:
-      '@algolia/client-common': 5.48.1
-      '@algolia/requester-browser-xhr': 5.48.1
-      '@algolia/requester-fetch': 5.48.1
-      '@algolia/requester-node-http': 5.48.1
-
-  '@algolia/ingestion@1.48.1':
-    dependencies:
-      '@algolia/client-common': 5.48.1
-      '@algolia/requester-browser-xhr': 5.48.1
-      '@algolia/requester-fetch': 5.48.1
-      '@algolia/requester-node-http': 5.48.1
-
-  '@algolia/monitoring@1.48.1':
-    dependencies:
-      '@algolia/client-common': 5.48.1
-      '@algolia/requester-browser-xhr': 5.48.1
-      '@algolia/requester-fetch': 5.48.1
-      '@algolia/requester-node-http': 5.48.1
-
-  '@algolia/recommend@5.48.1':
-    dependencies:
-      '@algolia/client-common': 5.48.1
-      '@algolia/requester-browser-xhr': 5.48.1
-      '@algolia/requester-fetch': 5.48.1
-      '@algolia/requester-node-http': 5.48.1
-
-  '@algolia/requester-browser-xhr@5.48.1':
-    dependencies:
-      '@algolia/client-common': 5.48.1
-
-  '@algolia/requester-fetch@5.48.1':
-    dependencies:
-      '@algolia/client-common': 5.48.1
-
-  '@algolia/requester-node-http@5.48.1':
-    dependencies:
-      '@algolia/client-common': 5.48.1
-
   '@ampproject/remapping@2.3.0':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@angular-devkit/architect@0.2102.14(chokidar@5.0.0)':
+  '@angular-devkit/architect@0.2201.5(chokidar@5.0.0)':
     dependencies:
-      '@angular-devkit/core': 21.2.14(chokidar@5.0.0)
+      '@angular-devkit/core': 22.1.5(chokidar@5.0.0)
       rxjs: 7.8.2
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/core@21.2.14(chokidar@5.0.0)':
+  '@angular-devkit/core@22.1.5(chokidar@5.0.0)':
     dependencies:
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
       jsonc-parser: 3.3.1
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       rxjs: 7.8.2
       source-map: 0.7.6
     optionalDependencies:
       chokidar: 5.0.0
 
-  '@angular-devkit/schematics@21.2.14(chokidar@5.0.0)':
+  '@angular-devkit/schematics@22.1.5(chokidar@5.0.0)':
     dependencies:
-      '@angular-devkit/core': 21.2.14(chokidar@5.0.0)
+      '@angular-devkit/core': 22.1.5(chokidar@5.0.0)
       jsonc-parser: 3.3.1
-      magic-string: 0.30.21
-      ora: 9.3.0
+      magic-string: 1.0.0
+      ora: 9.4.1
       rxjs: 7.8.2
     transitivePeerDependencies:
       - chokidar
 
-  '@angular/animations@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))':
+  '@angular/animations@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))':
     dependencies:
-      '@angular/core': 21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)
+      '@angular/core': 22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)
       tslib: 2.8.1
 
-  '@angular/build@21.2.14(@angular/compiler-cli@21.2.16(@angular/compiler@21.2.16)(typescript@5.9.3))(@angular/compiler@21.2.16)(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(@angular/platform-browser@21.2.16(@angular/animations@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(chokidar@5.0.0)(postcss@8.5.15)(tslib@2.8.1)(typescript@5.9.3)(vitest@4.1.8(jsdom@29.1.1)(vite@7.3.2(sass@1.97.3)))':
+  '@angular/build@22.1.5(@angular/compiler-cli@22.1.3(@angular/compiler@22.1.3)(typescript@6.0.3))(@angular/compiler@22.1.3)(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(@angular/platform-browser@22.1.3(@angular/animations@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)))(@angular/common@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)))(chokidar@5.0.0)(istanbul-lib-instrument@6.0.3)(postcss@8.5.15)(rollup@4.61.0)(tslib@2.8.1)(typescript@6.0.3)(vitest@4.1.11(jsdom@30.0.1)(vite@8.1.5(esbuild@0.28.2)(sass@1.101.0)))':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.2102.14(chokidar@5.0.0)
-      '@angular/compiler': 21.2.16
-      '@angular/compiler-cli': 21.2.16(@angular/compiler@21.2.16)(typescript@5.9.3)
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
+      '@angular-devkit/architect': 0.2201.5(chokidar@5.0.0)
+      '@angular/compiler': 22.1.3
+      '@angular/compiler-cli': 22.1.3(@angular/compiler@22.1.3)(typescript@6.0.3)
+      '@babel/core': 8.0.1
+      '@babel/helper-annotate-as-pure': 8.0.0
       '@babel/helper-split-export-declaration': 7.24.7
-      '@inquirer/confirm': 5.1.21
-      '@vitejs/plugin-basic-ssl': 2.1.4(vite@7.3.2(sass@1.97.3))
-      beasties: 0.4.1
+      '@inquirer/confirm': 6.1.1
+      '@vitejs/plugin-basic-ssl': 2.3.0(vite@8.1.5(esbuild@0.28.2)(sass@1.101.0))
+      beasties: 0.4.3
       browserslist: 4.28.2
-      esbuild: 0.27.3
-      https-proxy-agent: 7.0.6
-      istanbul-lib-instrument: 6.0.3
+      esbuild: 0.28.2
+      https-proxy-agent: 9.1.0
       jsonc-parser: 3.3.1
-      listr2: 9.0.5
-      magic-string: 0.30.21
+      listr2: 11.0.0
+      magic-string: 1.0.0
       mrmime: 2.0.1
-      parse5-html-rewriting-stream: 8.0.0
-      picomatch: 4.0.4
-      piscina: 5.1.4
-      rolldown: 1.0.0-rc.4(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
-      sass: 1.97.3
-      semver: 7.7.4
+      oxc-parser: 0.142.0
+      parse5-html-rewriting-stream: 8.0.1
+      picomatch: 4.0.5
+      piscina: 5.2.0
+      rolldown: 1.2.0
+      sass: 1.101.0
+      semver: 7.8.5
       source-map-support: 0.5.21
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tslib: 2.8.1
-      typescript: 5.9.3
-      undici: 7.24.4
-      vite: 7.3.2(sass@1.97.3)
-      watchpack: 2.5.1
+      typescript: 6.0.3
+      vite: 8.1.5(esbuild@0.28.2)(sass@1.101.0)
+      watchpack: 2.5.2
     optionalDependencies:
-      '@angular/core': 21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)
-      '@angular/platform-browser': 21.2.16(@angular/animations@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))
-      lmdb: 3.5.1
+      '@angular/core': 22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)
+      '@angular/platform-browser': 22.1.3(@angular/animations@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)))(@angular/common@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))
+      istanbul-lib-instrument: 6.0.3
+      lmdb: 3.5.6
       postcss: 8.5.15
-      vitest: 4.1.8(jsdom@29.1.1)(vite@7.3.2(sass@1.97.3))
+      rollup: 4.61.0
+      vitest: 4.1.11(jsdom@30.0.1)(vite@8.1.5(esbuild@0.28.2)(sass@1.101.0))
     transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
       - '@types/node'
+      - '@vitejs/devtools'
       - chokidar
       - jiti
-      - lightningcss
+      - kerberos
       - sass-embedded
       - stylus
       - sugarss
@@ -2934,126 +2867,125 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/cdk@21.2.14(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(@angular/platform-browser@21.2.16(@angular/animations@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(rxjs@7.8.2)':
+  '@angular/cdk@22.1.3(@angular/common@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(@angular/platform-browser@22.1.3(@angular/animations@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)))(@angular/common@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)))(rxjs@7.8.2)':
     dependencies:
-      '@angular/common': 21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2)
-      '@angular/core': 21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)
-      '@angular/platform-browser': 21.2.16(@angular/animations@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))
+      '@angular/common': 22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(rxjs@7.8.2)
+      '@angular/core': 22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)
+      '@angular/platform-browser': 22.1.3(@angular/animations@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)))(@angular/common@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))
       parse5: 8.0.1
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@angular/cli@21.2.14(chokidar@5.0.0)':
+  '@angular/cli@22.1.5(chokidar@5.0.0)':
     dependencies:
-      '@angular-devkit/architect': 0.2102.14(chokidar@5.0.0)
-      '@angular-devkit/core': 21.2.14(chokidar@5.0.0)
-      '@angular-devkit/schematics': 21.2.14(chokidar@5.0.0)
-      '@inquirer/prompts': 7.10.1
-      '@listr2/prompt-adapter-inquirer': 3.0.5(@inquirer/prompts@7.10.1)(listr2@9.0.5)
-      '@modelcontextprotocol/sdk': 1.26.0(zod@4.3.6)
-      '@schematics/angular': 21.2.14(chokidar@5.0.0)
-      '@yarnpkg/lockfile': 1.1.0
-      algoliasearch: 5.48.1
-      ini: 6.0.0
+      '@angular-devkit/architect': 0.2201.5(chokidar@5.0.0)
+      '@angular-devkit/core': 22.1.5(chokidar@5.0.0)
+      '@angular-devkit/schematics': 22.1.5(chokidar@5.0.0)
+      '@inquirer/prompts': 8.5.2
+      '@listr2/prompt-adapter-inquirer': 4.2.5(@inquirer/prompts@8.5.2)(listr2@11.0.0)
+      '@modelcontextprotocol/sdk': 1.30.0(zod@4.4.3)
+      '@schematics/angular': 22.1.5(chokidar@5.0.0)
       jsonc-parser: 3.3.1
-      listr2: 9.0.5
-      npm-package-arg: 13.0.2
-      pacote: 21.3.1
-      parse5-html-rewriting-stream: 8.0.0
-      semver: 7.7.4
-      yargs: 18.0.0
-      zod: 4.3.6
+      listr2: 11.0.0
+      npm-package-arg: 14.0.0
+      parse5-html-rewriting-stream: 8.0.1
+      semver: 7.8.5
+      yargs: 18.1.0
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - '@types/node'
       - chokidar
       - supports-color
 
-  '@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2)':
+  '@angular/common@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(rxjs@7.8.2)':
     dependencies:
-      '@angular/core': 21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)
+      '@angular/core': 22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@angular/compiler-cli@21.2.16(@angular/compiler@21.2.16)(typescript@5.9.3)':
+  '@angular/compiler-cli@22.1.3(@angular/compiler@22.1.3)(typescript@6.0.3)':
     dependencies:
-      '@angular/compiler': 21.2.16
-      '@babel/core': 7.29.0
+      '@angular/compiler': 22.1.3
+      '@babel/core': 8.0.1
       '@jridgewell/sourcemap-codec': 1.5.5
       chokidar: 5.0.0
       convert-source-map: 1.9.0
       reflect-metadata: 0.2.2
-      semver: 7.8.1
+      semver: 7.8.5
       tslib: 2.8.1
-      yargs: 18.0.0
+      yargs: 18.1.0
     optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
+      typescript: 6.0.3
 
-  '@angular/compiler@21.2.16':
+  '@angular/compiler@22.1.3':
     dependencies:
       tslib: 2.8.1
 
-  '@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)':
+  '@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)':
     dependencies:
       rxjs: 7.8.2
       tslib: 2.8.1
     optionalDependencies:
-      '@angular/compiler': 21.2.16
+      '@angular/compiler': 22.1.3
 
-  '@angular/forms@21.2.16(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(@angular/platform-browser@21.2.16(@angular/animations@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(rxjs@7.8.2)':
+  '@angular/forms@22.1.3(@angular/common@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(@angular/platform-browser@22.1.3(@angular/animations@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)))(@angular/common@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)))(rxjs@7.8.2)':
     dependencies:
-      '@angular/common': 21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2)
-      '@angular/core': 21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)
-      '@angular/platform-browser': 21.2.16(@angular/animations@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))
+      '@angular/common': 22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(rxjs@7.8.2)
+      '@angular/core': 22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)
+      '@angular/platform-browser': 22.1.3(@angular/animations@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)))(@angular/common@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))
       '@standard-schema/spec': 1.1.0
       rxjs: 7.8.2
       tslib: 2.8.1
+      zod: 4.4.3
 
-  '@angular/platform-browser@21.2.16(@angular/animations@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))':
+  '@angular/platform-browser@22.1.3(@angular/animations@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)))(@angular/common@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))':
     dependencies:
-      '@angular/common': 21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2)
-      '@angular/core': 21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)
+      '@angular/common': 22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(rxjs@7.8.2)
+      '@angular/core': 22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)
       tslib: 2.8.1
     optionalDependencies:
-      '@angular/animations': 21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))
+      '@angular/animations': 22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))
 
-  '@angular/router@21.2.16(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(@angular/platform-browser@21.2.16(@angular/animations@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(rxjs@7.8.2)':
+  '@angular/router@22.1.3(@angular/common@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(@angular/platform-browser@22.1.3(@angular/animations@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)))(@angular/common@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)))(rxjs@7.8.2)':
     dependencies:
-      '@angular/common': 21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2)
-      '@angular/core': 21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)
-      '@angular/platform-browser': 21.2.16(@angular/animations@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))
+      '@angular/common': 22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(rxjs@7.8.2)
+      '@angular/core': 22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)
+      '@angular/platform-browser': 22.1.3(@angular/animations@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2)))(@angular/common@22.1.3(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.1.3(@angular/compiler@22.1.3)(rxjs@7.8.2))
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@asamuzakjp/css-color@5.1.11':
+  '@asamuzakjp/css-color@6.0.7':
     dependencies:
-      '@asamuzakjp/generational-cache': 1.0.1
-      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
-      '@csstools/css-color-parser': 4.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
 
-  '@asamuzakjp/dom-selector@7.1.1':
+  '@asamuzakjp/dom-selector@8.3.2':
     dependencies:
-      '@asamuzakjp/generational-cache': 1.0.1
-      '@asamuzakjp/nwsapi': 2.3.9
       bidi-js: 1.0.3
       css-tree: 3.2.1
       is-potential-custom-element-name: 1.0.1
-
-  '@asamuzakjp/generational-cache@1.0.1': {}
-
-  '@asamuzakjp/nwsapi@2.3.9': {}
+      lru-cache: 11.5.2
 
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
+    optional: true
 
-  '@babel/compat-data@7.29.7': {}
+  '@babel/code-frame@8.0.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 8.0.4
+      js-tokens: 10.0.0
+
+  '@babel/compat-data@7.29.7':
+    optional: true
+
+  '@babel/compat-data@8.0.0': {}
 
   '@babel/core@7.29.0':
     dependencies:
@@ -3074,6 +3006,26 @@ snapshots:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+    optional: true
+
+  '@babel/core@8.0.1':
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/generator': 8.0.0
+      '@babel/helper-compilation-targets': 8.0.0
+      '@babel/helpers': 8.0.0
+      '@babel/parser': 8.0.4
+      '@babel/template': 8.0.0
+      '@babel/traverse': 8.0.4
+      '@babel/types': 8.0.4
+      '@types/gensync': 1.0.5
+      convert-source-map: 2.0.0
+      empathic: 2.0.1
+      gensync: 1.0.0-beta.2
+      import-meta-resolve: 4.2.0
+      json5: 2.2.3
+      obug: 2.1.1
+      semver: 7.8.5
 
   '@babel/generator@7.29.7':
     dependencies:
@@ -3082,10 +3034,20 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
+    optional: true
 
-  '@babel/helper-annotate-as-pure@7.27.3':
+  '@babel/generator@8.0.0':
     dependencies:
-      '@babel/types': 7.29.7
+      '@babel/parser': 8.0.4
+      '@babel/types': 8.0.4
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/jsesc': 2.5.1
+      jsesc: 3.1.0
+
+  '@babel/helper-annotate-as-pure@8.0.0':
+    dependencies:
+      '@babel/types': 8.0.4
 
   '@babel/helper-compilation-targets@7.29.7':
     dependencies:
@@ -3094,8 +3056,20 @@ snapshots:
       browserslist: 4.28.2
       lru-cache: 5.1.1
       semver: 6.3.1
+    optional: true
 
-  '@babel/helper-globals@7.29.7': {}
+  '@babel/helper-compilation-targets@8.0.0':
+    dependencies:
+      '@babel/compat-data': 8.0.0
+      '@babel/helper-validator-option': 8.0.0
+      browserslist: 4.28.2
+      lru-cache: 11.5.1
+      semver: 7.8.5
+
+  '@babel/helper-globals@7.29.7':
+    optional: true
+
+  '@babel/helper-globals@8.0.0': {}
 
   '@babel/helper-module-imports@7.29.7':
     dependencies:
@@ -3103,6 +3077,7 @@ snapshots:
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.0)':
     dependencies:
@@ -3112,6 +3087,7 @@ snapshots:
       '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/helper-split-export-declaration@7.24.7':
     dependencies:
@@ -3119,24 +3095,49 @@ snapshots:
 
   '@babel/helper-string-parser@7.29.7': {}
 
+  '@babel/helper-string-parser@8.0.0': {}
+
   '@babel/helper-validator-identifier@7.29.7': {}
 
-  '@babel/helper-validator-option@7.29.7': {}
+  '@babel/helper-validator-identifier@8.0.4': {}
+
+  '@babel/helper-validator-option@7.29.7':
+    optional: true
+
+  '@babel/helper-validator-option@8.0.0': {}
 
   '@babel/helpers@7.29.7':
     dependencies:
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
+    optional: true
+
+  '@babel/helpers@8.0.0':
+    dependencies:
+      '@babel/template': 8.0.0
+      '@babel/types': 8.0.4
 
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
+    optional: true
+
+  '@babel/parser@8.0.4':
+    dependencies:
+      '@babel/types': 8.0.4
 
   '@babel/template@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
+    optional: true
+
+  '@babel/template@8.0.0':
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/parser': 8.0.4
+      '@babel/types': 8.0.4
 
   '@babel/traverse@7.29.7':
     dependencies:
@@ -3149,27 +3150,43 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+    optional: true
+
+  '@babel/traverse@8.0.4':
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/generator': 8.0.0
+      '@babel/helper-globals': 8.0.0
+      '@babel/parser': 8.0.4
+      '@babel/template': 8.0.0
+      '@babel/types': 8.0.4
+      obug: 2.1.1
 
   '@babel/types@7.29.7':
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
+  '@babel/types@8.0.4':
+    dependencies:
+      '@babel/helper-string-parser': 8.0.0
+      '@babel/helper-validator-identifier': 8.0.4
+
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
 
-  '@csstools/color-helpers@6.0.2': {}
+  '@csstools/color-helpers@6.1.1': {}
 
-  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
-  '@csstools/css-color-parser@4.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+  '@csstools/css-color-parser@4.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
-      '@csstools/color-helpers': 6.0.2
-      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/color-helpers': 6.1.1
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
@@ -3177,109 +3194,118 @@ snapshots:
     dependencies:
       '@csstools/css-tokenizer': 4.0.0
 
-  '@csstools/css-syntax-patches-for-csstree@1.1.5(css-tree@3.2.1)':
+  '@csstools/css-syntax-patches-for-csstree@1.1.8(css-tree@3.2.1)':
     optionalDependencies:
       css-tree: 3.2.1
 
   '@csstools/css-tokenizer@4.0.0': {}
 
-  '@emnapi/core@1.9.1':
+  '@emnapi/core@1.11.1':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.0
+      '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.9.1':
+  '@emnapi/core@1.11.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/wasi-threads@1.2.0':
+  '@emnapi/runtime@1.11.2':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.3':
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
     optional: true
 
-  '@esbuild/android-arm64@0.27.3':
+  '@esbuild/aix-ppc64@0.28.2':
     optional: true
 
-  '@esbuild/android-arm@0.27.3':
+  '@esbuild/android-arm64@0.28.2':
     optional: true
 
-  '@esbuild/android-x64@0.27.3':
+  '@esbuild/android-arm@0.28.2':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.3':
+  '@esbuild/android-x64@0.28.2':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.3':
+  '@esbuild/darwin-arm64@0.28.2':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.3':
+  '@esbuild/darwin-x64@0.28.2':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.3':
+  '@esbuild/freebsd-arm64@0.28.2':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.3':
+  '@esbuild/freebsd-x64@0.28.2':
     optional: true
 
-  '@esbuild/linux-arm@0.27.3':
+  '@esbuild/linux-arm64@0.28.2':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.3':
+  '@esbuild/linux-arm@0.28.2':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.3':
+  '@esbuild/linux-ia32@0.28.2':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.3':
+  '@esbuild/linux-loong64@0.28.2':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.3':
+  '@esbuild/linux-mips64el@0.28.2':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.3':
+  '@esbuild/linux-ppc64@0.28.2':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.3':
+  '@esbuild/linux-riscv64@0.28.2':
     optional: true
 
-  '@esbuild/linux-x64@0.27.3':
+  '@esbuild/linux-s390x@0.28.2':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.3':
+  '@esbuild/linux-x64@0.28.2':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.3':
+  '@esbuild/netbsd-arm64@0.28.2':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.3':
+  '@esbuild/netbsd-x64@0.28.2':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.3':
+  '@esbuild/openbsd-arm64@0.28.2':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.3':
+  '@esbuild/openbsd-x64@0.28.2':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.3':
+  '@esbuild/openharmony-arm64@0.28.2':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.3':
+  '@esbuild/sunos-x64@0.28.2':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.3':
+  '@esbuild/win32-arm64@0.28.2':
     optional: true
 
-  '@esbuild/win32-x64@0.27.3':
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
     optional: true
 
   '@exodus/bytes@1.15.1': {}
-
-  '@gar/promise-retry@1.0.3': {}
 
   '@harperfast/extended-iterable@1.0.3':
     optional: true
@@ -3288,108 +3314,114 @@ snapshots:
     dependencies:
       hono: 4.12.23
 
-  '@inquirer/ansi@1.0.2': {}
+  '@inquirer/ansi@2.0.7': {}
 
-  '@inquirer/checkbox@4.3.2':
+  '@inquirer/checkbox@5.2.2':
     dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10
-      yoctocolors-cjs: 2.1.3
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 12.0.0
+      '@inquirer/figures': 2.0.8
+      '@inquirer/type': 4.0.7
 
-  '@inquirer/confirm@5.1.21':
+  '@inquirer/confirm@6.1.1':
     dependencies:
-      '@inquirer/core': 10.3.2
-      '@inquirer/type': 3.0.10
+      '@inquirer/core': 11.2.1
+      '@inquirer/type': 4.0.7
 
-  '@inquirer/core@10.3.2':
+  '@inquirer/confirm@6.2.0':
     dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10
+      '@inquirer/core': 12.0.0
+      '@inquirer/type': 4.0.7
+
+  '@inquirer/core@11.2.1':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/figures': 2.0.8
+      '@inquirer/type': 4.0.7
       cli-width: 4.1.0
-      mute-stream: 2.0.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 3.0.0
       signal-exit: 4.1.0
-      wrap-ansi: 6.2.0
-      yoctocolors-cjs: 2.1.3
 
-  '@inquirer/editor@4.2.23':
+  '@inquirer/core@12.0.0':
     dependencies:
-      '@inquirer/core': 10.3.2
-      '@inquirer/external-editor': 1.0.3
-      '@inquirer/type': 3.0.10
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/figures': 2.0.8
+      '@inquirer/type': 4.0.7
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
 
-  '@inquirer/expand@4.0.23':
+  '@inquirer/editor@5.3.0':
     dependencies:
-      '@inquirer/core': 10.3.2
-      '@inquirer/type': 3.0.10
-      yoctocolors-cjs: 2.1.3
+      '@inquirer/core': 12.0.0
+      '@inquirer/external-editor': 3.0.4
+      '@inquirer/type': 4.0.7
 
-  '@inquirer/external-editor@1.0.3':
+  '@inquirer/expand@5.1.2':
+    dependencies:
+      '@inquirer/core': 12.0.0
+      '@inquirer/type': 4.0.7
+
+  '@inquirer/external-editor@3.0.4':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
 
-  '@inquirer/figures@1.0.15': {}
+  '@inquirer/figures@2.0.8': {}
 
-  '@inquirer/input@4.3.1':
+  '@inquirer/input@5.1.3':
     dependencies:
-      '@inquirer/core': 10.3.2
-      '@inquirer/type': 3.0.10
+      '@inquirer/core': 12.0.0
+      '@inquirer/type': 4.0.7
 
-  '@inquirer/number@3.0.23':
+  '@inquirer/number@4.2.0':
     dependencies:
-      '@inquirer/core': 10.3.2
-      '@inquirer/type': 3.0.10
+      '@inquirer/core': 12.0.0
+      '@inquirer/type': 4.0.7
 
-  '@inquirer/password@4.0.23':
+  '@inquirer/password@5.1.2':
     dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2
-      '@inquirer/type': 3.0.10
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 12.0.0
+      '@inquirer/type': 4.0.7
 
-  '@inquirer/prompts@7.10.1':
+  '@inquirer/prompts@8.5.2':
     dependencies:
-      '@inquirer/checkbox': 4.3.2
-      '@inquirer/confirm': 5.1.21
-      '@inquirer/editor': 4.2.23
-      '@inquirer/expand': 4.0.23
-      '@inquirer/input': 4.3.1
-      '@inquirer/number': 3.0.23
-      '@inquirer/password': 4.0.23
-      '@inquirer/rawlist': 4.1.11
-      '@inquirer/search': 3.2.2
-      '@inquirer/select': 4.4.2
+      '@inquirer/checkbox': 5.2.2
+      '@inquirer/confirm': 6.2.0
+      '@inquirer/editor': 5.3.0
+      '@inquirer/expand': 5.1.2
+      '@inquirer/input': 5.1.3
+      '@inquirer/number': 4.2.0
+      '@inquirer/password': 5.1.2
+      '@inquirer/rawlist': 5.3.2
+      '@inquirer/search': 4.3.0
+      '@inquirer/select': 5.2.2
 
-  '@inquirer/rawlist@4.1.11':
+  '@inquirer/rawlist@5.3.2':
     dependencies:
-      '@inquirer/core': 10.3.2
-      '@inquirer/type': 3.0.10
-      yoctocolors-cjs: 2.1.3
+      '@inquirer/core': 12.0.0
+      '@inquirer/type': 4.0.7
 
-  '@inquirer/search@3.2.2':
+  '@inquirer/search@4.3.0':
     dependencies:
-      '@inquirer/core': 10.3.2
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10
-      yoctocolors-cjs: 2.1.3
+      '@inquirer/core': 12.0.0
+      '@inquirer/figures': 2.0.8
+      '@inquirer/type': 4.0.7
 
-  '@inquirer/select@4.4.2':
+  '@inquirer/select@5.2.2':
     dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10
-      yoctocolors-cjs: 2.1.3
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 12.0.0
+      '@inquirer/figures': 2.0.8
+      '@inquirer/type': 4.0.7
 
-  '@inquirer/type@3.0.10': {}
+  '@inquirer/type@4.0.7': {}
 
-  '@isaacs/fs-minipass@4.0.1':
-    dependencies:
-      minipass: 7.1.3
-
-  '@istanbuljs/schema@0.1.6': {}
+  '@istanbuljs/schema@0.1.6':
+    optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -3400,6 +3432,7 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
+    optional: true
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
@@ -3410,36 +3443,36 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@listr2/prompt-adapter-inquirer@3.0.5(@inquirer/prompts@7.10.1)(listr2@9.0.5)':
+  '@listr2/prompt-adapter-inquirer@4.2.5(@inquirer/prompts@8.5.2)(listr2@11.0.0)':
     dependencies:
-      '@inquirer/prompts': 7.10.1
-      '@inquirer/type': 3.0.10
-      listr2: 9.0.5
+      '@inquirer/prompts': 8.5.2
+      '@inquirer/type': 4.0.7
+      listr2: 11.0.0
     transitivePeerDependencies:
       - '@types/node'
 
-  '@lmdb/lmdb-darwin-arm64@3.5.1':
+  '@lmdb/lmdb-darwin-arm64@3.5.6':
     optional: true
 
-  '@lmdb/lmdb-darwin-x64@3.5.1':
+  '@lmdb/lmdb-darwin-x64@3.5.6':
     optional: true
 
-  '@lmdb/lmdb-linux-arm64@3.5.1':
+  '@lmdb/lmdb-linux-arm64@3.5.6':
     optional: true
 
-  '@lmdb/lmdb-linux-arm@3.5.1':
+  '@lmdb/lmdb-linux-arm@3.5.6':
     optional: true
 
-  '@lmdb/lmdb-linux-x64@3.5.1':
+  '@lmdb/lmdb-linux-x64@3.5.6':
     optional: true
 
-  '@lmdb/lmdb-win32-arm64@3.5.1':
+  '@lmdb/lmdb-win32-arm64@3.5.6':
     optional: true
 
-  '@lmdb/lmdb-win32-x64@3.5.1':
+  '@lmdb/lmdb-win32-x64@3.5.6':
     optional: true
 
-  '@modelcontextprotocol/sdk@1.26.0(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.30.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 2.0.4(hono@4.12.23)
       ajv: 8.20.0
@@ -3456,8 +3489,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -3551,70 +3584,89 @@ snapshots:
       '@napi-rs/nice-win32-x64-msvc': 1.1.1
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@emnapi/core': 1.9.1
-      '@emnapi/runtime': 1.9.1
-      '@tybys/wasm-util': 0.10.2
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@npmcli/agent@4.0.2':
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     dependencies:
-      agent-base: 7.1.4
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      lru-cache: 11.5.1
-      socks-proxy-agent: 8.0.5
-    transitivePeerDependencies:
-      - supports-color
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
 
-  '@npmcli/fs@5.0.0':
+  '@oxc-parser/binding-android-arm-eabi@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.142.0':
     dependencies:
-      semver: 7.8.1
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optional: true
 
-  '@npmcli/git@7.0.2':
-    dependencies:
-      '@gar/promise-retry': 1.0.3
-      '@npmcli/promise-spawn': 9.0.1
-      ini: 6.0.0
-      lru-cache: 11.5.1
-      npm-pick-manifest: 11.0.3
-      proc-log: 6.1.0
-      semver: 7.8.1
-      which: 6.0.1
+  '@oxc-parser/binding-win32-arm64-msvc@0.142.0':
+    optional: true
 
-  '@npmcli/installed-package-contents@4.0.0':
-    dependencies:
-      npm-bundled: 5.0.0
-      npm-normalize-package-bin: 5.0.0
+  '@oxc-parser/binding-win32-ia32-msvc@0.142.0':
+    optional: true
 
-  '@npmcli/node-gyp@5.0.0': {}
+  '@oxc-parser/binding-win32-x64-msvc@0.142.0':
+    optional: true
 
-  '@npmcli/package-json@7.0.5':
-    dependencies:
-      '@npmcli/git': 7.0.2
-      glob: 13.0.6
-      hosted-git-info: 9.0.3
-      json-parse-even-better-errors: 5.0.0
-      proc-log: 6.1.0
-      semver: 7.8.1
-      spdx-expression-parse: 4.0.0
+  '@oxc-project/types@0.139.0': {}
 
-  '@npmcli/promise-spawn@9.0.1':
-    dependencies:
-      which: 6.0.1
+  '@oxc-project/types@0.140.0': {}
 
-  '@npmcli/redact@4.0.0': {}
-
-  '@npmcli/run-script@10.0.4':
-    dependencies:
-      '@npmcli/node-gyp': 5.0.0
-      '@npmcli/package-json': 7.0.5
-      '@npmcli/promise-spawn': 9.0.1
-      node-gyp: 12.3.0
-      proc-log: 6.1.0
-
-  '@oxc-project/types@0.113.0': {}
+  '@oxc-project/types@0.142.0': {}
 
   '@parcel/watcher-android-arm64@2.5.6':
     optional: true
@@ -3660,7 +3712,7 @@ snapshots:
       detect-libc: 2.1.2
       is-glob: 4.0.3
       node-addon-api: 7.1.1
-      picomatch: 4.0.4
+      picomatch: 4.0.5
     optionalDependencies:
       '@parcel/watcher-android-arm64': 2.5.6
       '@parcel/watcher-darwin-arm64': 2.5.6
@@ -3677,51 +3729,105 @@ snapshots:
       '@parcel/watcher-win32-x64': 2.5.6
     optional: true
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.4':
+  '@rolldown/binding-android-arm64@1.1.5':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.4':
+  '@rolldown/binding-android-arm64@1.2.0':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.4':
+  '@rolldown/binding-darwin-arm64@1.1.5':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.4':
+  '@rolldown/binding-darwin-arm64@1.2.0':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.4':
+  '@rolldown/binding-darwin-x64@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.4':
+  '@rolldown/binding-darwin-x64@1.2.0':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.4':
+  '@rolldown/binding-freebsd-x64@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.4':
+  '@rolldown/binding-freebsd-x64@1.2.0':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.4':
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.4':
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.0':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.4(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.0':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.0':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.0':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.0':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.0':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.2.0':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.0':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.4':
+  '@rolldown/binding-wasm32-wasi@1.2.0':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.4':
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-rc.4': {}
+  '@rolldown/binding-win32-arm64-msvc@1.2.0':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.0':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/rollup-android-arm-eabi@4.61.0':
     optional: true
@@ -3798,56 +3904,18 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.61.0':
     optional: true
 
-  '@schematics/angular@21.2.14(chokidar@5.0.0)':
+  '@schematics/angular@22.1.5(chokidar@5.0.0)':
     dependencies:
-      '@angular-devkit/core': 21.2.14(chokidar@5.0.0)
-      '@angular-devkit/schematics': 21.2.14(chokidar@5.0.0)
+      '@angular-devkit/core': 22.1.5(chokidar@5.0.0)
+      '@angular-devkit/schematics': 22.1.5(chokidar@5.0.0)
       jsonc-parser: 3.3.1
+      typescript: 6.0.3
     transitivePeerDependencies:
       - chokidar
 
-  '@sigstore/bundle@4.0.0':
-    dependencies:
-      '@sigstore/protobuf-specs': 0.5.1
-
-  '@sigstore/core@3.2.1': {}
-
-  '@sigstore/protobuf-specs@0.5.1': {}
-
-  '@sigstore/sign@4.1.1':
-    dependencies:
-      '@gar/promise-retry': 1.0.3
-      '@sigstore/bundle': 4.0.0
-      '@sigstore/core': 3.2.1
-      '@sigstore/protobuf-specs': 0.5.1
-      make-fetch-happen: 15.0.6
-      proc-log: 6.1.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@sigstore/tuf@4.0.2':
-    dependencies:
-      '@sigstore/protobuf-specs': 0.5.1
-      tuf-js: 4.1.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@sigstore/verify@3.1.1':
-    dependencies:
-      '@sigstore/bundle': 4.0.0
-      '@sigstore/core': 3.2.1
-      '@sigstore/protobuf-specs': 0.5.1
-
   '@standard-schema/spec@1.1.0': {}
 
-  '@tufjs/canonical-json@2.0.0': {}
-
-  '@tufjs/models@4.1.0':
-    dependencies:
-      '@tufjs/canonical-json': 2.0.0
-      minimatch: 10.2.5
-
-  '@tybys/wasm-util@0.10.2':
+  '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -3871,76 +3939,65 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
-  '@vitejs/plugin-basic-ssl@2.1.4(vite@7.3.2(sass@1.97.3))':
-    dependencies:
-      vite: 7.3.2(sass@1.97.3)
+  '@types/gensync@1.0.5': {}
 
-  '@vitest/expect@4.1.8':
+  '@types/jsesc@2.5.1': {}
+
+  '@vitejs/plugin-basic-ssl@2.3.0(vite@8.1.5(esbuild@0.28.2)(sass@1.101.0))':
+    dependencies:
+      vite: 8.1.5(esbuild@0.28.2)(sass@1.101.0)
+
+  '@vitest/expect@4.1.11':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.8
-      '@vitest/utils': 4.1.8
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@7.3.2(sass@1.97.3))':
+  '@vitest/mocker@4.1.11(vite@8.1.5(esbuild@0.28.2)(sass@1.101.0))':
     dependencies:
-      '@vitest/spy': 4.1.8
+      '@vitest/spy': 4.1.11
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(sass@1.97.3)
+      vite: 8.1.5(esbuild@0.28.2)(sass@1.101.0)
 
-  '@vitest/pretty-format@4.1.8':
+  '@vitest/pretty-format@4.1.11':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.8':
+  '@vitest/runner@4.1.11':
     dependencies:
-      '@vitest/utils': 4.1.8
+      '@vitest/utils': 4.1.11
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.8':
+  '@vitest/snapshot@4.1.11':
     dependencies:
-      '@vitest/pretty-format': 4.1.8
-      '@vitest/utils': 4.1.8
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/utils': 4.1.11
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.8': {}
+  '@vitest/spy@4.1.11': {}
 
-  '@vitest/utils@4.1.8':
+  '@vitest/utils@4.1.11':
     dependencies:
-      '@vitest/pretty-format': 4.1.8
+      '@vitest/pretty-format': 4.1.11
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
-
-  '@yarnpkg/lockfile@1.1.0': {}
-
-  abbrev@4.0.0: {}
 
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  agent-base@7.1.4: {}
-
-  ajv-formats@3.0.1(ajv@8.18.0):
-    optionalDependencies:
-      ajv: 8.18.0
+  agent-base@9.0.0: {}
 
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
-
-  ajv@8.18.0:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
@@ -3949,44 +4006,19 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  algoliasearch@5.48.1:
-    dependencies:
-      '@algolia/abtesting': 1.14.1
-      '@algolia/client-abtesting': 5.48.1
-      '@algolia/client-analytics': 5.48.1
-      '@algolia/client-common': 5.48.1
-      '@algolia/client-insights': 5.48.1
-      '@algolia/client-personalization': 5.48.1
-      '@algolia/client-query-suggestions': 5.48.1
-      '@algolia/client-search': 5.48.1
-      '@algolia/ingestion': 1.48.1
-      '@algolia/monitoring': 1.48.1
-      '@algolia/recommend': 5.48.1
-      '@algolia/requester-browser-xhr': 5.48.1
-      '@algolia/requester-fetch': 5.48.1
-      '@algolia/requester-node-http': 5.48.1
-
   ansi-escapes@7.3.0:
     dependencies:
       environment: 1.1.0
 
-  ansi-regex@5.0.1: {}
-
   ansi-regex@6.2.2: {}
-
-  ansi-styles@4.3.0:
-    dependencies:
-      color-convert: 2.0.1
 
   ansi-styles@6.2.3: {}
 
   assertion-error@2.0.1: {}
 
-  balanced-match@4.0.4: {}
-
   baseline-browser-mapping@2.10.33: {}
 
-  beasties@0.4.1:
+  beasties@0.4.3:
     dependencies:
       css-select: 6.0.0
       css-what: 7.0.0
@@ -4018,10 +4050,6 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@5.0.6:
-    dependencies:
-      balanced-match: 4.0.4
-
   browserslist@4.28.2:
     dependencies:
       baseline-browser-mapping: 2.10.33
@@ -4033,19 +4061,6 @@ snapshots:
   buffer-from@1.1.2: {}
 
   bytes@3.1.2: {}
-
-  cacache@20.0.4:
-    dependencies:
-      '@npmcli/fs': 5.0.0
-      fs-minipass: 3.0.3
-      glob: 13.0.6
-      lru-cache: 11.5.1
-      minipass: 7.1.3
-      minipass-collect: 2.0.1
-      minipass-flush: 1.0.7
-      minipass-pipeline: 1.2.4
-      p-map: 7.0.4
-      ssri: 13.0.1
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -4065,15 +4080,9 @@ snapshots:
 
   chardet@2.1.1: {}
 
-  chokidar@4.0.3:
-    dependencies:
-      readdirp: 4.1.2
-
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
-
-  chownr@3.0.0: {}
 
   cli-cursor@5.0.0:
     dependencies:
@@ -4081,9 +4090,9 @@ snapshots:
 
   cli-spinners@3.4.0: {}
 
-  cli-truncate@5.2.0:
+  cli-truncate@6.1.1:
     dependencies:
-      slice-ansi: 8.0.0
+      slice-ansi: 9.0.0
       string-width: 8.2.1
 
   cli-width@4.1.0: {}
@@ -4093,14 +4102,6 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
-
-  color-convert@2.0.1:
-    dependencies:
-      color-name: 1.1.4
-
-  color-name@1.1.4: {}
-
-  colorette@2.0.20: {}
 
   content-disposition@1.1.0: {}
 
@@ -4172,8 +4173,7 @@ snapshots:
 
   depd@2.0.0: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -4210,23 +4210,17 @@ snapshots:
 
   emoji-regex@10.6.0: {}
 
-  emoji-regex@8.0.0: {}
+  empathic@2.0.1: {}
 
   encodeurl@2.0.0: {}
 
   entities@4.5.0: {}
 
-  entities@6.0.1: {}
-
   entities@7.0.1: {}
 
   entities@8.0.0: {}
 
-  env-paths@2.2.1: {}
-
   environment@1.1.0: {}
-
-  err-code@2.0.3: {}
 
   es-define-property@1.0.1: {}
 
@@ -4238,34 +4232,34 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
 
-  esbuild@0.27.3:
+  esbuild@0.28.2:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.3
-      '@esbuild/android-arm': 0.27.3
-      '@esbuild/android-arm64': 0.27.3
-      '@esbuild/android-x64': 0.27.3
-      '@esbuild/darwin-arm64': 0.27.3
-      '@esbuild/darwin-x64': 0.27.3
-      '@esbuild/freebsd-arm64': 0.27.3
-      '@esbuild/freebsd-x64': 0.27.3
-      '@esbuild/linux-arm': 0.27.3
-      '@esbuild/linux-arm64': 0.27.3
-      '@esbuild/linux-ia32': 0.27.3
-      '@esbuild/linux-loong64': 0.27.3
-      '@esbuild/linux-mips64el': 0.27.3
-      '@esbuild/linux-ppc64': 0.27.3
-      '@esbuild/linux-riscv64': 0.27.3
-      '@esbuild/linux-s390x': 0.27.3
-      '@esbuild/linux-x64': 0.27.3
-      '@esbuild/netbsd-arm64': 0.27.3
-      '@esbuild/netbsd-x64': 0.27.3
-      '@esbuild/openbsd-arm64': 0.27.3
-      '@esbuild/openbsd-x64': 0.27.3
-      '@esbuild/openharmony-arm64': 0.27.3
-      '@esbuild/sunos-x64': 0.27.3
-      '@esbuild/win32-arm64': 0.27.3
-      '@esbuild/win32-ia32': 0.27.3
-      '@esbuild/win32-x64': 0.27.3
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
 
   escalade@3.2.0: {}
 
@@ -4277,8 +4271,6 @@ snapshots:
 
   etag@1.8.1: {}
 
-  eventemitter3@5.0.4: {}
-
   eventsource-parser@3.1.0: {}
 
   eventsource@3.0.7:
@@ -4286,8 +4278,6 @@ snapshots:
       eventsource-parser: 3.1.0
 
   expect-type@1.3.0: {}
-
-  exponential-backoff@3.1.3: {}
 
   express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
@@ -4329,7 +4319,17 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.1.2: {}
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -4349,10 +4349,6 @@ snapshots:
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
-
-  fs-minipass@3.0.3:
-    dependencies:
-      minipass: 7.1.3
 
   fsevents@2.3.3:
     optional: true
@@ -4383,14 +4379,6 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.2
 
-  glob-to-regexp@0.4.1: {}
-
-  glob@13.0.6:
-    dependencies:
-      minimatch: 10.2.5
-      minipass: 7.1.3
-      path-scurry: 2.0.2
-
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -4403,7 +4391,7 @@ snapshots:
 
   hono@4.12.23: {}
 
-  hosted-git-info@9.0.3:
+  hosted-git-info@10.1.1:
     dependencies:
       lru-cache: 11.5.1
 
@@ -4420,8 +4408,6 @@ snapshots:
       domutils: 3.2.2
       entities: 7.0.1
 
-  http-cache-semantics@4.2.0: {}
-
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -4430,33 +4416,24 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@7.0.2:
+  https-proxy-agent@9.1.0:
     dependencies:
-      agent-base: 7.1.4
+      agent-base: 9.0.0
       debug: 4.4.3
+      proxy-agent-negotiate: 1.1.0
     transitivePeerDependencies:
-      - supports-color
-
-  https-proxy-agent@7.0.6:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
-    transitivePeerDependencies:
+      - kerberos
       - supports-color
 
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
 
-  ignore-walk@8.0.0:
-    dependencies:
-      minimatch: 10.2.5
-
   immutable@5.1.6: {}
 
-  inherits@2.0.4: {}
+  import-meta-resolve@4.2.0: {}
 
-  ini@6.0.0: {}
+  inherits@2.0.4: {}
 
   internmap@1.0.1: {}
 
@@ -4466,8 +4443,6 @@ snapshots:
 
   is-extglob@2.1.1:
     optional: true
-
-  is-fullwidth-code-point@3.0.0: {}
 
   is-fullwidth-code-point@5.1.0:
     dependencies:
@@ -4488,9 +4463,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  isexe@4.0.0: {}
-
-  istanbul-lib-coverage@3.2.2: {}
+  istanbul-lib-coverage@3.2.2:
+    optional: true
 
   istanbul-lib-instrument@6.0.3:
     dependencies:
@@ -4498,43 +4472,45 @@ snapshots:
       '@babel/parser': 7.29.7
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-coverage: 3.2.2
-      semver: 7.7.4
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   jose@6.2.3: {}
 
-  js-tokens@4.0.0: {}
+  js-tokens@10.0.0: {}
 
-  jsdom@29.1.1:
+  js-tokens@4.0.0:
+    optional: true
+
+  jsdom@30.0.1:
     dependencies:
-      '@asamuzakjp/css-color': 5.1.11
-      '@asamuzakjp/dom-selector': 7.1.1
+      '@asamuzakjp/css-color': 6.0.7
+      '@asamuzakjp/dom-selector': 8.3.2
       '@bramus/specificity': 2.4.2
-      '@csstools/css-syntax-patches-for-csstree': 1.1.5(css-tree@3.2.1)
+      '@csstools/css-syntax-patches-for-csstree': 1.1.8(css-tree@3.2.1)
       '@exodus/bytes': 1.15.1
       css-tree: 3.2.1
       data-urls: 7.0.0
       decimal.js: 10.6.0
       html-encoding-sniffer: 6.0.0
       is-potential-custom-element-name: 1.0.1
-      lru-cache: 11.5.1
+      lru-cache: 11.5.2
       parse5: 8.0.1
       saxes: 6.0.0
       symbol-tree: 3.2.4
-      tough-cookie: 6.0.1
-      undici: 7.27.0
+      tough-cookie: 6.0.2
+      undici: 8.10.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 17.1.0
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
 
   jsesc@3.1.0: {}
-
-  json-parse-even-better-errors@5.0.0: {}
 
   json-schema-traverse@1.0.0: {}
 
@@ -4544,18 +4520,62 @@ snapshots:
 
   jsonc-parser@3.3.1: {}
 
-  jsonparse@1.3.1: {}
+  lightningcss-android-arm64@1.33.0:
+    optional: true
 
-  listr2@9.0.5:
+  lightningcss-darwin-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    optional: true
+
+  lightningcss@1.33.0:
     dependencies:
-      cli-truncate: 5.2.0
-      colorette: 2.0.20
-      eventemitter3: 5.0.4
-      log-update: 6.1.0
-      rfdc: 1.4.1
-      wrap-ansi: 9.0.2
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
 
-  lmdb@3.5.1:
+  listr2@11.0.0:
+    dependencies:
+      cli-truncate: 6.1.1
+      log-update: 8.0.0
+      wrap-ansi: 10.0.1
+
+  lmdb@3.5.6:
     dependencies:
       '@harperfast/extended-iterable': 1.0.3
       msgpackr: 1.11.12
@@ -4564,13 +4584,13 @@ snapshots:
       ordered-binary: 1.6.1
       weak-lru-cache: 1.2.2
     optionalDependencies:
-      '@lmdb/lmdb-darwin-arm64': 3.5.1
-      '@lmdb/lmdb-darwin-x64': 3.5.1
-      '@lmdb/lmdb-linux-arm': 3.5.1
-      '@lmdb/lmdb-linux-arm64': 3.5.1
-      '@lmdb/lmdb-linux-x64': 3.5.1
-      '@lmdb/lmdb-win32-arm64': 3.5.1
-      '@lmdb/lmdb-win32-x64': 3.5.1
+      '@lmdb/lmdb-darwin-arm64': 3.5.6
+      '@lmdb/lmdb-darwin-x64': 3.5.6
+      '@lmdb/lmdb-linux-arm': 3.5.6
+      '@lmdb/lmdb-linux-arm64': 3.5.6
+      '@lmdb/lmdb-linux-x64': 3.5.6
+      '@lmdb/lmdb-win32-arm64': 3.5.6
+      '@lmdb/lmdb-win32-x64': 3.5.6
     optional: true
 
   log-symbols@7.0.1:
@@ -4578,40 +4598,31 @@ snapshots:
       is-unicode-supported: 2.1.0
       yoctocolors: 2.1.2
 
-  log-update@6.1.0:
+  log-update@8.0.0:
     dependencies:
       ansi-escapes: 7.3.0
       cli-cursor: 5.0.0
-      slice-ansi: 7.1.2
+      slice-ansi: 9.0.0
+      string-width: 8.2.1
       strip-ansi: 7.2.0
-      wrap-ansi: 9.0.2
+      wrap-ansi: 10.0.1
 
   lru-cache@11.5.1: {}
+
+  lru-cache@11.5.2: {}
 
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+    optional: true
 
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  make-fetch-happen@15.0.6:
+  magic-string@1.0.0:
     dependencies:
-      '@gar/promise-retry': 1.0.3
-      '@npmcli/agent': 4.0.2
-      '@npmcli/redact': 4.0.0
-      cacache: 20.0.4
-      http-cache-semantics: 4.2.0
-      minipass: 7.1.3
-      minipass-fetch: 5.0.2
-      minipass-flush: 1.0.7
-      minipass-pipeline: 1.2.4
-      negotiator: 1.0.0
-      proc-log: 6.1.0
-      ssri: 13.0.1
-    transitivePeerDependencies:
-      - supports-color
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
 
@@ -4628,44 +4639,6 @@ snapshots:
       mime-db: 1.54.0
 
   mimic-function@5.0.1: {}
-
-  minimatch@10.2.5:
-    dependencies:
-      brace-expansion: 5.0.6
-
-  minipass-collect@2.0.1:
-    dependencies:
-      minipass: 7.1.3
-
-  minipass-fetch@5.0.2:
-    dependencies:
-      minipass: 7.1.3
-      minipass-sized: 2.0.0
-      minizlib: 3.1.0
-    optionalDependencies:
-      iconv-lite: 0.7.2
-
-  minipass-flush@1.0.7:
-    dependencies:
-      minipass: 3.3.6
-
-  minipass-pipeline@1.2.4:
-    dependencies:
-      minipass: 3.3.6
-
-  minipass-sized@2.0.0:
-    dependencies:
-      minipass: 7.1.3
-
-  minipass@3.3.6:
-    dependencies:
-      yallist: 4.0.0
-
-  minipass@7.1.3: {}
-
-  minizlib@3.1.0:
-    dependencies:
-      minipass: 7.1.3
 
   mrmime@2.0.1: {}
 
@@ -4688,9 +4661,11 @@ snapshots:
       msgpackr-extract: 3.0.4
     optional: true
 
-  mute-stream@2.0.0: {}
+  mute-stream@3.0.0: {}
 
   nanoid@3.3.12: {}
+
+  nanoid@3.3.18: {}
 
   negotiator@1.0.0: {}
 
@@ -4705,66 +4680,14 @@ snapshots:
       detect-libc: 2.1.2
     optional: true
 
-  node-gyp@12.3.0:
-    dependencies:
-      env-paths: 2.2.1
-      exponential-backoff: 3.1.3
-      graceful-fs: 4.2.11
-      nopt: 9.0.0
-      proc-log: 6.1.0
-      semver: 7.8.1
-      tar: 7.5.16
-      tinyglobby: 0.2.17
-      undici: 6.26.0
-      which: 6.0.1
-
   node-releases@2.0.47: {}
 
-  nopt@9.0.0:
+  npm-package-arg@14.0.0:
     dependencies:
-      abbrev: 4.0.0
-
-  npm-bundled@5.0.0:
-    dependencies:
-      npm-normalize-package-bin: 5.0.0
-
-  npm-install-checks@8.0.0:
-    dependencies:
-      semver: 7.8.1
-
-  npm-normalize-package-bin@5.0.0: {}
-
-  npm-package-arg@13.0.2:
-    dependencies:
-      hosted-git-info: 9.0.3
-      proc-log: 6.1.0
-      semver: 7.8.1
-      validate-npm-package-name: 7.0.2
-
-  npm-packlist@10.0.4:
-    dependencies:
-      ignore-walk: 8.0.0
-      proc-log: 6.1.0
-
-  npm-pick-manifest@11.0.3:
-    dependencies:
-      npm-install-checks: 8.0.0
-      npm-normalize-package-bin: 5.0.0
-      npm-package-arg: 13.0.2
-      semver: 7.8.1
-
-  npm-registry-fetch@19.1.1:
-    dependencies:
-      '@npmcli/redact': 4.0.0
-      jsonparse: 1.3.1
-      make-fetch-happen: 15.0.6
-      minipass: 7.1.3
-      minipass-fetch: 5.0.2
-      minizlib: 3.1.0
-      npm-package-arg: 13.0.2
-      proc-log: 6.1.0
-    transitivePeerDependencies:
-      - supports-color
+      hosted-git-info: 10.1.1
+      proc-log: 7.0.0
+      semver: 7.8.5
+      validate-npm-package-name: 8.0.0
 
   nth-check@2.1.1:
     dependencies:
@@ -4788,7 +4711,7 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  ora@9.3.0:
+  ora@9.4.1:
     dependencies:
       chalk: 5.6.2
       cli-cursor: 5.0.0
@@ -4802,33 +4725,34 @@ snapshots:
   ordered-binary@1.6.1:
     optional: true
 
-  p-map@7.0.4: {}
-
-  pacote@21.3.1:
+  oxc-parser@0.142.0:
     dependencies:
-      '@npmcli/git': 7.0.2
-      '@npmcli/installed-package-contents': 4.0.0
-      '@npmcli/package-json': 7.0.5
-      '@npmcli/promise-spawn': 9.0.1
-      '@npmcli/run-script': 10.0.4
-      cacache: 20.0.4
-      fs-minipass: 3.0.3
-      minipass: 7.1.3
-      npm-package-arg: 13.0.2
-      npm-packlist: 10.0.4
-      npm-pick-manifest: 11.0.3
-      npm-registry-fetch: 19.1.1
-      proc-log: 6.1.0
-      promise-retry: 2.0.1
-      sigstore: 4.1.1
-      ssri: 13.0.1
-      tar: 7.5.16
-    transitivePeerDependencies:
-      - supports-color
+      '@oxc-project/types': 0.142.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.142.0
+      '@oxc-parser/binding-android-arm64': 0.142.0
+      '@oxc-parser/binding-darwin-arm64': 0.142.0
+      '@oxc-parser/binding-darwin-x64': 0.142.0
+      '@oxc-parser/binding-freebsd-x64': 0.142.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.142.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.142.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.142.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.142.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.142.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.142.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.142.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.142.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.142.0
+      '@oxc-parser/binding-linux-x64-musl': 0.142.0
+      '@oxc-parser/binding-openharmony-arm64': 0.142.0
+      '@oxc-parser/binding-wasm32-wasi': 0.142.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.142.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.142.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.142.0
 
-  parse5-html-rewriting-stream@8.0.0:
+  parse5-html-rewriting-stream@8.0.1:
     dependencies:
-      entities: 6.0.1
+      entities: 8.0.0
       parse5: 8.0.1
       parse5-sax-parser: 8.0.0
 
@@ -4844,11 +4768,6 @@ snapshots:
 
   path-key@3.1.1: {}
 
-  path-scurry@2.0.2:
-    dependencies:
-      lru-cache: 11.5.1
-      minipass: 7.1.3
-
   path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
@@ -4857,7 +4776,9 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  piscina@5.1.4:
+  picomatch@4.0.5: {}
+
+  piscina@5.2.0:
     optionalDependencies:
       '@napi-rs/nice': 1.1.1
 
@@ -4875,17 +4796,20 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  proc-log@6.1.0: {}
-
-  promise-retry@2.0.1:
+  postcss@8.5.26:
     dependencies:
-      err-code: 2.0.3
-      retry: 0.12.0
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  proc-log@7.0.0: {}
 
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  proxy-agent-negotiate@1.1.0: {}
 
   punycode@2.3.1: {}
 
@@ -4902,8 +4826,6 @@ snapshots:
       iconv-lite: 0.7.2
       unpipe: 1.0.0
 
-  readdirp@4.1.2: {}
-
   readdirp@5.0.0: {}
 
   reflect-metadata@0.2.2: {}
@@ -4915,31 +4837,47 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
-  retry@0.12.0: {}
-
-  rfdc@1.4.1: {}
-
-  rolldown@1.0.0-rc.4(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1):
+  rolldown@1.1.5:
     dependencies:
-      '@oxc-project/types': 0.113.0
-      '@rolldown/pluginutils': 1.0.0-rc.4
+      '@oxc-project/types': 0.139.0
+      '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.4
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.4
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.4
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.4
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.4
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.4
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.4
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.4
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.4
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.4
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.4(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.4
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.4
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
+      '@rolldown/binding-android-arm64': 1.1.5
+      '@rolldown/binding-darwin-arm64': 1.1.5
+      '@rolldown/binding-darwin-x64': 1.1.5
+      '@rolldown/binding-freebsd-x64': 1.1.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
+      '@rolldown/binding-linux-arm64-gnu': 1.1.5
+      '@rolldown/binding-linux-arm64-musl': 1.1.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
+      '@rolldown/binding-linux-s390x-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-musl': 1.1.5
+      '@rolldown/binding-openharmony-arm64': 1.1.5
+      '@rolldown/binding-wasm32-wasi': 1.1.5
+      '@rolldown/binding-win32-arm64-msvc': 1.1.5
+      '@rolldown/binding-win32-x64-msvc': 1.1.5
+
+  rolldown@1.2.0:
+    dependencies:
+      '@oxc-project/types': 0.140.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.2.0
+      '@rolldown/binding-darwin-arm64': 1.2.0
+      '@rolldown/binding-darwin-x64': 1.2.0
+      '@rolldown/binding-freebsd-x64': 1.2.0
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.0
+      '@rolldown/binding-linux-arm64-gnu': 1.2.0
+      '@rolldown/binding-linux-arm64-musl': 1.2.0
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.0
+      '@rolldown/binding-linux-s390x-gnu': 1.2.0
+      '@rolldown/binding-linux-x64-gnu': 1.2.0
+      '@rolldown/binding-linux-x64-musl': 1.2.0
+      '@rolldown/binding-openharmony-arm64': 1.2.0
+      '@rolldown/binding-wasm32-wasi': 1.2.0
+      '@rolldown/binding-win32-arm64-msvc': 1.2.0
+      '@rolldown/binding-win32-x64-msvc': 1.2.0
 
   rollup@4.61.0:
     dependencies:
@@ -4971,6 +4909,7 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.61.0
       '@rollup/rollup-win32-x64-msvc': 4.61.0
       fsevents: 2.3.3
+    optional: true
 
   router@2.2.0:
     dependencies:
@@ -4988,9 +4927,9 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass@1.97.3:
+  sass@1.101.0:
     dependencies:
-      chokidar: 4.0.3
+      chokidar: 5.0.0
       immutable: 5.1.6
       source-map-js: 1.2.1
     optionalDependencies:
@@ -5000,11 +4939,10 @@ snapshots:
     dependencies:
       xmlchars: 2.2.0
 
-  semver@6.3.1: {}
+  semver@6.3.1:
+    optional: true
 
-  semver@7.7.4: {}
-
-  semver@7.8.1: {}
+  semver@7.8.5: {}
 
   send@1.2.1:
     dependencies:
@@ -5071,41 +5009,10 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  sigstore@4.1.1:
-    dependencies:
-      '@sigstore/bundle': 4.0.0
-      '@sigstore/core': 3.2.1
-      '@sigstore/protobuf-specs': 0.5.1
-      '@sigstore/sign': 4.1.1
-      '@sigstore/tuf': 4.0.2
-      '@sigstore/verify': 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-
-  slice-ansi@7.1.2:
+  slice-ansi@9.0.0:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
-
-  slice-ansi@8.0.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      is-fullwidth-code-point: 5.1.0
-
-  smart-buffer@4.2.0: {}
-
-  socks-proxy-agent@8.0.5:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
-      socks: 2.8.9
-    transitivePeerDependencies:
-      - supports-color
-
-  socks@2.8.9:
-    dependencies:
-      ip-address: 10.2.0
-      smart-buffer: 4.2.0
 
   source-map-js@1.2.1: {}
 
@@ -5118,19 +5025,6 @@ snapshots:
 
   source-map@0.7.6: {}
 
-  spdx-exceptions@2.5.0: {}
-
-  spdx-expression-parse@4.0.0:
-    dependencies:
-      spdx-exceptions: 2.5.0
-      spdx-license-ids: 3.0.23
-
-  spdx-license-ids@3.0.23: {}
-
-  ssri@13.0.1:
-    dependencies:
-      minipass: 7.1.3
-
   stackback@0.0.2: {}
 
   statuses@2.0.2: {}
@@ -5138,12 +5032,6 @@ snapshots:
   std-env@4.1.0: {}
 
   stdin-discarder@0.3.2: {}
-
-  string-width@4.2.3:
-    dependencies:
-      emoji-regex: 8.0.0
-      is-fullwidth-code-point: 3.0.0
-      strip-ansi: 6.0.1
 
   string-width@7.2.0:
     dependencies:
@@ -5156,32 +5044,15 @@ snapshots:
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
 
-  strip-ansi@6.0.1:
-    dependencies:
-      ansi-regex: 5.0.1
-
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
 
   symbol-tree@3.2.4: {}
 
-  tar@7.5.16:
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.3
-      minizlib: 3.1.0
-      yallist: 5.0.0
-
   tinybench@2.9.0: {}
 
   tinyexec@1.2.4: {}
-
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
 
   tinyglobby@0.2.17:
     dependencies:
@@ -5198,7 +5069,7 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
-  tough-cookie@6.0.1:
+  tough-cookie@6.0.2:
     dependencies:
       tldts: 7.4.2
 
@@ -5210,27 +5081,15 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tuf-js@4.1.0:
-    dependencies:
-      '@tufjs/models': 4.1.0
-      debug: 4.4.3
-      make-fetch-happen: 15.0.6
-    transitivePeerDependencies:
-      - supports-color
-
   type-is@2.1.0:
     dependencies:
       content-type: 2.0.0
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
-  undici@6.26.0: {}
-
-  undici@7.24.4: {}
-
-  undici@7.27.0: {}
+  undici@8.10.0: {}
 
   unpipe@1.0.0: {}
 
@@ -5240,46 +5099,46 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  validate-npm-package-name@7.0.2: {}
+  validate-npm-package-name@8.0.0: {}
 
   vary@1.1.2: {}
 
-  vite@7.3.2(sass@1.97.3):
+  vite@8.1.5(esbuild@0.28.2)(sass@1.101.0):
     dependencies:
-      esbuild: 0.27.3
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rollup: 4.61.0
-      tinyglobby: 0.2.15
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
     optionalDependencies:
+      esbuild: 0.28.2
       fsevents: 2.3.3
-      sass: 1.97.3
+      sass: 1.101.0
 
-  vitest@4.1.8(jsdom@29.1.1)(vite@7.3.2(sass@1.97.3)):
+  vitest@4.1.11(jsdom@30.0.1)(vite@8.1.5(esbuild@0.28.2)(sass@1.101.0)):
     dependencies:
-      '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@7.3.2(sass@1.97.3))
-      '@vitest/pretty-format': 4.1.8
-      '@vitest/runner': 4.1.8
-      '@vitest/snapshot': 4.1.8
-      '@vitest/spy': 4.1.8
-      '@vitest/utils': 4.1.8
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@8.1.5(esbuild@0.28.2)(sass@1.101.0))
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.2(sass@1.97.3)
+      vite: 8.1.5(esbuild@0.28.2)(sass@1.101.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      jsdom: 29.1.1
+      jsdom: 30.0.1
     transitivePeerDependencies:
       - msw
 
@@ -5287,9 +5146,8 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
-  watchpack@2.5.1:
+  watchpack@2.5.2:
     dependencies:
-      glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
 
   weak-lru-cache@1.2.2:
@@ -5307,24 +5165,27 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  whatwg-url@17.1.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
-
-  which@6.0.1:
-    dependencies:
-      isexe: 4.0.0
 
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  wrap-ansi@6.2.0:
+  wrap-ansi@10.0.1:
     dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
+      ansi-styles: 6.2.3
+      string-width: 8.2.1
 
   wrap-ansi@9.0.2:
     dependencies:
@@ -5340,32 +5201,27 @@ snapshots:
 
   y18n@5.0.8: {}
 
-  yallist@3.1.1: {}
-
-  yallist@4.0.0: {}
-
-  yallist@5.0.0: {}
+  yallist@3.1.1:
+    optional: true
 
   yargs-parser@22.0.0: {}
 
-  yargs@18.0.0:
+  yargs@18.1.0:
     dependencies:
       cliui: 9.0.1
       escalade: 3.2.0
       get-caller-file: 2.0.5
-      string-width: 7.2.0
+      string-width: 8.2.1
       y18n: 5.0.8
       yargs-parser: 22.0.0
 
-  yoctocolors-cjs@2.1.3: {}
-
   yoctocolors@2.1.2: {}
 
-  zod-to-json-schema@3.25.2(zod@4.3.6):
+  zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
-  zod@4.3.6: {}
+  zod@4.4.3: {}
 
   zrender@6.1.0:
     dependencies:

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -59,21 +59,12 @@ importers:
       '@angular/router':
         specifier: ^21.2.16
         version: 21.2.16(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(@angular/platform-browser@21.2.16(@angular/animations@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(rxjs@7.8.2)
-      '@primeuix/themes':
-        specifier: 2.0.3
-        version: 2.0.3
       d3-sankey:
         specifier: ^0.12.3
         version: 0.12.3
       echarts:
         specifier: ^6.1.0
         version: 6.1.0
-      primeicons:
-        specifier: 7.0.0
-        version: 7.0.0
-      primeng:
-        specifier: 21.1.9
-        version: 21.1.9(745a99beccf3168cd03421516bfb3e8f)
       rxjs:
         specifier: ~7.8.2
         version: 7.8.2
@@ -1102,28 +1093,6 @@ packages:
   '@parcel/watcher@2.5.6':
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
-
-  '@primeuix/motion@0.0.10':
-    resolution: {integrity: sha512-PsZwOPq79Scp7/ionshRcQ5xKVf9+zuLcyY5mf6onK8chHT5C9JGphmcIZ4CzcqxuGEpsm8AIbTGy+zS3RtzLA==}
-    engines: {node: '>=12.11.0'}
-
-  '@primeuix/styled@0.7.4':
-    resolution: {integrity: sha512-QSO/NpOQg8e9BONWRBx9y8VGMCMYz0J/uKfNJEya/RGEu7ARx0oYW0ugI1N3/KB1AAvyGxzKBzGImbwg0KUiOQ==}
-    engines: {node: '>=12.11.0'}
-
-  '@primeuix/styles@2.0.3':
-    resolution: {integrity: sha512-2ykAB6BaHzR/6TwF8ShpJTsZrid6cVIEBVlookSdvOdmlWuevGu5vWOScgIwqWwlZcvkFYAGR/SUV3OHCTBMdw==}
-
-  '@primeuix/themes@2.0.3':
-    resolution: {integrity: sha512-3fS1883mtCWhgUgNf/feiaaDSOND4EBIOu9tZnzJlJ8QtYyL6eFLcA6V3ymCWqLVXQ1+lTVEZv1gl47FIdXReg==}
-
-  '@primeuix/utils@0.6.4':
-    resolution: {integrity: sha512-pZ5f+vj7wSzRhC7KoEQRU5fvYAe+RP9+m39CTscZ3UywCD1Y2o6Fe1rRgklMPSkzUcty2jzkA0zMYkiJBD1hgg==}
-    engines: {node: '>=12.11.0'}
-
-  '@primeuix/utils@0.7.2':
-    resolution: {integrity: sha512-pmEbSfP0Phf9W9RweiM66zXnkn73ZeKyYINElbX3uZ2+stzzaba2svLAl3B1pHVcRw5t43O0VciaGe4ye2EXKw==}
-    engines: {node: '>=12.11.0'}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.4':
     resolution: {integrity: sha512-vRq9f4NzvbdZavhQbjkJBx7rRebDKYR9zHfO/Wg486+I7bSecdUapzCm5cyXoK+LHokTxgSq7A5baAXUZkIz0w==}
@@ -2289,20 +2258,6 @@ packages:
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
-
-  primeicons@7.0.0:
-    resolution: {integrity: sha512-jK3Et9UzwzTsd6tzl2RmwrVY/b8raJ3QZLzoDACj+oTJ0oX7L9Hy+XnVwgo4QVKlKpnP/Ur13SXV/pVh4LzaDw==}
-
-  primeng@21.1.9:
-    resolution: {integrity: sha512-Z76PtF08X0PNSTCNMobao8Qm71vC56mtZSdUtX/gsn4+q4x0NbUUtkeK1pc33a+kxVm2zkmOwzUIEGmb9VdoIA==}
-    peerDependencies:
-      '@angular/cdk': ^21.0.0
-      '@angular/common': ^21.0.0
-      '@angular/core': '>=21.1.6'
-      '@angular/forms': ^21.0.0
-      '@angular/platform-browser': ^21.0.0
-      '@angular/router': ^21.0.0
-      rxjs: ^6.0.0 || ^7.8.1
 
   proc-log@6.1.0:
     resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
@@ -3722,26 +3677,6 @@ snapshots:
       '@parcel/watcher-win32-x64': 2.5.6
     optional: true
 
-  '@primeuix/motion@0.0.10':
-    dependencies:
-      '@primeuix/utils': 0.6.4
-
-  '@primeuix/styled@0.7.4':
-    dependencies:
-      '@primeuix/utils': 0.6.4
-
-  '@primeuix/styles@2.0.3':
-    dependencies:
-      '@primeuix/styled': 0.7.4
-
-  '@primeuix/themes@2.0.3':
-    dependencies:
-      '@primeuix/styled': 0.7.4
-
-  '@primeuix/utils@0.6.4': {}
-
-  '@primeuix/utils@0.7.2': {}
-
   '@rolldown/binding-android-arm64@1.0.0-rc.4':
     optional: true
 
@@ -4939,23 +4874,6 @@ snapshots:
       nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
-
-  primeicons@7.0.0: {}
-
-  primeng@21.1.9(745a99beccf3168cd03421516bfb3e8f):
-    dependencies:
-      '@angular/cdk': 21.2.14(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(@angular/platform-browser@21.2.16(@angular/animations@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(rxjs@7.8.2)
-      '@angular/common': 21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2)
-      '@angular/core': 21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)
-      '@angular/forms': 21.2.16(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(@angular/platform-browser@21.2.16(@angular/animations@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(rxjs@7.8.2)
-      '@angular/platform-browser': 21.2.16(@angular/animations@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))
-      '@angular/router': 21.2.16(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(@angular/platform-browser@21.2.16(@angular/animations@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)))(rxjs@7.8.2)
-      '@primeuix/motion': 0.0.10
-      '@primeuix/styled': 0.7.4
-      '@primeuix/styles': 2.0.3
-      '@primeuix/utils': 0.7.2
-      rxjs: 7.8.2
-      tslib: 2.8.1
 
   proc-log@6.1.0: {}
 

--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -8,8 +8,6 @@ import { ApplicationConfig, APP_INITIALIZER, provideBrowserGlobalErrorListeners,
 import { provideRouter, TitleStrategy, withRouterConfig } from '@angular/router';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { provideAnimations } from '@angular/platform-browser/animations';
-import { providePrimeNG } from 'primeng/config';
-import Aura from '@primeuix/themes/aura';
 
 import { routes } from './app.routes';
 import { authInterceptor } from '@core/interceptors/auth.interceptor';
@@ -26,15 +24,6 @@ export const appConfig: ApplicationConfig = {
       withInterceptors([authInterceptor, errorInterceptor])
     ),
     provideAnimations(),
-    providePrimeNG({
-      theme: {
-        preset: Aura,
-        options: {
-          darkModeSelector: '.app-dark',
-          cssLayer: false,
-        }
-      }
-    }),
     {
       provide: APP_INITIALIZER,
       useFactory: () => {

--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -6,7 +6,7 @@
 
 import { ApplicationConfig, APP_INITIALIZER, provideBrowserGlobalErrorListeners, inject } from '@angular/core';
 import { provideRouter, TitleStrategy, withRouterConfig } from '@angular/router';
-import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { provideHttpClient, withInterceptors, withXhr } from '@angular/common/http';
 import { provideAnimations } from '@angular/platform-browser/animations';
 
 import { routes } from './app.routes';
@@ -20,7 +20,7 @@ export const appConfig: ApplicationConfig = {
     provideBrowserGlobalErrorListeners(),
     provideRouter(routes, withRouterConfig({ paramsInheritanceStrategy: 'always' })),
     { provide: TitleStrategy, useClass: GradientTitleStrategy },
-    provideHttpClient(
+    provideHttpClient(withXhr(), 
       withInterceptors([authInterceptor, errorInterceptor])
     ),
     provideAnimations(),

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, inject, computed } from '@angular/core';
+import { Component, inject, computed, ChangeDetectionStrategy } from '@angular/core';
 import { Router, RouterOutlet, NavigationEnd } from '@angular/router';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { filter, map, startWith } from 'rxjs/operators';
@@ -16,6 +16,7 @@ import { AuthService } from '@core/services/auth.service';
   selector: 'app-root',
   imports: [RouterOutlet, HeaderComponent, FooterComponent],
   templateUrl: './app.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './app.scss'
 })
 export class App {

--- a/frontend/src/app/features/admin/github-app/github-app.component.html
+++ b/frontend/src/app/features/admin/github-app/github-app.component.html
@@ -15,7 +15,7 @@
       <label for="github-host">GitHub Enterprise host (optional)</label>
       <input
         id="github-host"
-        pInputText
+        grInput
         type="text"
         placeholder="github.com"
         [ngModel]="host()"
@@ -23,7 +23,7 @@
       />
 
       <button
-        pButton
+        grButton
         type="button"
         label="Create on GitHub"
         data-testid="github-app-create-button"
@@ -48,31 +48,31 @@
         <div class="credential">
           <div class="label">App ID</div>
           <code>{{ c.id }}</code>
-          <button pButton type="button" icon="pi pi-copy" (click)="copy(c.id.toString())"></button>
+          <button grButton type="button" icon="content_copy" (click)="copy(c.id.toString())"></button>
         </div>
 
         <div class="credential">
           <div class="label">Webhook secret</div>
           <code>{{ c.webhook_secret }}</code>
-          <button pButton type="button" icon="pi pi-copy" (click)="copy(c.webhook_secret)"></button>
+          <button grButton type="button" icon="content_copy" (click)="copy(c.webhook_secret)"></button>
         </div>
 
         <div class="credential">
           <div class="label">Private key (PEM)</div>
           <pre><code>{{ c.pem }}</code></pre>
-          <button pButton type="button" icon="pi pi-copy" (click)="copy(c.pem)"></button>
+          <button grButton type="button" icon="content_copy" (click)="copy(c.pem)"></button>
         </div>
 
         <div class="credential">
           <div class="label">Client ID</div>
           <code>{{ c.client_id }}</code>
-          <button pButton type="button" icon="pi pi-copy" (click)="copy(c.client_id)"></button>
+          <button grButton type="button" icon="content_copy" (click)="copy(c.client_id)"></button>
         </div>
 
         <div class="credential">
           <div class="label">Client secret</div>
           <code>{{ c.client_secret }}</code>
-          <button pButton type="button" icon="pi pi-copy" (click)="copy(c.client_secret)"></button>
+          <button grButton type="button" icon="content_copy" (click)="copy(c.client_secret)"></button>
         </div>
 
         <h3>Server configuration</h3>

--- a/frontend/src/app/features/admin/github-app/github-app.component.ts
+++ b/frontend/src/app/features/admin/github-app/github-app.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, HostListener, OnInit, computed, inject, signal } from '@angular/core';
+import { Component, HostListener, OnInit, computed, inject, signal, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -16,6 +16,7 @@ import { ButtonComponent, InputDirective } from '@shared/ui';
   standalone: true,
   imports: [CommonModule, RouterModule, FormsModule, ButtonComponent, InputDirective],
   templateUrl: './github-app.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './github-app.component.scss',
 })
 export class GithubAppComponent implements OnInit {

--- a/frontend/src/app/features/admin/github-app/github-app.component.ts
+++ b/frontend/src/app/features/admin/github-app/github-app.component.ts
@@ -8,14 +8,13 @@ import { Component, HostListener, OnInit, computed, inject, signal } from '@angu
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { ButtonModule } from 'primeng/button';
-import { InputTextModule } from 'primeng/inputtext';
 import { AdminService, GithubAppCredentials } from '@core/services/admin.service';
+import { ButtonComponent, InputDirective } from '@shared/ui';
 
 @Component({
   selector: 'app-admin-github-app',
   standalone: true,
-  imports: [CommonModule, RouterModule, FormsModule, ButtonModule, InputTextModule],
+  imports: [CommonModule, RouterModule, FormsModule, ButtonComponent, InputDirective],
   templateUrl: './github-app.component.html',
   styleUrl: './github-app.component.scss',
 })

--- a/frontend/src/app/features/auth/cli-authorize/cli-authorize.component.html
+++ b/frontend/src/app/features/auth/cli-authorize/cli-authorize.component.html
@@ -54,7 +54,7 @@
         </p>
         <div class="actions">
           <button
-            pButton
+            grButton
             type="button"
             class="w-full"
             label="Authorize"
@@ -63,7 +63,7 @@
             (click)="authorize()"
           ></button>
           <button
-            pButton
+            grButton
             type="button"
             class="w-full"
             label="Deny"
@@ -88,7 +88,7 @@
           />
         </div>
         <button
-          pButton
+          grButton
           type="submit"
           class="w-full"
           label="Continue"

--- a/frontend/src/app/features/auth/cli-authorize/cli-authorize.component.ts
+++ b/frontend/src/app/features/auth/cli-authorize/cli-authorize.component.ts
@@ -13,10 +13,10 @@ import {
   Validators,
 } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
-import { ButtonModule } from 'primeng/button';
 import { ApiService } from '@core/services/api.service';
 import { AuthService } from '@core/services/auth.service';
 import { take } from 'rxjs';
+import { ButtonComponent } from '@shared/ui';
 
 interface CliDeviceInfo {
   user_code: string;
@@ -28,7 +28,7 @@ interface CliDeviceInfo {
 @Component({
   selector: 'app-cli-authorize',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, ButtonModule],
+  imports: [CommonModule, ReactiveFormsModule, ButtonComponent],
   templateUrl: './cli-authorize.component.html',
   styleUrl: './cli-authorize.component.scss',
 })

--- a/frontend/src/app/features/auth/cli-authorize/cli-authorize.component.ts
+++ b/frontend/src/app/features/auth/cli-authorize/cli-authorize.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal } from '@angular/core';
+import { Component, OnInit, inject, signal, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
   FormBuilder,
@@ -30,6 +30,7 @@ interface CliDeviceInfo {
   standalone: true,
   imports: [CommonModule, ReactiveFormsModule, ButtonComponent],
   templateUrl: './cli-authorize.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './cli-authorize.component.scss',
 })
 export class CliAuthorizeComponent implements OnInit {

--- a/frontend/src/app/features/auth/login/login.component.html
+++ b/frontend/src/app/features/auth/login/login.component.html
@@ -64,7 +64,7 @@
         </div>
 
         <button
-          pButton
+          grButton
           type="submit"
           class="w-full"
           [label]="loading() ? 'Signing in...' : 'Sign In'"
@@ -81,11 +81,11 @@
         </div>
       }
       <button
-        pButton
+        grButton
         type="button"
         class="w-full"
         severity="secondary"
-        icon="pi pi-sign-in"
+        icon="login"
         label="Sign in with SSO"
         (click)="loginWithOIDC()"
       ></button>

--- a/frontend/src/app/features/auth/login/login.component.ts
+++ b/frontend/src/app/features/auth/login/login.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, inject, signal } from '@angular/core';
+import { Component, inject, signal, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
@@ -19,6 +19,7 @@ import { ButtonComponent } from '@shared/ui';
   standalone: true,
   imports: [CommonModule, ReactiveFormsModule, RouterModule, ButtonComponent],
   templateUrl: './login.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './login.component.scss',
 })
 export class LoginComponent {

--- a/frontend/src/app/features/auth/login/login.component.ts
+++ b/frontend/src/app/features/auth/login/login.component.ts
@@ -8,16 +8,16 @@ import { Component, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
-import { ButtonModule } from 'primeng/button';
 import { AuthService } from '@core/services/auth.service';
 import { ConfigService } from '@core/services/config.service';
 import { take } from 'rxjs';
 import { environment } from '@environments/environment';
+import { ButtonComponent } from '@shared/ui';
 
 @Component({
   selector: 'app-login',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, RouterModule, ButtonModule],
+  imports: [CommonModule, ReactiveFormsModule, RouterModule, ButtonComponent],
   templateUrl: './login.component.html',
   styleUrl: './login.component.scss',
 })

--- a/frontend/src/app/features/auth/oidc-callback/oidc-callback.component.ts
+++ b/frontend/src/app/features/auth/oidc-callback/oidc-callback.component.ts
@@ -4,13 +4,14 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject } from '@angular/core';
+import { Component, OnInit, inject, ChangeDetectionStrategy } from '@angular/core';
 import { Router } from '@angular/router';
 import { AuthService } from '@core/services/auth.service';
 
 @Component({
   selector: 'app-oidc-callback',
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.Eager,
   template: '<p>Completing sign in...</p>',
 })
 export class OidcCallbackComponent implements OnInit {

--- a/frontend/src/app/features/auth/register/register.component.html
+++ b/frontend/src/app/features/auth/register/register.component.html
@@ -18,10 +18,10 @@
         <p>This server requires SSO sign-in. Use the button below to create or access your account.</p>
       </div>
       <button
-        pButton
+        grButton
         type="button"
         class="w-full"
-        icon="pi pi-sign-in"
+        icon="login"
         label="Continue with SSO"
         (click)="loginWithOIDC()"
       ></button>
@@ -188,7 +188,7 @@
           </div>
 
           <button
-            pButton
+            grButton
             type="submit"
             class="w-full"
             [label]="loading() ? 'Creating account...' : 'Create Account'"

--- a/frontend/src/app/features/auth/register/register.component.ts
+++ b/frontend/src/app/features/auth/register/register.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, inject, signal } from '@angular/core';
+import { Component, inject, signal, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
   FormBuilder,
@@ -27,6 +27,7 @@ import { ButtonComponent } from '@shared/ui';
   standalone: true,
   imports: [CommonModule, ReactiveFormsModule, RouterModule, ButtonComponent],
   templateUrl: './register.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './register.component.scss',
 })
 export class RegisterComponent {

--- a/frontend/src/app/features/auth/register/register.component.ts
+++ b/frontend/src/app/features/auth/register/register.component.ts
@@ -15,17 +15,17 @@ import {
   ValidationErrors,
 } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
-import { ButtonModule } from 'primeng/button';
 import { AuthService } from '@core/services/auth.service';
 import { ConfigService } from '@core/services/config.service';
 import { environment } from '@environments/environment';
 import { switchMap, map } from 'rxjs/operators';
 import { of, timer } from 'rxjs';
+import { ButtonComponent } from '@shared/ui';
 
 @Component({
   selector: 'app-register',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, RouterModule, ButtonModule],
+  imports: [CommonModule, ReactiveFormsModule, RouterModule, ButtonComponent],
   templateUrl: './register.component.html',
   styleUrl: './register.component.scss',
 })

--- a/frontend/src/app/features/board/board-layout.component.ts
+++ b/frontend/src/app/features/board/board-layout.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component } from '@angular/core';
+import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 
@@ -31,6 +31,7 @@ import { RouterModule } from '@angular/router';
       <router-outlet></router-outlet>
     </div>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
   styles: [
     `
       .board {

--- a/frontend/src/app/features/board/cache/cache.component.ts
+++ b/frontend/src/app/features/board/cache/cache.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, OnDestroy, inject, signal, computed } from '@angular/core';
+import { Component, OnInit, OnDestroy, inject, signal, computed, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Subscription } from 'rxjs';
 import { auditTime } from 'rxjs/operators';
@@ -67,6 +67,7 @@ const GIB = 1024 ** 3;
       ></app-metric-chart>
     }
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
   styles: [
     `
       .kpis { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 1rem; margin-bottom: 1.5rem; }

--- a/frontend/src/app/features/board/durations/durations.component.ts
+++ b/frontend/src/app/features/board/durations/durations.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import { Component, OnInit, inject, signal, computed, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { BoardService, MetricPoint, DurationsHeatmap } from '@core/services/board.service';
 import { MetricChartComponent } from '@shared/components/metric-chart/metric-chart.component';
@@ -38,6 +38,7 @@ import { MetricChartComponent } from '@shared/components/metric-chart/metric-cha
       [colors]="['#6f42c1', '#fd7e14']"
     ></app-metric-chart>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
   styles: [`app-metric-chart { display: block; margin-bottom: 1rem; }`],
 })
 export class BoardDurationsComponent implements OnInit {

--- a/frontend/src/app/features/board/expensive-evals/expensive-evals.component.ts
+++ b/frontend/src/app/features/board/expensive-evals/expensive-evals.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import { Component, OnInit, inject, signal, computed, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { BoardService, ExpensiveEval } from '@core/services/board.service';
 
@@ -42,6 +42,7 @@ type Tab = 'time' | 'rss' | 'heap' | 'thunks' | 'fncalls' | 'alloc';
       </tbody>
     </table>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
   styles: [
     `
       .tabs { display: flex; gap: 0.5rem; margin-bottom: 1rem; flex-wrap: wrap; }

--- a/frontend/src/app/features/board/expensive-jobs/expensive-jobs.component.ts
+++ b/frontend/src/app/features/board/expensive-jobs/expensive-jobs.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import { Component, OnInit, inject, signal, computed, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
   BoardService,
@@ -76,6 +76,7 @@ type Tab = 'time' | 'ram' | 'cpu' | 'disk' | 'network';
       ></app-metric-chart>
     }
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
   styles: [
     `
       .tabs { display: flex; gap: 0.5rem; margin-bottom: 1rem; flex-wrap: wrap; }

--- a/frontend/src/app/features/board/health/health.component.ts
+++ b/frontend/src/app/features/board/health/health.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal } from '@angular/core';
+import { Component, OnInit, inject, signal, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { BoardService, BoardHealth } from '@core/services/board.service';
@@ -77,6 +77,7 @@ const MIB = 1024 ** 2;
       <p class="muted">Loading… (superuser only)</p>
     }
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
   styles: [
     `
       .kpis { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 1rem; margin-bottom: 1rem; }

--- a/frontend/src/app/features/board/job-detail/job-detail.component.ts
+++ b/frontend/src/app/features/board/job-detail/job-detail.component.ts
@@ -8,9 +8,6 @@ import { Component, OnInit, DestroyRef, inject, signal, computed } from '@angula
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
-import { DialogModule } from 'primeng/dialog';
-import { ButtonModule } from 'primeng/button';
-import { PopoverModule, Popover } from 'primeng/popover';
 import {
   BoardService,
   DispatchedJobDetail,
@@ -21,6 +18,7 @@ import {
   Windowed,
 } from '@core/services/board.service';
 import { EvaluationsService, BuildWithOutputs } from '@core/services/evaluations.service';
+import { ButtonComponent, DialogComponent, PopoverComponent } from '@shared/ui';
 
 interface RuleRow {
   name: string;
@@ -33,7 +31,7 @@ interface RuleRow {
 @Component({
   selector: 'app-board-job-detail',
   standalone: true,
-  imports: [CommonModule, RouterModule, DialogModule, ButtonModule, PopoverModule],
+  imports: [CommonModule, RouterModule, DialogComponent, ButtonComponent, PopoverComponent],
   template: `
     <a routerLink="/board/live" class="back">← Live Jobs</a>
 
@@ -87,11 +85,11 @@ interface RuleRow {
         </tbody>
       </table>
 
-      <p-popover #rulePop>
+      <gr-popover #rulePop>
         @if (activeRule(); as a) {
           <div class="rule-help"><strong>{{ a.rule }}</strong><p>{{ a.description }}</p></div>
         }
-      </p-popover>
+      </gr-popover>
 
       @if (j.candidates) {
         <h2>Runner-up candidates</h2>
@@ -240,14 +238,11 @@ interface RuleRow {
       <p class="muted">Loading job…</p>
     }
 
-    <p-dialog
+    <gr-dialog
       header="Build info"
       [visible]="buildDialog()"
       (visibleChange)="buildDialog.set($event)"
-      [modal]="true"
-      [style]="{ width: '640px' }"
-      [draggable]="false"
-      [resizable]="false"
+      width="640px"
     >
       @if (buildLoading()) {
         <p class="muted">Loading build…</p>
@@ -272,10 +267,10 @@ interface RuleRow {
           }
         </div>
       }
-      <ng-template pTemplate="footer">
-        <button pButton label="Close" severity="secondary" (click)="buildDialog.set(false)"></button>
-      </ng-template>
-    </p-dialog>
+      <div grDialogFooter>
+        <button grButton label="Close" severity="secondary" (click)="buildDialog.set(false)"></button>
+      </div>
+    </gr-dialog>
   `,
   styles: [
     `
@@ -374,7 +369,7 @@ export class BoardJobDetailComponent implements OnInit {
       .sort((a, b) => Math.abs(b.value) - Math.abs(a.value));
   });
 
-  showHelp(event: Event, row: RuleRow, popover: Popover): void {
+  showHelp(event: Event, row: RuleRow, popover: PopoverComponent): void {
     this.activeRule.set({ rule: row.name, description: row.description });
     popover.toggle(event);
   }

--- a/frontend/src/app/features/board/job-detail/job-detail.component.ts
+++ b/frontend/src/app/features/board/job-detail/job-detail.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, DestroyRef, inject, signal, computed } from '@angular/core';
+import { Component, OnInit, DestroyRef, inject, signal, computed, ChangeDetectionStrategy } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
@@ -272,6 +272,7 @@ interface RuleRow {
       </div>
     </gr-dialog>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
   styles: [
     `
       :host { display: block; padding: 1.5rem; max-width: 1000px; margin: 0 auto; }

--- a/frontend/src/app/features/board/live-jobs/live-jobs.component.spec.ts
+++ b/frontend/src/app/features/board/live-jobs/live-jobs.component.spec.ts
@@ -10,7 +10,7 @@ import { of, EMPTY } from 'rxjs';
 import { BoardLiveJobsComponent } from './live-jobs.component';
 import { BoardService } from '@core/services/board.service';
 import { BoardLiveService } from '@core/services/board-live.service';
-import { DispatchedJobSummary, PendingJobSummary } from '@core/services/board.service';
+import { DispatchDecisionView, DispatchedJobSummary, PendingJobSummary } from '@core/services/board.service';
 
 const PENDING: PendingJobSummary = {
   kind: 1,
@@ -98,6 +98,21 @@ describe('BoardLiveJobsComponent - dispatched pname column', () => {
   });
 });
 
+// Shaped by DispatchDecisionView so the compiler catches drift: the server
+// sends a per-candidate `id` and `won`, not just a decision-level `winner`.
+const DECISIONS: DispatchDecisionView[] = [
+  {
+    at: '2026-06-08T00:00:00Z',
+    worker_id: 'w1',
+    kind: 1,
+    winner: 'j1',
+    candidates: [
+      { id: 'c1', job_id: 'j1', kind: 1, project: 'o1', build_id: 'b1', evaluation_id: 'e1', pname: 'win', score: 12, won: true },
+      { id: 'c2', job_id: 'j2', kind: 1, project: 'o2', build_id: 'b2', evaluation_id: 'e2', pname: 'loser', score: -8, won: false },
+    ],
+  },
+];
+
 describe('BoardLiveJobsComponent - decision scores (#419)', () => {
   beforeEach(() => sessionStorage.clear());
 
@@ -111,19 +126,7 @@ describe('BoardLiveJobsComponent - decision scores (#419)', () => {
           useValue: {
             getDispatchedJobs: () => of({ jobs: [], other_running: 0 }),
             getPendingJobs: () => of({ jobs: [], other_pending: 0 }),
-            getDispatchDecisions: () =>
-              of([
-                {
-                  at: '2026-06-08T00:00:00Z',
-                  worker_id: 'w1',
-                  kind: 1,
-                  winner: 'j1',
-                  candidates: [
-                    { job_id: 'j1', kind: 1, project: 'o1', build_id: 'b1', evaluation_id: 'e1', pname: 'win', score: 12 },
-                    { job_id: 'j2', kind: 1, project: 'o2', build_id: 'b2', evaluation_id: 'e2', pname: 'loser', score: -8 },
-                  ],
-                },
-              ]),
+            getDispatchDecisions: () => of(DECISIONS),
           },
         },
         { provide: BoardLiveService, useValue: { connect: () => EMPTY } },

--- a/frontend/src/app/features/board/live-jobs/live-jobs.component.ts
+++ b/frontend/src/app/features/board/live-jobs/live-jobs.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnDestroy, OnInit, inject, signal, computed, effect } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject, signal, computed, effect, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
@@ -140,6 +140,7 @@ interface DecisionRow {
       </table>
     }
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
   styles: [
     `
       .banner { color: #abb0b4; margin-bottom: 1rem; }

--- a/frontend/src/app/features/board/network/network.component.ts
+++ b/frontend/src/app/features/board/network/network.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import { Component, OnInit, inject, signal, computed, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { BoardService, BoardNetworkStats, HttpRouteStat } from '@core/services/board.service';
 import { MetricChartComponent } from '@shared/components/metric-chart/metric-chart.component';
@@ -68,6 +68,7 @@ type HttpSortKey = keyof Pick<HttpRouteStat, 'method' | 'route' | 'count' | 'avg
       </tbody>
     </table>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
   styles: [
     `
       app-metric-chart { display: block; margin-bottom: 1rem; }

--- a/frontend/src/app/features/board/overview/overview.component.ts
+++ b/frontend/src/app/features/board/overview/overview.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnDestroy, OnInit, inject, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject, signal, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Subscription } from 'rxjs';
 import { BoardService, MetricPoint } from '@core/services/board.service';
@@ -31,6 +31,7 @@ import { MetricChartComponent } from '@shared/components/metric-chart/metric-cha
       [colors]="['#28a745']"
     ></app-metric-chart>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
   styles: [
     `
       .kpis {

--- a/frontend/src/app/features/board/scheduler/scheduler.component.ts
+++ b/frontend/src/app/features/board/scheduler/scheduler.component.ts
@@ -6,14 +6,14 @@
 
 import { Component, OnInit, inject, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { PopoverModule, Popover } from 'primeng/popover';
 import { BoardService, MetricPoint, RuleDescription, ScoringSummary } from '@core/services/board.service';
 import { MetricChartComponent } from '@shared/components/metric-chart/metric-chart.component';
+import { PopoverComponent } from '@shared/ui';
 
 @Component({
   selector: 'app-board-scheduler',
   standalone: true,
-  imports: [CommonModule, PopoverModule, MetricChartComponent],
+  imports: [CommonModule, PopoverComponent, MetricChartComponent],
   template: `
     <div class="kpis">
       <div class="kpi"><span class="label">Scored dispatches (24h)</span><span class="value">{{ summary()?.sample_size ?? 0 }}</span></div>
@@ -60,11 +60,11 @@ import { MetricChartComponent } from '@shared/components/metric-chart/metric-cha
       </tbody>
     </table>
 
-    <p-popover #rulePop>
+    <gr-popover #rulePop>
       @if (activeRule(); as a) {
         <div class="rule-help"><strong>{{ a.rule }}</strong><p>{{ a.description }}</p></div>
       }
-    </p-popover>
+    </gr-popover>
   `,
   styles: [
     `
@@ -129,7 +129,7 @@ export class BoardSchedulerComponent implements OnInit {
     }));
   });
 
-  showHelp(event: Event, row: { rule: string; description: string }, popover: Popover): void {
+  showHelp(event: Event, row: { rule: string; description: string }, popover: PopoverComponent): void {
     this.activeRule.set({ rule: row.rule, description: row.description });
     popover.toggle(event);
   }

--- a/frontend/src/app/features/board/scheduler/scheduler.component.ts
+++ b/frontend/src/app/features/board/scheduler/scheduler.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import { Component, OnInit, inject, signal, computed, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { BoardService, MetricPoint, RuleDescription, ScoringSummary } from '@core/services/board.service';
 import { MetricChartComponent } from '@shared/components/metric-chart/metric-chart.component';
@@ -66,6 +66,7 @@ import { PopoverComponent } from '@shared/ui';
       }
     </gr-popover>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
   styles: [
     `
       .kpis { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 1rem; margin-bottom: 1.5rem; }

--- a/frontend/src/app/features/board/throughput/throughput.component.ts
+++ b/frontend/src/app/features/board/throughput/throughput.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal } from '@angular/core';
+import { Component, OnInit, inject, signal, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { forkJoin } from 'rxjs';
 import { BoardService, MetricPoint, BoardWorker } from '@core/services/board.service';
@@ -39,6 +39,7 @@ import { MetricChartComponent } from '@shared/components/metric-chart/metric-cha
       [colors]="['#fd7e14']"
     ></app-metric-chart>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
   styles: [`app-metric-chart { display: block; margin-bottom: 1rem; }`],
 })
 export class BoardThroughputComponent implements OnInit {

--- a/frontend/src/app/features/board/workers/workers.component.ts
+++ b/frontend/src/app/features/board/workers/workers.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import { Component, OnInit, inject, signal, computed, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
   BoardService,
@@ -94,6 +94,7 @@ import { MetricChartComponent } from '@shared/components/metric-chart/metric-cha
       </tbody>
     </table>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
   styles: [
     `
       app-metric-chart { display: block; margin-bottom: 1rem; }

--- a/frontend/src/app/features/caches/cache-detail/cache-detail.component.html
+++ b/frontend/src/app/features/caches/cache-detail/cache-detail.component.html
@@ -32,9 +32,9 @@
         </div>
       </div>
       <div class="header-actions">
-        <button pButton label="NARs" icon="pi pi-database" severity="secondary" [routerLink]="['/caches', cacheName, 'nars']"></button>
+        <button grButton label="NARs" icon="database" severity="secondary" [routerLink]="['/caches', cacheName, 'nars']"></button>
         @if (c.can_edit) {
-          <button pButton label="Settings" icon="pi pi-cog" severity="secondary" [routerLink]="['/caches', cacheName, 'settings']"></button>
+          <button grButton label="Settings" icon="settings" severity="secondary" [routerLink]="['/caches', cacheName, 'settings']"></button>
         }
       </div>
     </div>

--- a/frontend/src/app/features/caches/cache-detail/cache-detail.component.ts
+++ b/frontend/src/app/features/caches/cache-detail/cache-detail.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import { Component, OnInit, inject, signal, computed, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { CachesService, CacheStats, CacheMetricPoint, StorageMetricPoint, UpstreamCache } from '@core/services/caches.service';
@@ -36,6 +36,7 @@ const CHART_COLORS = {
     MetricChartComponent,
   ],
   templateUrl: './cache-detail.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './cache-detail.component.scss',
 })
 export class CacheDetailComponent implements OnInit {

--- a/frontend/src/app/features/caches/cache-detail/cache-detail.component.ts
+++ b/frontend/src/app/features/caches/cache-detail/cache-detail.component.ts
@@ -7,14 +7,13 @@
 import { Component, OnInit, inject, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
-import { ButtonModule } from 'primeng/button';
-import { CardModule } from 'primeng/card';
 import { CachesService, CacheStats, CacheMetricPoint, StorageMetricPoint, UpstreamCache } from '@core/services/caches.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { LabelHelpComponent } from '@shared/components/form';
 import { Cache } from '@core/models';
 import { MetricChartComponent } from '@shared/components/metric-chart/metric-chart.component';
 import { MetricSeries } from '@shared/components/metric-chart/metric-chart.options';
+import { ButtonComponent } from '@shared/ui';
 
 type Window = 'minutes' | 'hours' | 'days' | 'weeks';
 
@@ -31,8 +30,7 @@ const CHART_COLORS = {
   imports: [
     CommonModule,
     RouterModule,
-    ButtonModule,
-    CardModule,
+    ButtonComponent,
     LoadingSpinnerComponent,
     LabelHelpComponent,
     MetricChartComponent,

--- a/frontend/src/app/features/caches/cache-list/cache-list.component.html
+++ b/frontend/src/app/features/caches/cache-list/cache-list.component.html
@@ -11,7 +11,7 @@
       <p class="text-secondary">Manage your build caches</p>
     </div>
     @if (canCreateCache) {
-      <button pButton label="Create Cache" icon="pi pi-plus" (click)="openCreateDialog()"></button>
+      <button grButton label="Create Cache" icon="add" (click)="openCreateDialog()"></button>
     }
   </div>
 
@@ -130,13 +130,10 @@
 </div>
 
 <!-- Create Cache Dialog -->
-<p-dialog
+<gr-dialog
   header="Create Cache"
   [(visible)]="showCreateDialog"
-  [modal]="true"
-  [style]="{ width: '500px' }"
-  [draggable]="false"
-  [resizable]="false"
+  width="500px"
 >
   @if (createError()) {
     <div class="dialog-error">
@@ -148,7 +145,7 @@
     <div class="form-group">
       <label for="cache-display">Display Name *</label>
       <input
-        pInputText
+        grInput
         id="cache-display"
         [(ngModel)]="newCache.display_name"
         placeholder="My Cache"
@@ -161,7 +158,7 @@
       <label for="cache-name">Name *</label>
       <div class="name-input-wrapper">
         <input
-          pInputText
+          grInput
           id="cache-name"
           [(ngModel)]="newCache.name"
           placeholder="cache-name"
@@ -170,7 +167,7 @@
           (input)="onCacheNameUserInput()"
         />
         @if (nameCheckState() === 'checking') {
-          <span class="name-check-icon"><i class="pi pi-spin pi-spinner"></i></span>
+          <span class="name-check-icon"><span class="material-symbols-outlined gr-spin">progress_activity</span></span>
         } @else if (nameCheckState() === 'available') {
           <span class="name-check-icon available"><span class="material-symbols-outlined">check</span></span>
         } @else if (nameCheckState() === 'taken' || nameCheckState() === 'invalid') {
@@ -189,7 +186,7 @@
     <div class="form-group">
       <label for="cache-desc">Description</label>
       <textarea
-        pInputTextarea
+        grInput
         id="cache-desc"
         [(ngModel)]="newCache.description"
         placeholder="Describe your cache..."
@@ -208,20 +205,20 @@
     </div>
   </div>
 
-  <ng-template pTemplate="footer">
+  <div grDialogFooter>
     <button
-      pButton
+      grButton
       label="Cancel"
       severity="secondary"
       (click)="showCreateDialog.set(false)"
       [disabled]="creating()"
     ></button>
     <button
-      pButton
+      grButton
       label="Create"
       (click)="createCache()"
       [disabled]="!newCache.name || !newCache.display_name || nameCheckState() === 'taken' || nameCheckState() === 'invalid' || nameCheckState() === 'checking' || creating()"
       [loading]="creating()"
     ></button>
-  </ng-template>
-</p-dialog>
+  </div>
+</gr-dialog>

--- a/frontend/src/app/features/caches/cache-list/cache-list.component.ts
+++ b/frontend/src/app/features/caches/cache-list/cache-list.component.ts
@@ -10,10 +10,6 @@ import { RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { Subject, EMPTY } from 'rxjs';
 import { debounceTime, switchMap } from 'rxjs/operators';
-import { DialogModule } from 'primeng/dialog';
-import { ButtonModule } from 'primeng/button';
-import { InputTextModule } from 'primeng/inputtext';
-import { TextareaModule } from 'primeng/textarea';
 import { CachesService } from '@core/services/caches.service';
 import { AuthService } from '@core/services/auth.service';
 import { ConfigService } from '@core/services/config.service';
@@ -21,6 +17,7 @@ import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/load
 import { EmptyStateComponent } from '@shared/components/empty-state/empty-state.component';
 import { slugify } from '@shared/text';
 import { Cache } from '@core/models';
+import { ButtonComponent, DialogComponent, InputDirective } from '@shared/ui';
 
 @Component({
   selector: 'app-cache-list',
@@ -29,10 +26,10 @@ import { Cache } from '@core/models';
     CommonModule,
     RouterModule,
     FormsModule,
-    DialogModule,
-    ButtonModule,
-    InputTextModule,
-    TextareaModule,
+    DialogComponent,
+    ButtonComponent,
+    InputDirective,
+    InputDirective,
     LoadingSpinnerComponent,
     EmptyStateComponent,
   ],

--- a/frontend/src/app/features/caches/cache-list/cache-list.component.ts
+++ b/frontend/src/app/features/caches/cache-list/cache-list.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnDestroy, OnInit, inject, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject, signal, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -34,6 +34,7 @@ import { ButtonComponent, DialogComponent, InputDirective } from '@shared/ui';
     EmptyStateComponent,
   ],
   templateUrl: './cache-list.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './cache-list.component.scss',
 })
 export class CacheListComponent implements OnInit, OnDestroy {

--- a/frontend/src/app/features/caches/cache-nars/cache-nars-detail-drawer.component.html
+++ b/frontend/src/app/features/caches/cache-nars/cache-nars-detail-drawer.component.html
@@ -4,14 +4,11 @@
   SPDX-License-Identifier: AGPL-3.0-only
 -->
 
-<p-dialog
+<gr-dialog
   header="NAR details"
   [visible]="visible()"
   (visibleChange)="onVisibleChange($event)"
-  [modal]="true"
-  [style]="{ width: '640px' }"
-  [draggable]="false"
-  [resizable]="false"
+  width="640px"
 >
   @if (loading()) {
     <app-loading-spinner message="Loading NAR..." />
@@ -91,7 +88,7 @@
       </div>
     </div>
   }
-  <ng-template pTemplate="footer">
-    <button pButton label="Close" severity="secondary" (click)="onVisibleChange(false)"></button>
-  </ng-template>
-</p-dialog>
+  <div grDialogFooter>
+    <button grButton label="Close" severity="secondary" (click)="onVisibleChange(false)"></button>
+  </div>
+</gr-dialog>

--- a/frontend/src/app/features/caches/cache-nars/cache-nars-detail-drawer.component.ts
+++ b/frontend/src/app/features/caches/cache-nars/cache-nars-detail-drawer.component.ts
@@ -15,15 +15,14 @@ import {
   signal,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { DialogModule } from 'primeng/dialog';
-import { ButtonModule } from 'primeng/button';
 import { CachesService, NarDetail, NarSummary } from '@core/services/caches.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
+import { ButtonComponent, DialogComponent } from '@shared/ui';
 
 @Component({
   selector: 'app-cache-nars-detail-drawer',
   standalone: true,
-  imports: [CommonModule, DialogModule, ButtonModule, LoadingSpinnerComponent],
+  imports: [CommonModule, DialogComponent, ButtonComponent, LoadingSpinnerComponent],
   templateUrl: './cache-nars-detail-drawer.component.html',
   styleUrl: './cache-nars-detail-drawer.component.scss',
 })

--- a/frontend/src/app/features/caches/cache-nars/cache-nars-detail-drawer.component.ts
+++ b/frontend/src/app/features/caches/cache-nars/cache-nars-detail-drawer.component.ts
@@ -13,6 +13,7 @@ import {
   SimpleChanges,
   inject,
   signal,
+  ChangeDetectionStrategy
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { CachesService, NarDetail, NarSummary } from '@core/services/caches.service';
@@ -24,6 +25,7 @@ import { ButtonComponent, DialogComponent } from '@shared/ui';
   standalone: true,
   imports: [CommonModule, DialogComponent, ButtonComponent, LoadingSpinnerComponent],
   templateUrl: './cache-nars-detail-drawer.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './cache-nars-detail-drawer.component.scss',
 })
 export class CacheNarsDetailDrawerComponent implements OnChanges {

--- a/frontend/src/app/features/caches/cache-nars/cache-nars.component.html
+++ b/frontend/src/app/features/caches/cache-nars/cache-nars.component.html
@@ -47,15 +47,15 @@
   <div class="filter-row">
     <div class="filter-group">
       <label for="filter-hash">Hash</label>
-      <input pInputText id="filter-hash" [ngModel]="hash()" (ngModelChange)="hash.set($event)" placeholder="store hash prefix" class="w-full" (keydown.enter)="applyFilters()" />
+      <input grInput id="filter-hash" [ngModel]="hash()" (ngModelChange)="hash.set($event)" placeholder="store hash prefix" class="w-full" (keydown.enter)="applyFilters()" />
     </div>
     <div class="filter-group">
       <label for="filter-package">Package</label>
-      <input pInputText id="filter-package" [ngModel]="package()" (ngModelChange)="package.set($event)" placeholder="package name" class="w-full" (keydown.enter)="applyFilters()" />
+      <input grInput id="filter-package" [ngModel]="package()" (ngModelChange)="package.set($event)" placeholder="package name" class="w-full" (keydown.enter)="applyFilters()" />
     </div>
     <div class="filter-actions">
-      <button pButton type="button" label="Apply" icon="pi pi-filter" (click)="applyFilters()"></button>
-      <button pButton type="button" label="Reset" severity="secondary" (click)="reset()"></button>
+      <button grButton type="button" label="Apply" icon="filter_alt" (click)="applyFilters()"></button>
+      <button grButton type="button" label="Reset" severity="secondary" (click)="reset()"></button>
     </div>
   </div>
 
@@ -109,11 +109,11 @@
           <span class="col col-time text-secondary">{{ formatDate(row.created_at) }}</span>
           <span class="col col-time text-secondary">{{ formatDate(row.last_fetched_at, 'never') }}</span>
           <span class="col col-actions" (click)="$event.stopPropagation()">
-            <button pButton icon="pi pi-info-circle" severity="secondary" [text]="true" (click)="show(row)" title="Show details"></button>
+            <button grButton icon="info" severity="secondary" [text]="true" (click)="show(row)" title="Show details"></button>
             <button
               *appWritable="access()"
-              pButton
-              icon="pi pi-trash"
+              grButton
+              icon="delete"
               severity="danger"
               [text]="true"
               [loading]="deletingHash() === row.hash"
@@ -131,10 +131,10 @@
         Page {{ page() }} of {{ totalPages() }} &middot; {{ total() }} total
       </span>
       <div class="pagination-actions">
-        <button pButton icon="pi pi-angle-double-left" severity="secondary" [disabled]="page() <= 1" (click)="goToPage(1)"></button>
-        <button pButton icon="pi pi-angle-left" severity="secondary" [disabled]="page() <= 1" (click)="goToPage(page() - 1)"></button>
-        <button pButton icon="pi pi-angle-right" severity="secondary" [disabled]="page() >= totalPages()" (click)="goToPage(page() + 1)"></button>
-        <button pButton icon="pi pi-angle-double-right" severity="secondary" [disabled]="page() >= totalPages()" (click)="goToPage(totalPages())"></button>
+        <button grButton icon="keyboard_double_arrow_left" severity="secondary" [disabled]="page() <= 1" (click)="goToPage(1)"></button>
+        <button grButton icon="chevron_left" severity="secondary" [disabled]="page() <= 1" (click)="goToPage(page() - 1)"></button>
+        <button grButton icon="chevron_right" severity="secondary" [disabled]="page() >= totalPages()" (click)="goToPage(page() + 1)"></button>
+        <button grButton icon="keyboard_double_arrow_right" severity="secondary" [disabled]="page() >= totalPages()" (click)="goToPage(totalPages())"></button>
       </div>
     </div>
   }
@@ -146,14 +146,11 @@
   (closed)="closeDrawer()"
 />
 
-<p-dialog
+<gr-dialog
   header="Delete NAR"
   [visible]="pendingDelete() !== null"
   (visibleChange)="$event || cancelDelete()"
-  [modal]="true"
-  [style]="{ width: '480px' }"
-  [draggable]="false"
-  [resizable]="false"
+  width="480px"
   [closable]="!deletingHash()"
 >
   @if (deleteError()) {
@@ -170,8 +167,8 @@
       If other caches still hold this NAR, only this cache's signature is removed. Otherwise the NAR blob is deleted permanently.
     </p>
   }
-  <ng-template pTemplate="footer">
-    <button pButton label="Cancel" severity="secondary" (click)="cancelDelete()" [disabled]="deletingHash() !== null"></button>
-    <button pButton label="Delete" severity="danger" icon="pi pi-trash" (click)="confirmDelete()" [loading]="deletingHash() !== null"></button>
-  </ng-template>
-</p-dialog>
+  <div grDialogFooter>
+    <button grButton label="Cancel" severity="secondary" (click)="cancelDelete()" [disabled]="deletingHash() !== null"></button>
+    <button grButton label="Delete" severity="danger" icon="delete" (click)="confirmDelete()" [loading]="deletingHash() !== null"></button>
+  </div>
+</gr-dialog>

--- a/frontend/src/app/features/caches/cache-nars/cache-nars.component.ts
+++ b/frontend/src/app/features/caches/cache-nars/cache-nars.component.ts
@@ -8,9 +8,6 @@ import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { DialogModule } from 'primeng/dialog';
-import { ButtonModule } from 'primeng/button';
-import { InputTextModule } from 'primeng/inputtext';
 import {
   CachesService,
   NarListResponse,
@@ -21,6 +18,7 @@ import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/load
 import { WritableDirective } from '@shared/access';
 import { injectCacheAccess } from '@core/resolvers/inject-access';
 import { CacheNarsDetailDrawerComponent } from './cache-nars-detail-drawer.component';
+import { ButtonComponent, DialogComponent, InputDirective } from '@shared/ui';
 
 type SortKey = 'created_at' | 'nar_size' | 'last_fetched_at';
 type SortOrder = 'asc' | 'desc';
@@ -32,9 +30,9 @@ type SortOrder = 'asc' | 'desc';
     CommonModule,
     FormsModule,
     RouterModule,
-    DialogModule,
-    ButtonModule,
-    InputTextModule,
+    DialogComponent,
+    ButtonComponent,
+    InputDirective,
     LoadingSpinnerComponent,
     WritableDirective,
     CacheNarsDetailDrawerComponent,

--- a/frontend/src/app/features/caches/cache-nars/cache-nars.component.ts
+++ b/frontend/src/app/features/caches/cache-nars/cache-nars.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, computed, inject, signal } from '@angular/core';
+import { Component, OnInit, computed, inject, signal, ChangeDetectionStrategy } from '@angular/core';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
@@ -38,6 +38,7 @@ type SortOrder = 'asc' | 'desc';
     CacheNarsDetailDrawerComponent,
   ],
   templateUrl: './cache-nars.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './cache-nars.component.scss',
 })
 export class CacheNarsComponent implements OnInit {

--- a/frontend/src/app/features/caches/cache-settings/cache-settings.component.html
+++ b/frontend/src/app/features/caches/cache-settings/cache-settings.component.html
@@ -28,7 +28,7 @@
         <div class="form-group">
           <label for="cache-name">Name</label>
           <input
-            pInputText
+            grInput
             id="cache-name"
             [value]="c.name"
             disabled
@@ -40,7 +40,7 @@
         <div class="form-group">
           <label for="display-name">Display Name</label>
           <input
-            pInputText
+            grInput
             id="display-name"
             [(ngModel)]="formData.display_name"
             class="w-full"
@@ -51,7 +51,7 @@
         <div class="form-group">
           <label for="description">Description</label>
           <textarea
-            pInputTextarea
+            grInput
             id="description"
             [(ngModel)]="formData.description"
             rows="3"
@@ -134,9 +134,9 @@
         <div class="form-actions">
           <button
             *appWritable="access()"
-            pButton
+            grButton
             label="Save Changes"
-            icon="pi pi-check"
+            icon="check"
             (click)="saveSettings()"
             [loading]="saving()"
             [disabled]="priorityInvalid"
@@ -155,7 +155,7 @@
             <h3>Upstream Caches</h3>
             <p class="text-secondary">External and internal caches this cache pulls through from</p>
           </div>
-          <a pButton label="Manage Upstreams" icon="pi pi-cloud-download" severity="secondary" [routerLink]="['/caches', cacheName, 'upstreams']"></a>
+          <a grButton label="Manage Upstreams" icon="cloud_download" severity="secondary" [routerLink]="['/caches', cacheName, 'upstreams']"></a>
         </div>
       </div>
     </div>
@@ -169,7 +169,7 @@
             <h3>Members & Roles</h3>
             <p class="text-secondary">Manage who has access to this cache and what they can do</p>
           </div>
-          <a pButton label="Manage Members" icon="pi pi-users" severity="secondary" [routerLink]="['/caches', cacheName, 'members-roles']"></a>
+          <a grButton label="Manage Members" icon="group" severity="secondary" [routerLink]="['/caches', cacheName, 'members-roles']"></a>
         </div>
       </div>
     </div>
@@ -185,25 +185,25 @@
               <p class="text-secondary">{{ c.active ? 'Stop serving this cache to Nix clients.' : 'Start serving this cache to Nix clients.' }}</p>
             </div>
             <button
-              pButton
+              grButton
               [label]="c.active ? 'Deactivate' : 'Activate'"
-              [icon]="c.active ? 'pi pi-times' : 'pi pi-check'"
+              [icon]="c.active ? 'close' : 'check'"
               [severity]="c.active ? 'danger' : 'success'"
               (click)="toggleActive()"
               [loading]="toggling()"
               [appManagedDisable]="access()"
             ></button>
           </div>
-          <p-divider />
+          <gr-divider />
           <div class="danger-row">
             <div>
               <h3>Delete Cache</h3>
               <p class="text-secondary">Permanently delete this cache and all its stored artifacts.</p>
             </div>
             <button
-              pButton
+              grButton
               label="Delete Cache"
-              icon="pi pi-trash"
+              icon="delete"
               severity="danger"
               (click)="showDeleteDialog.set(true)"
               [appManagedDisable]="access()"
@@ -216,17 +216,14 @@
 </div>
 
 <!-- Delete Confirmation Dialog -->
-<p-dialog
+<gr-dialog
   header="Delete Cache"
   [(visible)]="showDeleteDialog"
-  [modal]="true"
-  [style]="{ width: '400px' }"
-  [draggable]="false"
-  [resizable]="false"
+  width="400px"
 >
   <p>Are you sure you want to delete <strong>{{ cache()?.display_name }}</strong>? This action cannot be undone.</p>
-  <ng-template pTemplate="footer">
-    <button pButton label="Cancel" severity="secondary" (click)="showDeleteDialog.set(false)" [disabled]="deleting()"></button>
-    <button pButton label="Delete" severity="danger" (click)="deleteCache()" [loading]="deleting()" [disabled]="deleting()"></button>
-  </ng-template>
-</p-dialog>
+  <div grDialogFooter>
+    <button grButton label="Cancel" severity="secondary" (click)="showDeleteDialog.set(false)" [disabled]="deleting()"></button>
+    <button grButton label="Delete" severity="danger" (click)="deleteCache()" [loading]="deleting()" [disabled]="deleting()"></button>
+  </div>
+</gr-dialog>

--- a/frontend/src/app/features/caches/cache-settings/cache-settings.component.ts
+++ b/frontend/src/app/features/caches/cache-settings/cache-settings.component.ts
@@ -8,16 +8,12 @@ import { Component, OnInit, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { DialogModule } from 'primeng/dialog';
-import { DividerModule } from 'primeng/divider';
-import { ButtonModule } from 'primeng/button';
-import { InputTextModule } from 'primeng/inputtext';
-import { TextareaModule } from 'primeng/textarea';
 import { CachesService } from '@core/services/caches.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { WritableDirective, ManagedDisableDirective } from '@shared/access';
 import { injectCacheAccess } from '@core/resolvers/inject-access';
 import { Cache } from '@core/models';
+import { ButtonComponent, DialogComponent, DividerComponent, InputDirective } from '@shared/ui';
 
 @Component({
   selector: 'app-cache-settings',
@@ -26,11 +22,11 @@ import { Cache } from '@core/models';
     CommonModule,
     RouterModule,
     FormsModule,
-    DialogModule,
-    DividerModule,
-    ButtonModule,
-    InputTextModule,
-    TextareaModule,
+    DialogComponent,
+    DividerComponent,
+    ButtonComponent,
+    InputDirective,
+    InputDirective,
     LoadingSpinnerComponent,
     WritableDirective,
     ManagedDisableDirective,

--- a/frontend/src/app/features/caches/cache-settings/cache-settings.component.ts
+++ b/frontend/src/app/features/caches/cache-settings/cache-settings.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal } from '@angular/core';
+import { Component, OnInit, inject, signal, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -32,6 +32,7 @@ import { ButtonComponent, DialogComponent, DividerComponent, InputDirective } fr
     ManagedDisableDirective,
   ],
   templateUrl: './cache-settings.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './cache-settings.component.scss',
 })
 export class CacheSettingsComponent implements OnInit {

--- a/frontend/src/app/features/caches/cache-upstreams/cache-upstreams.component.html
+++ b/frontend/src/app/features/caches/cache-upstreams/cache-upstreams.component.html
@@ -21,9 +21,9 @@
     </div>
     <button
       *appWritable="access()"
-      pButton
+      grButton
       label="Add Upstream"
-      icon="pi pi-plus"
+      icon="add"
       (click)="openAddDialog()"
       [appManagedDisable]="access()"
     ></button>
@@ -39,9 +39,9 @@
         <p class="text-secondary">Add an upstream to enable pull-through caching from another cache.</p>
         <button
           *appWritable="access()"
-          pButton
+          grButton
           label="Add Upstream"
-          icon="pi pi-plus"
+          icon="add"
           (click)="openAddDialog()"
           [appManagedDisable]="access()"
         ></button>
@@ -64,16 +64,16 @@
             <div class="upstream-actions">
               <button
                 *appWritable="access()"
-                pButton
-                icon="pi pi-pencil"
+                grButton
+                icon="edit"
                 severity="secondary"
                 [disabled]="rowDisabled()"
                 (click)="openEditDialog(u)"
               ></button>
               <button
                 *appWritable="access()"
-                pButton
-                icon="pi pi-trash"
+                grButton
+                icon="delete"
                 severity="danger"
                 [loading]="removingUpstreamId() === u.id"
                 [disabled]="rowDisabled()"
@@ -88,13 +88,10 @@
 </div>
 
 <!-- Edit Upstream Dialog -->
-<p-dialog
+<gr-dialog
   header="Edit Upstream Cache"
   [(visible)]="showEditDialog"
-  [modal]="true"
-  [style]="{ width: '480px' }"
-  [draggable]="false"
-  [resizable]="false"
+  width="480px"
 >
   @if (editError()) {
     <div class="dialog-error">
@@ -106,16 +103,16 @@
     <div class="upstream-form">
       <div class="form-group">
         <label for="edit-display-name">Display Name</label>
-        <input pInputText id="edit-display-name" [(ngModel)]="editForm.display_name" class="w-full" />
+        <input grInput id="edit-display-name" [(ngModel)]="editForm.display_name" class="w-full" />
       </div>
       @if (!u.upstream_cache_id) {
         <div class="form-group">
           <label for="edit-url">Substituter URL</label>
-          <input pInputText id="edit-url" [(ngModel)]="editForm.url" class="w-full" />
+          <input grInput id="edit-url" [(ngModel)]="editForm.url" class="w-full" />
         </div>
         <div class="form-group">
           <label for="edit-pubkey">Public Key</label>
-          <input pInputText id="edit-pubkey" [(ngModel)]="editForm.public_key" class="w-full" />
+          <input grInput id="edit-pubkey" [(ngModel)]="editForm.public_key" class="w-full" />
         </div>
         <small class="text-secondary">External caches are always Read Only.</small>
       } @else {
@@ -130,20 +127,17 @@
       }
     </div>
   }
-  <ng-template pTemplate="footer">
-    <button pButton label="Cancel" severity="secondary" (click)="showEditDialog.set(false)" [disabled]="savingUpstream()"></button>
-    <button pButton label="Save" icon="pi pi-check" (click)="saveUpstream()" [loading]="savingUpstream()" [disabled]="savingUpstream() || !isEditFormValid()"></button>
-  </ng-template>
-</p-dialog>
+  <div grDialogFooter>
+    <button grButton label="Cancel" severity="secondary" (click)="showEditDialog.set(false)" [disabled]="savingUpstream()"></button>
+    <button grButton label="Save" icon="check" (click)="saveUpstream()" [loading]="savingUpstream()" [disabled]="savingUpstream() || !isEditFormValid()"></button>
+  </div>
+</gr-dialog>
 
 <!-- Add Upstream Dialog -->
-<p-dialog
+<gr-dialog
   header="Add Upstream Cache"
   [(visible)]="showAddDialog"
-  [modal]="true"
-  [style]="{ width: '480px' }"
-  [draggable]="false"
-  [resizable]="false"
+  width="480px"
 >
   @if (addError()) {
     <div class="dialog-error">
@@ -164,11 +158,11 @@
     @if (upstreamType === 'internal') {
       <div class="form-group">
         <label for="up-cache-name">Cache Name</label>
-        <input pInputText id="up-cache-name" [(ngModel)]="upstreamForm.cache_name" placeholder="my-cache" class="w-full" />
+        <input grInput id="up-cache-name" [(ngModel)]="upstreamForm.cache_name" placeholder="my-cache" class="w-full" />
       </div>
       <div class="form-group">
         <label for="up-display-name-int">Display Name <span class="text-secondary">(optional)</span></label>
-        <input pInputText id="up-display-name-int" [(ngModel)]="upstreamForm.display_name" placeholder="Defaults to the cache's display name" class="w-full" />
+        <input grInput id="up-display-name-int" [(ngModel)]="upstreamForm.display_name" placeholder="Defaults to the cache's display name" class="w-full" />
       </div>
       <div class="form-group">
         <label for="up-mode">Mode</label>
@@ -184,19 +178,19 @@
     } @else if (upstreamType === 'gradient_proto') {
       <div class="form-group">
         <label for="up-gp-display-name">Display Name</label>
-        <input pInputText id="up-gp-display-name" [(ngModel)]="upstreamForm.display_name" placeholder="My Gradient Cache" class="w-full" />
+        <input grInput id="up-gp-display-name" [(ngModel)]="upstreamForm.display_name" placeholder="My Gradient Cache" class="w-full" />
       </div>
       <div class="form-group">
         <label for="up-gp-url">Server URL</label>
-        <input pInputText id="up-gp-url" [(ngModel)]="upstreamForm.url" placeholder="https://gradient.example.com" class="w-full" />
+        <input grInput id="up-gp-url" [(ngModel)]="upstreamForm.url" placeholder="https://gradient.example.com" class="w-full" />
       </div>
       <div class="form-group">
         <label for="up-gp-remote-cache">Remote Cache Name</label>
-        <input pInputText id="up-gp-remote-cache" [(ngModel)]="upstreamForm.remote_cache" placeholder="my-cache" class="w-full" />
+        <input grInput id="up-gp-remote-cache" [(ngModel)]="upstreamForm.remote_cache" placeholder="my-cache" class="w-full" />
       </div>
       <div class="form-group">
         <label for="up-gp-api-key">API Key <span class="text-secondary">(optional)</span></label>
-        <input pInputText type="password" id="up-gp-api-key" [(ngModel)]="upstreamForm.api_key" class="w-full" />
+        <input grInput type="password" id="up-gp-api-key" [(ngModel)]="upstreamForm.api_key" class="w-full" />
       </div>
       <div class="form-group">
         <label for="up-gp-mode">Mode</label>
@@ -209,11 +203,11 @@
     } @else {
       <div class="form-group">
         <label for="up-display-name">Display Name</label>
-        <input pInputText id="up-display-name" [(ngModel)]="upstreamForm.display_name" placeholder="cache.nixos.org" class="w-full" />
+        <input grInput id="up-display-name" [(ngModel)]="upstreamForm.display_name" placeholder="cache.nixos.org" class="w-full" />
       </div>
       <div class="form-group">
         <label for="up-url">Substituter URL</label>
-        <input pInputText id="up-url" [(ngModel)]="upstreamForm.url" placeholder="https://cache.nixos.org" class="w-full" (blur)="probeHttpUrl()" />
+        <input grInput id="up-url" [(ngModel)]="upstreamForm.url" placeholder="https://cache.nixos.org" class="w-full" (blur)="probeHttpUrl()" />
         @if (probeSuggestsProto()) {
           <div class="dialog-hint">
             <span class="material-symbols-outlined">lightbulb</span>
@@ -225,13 +219,13 @@
       </div>
       <div class="form-group">
         <label for="up-pubkey">Public Key</label>
-        <input pInputText id="up-pubkey" [(ngModel)]="upstreamForm.public_key" placeholder="cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=" class="w-full" />
+        <input grInput id="up-pubkey" [(ngModel)]="upstreamForm.public_key" placeholder="cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=" class="w-full" />
       </div>
       <small class="text-secondary">Http caches are always Read Only.</small>
     }
   </div>
-  <ng-template pTemplate="footer">
-    <button pButton label="Cancel" severity="secondary" (click)="showAddDialog.set(false)" [disabled]="addingUpstream()"></button>
-    <button pButton label="Add" icon="pi pi-plus" (click)="addUpstream()" [loading]="addingUpstream()" [disabled]="addingUpstream() || !isAddFormValid()"></button>
-  </ng-template>
-</p-dialog>
+  <div grDialogFooter>
+    <button grButton label="Cancel" severity="secondary" (click)="showAddDialog.set(false)" [disabled]="addingUpstream()"></button>
+    <button grButton label="Add" icon="add" (click)="addUpstream()" [loading]="addingUpstream()" [disabled]="addingUpstream() || !isAddFormValid()"></button>
+  </div>
+</gr-dialog>

--- a/frontend/src/app/features/caches/cache-upstreams/cache-upstreams.component.spec.ts
+++ b/frontend/src/app/features/caches/cache-upstreams/cache-upstreams.component.spec.ts
@@ -42,7 +42,7 @@ function findByText(root: HTMLElement, text: string): HTMLElement | null {
 function findIconButton(root: HTMLElement, icon: string): HTMLButtonElement | null {
   return (
     (Array.from(root.querySelectorAll('button')) as HTMLButtonElement[]).find(
-      (el) => !!el.querySelector(`.${icon}`),
+      (el) => el.querySelector('.gr-button__icon')?.textContent?.trim() === icon,
     ) ?? null
   );
 }
@@ -119,15 +119,15 @@ describe('CacheUpstreamsComponent - access gating', () => {
   it('hides Add Upstream, Edit, Delete under read-only access', () => {
     const fixture = setup({ managed: false, canEdit: false, canTrigger: false });
     expect(findByText(fixture.nativeElement, 'add upstream')).toBeNull();
-    expect(findIconButton(fixture.nativeElement, 'pi-pencil')).toBeNull();
-    expect(findIconButton(fixture.nativeElement, 'pi-trash')).toBeNull();
+    expect(findIconButton(fixture.nativeElement, 'edit')).toBeNull();
+    expect(findIconButton(fixture.nativeElement, 'delete')).toBeNull();
   });
 
   it('shows but disables Add / Edit / Delete under state-managed access', () => {
     const fixture = setup({ managed: true, canEdit: true, canTrigger: true });
     const addBtn = findByText(fixture.nativeElement, 'add upstream') as HTMLButtonElement | null;
-    const editBtn = findIconButton(fixture.nativeElement, 'pi-pencil');
-    const delBtn = findIconButton(fixture.nativeElement, 'pi-trash');
+    const editBtn = findIconButton(fixture.nativeElement, 'edit');
+    const delBtn = findIconButton(fixture.nativeElement, 'delete');
     expect(addBtn).not.toBeNull();
     expect(addBtn!.disabled).toBe(true);
     expect(editBtn).not.toBeNull();

--- a/frontend/src/app/features/caches/cache-upstreams/cache-upstreams.component.ts
+++ b/frontend/src/app/features/caches/cache-upstreams/cache-upstreams.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import { Component, OnInit, inject, signal, computed, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -30,6 +30,7 @@ import { ButtonComponent, DialogComponent, InputDirective } from '@shared/ui';
     ManagedDisableDirective,
   ],
   templateUrl: './cache-upstreams.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './cache-upstreams.component.scss',
 })
 export class CacheUpstreamsComponent implements OnInit {

--- a/frontend/src/app/features/caches/cache-upstreams/cache-upstreams.component.ts
+++ b/frontend/src/app/features/caches/cache-upstreams/cache-upstreams.component.ts
@@ -8,14 +8,12 @@ import { Component, OnInit, inject, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { DialogModule } from 'primeng/dialog';
-import { ButtonModule } from 'primeng/button';
-import { InputTextModule } from 'primeng/inputtext';
 import { CachesService, UpstreamCache, CacheSubscriptionMode } from '@core/services/caches.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { WritableDirective, ManagedDisableDirective, AccessService } from '@shared/access';
 import { injectCacheAccess } from '@core/resolvers/inject-access';
 import { normalizeProbeUrl, isGradientCacheInfo } from './cache-upstream-probe';
+import { ButtonComponent, DialogComponent, InputDirective } from '@shared/ui';
 
 @Component({
   selector: 'app-cache-upstreams',
@@ -24,9 +22,9 @@ import { normalizeProbeUrl, isGradientCacheInfo } from './cache-upstream-probe';
     CommonModule,
     RouterModule,
     FormsModule,
-    DialogModule,
-    ButtonModule,
-    InputTextModule,
+    DialogComponent,
+    ButtonComponent,
+    InputDirective,
     LoadingSpinnerComponent,
     WritableDirective,
     ManagedDisableDirective,

--- a/frontend/src/app/features/caches/members-roles/cache-members-roles.component.html
+++ b/frontend/src/app/features/caches/members-roles/cache-members-roles.component.html
@@ -26,9 +26,9 @@
       <h2>Members</h2>
       <button
         *appWritable="access()"
-        pButton
+        grButton
         label="Add Member"
-        icon="pi pi-plus"
+        icon="add"
         severity="secondary"
         (click)="openAddMemberDialog()"
         [disabled]="rolesLoading() || roles().length === 0"
@@ -61,8 +61,8 @@
                   </select>
                   <button
                     *appWritable="access()"
-                    pButton
-                    icon="pi pi-times"
+                    grButton
+                    icon="close"
                     severity="danger"
                     size="small"
                     [loading]="removingMember() === member.id"
@@ -87,9 +87,9 @@
       <h2>Roles</h2>
       <button
         *appWritable="access()"
-        pButton
+        grButton
         label="New Role"
-        icon="pi pi-plus"
+        icon="add"
         severity="secondary"
         (click)="openCreateRoleDialog()"
         [disabled]="rolesLoading() || availablePermissions().length === 0"
@@ -119,8 +119,8 @@
                   @if (!role.builtin) {
                     <button
                       *appWritable="access()"
-                      pButton
-                      icon="pi pi-pencil"
+                      grButton
+                      icon="edit"
                       severity="secondary"
                       size="small"
                       [disabled]="savingRole() || deletingRole() !== null"
@@ -129,8 +129,8 @@
                     ></button>
                     <button
                       *appWritable="access()"
-                      pButton
-                      icon="pi pi-trash"
+                      grButton
+                      icon="delete"
                       severity="danger"
                       size="small"
                       [loading]="deletingRole() === role.id"
@@ -152,13 +152,10 @@
 </div>
 
 <!-- Add Member Dialog -->
-<p-dialog
+<gr-dialog
   header="Add Member"
   [(visible)]="showAddMemberDialog"
-  [modal]="true"
-  [style]="{ width: '420px' }"
-  [draggable]="false"
-  [resizable]="false"
+  width="420px"
 >
   <div class="dialog-content">
     @if (memberError()) {
@@ -169,16 +166,14 @@
     }
     <div class="form-group">
       <label for="member-name">Username</label>
-      <p-autoComplete
-        id="member-name"
+      <gr-autocomplete
+        inputId="member-name"
         [(ngModel)]="newMember.user"
         [suggestions]="userSuggestions()"
         (completeMethod)="onUserSearch($event)"
         placeholder="Enter username"
-        styleClass="w-full"
         [forceSelection]="false"
-        appendTo="body"
-        (keyup.enter)="addMember()"
+        (enter)="addMember()"
       />
     </div>
     <div class="form-group">
@@ -190,32 +185,29 @@
       </select>
     </div>
   </div>
-  <ng-template pTemplate="footer">
+  <div grDialogFooter>
     <button
-      pButton
+      grButton
       label="Cancel"
       severity="secondary"
       (click)="showAddMemberDialog.set(false)"
       [disabled]="addingMember()"
     ></button>
     <button
-      pButton
+      grButton
       label="Add"
       (click)="addMember()"
       [disabled]="!newMember.user || !newMember.role || addingMember()"
       [loading]="addingMember()"
     ></button>
-  </ng-template>
-</p-dialog>
+  </div>
+</gr-dialog>
 
 <!-- Role Dialog (Create/Edit) -->
-<p-dialog
+<gr-dialog
   [header]="editingRole() ? 'Edit Role' : 'New Role'"
   [(visible)]="showRoleDialog"
-  [modal]="true"
-  [style]="{ width: '520px' }"
-  [draggable]="false"
-  [resizable]="false"
+  width="520px"
 >
   <div class="dialog-content">
     @if (roleError()) {
@@ -227,7 +219,7 @@
     <div class="form-group">
       <label for="role-name">Name</label>
       <input
-        pInputText
+        grInput
         id="role-name"
         [(ngModel)]="roleForm.name"
         class="w-full"
@@ -240,7 +232,7 @@
       <div class="permissions-grid">
         @for (perm of availablePermissions(); track perm.id) {
           <label class="permission-row">
-            <p-checkbox
+            <gr-checkbox
               [(ngModel)]="roleForm.permissions[perm.id]"
               [binary]="true"
             />
@@ -257,20 +249,20 @@
       </div>
     </div>
   </div>
-  <ng-template pTemplate="footer">
+  <div grDialogFooter>
     <button
-      pButton
+      grButton
       label="Cancel"
       severity="secondary"
       (click)="showRoleDialog.set(false)"
       [disabled]="savingRole()"
     ></button>
     <button
-      pButton
+      grButton
       [label]="editingRole() ? 'Save' : 'Create'"
       (click)="saveRole()"
       [disabled]="!roleForm.name.trim() || savingRole()"
       [loading]="savingRole()"
     ></button>
-  </ng-template>
-</p-dialog>
+  </div>
+</gr-dialog>

--- a/frontend/src/app/features/caches/members-roles/cache-members-roles.component.ts
+++ b/frontend/src/app/features/caches/members-roles/cache-members-roles.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, computed, inject, signal } from '@angular/core';
+import { Component, OnInit, computed, inject, signal, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -38,6 +38,7 @@ interface RoleFormState {
     ManagedDisableDirective,
   ],
   templateUrl: './cache-members-roles.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './cache-members-roles.component.scss',
 })
 export class CacheMembersRolesComponent implements OnInit {

--- a/frontend/src/app/features/caches/members-roles/cache-members-roles.component.ts
+++ b/frontend/src/app/features/caches/members-roles/cache-members-roles.component.ts
@@ -8,18 +8,13 @@ import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { DialogModule } from 'primeng/dialog';
-import { ButtonModule } from 'primeng/button';
-import { InputTextModule } from 'primeng/inputtext';
-import { AutoCompleteModule } from 'primeng/autocomplete';
-import { CheckboxModule } from 'primeng/checkbox';
-import { DividerModule } from 'primeng/divider';
 import { CachesService } from '@core/services/caches.service';
 import { CacheMemberItem, CacheRole, CachePermissionDescriptor } from '@core/models/cache-permission.model';
 import { UserService } from '@core/services/user.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { WritableDirective, ManagedDisableDirective } from '@shared/access';
 import { injectCacheAccess } from '@core/resolvers/inject-access';
+import { AutoCompleteComponent, ButtonComponent, CheckboxComponent, DialogComponent, InputDirective } from '@shared/ui';
 
 interface RoleFormState {
   name: string;
@@ -33,12 +28,11 @@ interface RoleFormState {
     CommonModule,
     RouterModule,
     FormsModule,
-    DialogModule,
-    ButtonModule,
-    InputTextModule,
-    AutoCompleteModule,
-    CheckboxModule,
-    DividerModule,
+    DialogComponent,
+    ButtonComponent,
+    InputDirective,
+    AutoCompleteComponent,
+    CheckboxComponent,
     LoadingSpinnerComponent,
     WritableDirective,
     ManagedDisableDirective,

--- a/frontend/src/app/features/dashboard/dashboard.component.ts
+++ b/frontend/src/app/features/dashboard/dashboard.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal } from '@angular/core';
+import { Component, OnInit, inject, signal, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { forkJoin } from 'rxjs';
@@ -24,6 +24,7 @@ import { Project, Cache } from '@core/models';
     EmptyStateComponent,
   ],
   templateUrl: './dashboard.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './dashboard.component.scss',
 })
 export class DashboardComponent implements OnInit {

--- a/frontend/src/app/features/errors/error-page/error-page.component.ts
+++ b/frontend/src/app/features/errors/error-page/error-page.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, computed, inject } from '@angular/core';
+import { Component, computed, inject, ChangeDetectionStrategy } from '@angular/core';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 
 interface ErrorMeta {
@@ -59,6 +59,7 @@ const FALLBACK_META: ErrorMeta = {
   standalone: true,
   imports: [RouterModule],
   templateUrl: './error-page.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './error-page.component.scss',
 })
 export class ErrorPageComponent {

--- a/frontend/src/app/features/evaluations/build-artefacts/build-artefacts.component.ts
+++ b/frontend/src/app/features/evaluations/build-artefacts/build-artefacts.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal } from '@angular/core';
+import { Component, OnInit, inject, signal, ChangeDetectionStrategy } from '@angular/core';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { EvaluationsService, BuildProduct, isHtmlArtefact } from '@core/services/evaluations.service';
 import { AuthService } from '@core/services/auth.service';
@@ -17,6 +17,7 @@ import { environment } from '@environments/environment';
   standalone: true,
   imports: [RouterModule, LoadingSpinnerComponent],
   templateUrl: './build-artefacts.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './build-artefacts.component.scss',
 })
 export class BuildArtefactsComponent implements OnInit {

--- a/frontend/src/app/features/evaluations/closure-graph/closure-graph.component.html
+++ b/frontend/src/app/features/evaluations/closure-graph/closure-graph.component.html
@@ -13,7 +13,7 @@
     <div class="error-state">
       <span class="material-symbols-outlined">error</span>
       <p>{{ errorMsg() }}</p>
-      <button pButton label="Go Back" severity="secondary" (click)="goBack()"></button>
+      <button grButton label="Go Back" severity="secondary" (click)="goBack()"></button>
     </div>
   } @else {
     <div class="closure-header">

--- a/frontend/src/app/features/evaluations/closure-graph/closure-graph.component.ts
+++ b/frontend/src/app/features/evaluations/closure-graph/closure-graph.component.ts
@@ -7,6 +7,7 @@
 import {
   Component, OnInit, OnDestroy, inject, signal, computed,
   ViewChild, ElementRef, NgZone, ChangeDetectorRef,
+  ChangeDetectionStrategy
 } from '@angular/core';
 import { CommonModule, Location } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -30,6 +31,7 @@ type LaidLink = { source: LaidNode; target: LaidNode; width?: number; value: num
   standalone: true,
   imports: [CommonModule, ButtonComponent, LoadingSpinnerComponent],
   templateUrl: './closure-graph.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './closure-graph.component.scss',
 })
 export class ClosureGraphComponent implements OnInit, OnDestroy {

--- a/frontend/src/app/features/evaluations/closure-graph/closure-graph.component.ts
+++ b/frontend/src/app/features/evaluations/closure-graph/closure-graph.component.ts
@@ -10,10 +10,10 @@ import {
 } from '@angular/core';
 import { CommonModule, Location } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
-import { ButtonModule } from 'primeng/button';
 import { EvaluationsService, ClosureGraph } from '@core/services/evaluations.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { buildClosureSankey, SankeyNode, SankeyLink } from './closure-aggregate';
+import { ButtonComponent } from '@shared/ui';
 
 const TOP_N = 500;
 const SVG_NS = 'http://www.w3.org/2000/svg';
@@ -28,7 +28,7 @@ type LaidLink = { source: LaidNode; target: LaidNode; width?: number; value: num
 @Component({
   selector: 'app-closure-graph',
   standalone: true,
-  imports: [CommonModule, ButtonModule, LoadingSpinnerComponent],
+  imports: [CommonModule, ButtonComponent, LoadingSpinnerComponent],
   templateUrl: './closure-graph.component.html',
   styleUrl: './closure-graph.component.scss',
 })

--- a/frontend/src/app/features/evaluations/dependency-graph/dependency-graph.component.html
+++ b/frontend/src/app/features/evaluations/dependency-graph/dependency-graph.component.html
@@ -13,7 +13,7 @@
     <div class="error-state">
       <span class="material-symbols-outlined">error</span>
       <p>{{ errorMsg() }}</p>
-      <button pButton label="Go Back" severity="secondary" (click)="goBack()"></button>
+      <button grButton label="Go Back" severity="secondary" (click)="goBack()"></button>
     </div>
   } @else {
 

--- a/frontend/src/app/features/evaluations/dependency-graph/dependency-graph.component.ts
+++ b/frontend/src/app/features/evaluations/dependency-graph/dependency-graph.component.ts
@@ -15,6 +15,7 @@ import {
   ElementRef,
   NgZone,
   ChangeDetectorRef,
+  ChangeDetectionStrategy
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
@@ -51,6 +52,7 @@ interface LayoutEdge {
   standalone: true,
   imports: [CommonModule, RouterModule, LoadingSpinnerComponent, ButtonComponent],
   templateUrl: './dependency-graph.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './dependency-graph.component.scss',
 })
 export class DependencyGraphComponent implements OnInit, OnDestroy {

--- a/frontend/src/app/features/evaluations/dependency-graph/dependency-graph.component.ts
+++ b/frontend/src/app/features/evaluations/dependency-graph/dependency-graph.component.ts
@@ -23,7 +23,7 @@ import { auditTime } from 'rxjs/operators';
 import { EvaluationsService, BuildGraph } from '@core/services/evaluations.service';
 import { LiveService } from '@core/services/live.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
-import { ButtonModule } from 'primeng/button';
+import { ButtonComponent } from '@shared/ui';
 
 const CARD_W = 200;
 const CARD_H = 78;
@@ -49,7 +49,7 @@ interface LayoutEdge {
 @Component({
   selector: 'app-dependency-graph',
   standalone: true,
-  imports: [CommonModule, RouterModule, LoadingSpinnerComponent, ButtonModule],
+  imports: [CommonModule, RouterModule, LoadingSpinnerComponent, ButtonComponent],
   templateUrl: './dependency-graph.component.html',
   styleUrl: './dependency-graph.component.scss',
 })

--- a/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.html
+++ b/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.html
@@ -186,17 +186,17 @@
             <code class="commit-hash" [title]="ev.commit || ''">{{ commitLabel(ev.commit) }}</code>
           </div>
           <div class="info-metric nav-btns">
-            <button pButton icon="pi pi-arrow-left" severity="secondary" size="small"
+            <button grButton icon="arrow_back" severity="secondary" size="small"
               [disabled]="!ev.previous"
               (click)="ev.previous && navigateToEvaluation(ev.previous)"></button>
-            <button pButton icon="pi pi-arrow-right" severity="secondary" size="small"
+            <button grButton icon="arrow_forward" severity="secondary" size="small"
               [disabled]="!ev.next"
               (click)="ev.next && navigateToEvaluation(ev.next)"></button>
           </div>
         </div>
         <div class="info-bar-right">
           @if (isRunning() && authService.isAuthenticated()) {
-            <button pButton label="Abort" icon="pi pi-times" severity="danger" size="small"
+            <button grButton label="Abort" icon="close" severity="danger" size="small"
               (click)="abortEvaluation()" [loading]="aborting()" [disabled]="aborting()"></button>
           }
         </div>
@@ -319,7 +319,7 @@
                 />
                 <span class="log-search-count">
                   @if (searchLoading()) {
-                    <i class="pi pi-spin pi-spinner"></i>
+                    <span class="material-symbols-outlined gr-spin">progress_activity</span>
                   } @else {
                     {{ searchHits().length === 0 ? 0 : currentHit() + 1 }} / {{ searchTotal() }}
                   }

--- a/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.ts
+++ b/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.ts
@@ -16,6 +16,7 @@ import {
   ChangeDetectorRef,
   DestroyRef,
   HostListener,
+  ChangeDetectionStrategy
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
@@ -46,6 +47,7 @@ import { ButtonComponent } from '@shared/ui';
   standalone: true,
   imports: [CommonModule, RouterModule, LoadingSpinnerComponent, ButtonComponent],
   templateUrl: './evaluation-log.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrls: [
     './evaluation-log.component.scss',
     './evaluation-log.sidebar.scss',

--- a/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.ts
+++ b/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.ts
@@ -38,13 +38,13 @@ import { Evaluation, EvaluationMessage, EvaluationStatus, WaitingReason, Trigger
 import { AuthService } from '@core/services/auth.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { commitLabel, formatEvaluationDuration, isRunningEvaluationStatus, parseUtcTimestamp } from '@shared/evaluation';
-import { ButtonModule } from 'primeng/button';
 import { environment } from '@environments/environment';
+import { ButtonComponent } from '@shared/ui';
 
 @Component({
   selector: 'app-evaluation-log',
   standalone: true,
-  imports: [CommonModule, RouterModule, LoadingSpinnerComponent, ButtonModule],
+  imports: [CommonModule, RouterModule, LoadingSpinnerComponent, ButtonComponent],
   templateUrl: './evaluation-log.component.html',
   styleUrls: [
     './evaluation-log.component.scss',

--- a/frontend/src/app/features/projects/cache-subscriptions/cache-subscriptions.component.html
+++ b/frontend/src/app/features/projects/cache-subscriptions/cache-subscriptions.component.html
@@ -19,9 +19,9 @@
     </div>
     <button
       *appWritable="access()"
-      pButton
+      grButton
       label="Subscribe to Cache"
-      icon="pi pi-plus"
+      icon="add"
       [appManagedDisable]="access()"
       (click)="openSubscribeDialog()"
     ></button>
@@ -37,9 +37,9 @@
         <p class="text-secondary">Subscribe to a Nix binary cache to have builds pushed there automatically.</p>
         <button
           *appWritable="access()"
-          pButton
+          grButton
           label="Subscribe to Cache"
-          icon="pi pi-plus"
+          icon="add"
           [appManagedDisable]="access()"
           (click)="openSubscribeDialog()"
         ></button>
@@ -55,9 +55,9 @@
             <div class="cache-actions">
               <button
                 *appWritable="access()"
-                pButton
+                grButton
                 label="Unsubscribe"
-                icon="pi pi-times"
+                icon="close"
                 severity="danger"
                 [loading]="unsubscribingId() === cache.id"
                 [disabled]="unsubscribingId() !== null"
@@ -73,13 +73,10 @@
 </div>
 
 <!-- Subscribe Dialog -->
-<p-dialog
+<gr-dialog
   header="Subscribe to Cache"
   [(visible)]="showSubscribeDialog"
-  [modal]="true"
-  [style]="{ width: '440px' }"
-  [draggable]="false"
-  [resizable]="false"
+  width="440px"
 >
   @if (errorMessage()) {
     <div class="dialog-error">
@@ -89,28 +86,26 @@
   }
   <div class="form-group">
     <label for="cache-name">Cache Name</label>
-    <p-autoComplete
-      id="cache-name"
+    <gr-autocomplete
+      inputId="cache-name"
       [(ngModel)]="newCacheName"
       [suggestions]="cacheSuggestions()"
       (completeMethod)="onCacheSearch($event)"
       placeholder="e.g. my-cache"
-      styleClass="w-full"
       [forceSelection]="false"
-      appendTo="body"
-      (keyup.enter)="subscribeCache()"
+      (enter)="subscribeCache()"
     />
     <small class="text-secondary">The name of the binary cache you own.</small>
   </div>
-  <ng-template pTemplate="footer">
-    <button pButton label="Cancel" severity="secondary" (click)="showSubscribeDialog.set(false)" [disabled]="subscribing()"></button>
+  <div grDialogFooter>
+    <button grButton label="Cancel" severity="secondary" (click)="showSubscribeDialog.set(false)" [disabled]="subscribing()"></button>
     <button
-      pButton
+      grButton
       label="Subscribe"
-      icon="pi pi-check"
+      icon="check"
       (click)="subscribeCache()"
       [loading]="subscribing()"
       [disabled]="subscribing() || !newCacheName.trim()"
     ></button>
-  </ng-template>
-</p-dialog>
+  </div>
+</gr-dialog>

--- a/frontend/src/app/features/projects/cache-subscriptions/cache-subscriptions.component.ts
+++ b/frontend/src/app/features/projects/cache-subscriptions/cache-subscriptions.component.ts
@@ -8,17 +8,13 @@ import { Component, OnInit, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { DialogModule } from 'primeng/dialog';
-import { ButtonModule } from 'primeng/button';
-import { InputTextModule } from 'primeng/inputtext';
-import { AutoCompleteModule } from 'primeng/autocomplete';
-import { TooltipModule } from 'primeng/tooltip';
 import { ProjectsService } from '@core/services/projects.service';
 import { CachesService } from '@core/services/caches.service';
 import { ProjectAccessService } from '@core/services/project-access.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { WritableDirective, ManagedDisableDirective } from '@shared/access';
 import { AccessState } from '@core/models';
+import { AutoCompleteComponent, ButtonComponent, DialogComponent, TooltipDirective } from '@shared/ui';
 
 @Component({
   selector: 'app-cache-subscriptions',
@@ -27,11 +23,9 @@ import { AccessState } from '@core/models';
     CommonModule,
     RouterModule,
     FormsModule,
-    DialogModule,
-    ButtonModule,
-    InputTextModule,
-    AutoCompleteModule,
-    TooltipModule,
+    DialogComponent,
+    ButtonComponent,
+    AutoCompleteComponent,
     LoadingSpinnerComponent,
     WritableDirective,
     ManagedDisableDirective,

--- a/frontend/src/app/features/projects/cache-subscriptions/cache-subscriptions.component.ts
+++ b/frontend/src/app/features/projects/cache-subscriptions/cache-subscriptions.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal } from '@angular/core';
+import { Component, OnInit, inject, signal, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -31,6 +31,7 @@ import { AutoCompleteComponent, ButtonComponent, DialogComponent, TooltipDirecti
     ManagedDisableDirective,
   ],
   templateUrl: './cache-subscriptions.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './cache-subscriptions.component.scss',
 })
 export class CacheSubscriptionsComponent implements OnInit {

--- a/frontend/src/app/features/projects/integrations/integrations.component.html
+++ b/frontend/src/app/features/projects/integrations/integrations.component.html
@@ -19,9 +19,9 @@
     </div>
     <button
       *appWritable="access()"
-      pButton
+      grButton
       label="New Integration"
-      icon="pi pi-plus"
+      icon="add"
       (click)="openCreateDialog()"
       [appManagedDisable]="access()"
     ></button>
@@ -64,9 +64,9 @@
           <p class="text-secondary">Create an inbound integration to receive forge webhooks, or an outbound integration to report build statuses.</p>
           <button
             *appWritable="access()"
-            pButton
+            grButton
             label="New Integration"
-            icon="pi pi-plus"
+            icon="add"
             (click)="openCreateDialog()"
             [appManagedDisable]="access()"
           ></button>
@@ -96,9 +96,9 @@
                   @if (integration.forge_type !== 'github') {
                     <button
                       *appWritable="access()"
-                      pButton
+                      grButton
                       label="Edit"
-                      icon="pi pi-pencil"
+                      icon="edit"
                       severity="secondary"
                       size="small"
                       (click)="openEditDialog(integration)"
@@ -107,9 +107,9 @@
                   }
                   <button
                     *appWritable="access()"
-                    pButton
+                    grButton
                     label="Delete"
-                    icon="pi pi-trash"
+                    icon="delete"
                     severity="danger"
                     size="small"
                     [loading]="deletingId() === integration.id"
@@ -140,7 +140,7 @@
                     <div class="forge-selector">
                       @for (opt of inboundForgeOptions; track opt.value) {
                         <button
-                          pButton
+                          grButton
                           type="button"
                           [label]="opt.label"
                           size="small"
@@ -154,10 +154,10 @@
                   <div class="form-group">
                     <label>Webhook URL</label>
                     <div class="copy-row">
-                      <input pInputText [value]="inboundUrl(integration)" readonly class="w-full" />
+                      <input grInput [value]="inboundUrl(integration)" readonly class="w-full" />
                       <button
-                        pButton
-                        [icon]="copiedUrlId() === integration.id ? 'pi pi-check' : 'pi pi-copy'"
+                        grButton
+                        [icon]="copiedUrlId() === integration.id ? 'check' : 'content_copy'"
                         [severity]="copiedUrlId() === integration.id ? 'success' : 'secondary'"
                         (click)="copyInboundUrl(integration)"
                       ></button>
@@ -201,13 +201,10 @@
 </div>
 
 <!-- Create Dialog -->
-<p-dialog
+<gr-dialog
   header="New Integration"
   [(visible)]="showCreateDialog"
-  [modal]="true"
-  [style]="{ width: '520px' }"
-  [draggable]="false"
-  [resizable]="false"
+  width="520px"
 >
   @if (errorMessage()) {
     <div class="dialog-error">
@@ -220,7 +217,7 @@
       Name
       <gr-label-help href="https://wavelens.github.io/gradient/usage/integration/" title="Learn about forge integrations" />
     </label>
-    <input pInputText id="int-name" [(ngModel)]="formData.name" [class.input-invalid]="nameInvalid" class="w-full" placeholder="e.g. main-gitea" />
+    <input grInput id="int-name" [(ngModel)]="formData.name" [class.input-invalid]="nameInvalid" class="w-full" placeholder="e.g. main-gitea" />
     @if (nameInvalid) {
       <small class="text-danger">Lowercase letters, digits, and dashes only. Cannot start or end with a dash.</small>
     } @else {
@@ -229,7 +226,7 @@
   </div>
   <div class="form-group">
     <label for="int-display-name">Display Name</label>
-    <input pInputText id="int-display-name" [(ngModel)]="formData.display_name" class="w-full" placeholder="Defaults to the name" />
+    <input grInput id="int-display-name" [(ngModel)]="formData.display_name" class="w-full" placeholder="Defaults to the name" />
     <small class="text-secondary">Human-readable label shown in the integrations list.</small>
   </div>
   <div class="form-group">
@@ -237,31 +234,29 @@
       Kind
       <gr-label-help href="https://wavelens.github.io/gradient/usage/integration/" title="Inbound vs outbound integrations" />
     </label>
-    <p-select
+    <gr-select
       inputId="int-kind"
       [(ngModel)]="formData.kind"
       [options]="kindOptions"
       optionLabel="label"
       optionValue="value"
-      styleClass="w-full"
     />
   </div>
   <div class="form-group">
     <label for="int-forge">Forge</label>
-    <p-select
+    <gr-select
       inputId="int-forge"
       [(ngModel)]="formData.forge_type"
       [options]="formData.kind === 'outbound' ? outboundForgeOptions() : allForgeOptions()"
       optionLabel="label"
       optionValue="value"
-      styleClass="w-full"
     />
   </div>
 
   @if (formData.forge_type === 'github') {
     <div class="form-group">
       <label for="int-installation-id">App Installation ID</label>
-      <input pInputText id="int-installation-id" [(ngModel)]="formData.installation_id" class="w-full"
+      <input grInput id="int-installation-id" [(ngModel)]="formData.installation_id" class="w-full"
         placeholder="e.g. 12345678" />
       <small class="text-secondary">The numeric installation ID from your GitHub App installation.</small>
     </div>
@@ -273,44 +268,41 @@
     <div class="form-group">
       <label for="int-secret">Webhook Secret</label>
       <div class="copy-row">
-        <input pInputText id="int-secret" [(ngModel)]="formData.secret" class="w-full" placeholder="Leave blank to omit verification" />
-        <button pButton type="button" icon="pi pi-refresh" severity="secondary" (click)="generateSecret()"></button>
+        <input grInput id="int-secret" [(ngModel)]="formData.secret" class="w-full" placeholder="Leave blank to omit verification" />
+        <button grButton type="button" icon="refresh" severity="secondary" (click)="generateSecret()"></button>
       </div>
       <small class="text-secondary">Copy this into your forge's webhook secret field. Store it now - it will not be shown again.</small>
     </div>
     <div class="form-group">
       <label for="int-allowed-ips">Allowed source IPs / CIDRs</label>
-      <textarea id="int-allowed-ips" pInputText rows="3" class="w-full" [(ngModel)]="formData.allowed_ips" placeholder="10.0.0.0/8&#10;203.0.113.5"></textarea>
+      <textarea id="int-allowed-ips" grInput rows="3" class="w-full" [(ngModel)]="formData.allowed_ips" placeholder="10.0.0.0/8&#10;203.0.113.5"></textarea>
       <small class="text-secondary">One CIDR per line. Leave blank to accept webhooks from any source.</small>
     </div>
   } @else {
     <div class="form-group">
       <label for="int-endpoint">Endpoint URL</label>
-      <input pInputText id="int-endpoint" [(ngModel)]="formData.endpoint_url" class="w-full"
+      <input grInput id="int-endpoint" [(ngModel)]="formData.endpoint_url" class="w-full"
         placeholder="e.g. https://gitea.example.com" />
       <small class="text-secondary">Base URL of your forge instance.</small>
     </div>
     <div class="form-group">
       <label for="int-token">Access Token</label>
-      <input pInputText id="int-token" type="password" [(ngModel)]="formData.access_token" class="w-full"
+      <input grInput id="int-token" type="password" [(ngModel)]="formData.access_token" class="w-full"
         placeholder="API token with commit status write permission" />
     </div>
   }
 
-  <ng-template pTemplate="footer">
-    <button pButton label="Cancel" severity="secondary" (click)="showCreateDialog.set(false)" [disabled]="saving()"></button>
-    <button pButton label="Create" icon="pi pi-check" (click)="createIntegration()" [loading]="saving()" [disabled]="saving() || !formData.name.trim() || nameInvalid"></button>
-  </ng-template>
-</p-dialog>
+  <div grDialogFooter>
+    <button grButton label="Cancel" severity="secondary" (click)="showCreateDialog.set(false)" [disabled]="saving()"></button>
+    <button grButton label="Create" icon="check" (click)="createIntegration()" [loading]="saving()" [disabled]="saving() || !formData.name.trim() || nameInvalid"></button>
+  </div>
+</gr-dialog>
 
 <!-- Edit Dialog -->
-<p-dialog
+<gr-dialog
   header="Edit Integration"
   [(visible)]="showEditDialog"
-  [modal]="true"
-  [style]="{ width: '520px' }"
-  [draggable]="false"
-  [resizable]="false"
+  width="520px"
 >
   @if (editingIntegration(); as target) {
     @if (errorMessage()) {
@@ -321,57 +313,56 @@
     }
     <div class="form-group">
       <label for="edit-name">Name</label>
-      <input pInputText id="edit-name" [(ngModel)]="formData.name" class="w-full" />
+      <input grInput id="edit-name" [(ngModel)]="formData.name" class="w-full" />
     </div>
     <div class="form-group">
       <label for="edit-display-name">Display Name</label>
-      <input pInputText id="edit-display-name" [(ngModel)]="formData.display_name" class="w-full" />
+      <input grInput id="edit-display-name" [(ngModel)]="formData.display_name" class="w-full" />
     </div>
     <div class="form-group">
       <label for="edit-forge">Forge</label>
-      <p-select
+      <gr-select
         inputId="edit-forge"
         [(ngModel)]="formData.forge_type"
         [options]="target.kind === 'outbound' ? outboundForgeOptions() : allForgeOptions()"
         optionLabel="label"
         optionValue="value"
-        styleClass="w-full"
       />
     </div>
     @if (target.kind === 'inbound') {
       <div class="form-group">
         <label for="edit-secret">Webhook Secret</label>
         <div class="copy-row">
-          <input pInputText id="edit-secret" [(ngModel)]="formData.secret" class="w-full" placeholder="Leave blank to keep existing" />
-          <button pButton type="button" icon="pi pi-refresh" severity="secondary" (click)="generateSecret()"></button>
+          <input grInput id="edit-secret" [(ngModel)]="formData.secret" class="w-full" placeholder="Leave blank to keep existing" />
+          <button grButton type="button" icon="refresh" severity="secondary" (click)="generateSecret()"></button>
         </div>
         <small class="text-secondary">Currently {{ target.has_secret ? 'configured' : 'not set' }}. Entering a new value replaces it.</small>
         @if (target.has_secret) {
-          <button pButton type="button" label="Clear Secret" icon="pi pi-trash" severity="danger" size="small" class="mt-sm" (click)="clearSecret()" [disabled]="saving()"></button>
+          <button grButton type="button" label="Clear Secret" icon="delete" severity="danger" size="small" class="mt-sm" (click)="clearSecret()" [disabled]="saving()"></button>
         }
       </div>
       <div class="form-group">
         <label for="edit-allowed-ips">Allowed source IPs / CIDRs</label>
-        <textarea id="edit-allowed-ips" pInputText rows="3" class="w-full" [(ngModel)]="formData.allowed_ips" placeholder="10.0.0.0/8&#10;203.0.113.5"></textarea>
+        <textarea id="edit-allowed-ips" grInput rows="3" class="w-full" [(ngModel)]="formData.allowed_ips" placeholder="10.0.0.0/8&#10;203.0.113.5"></textarea>
         <small class="text-secondary">One CIDR per line. Leave blank to accept webhooks from any source.</small>
       </div>
     } @else {
       <div class="form-group">
         <label for="edit-endpoint">Endpoint URL</label>
-        <input pInputText id="edit-endpoint" [(ngModel)]="formData.endpoint_url" class="w-full" />
+        <input grInput id="edit-endpoint" [(ngModel)]="formData.endpoint_url" class="w-full" />
       </div>
       <div class="form-group">
         <label for="edit-token">Access Token</label>
-        <input pInputText id="edit-token" type="password" [(ngModel)]="formData.access_token" class="w-full" placeholder="Leave blank to keep existing" />
+        <input grInput id="edit-token" type="password" [(ngModel)]="formData.access_token" class="w-full" placeholder="Leave blank to keep existing" />
         <small class="text-secondary">Currently {{ target.has_access_token ? 'configured' : 'not set' }}.</small>
         @if (target.has_access_token) {
-          <button pButton type="button" label="Clear Token" icon="pi pi-trash" severity="danger" size="small" class="mt-sm" (click)="clearAccessToken()" [disabled]="saving()"></button>
+          <button grButton type="button" label="Clear Token" icon="delete" severity="danger" size="small" class="mt-sm" (click)="clearAccessToken()" [disabled]="saving()"></button>
         }
       </div>
     }
   }
-  <ng-template pTemplate="footer">
-    <button pButton label="Cancel" severity="secondary" (click)="showEditDialog.set(false)" [disabled]="saving()"></button>
-    <button pButton label="Save" icon="pi pi-check" (click)="saveEdit()" [loading]="saving()" [disabled]="saving()"></button>
-  </ng-template>
-</p-dialog>
+  <div grDialogFooter>
+    <button grButton label="Cancel" severity="secondary" (click)="showEditDialog.set(false)" [disabled]="saving()"></button>
+    <button grButton label="Save" icon="check" (click)="saveEdit()" [loading]="saving()" [disabled]="saving()"></button>
+  </div>
+</gr-dialog>

--- a/frontend/src/app/features/projects/integrations/integrations.component.ts
+++ b/frontend/src/app/features/projects/integrations/integrations.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import { Component, OnInit, inject, signal, computed, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -47,6 +47,7 @@ interface Option<T> {
     ManagedDisableDirective,
   ],
   templateUrl: './integrations.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './integrations.component.scss',
 })
 export class IntegrationsComponent implements OnInit {

--- a/frontend/src/app/features/projects/integrations/integrations.component.ts
+++ b/frontend/src/app/features/projects/integrations/integrations.component.ts
@@ -8,10 +8,6 @@ import { Component, OnInit, inject, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { DialogModule } from 'primeng/dialog';
-import { ButtonModule } from 'primeng/button';
-import { InputTextModule } from 'primeng/inputtext';
-import { SelectModule } from 'primeng/select';
 import { IntegrationsService } from '@core/services/integrations.service';
 import { ProjectsService } from '@core/services/projects.service';
 import { ProjectAccessService } from '@core/services/project-access.service';
@@ -27,6 +23,7 @@ import {
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { LabelHelpComponent } from '@shared/components/form';
 import { WritableDirective, ManagedDisableDirective } from '@shared/access';
+import { ButtonComponent, DialogComponent, InputDirective, SelectComponent } from '@shared/ui';
 
 interface Option<T> {
   label: string;
@@ -40,10 +37,10 @@ interface Option<T> {
     CommonModule,
     RouterModule,
     FormsModule,
-    DialogModule,
-    ButtonModule,
-    InputTextModule,
-    SelectModule,
+    DialogComponent,
+    ButtonComponent,
+    InputDirective,
+    SelectComponent,
     LoadingSpinnerComponent,
     LabelHelpComponent,
     WritableDirective,

--- a/frontend/src/app/features/projects/members-roles/members-roles.component.html
+++ b/frontend/src/app/features/projects/members-roles/members-roles.component.html
@@ -24,9 +24,9 @@
       <h2>Members</h2>
       <button
         *appWritable="access()"
-        pButton
+        grButton
         label="Add Member"
-        icon="pi pi-plus"
+        icon="add"
         severity="secondary"
         (click)="openAddMemberDialog()"
         [disabled]="rolesLoading() || roles().length === 0"
@@ -59,8 +59,8 @@
                   </select>
                   <button
                     *appWritable="access()"
-                    pButton
-                    icon="pi pi-times"
+                    grButton
+                    icon="close"
                     severity="danger"
                     size="small"
                     [loading]="removingMember() === member.id"
@@ -85,9 +85,9 @@
       <h2>Roles</h2>
       <button
         *appWritable="access()"
-        pButton
+        grButton
         label="New Role"
-        icon="pi pi-plus"
+        icon="add"
         severity="secondary"
         (click)="openCreateRoleDialog()"
         [disabled]="rolesLoading() || availablePermissions().length === 0"
@@ -117,8 +117,8 @@
                   @if (!role.builtin) {
                     <button
                       *appWritable="access()"
-                      pButton
-                      icon="pi pi-pencil"
+                      grButton
+                      icon="edit"
                       severity="secondary"
                       size="small"
                       [disabled]="savingRole() || deletingRole() !== null"
@@ -127,8 +127,8 @@
                     ></button>
                     <button
                       *appWritable="access()"
-                      pButton
-                      icon="pi pi-trash"
+                      grButton
+                      icon="delete"
                       severity="danger"
                       size="small"
                       [loading]="deletingRole() === role.id"
@@ -150,13 +150,10 @@
 </div>
 
 <!-- Add Member Dialog -->
-<p-dialog
+<gr-dialog
   header="Add Member"
   [(visible)]="showAddMemberDialog"
-  [modal]="true"
-  [style]="{ width: '420px' }"
-  [draggable]="false"
-  [resizable]="false"
+  width="420px"
 >
   <div class="dialog-content">
     @if (memberError()) {
@@ -167,16 +164,14 @@
     }
     <div class="form-group">
       <label for="member-name">Username</label>
-      <p-autoComplete
-        id="member-name"
+      <gr-autocomplete
+        inputId="member-name"
         [(ngModel)]="newMember.user"
         [suggestions]="userSuggestions()"
         (completeMethod)="onUserSearch($event)"
         placeholder="Enter username"
-        styleClass="w-full"
         [forceSelection]="false"
-        appendTo="body"
-        (keyup.enter)="addMember()"
+        (enter)="addMember()"
       />
     </div>
     <div class="form-group">
@@ -188,32 +183,29 @@
       </select>
     </div>
   </div>
-  <ng-template pTemplate="footer">
+  <div grDialogFooter>
     <button
-      pButton
+      grButton
       label="Cancel"
       severity="secondary"
       (click)="showAddMemberDialog.set(false)"
       [disabled]="addingMember()"
     ></button>
     <button
-      pButton
+      grButton
       label="Add"
       (click)="addMember()"
       [disabled]="!newMember.user || !newMember.role || addingMember()"
       [loading]="addingMember()"
     ></button>
-  </ng-template>
-</p-dialog>
+  </div>
+</gr-dialog>
 
 <!-- Role Dialog (Create/Edit) -->
-<p-dialog
+<gr-dialog
   [header]="editingRole() ? 'Edit Role' : 'New Role'"
   [(visible)]="showRoleDialog"
-  [modal]="true"
-  [style]="{ width: '520px' }"
-  [draggable]="false"
-  [resizable]="false"
+  width="520px"
 >
   <div class="dialog-content">
     @if (roleError()) {
@@ -225,7 +217,7 @@
     <div class="form-group">
       <label for="role-name">Name</label>
       <input
-        pInputText
+        grInput
         id="role-name"
         [(ngModel)]="roleForm.name"
         class="w-full"
@@ -238,7 +230,7 @@
       <div class="permissions-grid">
         @for (perm of availablePermissions(); track perm.id) {
           <label class="permission-row">
-            <p-checkbox
+            <gr-checkbox
               [(ngModel)]="roleForm.permissions[perm.id]"
               [binary]="true"
             />
@@ -255,20 +247,20 @@
       </div>
     </div>
   </div>
-  <ng-template pTemplate="footer">
+  <div grDialogFooter>
     <button
-      pButton
+      grButton
       label="Cancel"
       severity="secondary"
       (click)="showRoleDialog.set(false)"
       [disabled]="savingRole()"
     ></button>
     <button
-      pButton
+      grButton
       [label]="editingRole() ? 'Save' : 'Create'"
       (click)="saveRole()"
       [disabled]="!roleForm.name.trim() || savingRole()"
       [loading]="savingRole()"
     ></button>
-  </ng-template>
-</p-dialog>
+  </div>
+</gr-dialog>

--- a/frontend/src/app/features/projects/members-roles/members-roles.component.ts
+++ b/frontend/src/app/features/projects/members-roles/members-roles.component.ts
@@ -8,12 +8,6 @@ import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { DialogModule } from 'primeng/dialog';
-import { ButtonModule } from 'primeng/button';
-import { InputTextModule } from 'primeng/inputtext';
-import { AutoCompleteModule } from 'primeng/autocomplete';
-import { CheckboxModule } from 'primeng/checkbox';
-import { DividerModule } from 'primeng/divider';
 import {
   ProjectsService,
   ProjectMember,
@@ -25,6 +19,7 @@ import { ProjectAccessService } from '@core/services/project-access.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { WritableDirective, ManagedDisableDirective } from '@shared/access';
 import { AccessState } from '@core/models';
+import { AutoCompleteComponent, ButtonComponent, CheckboxComponent, DialogComponent, InputDirective } from '@shared/ui';
 
 interface RoleFormState {
   name: string;
@@ -38,12 +33,11 @@ interface RoleFormState {
     CommonModule,
     RouterModule,
     FormsModule,
-    DialogModule,
-    ButtonModule,
-    InputTextModule,
-    AutoCompleteModule,
-    CheckboxModule,
-    DividerModule,
+    DialogComponent,
+    ButtonComponent,
+    InputDirective,
+    AutoCompleteComponent,
+    CheckboxComponent,
     LoadingSpinnerComponent,
     WritableDirective,
     ManagedDisableDirective,

--- a/frontend/src/app/features/projects/members-roles/members-roles.component.ts
+++ b/frontend/src/app/features/projects/members-roles/members-roles.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, computed, inject, signal } from '@angular/core';
+import { Component, OnInit, computed, inject, signal, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -43,6 +43,7 @@ interface RoleFormState {
     ManagedDisableDirective,
   ],
   templateUrl: './members-roles.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './members-roles.component.scss',
 })
 export class MembersRolesComponent implements OnInit {

--- a/frontend/src/app/features/projects/project-detail/project-detail.component.html
+++ b/frontend/src/app/features/projects/project-detail/project-detail.component.html
@@ -15,8 +15,8 @@
       </div>
       @if (project.role) {
         <div class="header-actions">
-          <button pButton label="Create Task" icon="pi pi-plus" (click)="openCreateDialog()"></button>
-          <button pButton label="Settings" icon="pi pi-cog" severity="secondary" [routerLink]="['/project', projectName, 'settings']"></button>
+          <button grButton label="Create Task" icon="add" (click)="openCreateDialog()"></button>
+          <button grButton label="Settings" icon="settings" severity="secondary" [routerLink]="['/project', projectName, 'settings']"></button>
         </div>
       }
     </div>
@@ -63,13 +63,10 @@
 </div>
 
 <!-- Create Task Dialog -->
-<p-dialog
+<gr-dialog
   header="Create Task"
   [(visible)]="showCreateDialog"
-  [modal]="true"
-  [style]="{ width: '550px' }"
-  [draggable]="false"
-  [resizable]="false"
+  width="550px"
 >
   @if (createError()) {
     <div class="dialog-error">
@@ -81,7 +78,7 @@
     <div class="form-group">
       <label for="proj-display">Display Name *</label>
       <input
-        pInputText
+        grInput
         id="proj-display"
         [(ngModel)]="newTask.display_name"
         placeholder="My Task"
@@ -95,7 +92,7 @@
       <label for="proj-name">Name *</label>
       <div class="name-input-wrapper">
         <input
-          pInputText
+          grInput
           id="proj-name"
           [(ngModel)]="newTask.name"
           placeholder="task-name"
@@ -105,7 +102,7 @@
           (keyup.enter)="createTask()"
         />
         @if (nameCheckState() === 'checking') {
-          <span class="name-check-icon"><i class="pi pi-spin pi-spinner"></i></span>
+          <span class="name-check-icon"><span class="material-symbols-outlined gr-spin">progress_activity</span></span>
         } @else if (nameCheckState() === 'available') {
           <span class="name-check-icon available"><span class="material-symbols-outlined">check</span></span>
         } @else if (nameCheckState() === 'taken' || nameCheckState() === 'invalid' || nameCheckState() === 'reserved') {
@@ -126,7 +123,7 @@
     <div class="form-group">
       <label for="proj-desc">Description</label>
       <textarea
-        pInputTextarea
+        grInput
         id="proj-desc"
         [(ngModel)]="newTask.description"
         placeholder="Describe your task..."
@@ -138,7 +135,7 @@
     <div class="form-group">
       <label for="proj-repo">Repository URL *</label>
       <input
-        pInputText
+        grInput
         id="proj-repo"
         [(ngModel)]="newTask.repository"
         placeholder="https://github.com/user/repo"
@@ -154,7 +151,7 @@
         <gr-label-help href="https://wavelens.github.io/gradient/usage/overview/#evaluation-wildcard" title="Learn about evaluation wildcards" />
       </label>
       <input
-        pInputText
+        grInput
         id="proj-wildcard"
         [(ngModel)]="newTask.wildcard"
         placeholder="**"
@@ -170,20 +167,20 @@
     </div>
   </div>
 
-  <ng-template pTemplate="footer">
+  <div grDialogFooter>
     <button
-      pButton
+      grButton
       label="Cancel"
       severity="secondary"
       (click)="showCreateDialog.set(false)"
       [disabled]="creating()"
     ></button>
     <button
-      pButton
+      grButton
       label="Create"
       (click)="createTask()"
       [disabled]="!newTask.name || !newTask.display_name || !newTask.repository || wildcardInvalid || nameCheckState() === 'taken' || nameCheckState() === 'invalid' || nameCheckState() === 'reserved' || nameCheckState() === 'checking' || creating()"
       [loading]="creating()"
     ></button>
-  </ng-template>
-</p-dialog>
+  </div>
+</gr-dialog>

--- a/frontend/src/app/features/projects/project-detail/project-detail.component.ts
+++ b/frontend/src/app/features/projects/project-detail/project-detail.component.ts
@@ -10,10 +10,6 @@ import { ActivatedRoute, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { Subject, forkJoin, EMPTY } from 'rxjs';
 import { debounceTime, switchMap } from 'rxjs/operators';
-import { DialogModule } from 'primeng/dialog';
-import { ButtonModule } from 'primeng/button';
-import { InputTextModule } from 'primeng/inputtext';
-import { TextareaModule } from 'primeng/textarea';
 import { AuthService } from '@core/services/auth.service';
 import { ProjectsService } from '@core/services/projects.service';
 import { TasksService } from '@core/services/tasks.service';
@@ -23,6 +19,7 @@ import { LabelHelpComponent } from '@shared/components/form';
 import { EvalStatusBadgeComponent } from '@shared/components/eval-status-badge/eval-status-badge.component';
 import { slugify } from '@shared/text';
 import { Project, Task } from '@core/models';
+import { ButtonComponent, DialogComponent, InputDirective } from '@shared/ui';
 
 const RESERVED_TASK_NAMES = ['build-request'];
 
@@ -33,10 +30,10 @@ const RESERVED_TASK_NAMES = ['build-request'];
     CommonModule,
     RouterModule,
     FormsModule,
-    DialogModule,
-    ButtonModule,
-    InputTextModule,
-    TextareaModule,
+    DialogComponent,
+    ButtonComponent,
+    InputDirective,
+    InputDirective,
     LoadingSpinnerComponent,
     EmptyStateComponent,
     LabelHelpComponent,

--- a/frontend/src/app/features/projects/project-detail/project-detail.component.ts
+++ b/frontend/src/app/features/projects/project-detail/project-detail.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnDestroy, OnInit, inject, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject, signal, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -40,6 +40,7 @@ const RESERVED_TASK_NAMES = ['build-request'];
     EvalStatusBadgeComponent,
   ],
   templateUrl: './project-detail.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './project-detail.component.scss',
 })
 export class ProjectDetailComponent implements OnInit, OnDestroy {

--- a/frontend/src/app/features/projects/project-list/project-list.component.html
+++ b/frontend/src/app/features/projects/project-list/project-list.component.html
@@ -11,7 +11,7 @@
       <p class="text-secondary">Manage your projects</p>
     </div>
     @if (canCreateProject) {
-      <button pButton label="Create Project" icon="pi pi-plus" (click)="openCreateDialog()"></button>
+      <button grButton label="Create Project" icon="add" (click)="openCreateDialog()"></button>
     }
   </div>
 
@@ -89,13 +89,10 @@
 </div>
 
 <!-- Create Project Dialog -->
-<p-dialog
+<gr-dialog
   header="Create Project"
   [(visible)]="showCreateDialog"
-  [modal]="true"
-  [style]="{ width: '500px' }"
-  [draggable]="false"
-  [resizable]="false"
+  width="500px"
 >
   @if (createError()) {
     <div class="dialog-error">
@@ -107,7 +104,7 @@
     <div class="form-group">
       <label for="display_name">Display Name *</label>
       <input
-        pInputText
+        grInput
         id="display_name"
         [(ngModel)]="newProject.display_name"
         placeholder="My Project"
@@ -121,7 +118,7 @@
       <label for="name">Name *</label>
       <div class="name-input-wrapper">
         <input
-          pInputText
+          grInput
           id="name"
           [(ngModel)]="newProject.name"
           placeholder="project-name"
@@ -131,7 +128,7 @@
           (keyup.enter)="createProject()"
         />
         @if (nameCheckState() === 'checking') {
-          <span class="name-check-icon"><i class="pi pi-spin pi-spinner"></i></span>
+          <span class="name-check-icon"><span class="material-symbols-outlined gr-spin">progress_activity</span></span>
         } @else if (nameCheckState() === 'available') {
           <span class="name-check-icon available"><span class="material-symbols-outlined">check</span></span>
         } @else if (nameCheckState() === 'taken' || nameCheckState() === 'invalid') {
@@ -150,7 +147,7 @@
     <div class="form-group">
       <label for="description">Description</label>
       <textarea
-        pInputTextarea
+        grInput
         id="description"
         [(ngModel)]="newProject.description"
         placeholder="Describe your project..."
@@ -169,20 +166,20 @@
     </div>
   </div>
 
-  <ng-template pTemplate="footer">
+  <div grDialogFooter>
     <button
-      pButton
+      grButton
       label="Cancel"
       severity="secondary"
       (click)="showCreateDialog.set(false)"
       [disabled]="creating()"
     ></button>
     <button
-      pButton
+      grButton
       label="Create"
       (click)="createProject()"
       [disabled]="!newProject.name || !newProject.display_name || nameCheckState() === 'taken' || nameCheckState() === 'invalid' || nameCheckState() === 'checking' || creating()"
       [loading]="creating()"
     ></button>
-  </ng-template>
-</p-dialog>
+  </div>
+</gr-dialog>

--- a/frontend/src/app/features/projects/project-list/project-list.component.ts
+++ b/frontend/src/app/features/projects/project-list/project-list.component.ts
@@ -10,10 +10,6 @@ import { RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { Subject, EMPTY } from 'rxjs';
 import { debounceTime, switchMap } from 'rxjs/operators';
-import { DialogModule } from 'primeng/dialog';
-import { ButtonModule } from 'primeng/button';
-import { InputTextModule } from 'primeng/inputtext';
-import { TextareaModule } from 'primeng/textarea';
 import { ProjectsService } from '@core/services/projects.service';
 import { AuthService } from '@core/services/auth.service';
 import { ConfigService } from '@core/services/config.service';
@@ -21,6 +17,7 @@ import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/load
 import { EmptyStateComponent } from '@shared/components/empty-state/empty-state.component';
 import { slugify } from '@shared/text';
 import { Project } from '@core/models';
+import { ButtonComponent, DialogComponent, InputDirective } from '@shared/ui';
 
 @Component({
   selector: 'app-project-list',
@@ -29,10 +26,10 @@ import { Project } from '@core/models';
     CommonModule,
     RouterModule,
     FormsModule,
-    DialogModule,
-    ButtonModule,
-    InputTextModule,
-    TextareaModule,
+    DialogComponent,
+    ButtonComponent,
+    InputDirective,
+    InputDirective,
     LoadingSpinnerComponent,
     EmptyStateComponent,
   ],

--- a/frontend/src/app/features/projects/project-list/project-list.component.ts
+++ b/frontend/src/app/features/projects/project-list/project-list.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnDestroy, OnInit, inject, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject, signal, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -34,6 +34,7 @@ import { ButtonComponent, DialogComponent, InputDirective } from '@shared/ui';
     EmptyStateComponent,
   ],
   templateUrl: './project-list.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './project-list.component.scss',
 })
 export class ProjectListComponent implements OnInit, OnDestroy {

--- a/frontend/src/app/features/projects/project-settings/project-settings.component.html
+++ b/frontend/src/app/features/projects/project-settings/project-settings.component.html
@@ -26,7 +26,7 @@
         <div class="form-group">
           <label for="project-name">Name</label>
           <input
-            pInputText
+            grInput
             id="project-name"
             [value]="project.name"
             disabled
@@ -38,7 +38,7 @@
         <div class="form-group">
           <label for="display-name">Display Name</label>
           <input
-            pInputText
+            grInput
             id="display-name"
             [(ngModel)]="formData.display_name"
             class="w-full"
@@ -49,7 +49,7 @@
         <div class="form-group">
           <label for="description">Description</label>
           <textarea
-            pInputTextarea
+            grInput
             id="description"
             [(ngModel)]="formData.description"
             rows="3"
@@ -68,7 +68,7 @@
         </div>
 
         <div class="form-group checkbox-group">
-          <p-checkbox
+          <gr-checkbox
             inputId="hide-build-requests"
             [(ngModel)]="formData.hide_build_requests"
             [binary]="true"
@@ -93,9 +93,9 @@
         <div class="form-actions">
           <button
             *appWritable="access()"
-            pButton
+            grButton
             label="Save Changes"
-            icon="pi pi-check"
+            icon="check"
             (click)="saveSettings()"
             [loading]="saving()"
             [appManagedDisable]="access()"
@@ -113,7 +113,7 @@
             <h3>Members & Roles</h3>
             <p class="text-secondary">Manage who is in this project and what they can do</p>
           </div>
-          <a pButton label="Manage Members" icon="pi pi-users" severity="secondary" [routerLink]="['/project', projectName, 'members']"></a>
+          <a grButton label="Manage Members" icon="group" severity="secondary" [routerLink]="['/project', projectName, 'members']"></a>
         </div>
       </div>
     </div>
@@ -127,23 +127,23 @@
             <h3>Workers</h3>
             <p class="text-secondary">Manage build workers for this project</p>
           </div>
-          <button pButton label="Manage Workers" icon="pi pi-cog" severity="secondary" [routerLink]="['/project', projectName, 'workers']"></button>
+          <button grButton label="Manage Workers" icon="settings" severity="secondary" [routerLink]="['/project', projectName, 'workers']"></button>
         </div>
-        <p-divider />
+        <gr-divider />
         <div class="nav-row">
           <div>
             <h3>Cache Subscriptions</h3>
             <p class="text-secondary">Nix binary caches this project pushes builds to</p>
           </div>
-          <button pButton label="Manage Caches" icon="pi pi-database" severity="secondary" [routerLink]="['/project', projectName, 'caches']"></button>
+          <button grButton label="Manage Caches" icon="database" severity="secondary" [routerLink]="['/project', projectName, 'caches']"></button>
         </div>
-        <p-divider />
+        <gr-divider />
         <div class="nav-row">
           <div>
             <h3>Integrations</h3>
             <p class="text-secondary">Inbound forge webhooks and outbound status reporters</p>
           </div>
-          <a pButton label="Manage Integrations" icon="pi pi-sitemap" severity="secondary" [routerLink]="['/project', projectName, 'integrations']"></a>
+          <a grButton label="Manage Integrations" icon="account_tree" severity="secondary" [routerLink]="['/project', projectName, 'integrations']"></a>
         </div>
       </div>
     </div>
@@ -160,7 +160,7 @@
             <div class="form-group">
               <label>Public Key</label>
               <textarea
-                pInputTextarea
+                grInput
                 [value]="sshKey()"
                 readonly
                 rows="4"
@@ -168,14 +168,14 @@
               ></textarea>
             </div>
             <div class="form-actions">
-              <button pButton label="Copy Key" icon="pi pi-copy" severity="secondary" (click)="copySSHKey()"></button>
+              <button grButton label="Copy Key" icon="content_copy" severity="secondary" (click)="copySSHKey()"></button>
             </div>
           } @else {
             <p class="text-secondary">No SSH key generated yet.</p>
             <button
-              pButton
+              grButton
               label="Generate SSH Key"
-              icon="pi pi-key"
+              icon="key"
               (click)="generateSSHKey()"
               [loading]="generatingSSH()"
               [disabled]="generatingSSH()"
@@ -197,16 +197,16 @@
                 <p class="text-secondary">Generate a new SSH key. The existing key will stop working immediately.</p>
               </div>
               <button
-                pButton
+                grButton
                 label="Regenerate Key"
-                icon="pi pi-refresh"
+                icon="refresh"
                 severity="danger"
                 (click)="showRegenerateKeyDialog.set(true)"
                 [disabled]="generatingSSH()"
                 [appManagedDisable]="access()"
               ></button>
             </div>
-            <p-divider />
+            <gr-divider />
           }
           <div class="danger-row">
             <div>
@@ -214,9 +214,9 @@
               <p class="text-secondary">Permanently delete this project and all its tasks.</p>
             </div>
             <button
-              pButton
+              grButton
               label="Delete Project"
-              icon="pi pi-trash"
+              icon="delete"
               severity="danger"
               (click)="showDeleteDialog.set(true)"
               [appManagedDisable]="access()"
@@ -229,33 +229,27 @@
 </div>
 
 <!-- Regenerate SSH Key Confirmation Dialog -->
-<p-dialog
+<gr-dialog
   header="Regenerate SSH Key"
   [(visible)]="showRegenerateKeyDialog"
-  [modal]="true"
-  [style]="{ width: '400px' }"
-  [draggable]="false"
-  [resizable]="false"
+  width="400px"
 >
   <p>Are you sure you want to regenerate the SSH key? The existing key will stop working immediately and any repositories using it will lose access.</p>
-  <ng-template pTemplate="footer">
-    <button pButton label="Cancel" severity="secondary" (click)="showRegenerateKeyDialog.set(false)" [disabled]="generatingSSH()"></button>
-    <button pButton label="Regenerate" severity="danger" icon="pi pi-refresh" (click)="confirmRegenerateSSHKey()" [loading]="generatingSSH()" [disabled]="generatingSSH()"></button>
-  </ng-template>
-</p-dialog>
+  <div grDialogFooter>
+    <button grButton label="Cancel" severity="secondary" (click)="showRegenerateKeyDialog.set(false)" [disabled]="generatingSSH()"></button>
+    <button grButton label="Regenerate" severity="danger" icon="refresh" (click)="confirmRegenerateSSHKey()" [loading]="generatingSSH()" [disabled]="generatingSSH()"></button>
+  </div>
+</gr-dialog>
 
 <!-- Delete Confirmation Dialog -->
-<p-dialog
+<gr-dialog
   header="Delete Project"
   [(visible)]="showDeleteDialog"
-  [modal]="true"
-  [style]="{ width: '400px' }"
-  [draggable]="false"
-  [resizable]="false"
+  width="400px"
 >
   <p>Are you sure you want to delete <strong>{{ project()?.display_name }}</strong>? This action cannot be undone.</p>
-  <ng-template pTemplate="footer">
-    <button pButton label="Cancel" severity="secondary" (click)="showDeleteDialog.set(false)" [disabled]="deleting()"></button>
-    <button pButton label="Delete" severity="danger" (click)="deleteProject()" [loading]="deleting()" [disabled]="deleting()"></button>
-  </ng-template>
-</p-dialog>
+  <div grDialogFooter>
+    <button grButton label="Cancel" severity="secondary" (click)="showDeleteDialog.set(false)" [disabled]="deleting()"></button>
+    <button grButton label="Delete" severity="danger" (click)="deleteProject()" [loading]="deleting()" [disabled]="deleting()"></button>
+  </div>
+</gr-dialog>

--- a/frontend/src/app/features/projects/project-settings/project-settings.component.ts
+++ b/frontend/src/app/features/projects/project-settings/project-settings.component.ts
@@ -8,17 +8,12 @@ import { Component, OnInit, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { DialogModule } from 'primeng/dialog';
-import { DividerModule } from 'primeng/divider';
-import { ButtonModule } from 'primeng/button';
-import { InputTextModule } from 'primeng/inputtext';
-import { TextareaModule } from 'primeng/textarea';
-import { CheckboxModule } from 'primeng/checkbox';
 import { ProjectsService } from '@core/services/projects.service';
 import { ProjectAccessService } from '@core/services/project-access.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { WritableDirective, ManagedDisableDirective } from '@shared/access';
 import { Project, AccessState } from '@core/models';
+import { ButtonComponent, CheckboxComponent, DialogComponent, DividerComponent, InputDirective } from '@shared/ui';
 
 @Component({
   selector: 'app-project-settings',
@@ -27,12 +22,12 @@ import { Project, AccessState } from '@core/models';
     CommonModule,
     RouterModule,
     FormsModule,
-    DialogModule,
-    DividerModule,
-    ButtonModule,
-    InputTextModule,
-    TextareaModule,
-    CheckboxModule,
+    DialogComponent,
+    DividerComponent,
+    ButtonComponent,
+    InputDirective,
+    InputDirective,
+    CheckboxComponent,
     LoadingSpinnerComponent,
     WritableDirective,
     ManagedDisableDirective,

--- a/frontend/src/app/features/projects/project-settings/project-settings.component.ts
+++ b/frontend/src/app/features/projects/project-settings/project-settings.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal } from '@angular/core';
+import { Component, OnInit, inject, signal, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -33,6 +33,7 @@ import { ButtonComponent, CheckboxComponent, DialogComponent, DividerComponent, 
     ManagedDisableDirective,
   ],
   templateUrl: './project-settings.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './project-settings.component.scss',
 })
 export class ProjectSettingsComponent implements OnInit {

--- a/frontend/src/app/features/projects/workers/worker-metrics/worker-metrics.component.ts
+++ b/frontend/src/app/features/projects/workers/worker-metrics/worker-metrics.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import { Component, OnInit, inject, signal, computed, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { WorkersService, WorkerSamplePoint, WorkerConnectionEntry } from '@core/services/workers.service';
@@ -46,6 +46,7 @@ import { MetricChartComponent } from '@shared/components/metric-chart/metric-cha
       </table>
     </div>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
   styles: [
     `
       .wm { padding: 1.5rem; max-width: 1200px; margin: 0 auto; }

--- a/frontend/src/app/features/projects/workers/workers.component.html
+++ b/frontend/src/app/features/projects/workers/workers.component.html
@@ -4,7 +4,7 @@
   SPDX-License-Identifier: AGPL-3.0-only
 -->
 
-<p-toast />
+<gr-toast />
 
 <div class="container">
   <div class="page-header">
@@ -21,9 +21,9 @@
     </div>
     <button
       *appWritable="access()"
-      pButton
+      grButton
       label="Register Worker"
-      icon="pi pi-plus"
+      icon="add"
       (click)="openRegisterDialog()"
       [appManagedDisable]="access()"
     ></button>
@@ -51,9 +51,9 @@
         <div class="peer-id-hint text-secondary">Use this as <code>peer_id</code> in your worker's peers file alongside the token issued during registration.</div>
       </div>
       <button
-        pButton
+        grButton
         [label]="peerIdCopied() ? 'Copied!' : 'Copy'"
-        [icon]="peerIdCopied() ? 'pi pi-check' : 'pi pi-copy'"
+        [icon]="peerIdCopied() ? 'check' : 'content_copy'"
         severity="secondary"
         (click)="copyPeerId()"
       ></button>
@@ -70,9 +70,9 @@
         <p class="text-secondary">Register a <code>gradient-worker</code> to run builds for this project.</p>
         <button
           *appWritable="access()"
-          pButton
+          grButton
           label="Register Worker"
-          icon="pi pi-plus"
+          icon="add"
           (click)="openRegisterDialog()"
           [appManagedDisable]="access()"
         ></button>
@@ -132,9 +132,9 @@
                 {{ worker.live ? 'Connected' : 'Offline' }}
               </span>
               <a
-                pButton
+                grButton
                 label="Metrics"
-                icon="pi pi-chart-line"
+                icon="show_chart"
                 severity="secondary"
                 size="small"
                 class="worker-action-btn"
@@ -142,9 +142,9 @@
               ></a>
               <button
                 *appWritable="access()"
-                pButton
+                grButton
                 label="Edit"
-                icon="pi pi-pencil"
+                icon="edit"
                 severity="secondary"
                 size="small"
                 class="worker-action-btn"
@@ -154,9 +154,9 @@
               ></button>
               <button
                 *appWritable="access()"
-                pButton
+                grButton
                 [label]="worker.active ? 'Deactivate' : 'Activate'"
-                [icon]="worker.active ? 'pi pi-pause' : 'pi pi-play'"
+                [icon]="worker.active ? 'pause' : 'play_arrow'"
                 [severity]="worker.active ? 'warn' : 'success'"
                 size="small"
                 class="worker-action-btn"
@@ -167,9 +167,9 @@
               ></button>
               <button
                 *appWritable="access()"
-                pButton
+                grButton
                 label="Fire Test"
-                icon="pi pi-bolt"
+                icon="bolt"
                 severity="secondary"
                 size="small"
                 class="worker-action-btn"
@@ -180,9 +180,9 @@
               ></button>
               <button
                 *appWritable="access()"
-                pButton
+                grButton
                 label="Delete"
-                icon="pi pi-trash"
+                icon="delete"
                 severity="danger"
                 size="small"
                 class="worker-action-btn"
@@ -200,13 +200,10 @@
 </div>
 
 <!-- Register Worker Dialog -->
-<p-dialog
+<gr-dialog
   header="Register Worker"
   [(visible)]="showRegisterDialog"
-  [modal]="true"
-  [style]="{ width: '480px' }"
-  [draggable]="false"
-  [resizable]="false"
+  width="480px"
 >
   @if (projectId()) {
     <div class="dialog-info">
@@ -227,7 +224,7 @@
   <div class="form-group">
     <label for="worker-name">Name</label>
     <input
-      pInputText
+      grInput
       id="worker-name"
       [(ngModel)]="newWorkerName"
       placeholder="e.g. Primary Build Server"
@@ -239,7 +236,7 @@
   <div class="form-group">
     <label for="worker-id">Worker ID</label>
     <input
-      pInputText
+      grInput
       id="worker-id"
       [(ngModel)]="newWorkerId"
       placeholder="e.g. a0b1c2d3-e4f5-4a6b-8c7d-9e0f1a2b3c4d"
@@ -251,7 +248,7 @@
   <div class="form-group">
     <label for="worker-url">Worker URL <span class="text-secondary">(optional)</span></label>
     <input
-      pInputText
+      grInput
       id="worker-url"
       [(ngModel)]="newWorkerUrl"
       placeholder="e.g. wss://worker.example.com/proto"
@@ -262,7 +259,7 @@
   <div class="form-group">
     <label for="worker-token">Token <span class="text-secondary">(optional)</span></label>
     <input
-      pInputText
+      grInput
       id="worker-token"
       [(ngModel)]="newWorkerToken"
       placeholder="Output of: openssl rand -base64 48"
@@ -306,27 +303,24 @@
     </div>
     <small class="text-secondary">Click a tag to toggle. Disabling a capability prevents the server from negotiating it with this worker, even if the worker advertises it.</small>
   </div>
-  <ng-template pTemplate="footer">
-    <button pButton label="Cancel" severity="secondary" (click)="showRegisterDialog.set(false)" [disabled]="registering()"></button>
+  <div grDialogFooter>
+    <button grButton label="Cancel" severity="secondary" (click)="showRegisterDialog.set(false)" [disabled]="registering()"></button>
     <button
-      pButton
+      grButton
       label="Register"
-      icon="pi pi-plus"
+      icon="add"
       (click)="registerWorker()"
       [loading]="registering()"
       [disabled]="registering() || !newWorkerId.trim() || !newWorkerName.trim()"
     ></button>
-  </ng-template>
-</p-dialog>
+  </div>
+</gr-dialog>
 
 <!-- Deactivate Warning Dialog -->
-<p-dialog
+<gr-dialog
   header="Deactivate Connected Worker"
   [(visible)]="showToggleWarningDialog"
-  [modal]="true"
-  [style]="{ width: '440px' }"
-  [draggable]="false"
-  [resizable]="false"
+  width="440px"
 >
   <div class="dialog-warning">
     <span class="material-symbols-outlined">warning</span>
@@ -335,20 +329,17 @@
       <strong>abort all active jobs</strong> assigned to this project. Are you sure?
     </p>
   </div>
-  <ng-template pTemplate="footer">
-    <button pButton label="Cancel" severity="secondary" (click)="cancelToggleWorker()"></button>
-    <button pButton label="Deactivate" icon="pi pi-pause" severity="warn" (click)="confirmToggleWorker()"></button>
-  </ng-template>
-</p-dialog>
+  <div grDialogFooter>
+    <button grButton label="Cancel" severity="secondary" (click)="cancelToggleWorker()"></button>
+    <button grButton label="Deactivate" icon="pause" severity="warn" (click)="confirmToggleWorker()"></button>
+  </div>
+</gr-dialog>
 
 <!-- Token Dialog (shown once after registration) -->
-<p-dialog
+<gr-dialog
   header="Worker Registered"
   [(visible)]="showTokenDialog"
-  [modal]="true"
-  [style]="{ width: '520px' }"
-  [draggable]="false"
-  [resizable]="false"
+  width="520px"
   [closable]="false"
 >
   @if (lastRegistration(); as reg) {
@@ -373,9 +364,9 @@
           <code class="copy-value token-value">{{ reg.token }}</code>
         </div>
         <button
-          pButton
+          grButton
           [label]="tokenCopied() ? 'Copied!' : 'Copy Token'"
-          [icon]="tokenCopied() ? 'pi pi-check' : 'pi pi-copy'"
+          [icon]="tokenCopied() ? 'check' : 'content_copy'"
           severity="secondary"
           class="copy-btn"
           (click)="copyToken()"
@@ -391,19 +382,16 @@
       <p class="text-secondary">Worker registered successfully. The token was pre-supplied and will not be echoed back.</p>
     }
   }
-  <ng-template pTemplate="footer">
-    <button pButton label="I've saved the token" icon="pi pi-check" (click)="closeTokenDialog()"></button>
-  </ng-template>
-</p-dialog>
+  <div grDialogFooter>
+    <button grButton label="I've saved the token" icon="check" (click)="closeTokenDialog()"></button>
+  </div>
+</gr-dialog>
 
 <!-- Edit Worker Dialog -->
-<p-dialog
+<gr-dialog
   header="Edit Worker"
   [(visible)]="showRenameDialog"
-  [modal]="true"
-  [style]="{ width: '480px' }"
-  [draggable]="false"
-  [resizable]="false"
+  width="480px"
 >
   @if (renamingWorker(); as worker) {
     <div class="form-group">
@@ -412,7 +400,7 @@
     <div class="form-group">
       <label for="rename-name">Name</label>
       <input
-        pInputText
+        grInput
         id="rename-name"
         [(ngModel)]="newName"
         placeholder="e.g. Primary Build Server"
@@ -457,15 +445,15 @@
       <small class="text-secondary">Changes take effect on the worker's next reconnect (a re-auth is triggered automatically).</small>
     </div>
   }
-  <ng-template pTemplate="footer">
-    <button pButton label="Cancel" severity="secondary" (click)="cancelRename()" [disabled]="renaming()"></button>
+  <div grDialogFooter>
+    <button grButton label="Cancel" severity="secondary" (click)="cancelRename()" [disabled]="renaming()"></button>
     <button
-      pButton
+      grButton
       label="Save"
-      icon="pi pi-check"
+      icon="check"
       (click)="confirmRename()"
       [loading]="renaming()"
       [disabled]="renaming() || !newName.trim()"
     ></button>
-  </ng-template>
-</p-dialog>
+  </div>
+</gr-dialog>

--- a/frontend/src/app/features/projects/workers/workers.component.ts
+++ b/frontend/src/app/features/projects/workers/workers.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal } from '@angular/core';
+import { Component, OnInit, inject, signal, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -33,6 +33,7 @@ import { ButtonComponent, DialogComponent, InputDirective, MessageService, Toast
   ],
   providers: [MessageService],
   templateUrl: './workers.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrls: ['./workers.component.scss', './workers.dialog.scss'],
 })
 export class WorkersComponent implements OnInit {

--- a/frontend/src/app/features/projects/workers/workers.component.ts
+++ b/frontend/src/app/features/projects/workers/workers.component.ts
@@ -8,17 +8,13 @@ import { Component, OnInit, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { DialogModule } from 'primeng/dialog';
-import { ButtonModule } from 'primeng/button';
-import { InputTextModule } from 'primeng/inputtext';
-import { ToastModule } from 'primeng/toast';
-import { MessageService } from 'primeng/api';
 import { WorkersService } from '@core/services/workers.service';
 import { ProjectsService } from '@core/services/projects.service';
 import { ProjectAccessService } from '@core/services/project-access.service';
 import { GradientCapabilities, Worker, WorkerRegistration, AccessState } from '@core/models';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { WritableDirective, ManagedDisableDirective } from '@shared/access';
+import { ButtonComponent, DialogComponent, InputDirective, MessageService, ToastComponent } from '@shared/ui';
 
 @Component({
   selector: 'app-workers',
@@ -27,10 +23,10 @@ import { WritableDirective, ManagedDisableDirective } from '@shared/access';
     CommonModule,
     RouterModule,
     FormsModule,
-    DialogModule,
-    ButtonModule,
-    InputTextModule,
-    ToastModule,
+    DialogComponent,
+    ButtonComponent,
+    InputDirective,
+    ToastComponent,
     LoadingSpinnerComponent,
     WritableDirective,
     ManagedDisableDirective,

--- a/frontend/src/app/features/settings/api-keys/api-keys.component.html
+++ b/frontend/src/app/features/settings/api-keys/api-keys.component.html
@@ -15,7 +15,7 @@
       <h1>API Keys</h1>
       <p class="text-secondary">Manage API keys for programmatic access</p>
     </div>
-    <button pButton label="New API Key" icon="pi pi-plus" (click)="openCreateDialog()"></button>
+    <button grButton label="New API Key" icon="add" (click)="openCreateDialog()"></button>
   </div>
 
   @if (loading()) {
@@ -26,7 +26,7 @@
         <span class="material-symbols-outlined">key</span>
         <h3>No API keys</h3>
         <p class="text-secondary">Create an API key to access Gradient programmatically.</p>
-        <button pButton label="Create API Key" icon="pi pi-plus" (click)="openCreateDialog()"></button>
+        <button grButton label="Create API Key" icon="add" (click)="openCreateDialog()"></button>
       </div>
     } @else {
       <div class="keys-list">
@@ -47,7 +47,7 @@
                 <div class="key-meta text-secondary">
                   <span
                     class="badge badge-info"
-                    [pTooltip]="permissionTooltip(key)"
+                    [grTooltip]="permissionTooltip(key)"
                     tooltipPosition="top"
                   >
                     {{ key.permissions.length }} permission{{ key.permissions.length === 1 ? '' : 's' }}
@@ -67,17 +67,17 @@
             <div class="key-actions">
               @if (!key.revoked_at) {
                 <button
-                  pButton
+                  grButton
                   label="Edit"
-                  icon="pi pi-pencil"
+                  icon="edit"
                   severity="secondary"
                   (click)="openEditDialog(key)"
                   [appManagedDisable]="rowAccess(key)"
                 ></button>
                 <button
-                  pButton
+                  grButton
                   label="Revoke"
-                  icon="pi pi-ban"
+                  icon="block"
                   severity="warn"
                   (click)="revokeKey(key)"
                   [loading]="revokingId() === key.id"
@@ -86,9 +86,9 @@
                 ></button>
               }
               <button
-                pButton
+                grButton
                 label="Delete"
-                icon="pi pi-trash"
+                icon="delete"
                 severity="danger"
                 (click)="deleteKey(key)"
                 [loading]="deletingId() === key.id"
@@ -104,12 +104,9 @@
 </div>
 
 <!-- Create / Edit Dialog -->
-<p-dialog
+<gr-dialog
   [(visible)]="showDialog"
-  [modal]="true"
-  [style]="{ width: '520px' }"
-  [draggable]="false"
-  [resizable]="false"
+  width="520px"
   [header]="editingKey() ? 'Edit API Key' : 'Create API Key'"
 >
   @if (errorMessage()) {
@@ -122,7 +119,7 @@
   <div class="form-group">
     <label for="key-name">Name</label>
     <input
-      pInputText
+      grInput
       id="key-name"
       [(ngModel)]="formName"
       placeholder="e.g. CI/CD Pipeline"
@@ -134,7 +131,7 @@
     <div class="form-group">
       <label for="key-expires">Expires in (days)</label>
       <input
-        pInputText
+        grInput
         id="key-expires"
         type="number"
         min="1"
@@ -145,11 +142,11 @@
     </div>
   }
 
-  <p-divider />
+  <gr-divider />
 
   <div class="form-group">
     <label>Scope</label>
-    <p-selectbutton
+    <gr-select-button
       [options]="scopeOptions"
       [(ngModel)]="formScope"
       optionLabel="label"
@@ -161,15 +158,13 @@
   @if (formScope === 'project') {
     <div class="form-group">
       <label for="key-project">Project</label>
-      <p-select
+      <gr-select
         inputId="key-project"
         [options]="projectOptions()"
         optionLabel="label"
         optionValue="value"
         [(ngModel)]="formProject"
         placeholder="Any project"
-        appendTo="body"
-        styleClass="w-full"
       />
     </div>
   }
@@ -177,15 +172,13 @@
   @if (formScope === 'cache') {
     <div class="form-group">
       <label for="key-cache">Cache</label>
-      <p-select
+      <gr-select
         inputId="key-cache"
         [options]="cacheOptions()"
         optionLabel="label"
         optionValue="value"
         [(ngModel)]="formCache"
         placeholder="Select a cache"
-        appendTo="body"
-        styleClass="w-full"
       />
     </div>
   }
@@ -197,7 +190,7 @@
     </label>
     <textarea
       id="key-allowed-ips"
-      pInputText
+      grInput
       rows="3"
       class="w-full"
       [(ngModel)]="formAllowedIps"
@@ -205,14 +198,14 @@
     ></textarea>
   </div>
 
-  <p-divider />
+  <gr-divider />
 
   <div class="form-group">
     <label>Permissions</label>
     <div class="permission-grid">
       @for (p of activePermissions(); track p.id) {
         <div class="permission-row">
-          <p-checkbox
+          <gr-checkbox
             [(ngModel)]="formPermissions[p.id]"
             [binary]="true"
             [inputId]="'perm-' + p.id"
@@ -223,40 +216,37 @@
     </div>
   </div>
 
-  <ng-template pTemplate="footer">
+  <div grDialogFooter>
     <button
-      pButton
+      grButton
       label="Cancel"
       severity="secondary"
       (click)="showDialog.set(false)"
       [disabled]="creating() || saving()"
     ></button>
     <button
-      pButton
+      grButton
       [label]="editingKey() ? 'Save' : 'Create'"
-      [icon]="editingKey() ? 'pi pi-check' : 'pi pi-plus'"
+      [icon]="editingKey() ? 'check' : 'add'"
       (click)="saveKey()"
       [loading]="creating() || saving()"
       [disabled]="creating() || saving() || !formName.trim()"
     ></button>
-  </ng-template>
-</p-dialog>
+  </div>
+</gr-dialog>
 
 <!-- Show Created Key Dialog -->
-<p-dialog
+<gr-dialog
   header="API Key Created"
   [(visible)]="showKeyDialog"
-  [modal]="true"
-  [style]="{ width: '500px' }"
-  [draggable]="false"
-  [resizable]="false"
+  width="500px"
 >
   <p>Your new API key has been created. Copy it now - it will not be shown again.</p>
   <div class="key-display">
     <code class="key-value">{{ createdKeyValue() }}</code>
-    <button pButton icon="pi pi-copy" severity="secondary" (click)="copyKey()" title="Copy to clipboard"></button>
+    <button grButton icon="content_copy" severity="secondary" (click)="copyKey()" title="Copy to clipboard"></button>
   </div>
-  <ng-template pTemplate="footer">
-    <button pButton label="Done" (click)="showKeyDialog.set(false)"></button>
-  </ng-template>
-</p-dialog>
+  <div grDialogFooter>
+    <button grButton label="Done" (click)="showKeyDialog.set(false)"></button>
+  </div>
+</gr-dialog>

--- a/frontend/src/app/features/settings/api-keys/api-keys.component.ts
+++ b/frontend/src/app/features/settings/api-keys/api-keys.component.ts
@@ -8,14 +8,6 @@ import { Component, OnInit, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { DialogModule } from 'primeng/dialog';
-import { ButtonModule } from 'primeng/button';
-import { InputTextModule } from 'primeng/inputtext';
-import { CheckboxModule } from 'primeng/checkbox';
-import { DividerModule } from 'primeng/divider';
-import { SelectModule } from 'primeng/select';
-import { SelectButtonModule } from 'primeng/selectbutton';
-import { TooltipModule } from 'primeng/tooltip';
 import { UserService } from '@core/services/user.service';
 import { ProjectsService } from '@core/services/projects.service';
 import { CachesService } from '@core/services/caches.service';
@@ -24,6 +16,7 @@ import { PermissionDescriptor } from '@core/models/permission.model';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { ManagedDisableDirective } from '@shared/access';
 import { AccessState } from '@core/models';
+import { ButtonComponent, CheckboxComponent, DialogComponent, DividerComponent, InputDirective, SelectButtonComponent, SelectComponent, TooltipDirective } from '@shared/ui';
 
 type ScopeType = 'none' | 'project' | 'cache';
 
@@ -39,14 +32,14 @@ interface SelectOption {
     CommonModule,
     RouterModule,
     FormsModule,
-    DialogModule,
-    ButtonModule,
-    InputTextModule,
-    CheckboxModule,
-    DividerModule,
-    SelectModule,
-    SelectButtonModule,
-    TooltipModule,
+    DialogComponent,
+    ButtonComponent,
+    InputDirective,
+    CheckboxComponent,
+    DividerComponent,
+    SelectComponent,
+    SelectButtonComponent,
+    TooltipDirective,
     LoadingSpinnerComponent,
     ManagedDisableDirective,
   ],

--- a/frontend/src/app/features/settings/api-keys/api-keys.component.ts
+++ b/frontend/src/app/features/settings/api-keys/api-keys.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal } from '@angular/core';
+import { Component, OnInit, inject, signal, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -44,6 +44,7 @@ interface SelectOption {
     ManagedDisableDirective,
   ],
   templateUrl: './api-keys.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './api-keys.component.scss',
 })
 export class ApiKeysComponent implements OnInit {

--- a/frontend/src/app/features/settings/profile/profile.component.html
+++ b/frontend/src/app/features/settings/profile/profile.component.html
@@ -44,24 +44,24 @@
       <div class="settings-card">
         <div class="form-group">
           <label for="username">Username</label>
-          <input pInputText id="username" [(ngModel)]="formData.username" class="w-full" [appManagedDisable]="access()" />
+          <input grInput id="username" [(ngModel)]="formData.username" class="w-full" [appManagedDisable]="access()" />
         </div>
 
         <div class="form-group">
           <label for="name">Full Name</label>
-          <input pInputText id="name" [(ngModel)]="formData.name" class="w-full" [appManagedDisable]="access()" />
+          <input grInput id="name" [(ngModel)]="formData.name" class="w-full" [appManagedDisable]="access()" />
         </div>
 
         <div class="form-group">
           <label for="email">Email</label>
-          <input pInputText id="email" type="email" [(ngModel)]="formData.email" class="w-full" [appManagedDisable]="access()" />
+          <input grInput id="email" type="email" [(ngModel)]="formData.email" class="w-full" [appManagedDisable]="access()" />
         </div>
 
         <div class="form-actions">
           <button
-            pButton
+            grButton
             label="Save Changes"
-            icon="pi pi-check"
+            icon="check"
             (click)="saveSettings()"
             [loading]="saving()"
             [appManagedDisable]="access()"
@@ -79,15 +79,15 @@
             <h3>API Keys</h3>
             <p class="text-secondary">Manage API keys for programmatic access</p>
           </div>
-          <button pButton label="Manage API Keys" icon="pi pi-key" severity="secondary" routerLink="/settings/keys"></button>
+          <button grButton label="Manage API Keys" icon="key" severity="secondary" routerLink="/settings/keys"></button>
         </div>
-        <p-divider />
+        <gr-divider />
         <div class="nav-row">
           <div>
             <h3>Active Sessions</h3>
             <p class="text-secondary">View and revoke devices currently signed in to your account</p>
           </div>
-          <button pButton label="Manage Sessions" icon="pi pi-desktop" severity="secondary" routerLink="/settings/sessions"></button>
+          <button grButton label="Manage Sessions" icon="desktop_windows" severity="secondary" routerLink="/settings/sessions"></button>
         </div>
       </div>
     </div>
@@ -101,7 +101,7 @@
             <h3>Delete Account</h3>
             <p class="text-secondary">Permanently delete your account and all associated data.</p>
           </div>
-          <button pButton label="Delete Account" icon="pi pi-trash" severity="danger" (click)="openDeleteDialog()" [appManagedDisable]="access()"></button>
+          <button grButton label="Delete Account" icon="delete" severity="danger" (click)="openDeleteDialog()" [appManagedDisable]="access()"></button>
         </div>
       </div>
     </div>
@@ -109,13 +109,10 @@
 </div>
 
 <!-- Delete Confirmation Dialog -->
-<p-dialog
+<gr-dialog
   header="Delete Account"
   [(visible)]="showDeleteDialog"
-  [modal]="true"
-  [style]="{ width: '400px' }"
-  [draggable]="false"
-  [resizable]="false"
+  width="400px"
 >
   <p>Are you sure you want to permanently delete your account? This action cannot be undone.</p>
   @if (deleteError()) {
@@ -127,23 +124,23 @@
   @if (isOidc()) {
     <div class="form-group">
       <label for="confirm-username">Type your username (<code>{{ formData.username }}</code>) to confirm</label>
-      <input pInputText id="confirm-username" [(ngModel)]="deleteUsernameConfirm" class="w-full" />
+      <input grInput id="confirm-username" [(ngModel)]="deleteUsernameConfirm" class="w-full" />
     </div>
   } @else {
     <div class="form-group">
       <label for="confirm-password">Confirm with your password</label>
-      <input pInputText id="confirm-password" type="password" [(ngModel)]="deletePassword" class="w-full" />
+      <input grInput id="confirm-password" type="password" [(ngModel)]="deletePassword" class="w-full" />
     </div>
   }
-  <ng-template pTemplate="footer">
-    <button pButton label="Cancel" severity="secondary" (click)="showDeleteDialog.set(false)" [disabled]="deleting()"></button>
+  <div grDialogFooter>
+    <button grButton label="Cancel" severity="secondary" (click)="showDeleteDialog.set(false)" [disabled]="deleting()"></button>
     <button
-      pButton
+      grButton
       label="Delete Account"
       severity="danger"
       (click)="deleteAccount()"
       [loading]="deleting()"
       [disabled]="deleting() || (isOidc() ? deleteUsernameConfirm !== formData.username : deletePassword.length === 0)"
     ></button>
-  </ng-template>
-</p-dialog>
+  </div>
+</gr-dialog>

--- a/frontend/src/app/features/settings/profile/profile.component.ts
+++ b/frontend/src/app/features/settings/profile/profile.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, computed, inject, signal } from '@angular/core';
+import { Component, OnInit, computed, inject, signal, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -30,6 +30,7 @@ import { ButtonComponent, DialogComponent, DividerComponent, InputDirective } fr
     ManagedDisableDirective,
   ],
   templateUrl: './profile.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './profile.component.scss',
 })
 export class ProfileComponent implements OnInit {

--- a/frontend/src/app/features/settings/profile/profile.component.ts
+++ b/frontend/src/app/features/settings/profile/profile.component.ts
@@ -8,15 +8,12 @@ import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { DialogModule } from 'primeng/dialog';
-import { DividerModule } from 'primeng/divider';
-import { ButtonModule } from 'primeng/button';
-import { InputTextModule } from 'primeng/inputtext';
 import { UserService } from '@core/services/user.service';
 import { AuthService } from '@core/services/auth.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { ManagedDisableDirective } from '@shared/access';
 import { AccessState } from '@core/models';
+import { ButtonComponent, DialogComponent, DividerComponent, InputDirective } from '@shared/ui';
 
 @Component({
   selector: 'app-profile',
@@ -25,10 +22,10 @@ import { AccessState } from '@core/models';
     CommonModule,
     RouterModule,
     FormsModule,
-    DialogModule,
-    DividerModule,
-    ButtonModule,
-    InputTextModule,
+    DialogComponent,
+    DividerComponent,
+    ButtonComponent,
+    InputDirective,
     LoadingSpinnerComponent,
     ManagedDisableDirective,
   ],

--- a/frontend/src/app/features/settings/sessions/sessions.component.html
+++ b/frontend/src/app/features/settings/sessions/sessions.component.html
@@ -42,9 +42,9 @@
               </div>
               <div class="session-actions">
                 <button
-                  pButton
+                  grButton
                   label="Revoke"
-                  icon="pi pi-sign-out"
+                  icon="logout"
                   severity="danger"
                   [disabled]="s.current || revokingId() === s.id"
                   [loading]="revokingId() === s.id"

--- a/frontend/src/app/features/settings/sessions/sessions.component.ts
+++ b/frontend/src/app/features/settings/sessions/sessions.component.ts
@@ -7,15 +7,15 @@
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
-import { ButtonModule } from 'primeng/button';
 import { UserService } from '@core/services/user.service';
 import { Session } from '@core/models';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
+import { ButtonComponent } from '@shared/ui';
 
 @Component({
   selector: 'app-sessions',
   standalone: true,
-  imports: [CommonModule, RouterModule, ButtonModule, LoadingSpinnerComponent],
+  imports: [CommonModule, RouterModule, ButtonComponent, LoadingSpinnerComponent],
   templateUrl: './sessions.component.html',
   styleUrl: './sessions.component.scss',
 })

--- a/frontend/src/app/features/settings/sessions/sessions.component.ts
+++ b/frontend/src/app/features/settings/sessions/sessions.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal } from '@angular/core';
+import { Component, OnInit, inject, signal, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { UserService } from '@core/services/user.service';
@@ -17,6 +17,7 @@ import { ButtonComponent } from '@shared/ui';
   standalone: true,
   imports: [CommonModule, RouterModule, ButtonComponent, LoadingSpinnerComponent],
   templateUrl: './sessions.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './sessions.component.scss',
 })
 export class SessionsComponent implements OnInit {

--- a/frontend/src/app/features/styleguide/styleguide.component.html
+++ b/frontend/src/app/features/styleguide/styleguide.component.html
@@ -122,16 +122,6 @@
           </div>
         }
       </div>
-
-      <h3>PrimeIcons</h3>
-      <div class="sg-icons">
-        @for (i of primeIcons; track i) {
-          <div class="sg-icon">
-            <i class="pi" [class]="i"></i>
-            <span class="sg-icon__name">{{ i }}</span>
-          </div>
-        }
-      </div>
     </section>
 
     <!-- ─── Buttons ─── -->
@@ -344,7 +334,7 @@
 
       <h3>Popup Menu</h3>
       <p class="text-secondary">
-        PrimeNG <code>p-menu</code> with <code>[popup]="true"</code> attached to a
+        <code>gr-menu</code> anchored to a
         trigger button. Use for row-level "more actions" menus.
       </p>
       <div class="sg-row">
@@ -362,7 +352,7 @@
 
       <h3>Popover</h3>
       <p class="text-secondary">
-        PrimeNG <code>p-popover</code> for richer overlay content (forms, hints, mini-cards).
+        <code>gr-popover</code> for richer overlay content (forms, hints, mini-cards).
       </p>
       <div class="sg-row">
         <button grButton label="Open popover" icon="info"
@@ -628,7 +618,7 @@
         Title + description on the left, action button on the right. Used in
         project / task settings to send the user to a sub-page (Manage
         Workers, Manage Caches, etc.). Stack rows in one card with
-        <code>p-divider</code> between them.
+        <code>gr-divider</code> between them.
       </p>
       <div class="sg-card">
         <div class="sg-nav-row">

--- a/frontend/src/app/features/styleguide/styleguide.component.html
+++ b/frontend/src/app/features/styleguide/styleguide.component.html
@@ -140,28 +140,28 @@
 
       <h3>Severities</h3>
       <div class="sg-row">
-        <button pButton label="Primary"></button>
-        <button pButton label="Secondary" severity="secondary"></button>
-        <button pButton label="Success" severity="success"></button>
-        <button pButton label="Danger" severity="danger"></button>
-        <button pButton label="Warn" severity="warn"></button>
-        <button pButton label="Info" severity="info"></button>
+        <button grButton label="Primary"></button>
+        <button grButton label="Secondary" severity="secondary"></button>
+        <button grButton label="Success" severity="success"></button>
+        <button grButton label="Danger" severity="danger"></button>
+        <button grButton label="Warn" severity="warn"></button>
+        <button grButton label="Info" severity="info"></button>
       </div>
 
       <h3>Variants</h3>
       <div class="sg-row">
-        <button pButton label="With icon" icon="pi pi-plus"></button>
-        <button pButton icon="pi pi-trash" severity="danger" aria-label="Delete"></button>
-        <button pButton label="Text" [text]="true"></button>
-        <button pButton label="Outlined" [outlined]="true"></button>
-        <button pButton label="Rounded" [rounded]="true"></button>
+        <button grButton label="With icon" icon="add"></button>
+        <button grButton icon="delete" severity="danger" aria-label="Delete"></button>
+        <button grButton label="Text" [text]="true"></button>
+        <button grButton label="Outlined" [outlined]="true"></button>
+        <button grButton label="Rounded" [rounded]="true"></button>
       </div>
 
       <h3>States</h3>
       <div class="sg-row">
-        <button pButton label="Default"></button>
-        <button pButton label="Disabled" [disabled]="true"></button>
-        <button pButton label="Loading" [loading]="true"></button>
+        <button grButton label="Default"></button>
+        <button grButton label="Disabled" [disabled]="true"></button>
+        <button grButton label="Loading" [loading]="true"></button>
       </div>
     </section>
 
@@ -183,7 +183,7 @@
             [control]="demoForm.controls['name']"
             hint="At least 3 characters."
           >
-            <input pInputText id="sg-name" formControlName="name" class="w-full" />
+            <input grInput id="sg-name" formControlName="name" class="w-full" />
           </gr-form-field>
 
           <gr-form-field
@@ -192,7 +192,7 @@
             [required]="true"
             [control]="demoForm.controls['email']"
           >
-            <input pInputText id="sg-email" type="email" formControlName="email" class="w-full" />
+            <input grInput id="sg-email" type="email" formControlName="email" class="w-full" />
           </gr-form-field>
 
           <gr-form-field
@@ -227,13 +227,12 @@
             for="sg-role"
             [control]="demoForm.controls['role']"
           >
-            <p-select
+            <gr-select
               inputId="sg-role"
               [options]="roles"
               optionLabel="label"
               optionValue="value"
               formControlName="role"
-              styleClass="w-full"
             />
           </gr-form-field>
 
@@ -243,19 +242,19 @@
             [control]="demoForm.controls['bio']"
             hint="Max 200 characters."
           >
-            <textarea pTextarea id="sg-bio" formControlName="bio" rows="3" class="w-full"></textarea>
+            <textarea grInput id="sg-bio" formControlName="bio" rows="3" class="w-full"></textarea>
           </gr-form-field>
 
           <gr-form-field [control]="demoForm.controls['accept']">
             <label class="sg-check">
-              <p-checkbox formControlName="accept" [binary]="true" />
+              <gr-checkbox formControlName="accept" [binary]="true" />
               <span>Accept terms</span>
             </label>
           </gr-form-field>
 
           <div class="gr-form-actions">
-            <button pButton type="submit" label="Submit"></button>
-            <button pButton type="button" label="Reset" severity="secondary" (click)="demoForm.reset()"></button>
+            <button grButton type="submit" label="Submit"></button>
+            <button grButton type="button" label="Reset" severity="secondary" (click)="demoForm.reset()"></button>
           </div>
         </form>
 
@@ -304,7 +303,7 @@
               title="Learn about evaluation wildcards"
             />
           </label>
-          <input pInputText id="sg-lh-wild" class="w-full" value="packages.x86_64-linux.*" />
+          <input grInput id="sg-lh-wild" class="w-full" value="packages.x86_64-linux.*" />
         </div>
       </div>
     </section>
@@ -314,13 +313,13 @@
       <h2>Popups &amp; Overlays</h2>
 
       <div class="sg-row">
-        <button pButton label="Open form dialog" icon="pi pi-pencil" (click)="openDialog()"></button>
-        <button pButton label="Confirm delete" severity="danger" icon="pi pi-trash" (click)="confirmDelete()"></button>
-        <button pButton label="Toast: success" severity="success" (click)="toast('success', 'Saved', 'Looking good.')"></button>
-        <button pButton label="Toast: error" severity="danger" (click)="toast('error', 'Failed', 'Could not save.')"></button>
-        <button pButton label="Toast: info" severity="info" (click)="toast('info', 'FYI', 'Just an info note.')"></button>
-        <button pButton label="Toast: warn" severity="warn" (click)="toast('warn', 'Heads up', 'Be careful.')"></button>
-        <button pButton label="Hover for tooltip" pTooltip="Tooltip content" tooltipPosition="top"></button>
+        <button grButton label="Open form dialog" icon="edit" (click)="openDialog()"></button>
+        <button grButton label="Confirm delete" severity="danger" icon="delete" (click)="confirmDelete()"></button>
+        <button grButton label="Toast: success" severity="success" (click)="toast('success', 'Saved', 'Looking good.')"></button>
+        <button grButton label="Toast: error" severity="danger" (click)="toast('error', 'Failed', 'Could not save.')"></button>
+        <button grButton label="Toast: info" severity="info" (click)="toast('info', 'FYI', 'Just an info note.')"></button>
+        <button grButton label="Toast: warn" severity="warn" (click)="toast('warn', 'Heads up', 'Be careful.')"></button>
+        <button grButton label="Hover for tooltip" grTooltip="Tooltip content" tooltipPosition="top"></button>
       </div>
 
       <gr-form-dialog
@@ -338,7 +337,7 @@
             [required]="true"
             [control]="dialogForm.controls['label']"
           >
-            <input pInputText id="sg-dlg-label" formControlName="label" class="w-full" />
+            <input grInput id="sg-dlg-label" formControlName="label" class="w-full" />
           </gr-form-field>
         </form>
       </gr-form-dialog>
@@ -350,37 +349,37 @@
       </p>
       <div class="sg-row">
         <button
-          pButton
-          icon="pi pi-ellipsis-v"
+          grButton
+          icon="more_vert"
           severity="secondary"
           aria-label="Open actions menu"
           (click)="rowMenu.toggle($event)"
         ></button>
-        <button pButton label="Actions" icon="pi pi-chevron-down" iconPos="right"
+        <button grButton label="Actions" icon="expand_more" iconPos="right"
           severity="secondary" (click)="rowMenu.toggle($event)"></button>
       </div>
-      <p-menu #rowMenu [model]="rowMenuItems" [popup]="true" appendTo="body" />
+      <gr-menu #rowMenu [model]="rowMenuItems" />
 
       <h3>Popover</h3>
       <p class="text-secondary">
         PrimeNG <code>p-popover</code> for richer overlay content (forms, hints, mini-cards).
       </p>
       <div class="sg-row">
-        <button pButton label="Open popover" icon="pi pi-info-circle"
+        <button grButton label="Open popover" icon="info"
           severity="secondary" (click)="popover.toggle($event)"></button>
       </div>
-      <p-popover #popover>
+      <gr-popover #popover>
         <div class="sg-popover-body">
           <strong>Quick info</strong>
           <p class="text-secondary">
             Popovers can hold any content - text, mini-forms, or action lists.
           </p>
-          <button pButton label="Got it" size="small" (click)="popover.hide()"></button>
+          <button grButton label="Got it" size="small" (click)="popover.hide()"></button>
         </div>
-      </p-popover>
+      </gr-popover>
 
-      <p-confirmDialog />
-      <p-toast />
+      <gr-confirm-dialog />
+      <gr-toast />
     </section>
 
     <!-- ─── Feedback ─── -->
@@ -450,7 +449,7 @@
           <div class="gr-grid-rows sg-row-item">
             <span><strong>{{ r.name }}</strong></span>
             <span class="text-secondary">{{ r.status }}</span>
-            <button pButton icon="pi pi-cog" severity="secondary" aria-label="Settings"></button>
+            <button grButton icon="settings" severity="secondary" aria-label="Settings"></button>
           </div>
         }
       </div>
@@ -503,7 +502,7 @@
               >
                 {{ w.status }}
               </span>
-              <button pButton label="Edit" icon="pi pi-pencil" severity="secondary" size="small"></button>
+              <button grButton label="Edit" icon="edit" severity="secondary" size="small"></button>
             </div>
           </div>
         }
@@ -547,10 +546,10 @@
       <h3>.gr-grid-form</h3>
       <div class="sg-card">
         <div class="gr-grid-form">
-          <gr-form-field label="First"><input pInputText class="w-full" /></gr-form-field>
-          <gr-form-field label="Last"><input pInputText class="w-full" /></gr-form-field>
+          <gr-form-field label="First"><input grInput class="w-full" /></gr-form-field>
+          <gr-form-field label="Last"><input grInput class="w-full" /></gr-form-field>
           <gr-form-field label="Email" class="gr-grid-form__full">
-            <input pInputText class="w-full" />
+            <input grInput class="w-full" />
           </gr-form-field>
         </div>
       </div>
@@ -566,7 +565,7 @@
       <div class="sg-card">
         <div class="gr-grid-rows sg-row-item">
           <span>Label</span><span>Value</span>
-          <button pButton label="Action" severity="secondary"></button>
+          <button grButton label="Action" severity="secondary"></button>
         </div>
       </div>
     </section>
@@ -593,13 +592,13 @@
 
           <gr-settings-section title="Personal Information" description="Public profile details.">
             <gr-form-field label="Username" for="lay-uname">
-              <input pInputText id="lay-uname" class="w-full" value="john" />
+              <input grInput id="lay-uname" class="w-full" value="john" />
             </gr-form-field>
             <gr-form-field label="Email" for="lay-email">
-              <input pInputText id="lay-email" class="w-full" value="john@example.com" />
+              <input grInput id="lay-email" class="w-full" value="john@example.com" />
             </gr-form-field>
             <div class="gr-form-actions">
-              <button pButton label="Save Changes" icon="pi pi-check"></button>
+              <button grButton label="Save Changes" icon="check"></button>
             </div>
           </gr-settings-section>
 
@@ -619,7 +618,7 @@
       </p>
       <div class="sg-page-frame">
         <gr-page-layout title="Workers" subtitle="Build workers for this project">
-          <button slot="actions" pButton label="Register Worker" icon="pi pi-plus"></button>
+          <button slot="actions" grButton label="Register Worker" icon="add"></button>
           <p class="text-secondary">List of workers would go here.</p>
         </gr-page-layout>
       </div>
@@ -637,23 +636,23 @@
             <h4>Workers</h4>
             <p class="text-secondary">Manage build workers for this project</p>
           </div>
-          <button pButton label="Manage Workers" icon="pi pi-cog" severity="secondary"></button>
+          <button grButton label="Manage Workers" icon="settings" severity="secondary"></button>
         </div>
-        <p-divider />
+        <gr-divider />
         <div class="sg-nav-row">
           <div>
             <h4>Cache Subscriptions</h4>
             <p class="text-secondary">Nix binary caches this project pushes builds to</p>
           </div>
-          <button pButton label="Manage Caches" icon="pi pi-database" severity="secondary"></button>
+          <button grButton label="Manage Caches" icon="database" severity="secondary"></button>
         </div>
-        <p-divider />
+        <gr-divider />
         <div class="sg-nav-row">
           <div>
             <h4>Integrations</h4>
             <p class="text-secondary">Forge integrations for inbound webhooks and CI status</p>
           </div>
-          <button pButton label="Manage Integrations" icon="pi pi-link" severity="secondary"></button>
+          <button grButton label="Manage Integrations" icon="link" severity="secondary"></button>
         </div>
       </div>
     </section>

--- a/frontend/src/app/features/styleguide/styleguide.component.ts
+++ b/frontend/src/app/features/styleguide/styleguide.component.ts
@@ -7,19 +7,6 @@
 import { Component, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
-import { ButtonModule } from 'primeng/button';
-import { InputTextModule } from 'primeng/inputtext';
-import { TextareaModule } from 'primeng/textarea';
-import { SelectModule } from 'primeng/select';
-import { CheckboxModule } from 'primeng/checkbox';
-import { RadioButtonModule } from 'primeng/radiobutton';
-import { TooltipModule } from 'primeng/tooltip';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
-import { ToastModule } from 'primeng/toast';
-import { MenuModule } from 'primeng/menu';
-import { PopoverModule } from 'primeng/popover';
-import { DividerModule } from 'primeng/divider';
-import { ConfirmationService, MenuItem, MessageService } from 'primeng/api';
 
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { EmptyStateComponent } from '@shared/components/empty-state/empty-state.component';
@@ -38,6 +25,7 @@ import {
   PageLayoutComponent,
   SettingsSectionComponent,
 } from '@shared/components/layout';
+import { ButtonComponent, CheckboxComponent, ConfirmDialogComponent, ConfirmationService, DividerComponent, InputDirective, MenuComponent, MenuItem, MessageService, PopoverComponent, SelectComponent, ToastComponent, TooltipDirective } from '@shared/ui';
 
 interface DemoCounty {
   label: string;
@@ -50,18 +38,17 @@ interface DemoCounty {
   imports: [
     CommonModule,
     ReactiveFormsModule,
-    ButtonModule,
-    InputTextModule,
-    TextareaModule,
-    SelectModule,
-    CheckboxModule,
-    RadioButtonModule,
-    TooltipModule,
-    ConfirmDialogModule,
-    ToastModule,
-    MenuModule,
-    PopoverModule,
-    DividerModule,
+    ButtonComponent,
+    InputDirective,
+    InputDirective,
+    SelectComponent,
+    CheckboxComponent,
+    TooltipDirective,
+    ConfirmDialogComponent,
+    ToastComponent,
+    MenuComponent,
+    PopoverComponent,
+    DividerComponent,
     LoadingSpinnerComponent,
     EmptyStateComponent,
     StatCardComponent,
@@ -198,10 +185,10 @@ export class StyleguideComponent {
   apiToken = 'GRAD_b3a8f9e1d2c4a6b8e0f1a3c5d7e9b1d3f5a7c9e1';
 
   rowMenuItems: MenuItem[] = [
-    { label: 'Edit', icon: 'pi pi-pencil' },
-    { label: 'Duplicate', icon: 'pi pi-clone' },
+    { label: 'Edit', icon: 'edit' },
+    { label: 'Duplicate', icon: 'content_copy' },
     { separator: true },
-    { label: 'Delete', icon: 'pi pi-trash' },
+    { label: 'Delete', icon: 'delete' },
   ];
 
   // ── Sample data ────────────────────────────────────────────────────────────
@@ -268,7 +255,7 @@ export class StyleguideComponent {
     this.confirmService.confirm({
       message: 'Are you sure you want to delete this item?',
       header: 'Confirm Delete',
-      icon: 'pi pi-exclamation-triangle',
+      icon: 'warning',
       acceptButtonProps: { label: 'Delete', severity: 'danger' },
       rejectButtonProps: { label: 'Cancel', severity: 'secondary' },
       accept: () => this.toast('success', 'Deleted', 'Item removed.'),

--- a/frontend/src/app/features/styleguide/styleguide.component.ts
+++ b/frontend/src/app/features/styleguide/styleguide.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, inject, signal } from '@angular/core';
+import { Component, inject, signal, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 
@@ -63,6 +63,7 @@ interface DemoCounty {
   ],
   providers: [ConfirmationService, MessageService],
   templateUrl: './styleguide.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrls: ['./styleguide.component.scss', './styleguide.demos.scss'],
 })
 export class StyleguideComponent {
@@ -132,13 +133,6 @@ export class StyleguideComponent {
     'info', 'visibility', 'visibility_off', 'edit', 'delete', 'add', 'close',
     'search', 'menu', 'arrow_back', 'arrow_forward', 'expand_more', 'refresh',
   ];
-  primeIcons = [
-    'pi-home', 'pi-cog', 'pi-user', 'pi-sign-out', 'pi-check', 'pi-times',
-    'pi-info-circle', 'pi-exclamation-triangle', 'pi-pencil', 'pi-trash',
-    'pi-plus', 'pi-minus', 'pi-search', 'pi-bars', 'pi-arrow-left',
-    'pi-arrow-right', 'pi-chevron-down', 'pi-refresh', 'pi-copy', 'pi-link',
-  ];
-
   // ── TOC ────────────────────────────────────────────────────────────────────
   toc = [
     { id: 'colors', label: 'Colors' },

--- a/frontend/src/app/features/tasks/entry-point-metrics/entry-point-metrics.component.html
+++ b/frontend/src/app/features/tasks/entry-point-metrics/entry-point-metrics.component.html
@@ -18,7 +18,7 @@
       <p class="text-secondary">Build history over the last {{ keepEvaluations() }} completed evaluations.</p>
     </div>
     @if (latestBuildId()) {
-      <button pButton label="View Closure" icon="pi pi-sitemap" severity="secondary"
+      <button grButton label="View Closure" icon="account_tree" severity="secondary"
          [routerLink]="['/project', projectName, 'closure', 'build', latestBuildId()]"></button>
     }
   </div>

--- a/frontend/src/app/features/tasks/entry-point-metrics/entry-point-metrics.component.ts
+++ b/frontend/src/app/features/tasks/entry-point-metrics/entry-point-metrics.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import { Component, OnInit, inject, signal, computed, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { MetricChartComponent } from '@shared/components/metric-chart/metric-chart.component';
@@ -26,6 +26,7 @@ const CHART_COLORS = {
   standalone: true,
   imports: [CommonModule, RouterModule, ButtonComponent, MetricChartComponent, LoadingSpinnerComponent],
   templateUrl: './entry-point-metrics.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './entry-point-metrics.component.scss',
 })
 export class EntryPointMetricsComponent implements OnInit {

--- a/frontend/src/app/features/tasks/entry-point-metrics/entry-point-metrics.component.ts
+++ b/frontend/src/app/features/tasks/entry-point-metrics/entry-point-metrics.component.ts
@@ -8,10 +8,10 @@ import { Component, OnInit, inject, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { MetricChartComponent } from '@shared/components/metric-chart/metric-chart.component';
-import { ButtonModule } from 'primeng/button';
 import { TasksService, EntryPointMetricPoint, EntryPointMetricsResponse } from '@core/services/tasks.service';
 import { ProjectsService } from '@core/services/projects.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
+import { ButtonComponent } from '@shared/ui';
 
 const CHART_COLORS = {
   buildTime: '#17a2b8',
@@ -24,7 +24,7 @@ const CHART_COLORS = {
 @Component({
   selector: 'app-entry-point-metrics',
   standalone: true,
-  imports: [CommonModule, RouterModule, ButtonModule, MetricChartComponent, LoadingSpinnerComponent],
+  imports: [CommonModule, RouterModule, ButtonComponent, MetricChartComponent, LoadingSpinnerComponent],
   templateUrl: './entry-point-metrics.component.html',
   styleUrl: './entry-point-metrics.component.scss',
 })

--- a/frontend/src/app/features/tasks/task-actions/action-deliveries.component.ts
+++ b/frontend/src/app/features/tasks/task-actions/action-deliveries.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, inject, input, output, signal, OnInit } from '@angular/core';
+import { Component, inject, input, output, signal, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActionsService } from '../../../core/services/actions.service';
 import { ActionDelivery, ActionDeliveryDetail } from '../../../core/models/action.model';
@@ -14,6 +14,7 @@ import { ActionDelivery, ActionDeliveryDetail } from '../../../core/models/actio
   standalone: true,
   imports: [CommonModule],
   templateUrl: './action-deliveries.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './action-deliveries.component.scss',
 })
 export class ActionDeliveriesComponent implements OnInit {

--- a/frontend/src/app/features/tasks/task-actions/action-events.component.ts
+++ b/frontend/src/app/features/tasks/task-actions/action-events.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, computed, input, output } from '@angular/core';
+import { Component, computed, input, output, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ACTION_EVENTS } from '../../../core/models/action.model';
 
@@ -13,6 +13,7 @@ import { ACTION_EVENTS } from '../../../core/models/action.model';
   standalone: true,
   imports: [CommonModule],
   templateUrl: './action-events.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './action-events.component.scss',
 })
 export class ActionEventsComponent {

--- a/frontend/src/app/features/tasks/task-actions/action-form.component.html
+++ b/frontend/src/app/features/tasks/task-actions/action-form.component.html
@@ -4,14 +4,11 @@
   SPDX-License-Identifier: AGPL-3.0-only
 -->
 
-<p-dialog
+<gr-dialog
   [header]="mode() === 'create' ? 'New Action' : 'Edit Action'"
   [visible]="visible()"
   (visibleChange)="onVisibleChange($event)"
-  [modal]="true"
-  [style]="{ width: '560px' }"
-  [draggable]="false"
-  [resizable]="false"
+  width="560px"
 >
   @if (error()) {
     <div class="dialog-error">
@@ -22,12 +19,12 @@
 
   <div class="form-group">
     <label for="action-name">Name</label>
-    <input pInputText id="action-name" [ngModel]="name()" (ngModelChange)="name.set($event)" class="w-full" />
+    <input grInput id="action-name" [ngModel]="name()" (ngModelChange)="name.set($event)" class="w-full" />
   </div>
 
   <div class="form-group">
     <label>Type</label>
-    <p-selectbutton
+    <gr-select-button
       [options]="typeOptions()"
       [ngModel]="type()"
       (ngModelChange)="onTypeChange($event)"
@@ -45,7 +42,7 @@
     <div class="form-group">
       <label for="action-recipients">Recipients</label>
       <input
-        pInputText
+        grInput
         id="action-recipients"
         [ngModel]="recipientsRaw()"
         (ngModelChange)="recipientsRaw.set($event)"
@@ -57,7 +54,7 @@
     <div class="form-group">
       <label for="action-subject">Subject Template (optional)</label>
       <input
-        pInputText
+        grInput
         id="action-subject"
         [ngModel]="subjectTemplate()"
         (ngModelChange)="subjectTemplate.set($event)"
@@ -71,7 +68,7 @@
     <div class="form-group">
       <label for="action-url">URL</label>
       <input
-        pInputText
+        grInput
         id="action-url"
         [ngModel]="url()"
         (ngModelChange)="url.set($event)"
@@ -83,14 +80,14 @@
       <label for="action-token">Token</label>
       <div class="token-row">
         <input
-          pInputText
+          grInput
           id="action-token"
           [ngModel]="tokenValue()"
           (ngModelChange)="tokenValue.set($event)"
           [placeholder]="mode() === 'edit' ? 'Leave blank to keep existing token' : ''"
           class="w-full"
         />
-        <button pButton type="button" label="Generate" severity="secondary" (click)="generateToken()"></button>
+        <button grButton type="button" label="Generate" severity="secondary" (click)="generateToken()"></button>
       </div>
       <small class="text-secondary">
         @if (mode() === 'edit') {
@@ -105,14 +102,13 @@
   @if (type() === 'forge_status_report') {
     <div class="form-group">
       <label for="action-integration">Outbound Integration</label>
-      <p-select
+      <gr-select
         inputId="action-integration"
         [ngModel]="integrationId()"
         (ngModelChange)="integrationId.set($event)"
         [options]="integrationOptions()"
         optionLabel="label"
         optionValue="value"
-        styleClass="w-full"
       />
     </div>
   }
@@ -120,56 +116,52 @@
   @if (type() === 'open_pr') {
     <div class="form-group">
       <label for="pr-integration">Outbound Integration</label>
-      <p-select
+      <gr-select
         inputId="pr-integration"
         [ngModel]="integrationId()"
         (ngModelChange)="integrationId.set($event)"
         [options]="integrationOptions()"
         optionLabel="label"
         optionValue="value"
-        styleClass="w-full"
       />
     </div>
     <div class="form-group">
       <label for="pr-generator">Generator</label>
-      <p-select
+      <gr-select
         inputId="pr-generator"
         [ngModel]="prGenerator()"
         (ngModelChange)="prGenerator.set($event)"
         [options]="generatorOptions"
         optionLabel="label"
         optionValue="value"
-        styleClass="w-full"
       />
     </div>
     <div class="form-group">
       <label for="pr-granularity">Granularity</label>
-      <p-select
+      <gr-select
         inputId="pr-granularity"
         [ngModel]="prGranularity()"
         (ngModelChange)="prGranularity.set($event)"
         [options]="granularityOptions"
         optionLabel="label"
         optionValue="value"
-        styleClass="w-full"
       />
     </div>
     <div class="form-group">
       <label for="pr-verify-gate">Verify Gate</label>
-      <p-select
+      <gr-select
         inputId="pr-verify-gate"
         [ngModel]="prVerifyGate()"
         (ngModelChange)="prVerifyGate.set($event)"
         [options]="verifyGateOptions"
         optionLabel="label"
         optionValue="value"
-        styleClass="w-full"
       />
     </div>
     <div class="form-group">
       <label for="pr-branch-pattern">Branch Pattern</label>
       <input
-        pInputText
+        grInput
         id="pr-branch-pattern"
         [ngModel]="prBranchPattern()"
         (ngModelChange)="prBranchPattern.set($event)"
@@ -181,7 +173,7 @@
     <div class="form-group">
       <label for="pr-title-template">Title Template (optional)</label>
       <input
-        pInputText
+        grInput
         id="pr-title-template"
         [ngModel]="prTitleTemplate()"
         (ngModelChange)="prTitleTemplate.set($event)"
@@ -191,7 +183,7 @@
     <div class="form-group">
       <label for="pr-body-template">Body Template (optional)</label>
       <textarea
-        pInputTextarea
+        grInput
         id="pr-body-template"
         [ngModel]="prBodyTemplate()"
         (ngModelChange)="prBodyTemplate.set($event)"
@@ -200,7 +192,7 @@
       ></textarea>
     </div>
     <div class="form-group checkbox-group">
-      <p-checkbox
+      <gr-checkbox
         inputId="pr-update-existing"
         [ngModel]="prUpdateExisting()"
         (ngModelChange)="prUpdateExisting.set($event)"
@@ -233,12 +225,12 @@
   }
 
   <div class="form-group checkbox-group">
-    <p-checkbox inputId="action-active" [ngModel]="active()" (ngModelChange)="active.set($event)" [binary]="true" />
+    <gr-checkbox inputId="action-active" [ngModel]="active()" (ngModelChange)="active.set($event)" [binary]="true" />
     <label for="action-active">Active</label>
   </div>
 
-  <ng-template pTemplate="footer">
-    <button pButton label="Cancel" severity="secondary" (click)="onCancel()"></button>
-    <button pButton [label]="mode() === 'create' ? 'Create' : 'Save'" icon="pi pi-check" (click)="onSubmit()"></button>
-  </ng-template>
-</p-dialog>
+  <div grDialogFooter>
+    <button grButton label="Cancel" severity="secondary" (click)="onCancel()"></button>
+    <button grButton [label]="mode() === 'create' ? 'Create' : 'Save'" icon="check" (click)="onSubmit()"></button>
+  </div>
+</gr-dialog>

--- a/frontend/src/app/features/tasks/task-actions/action-form.component.spec.ts
+++ b/frontend/src/app/features/tasks/task-actions/action-form.component.spec.ts
@@ -118,7 +118,7 @@ describe('ActionFormComponent', () => {
     fixture.componentRef.setInput('open', true);
     fixture.componentRef.setInput('error', 'Integration not found');
     fixture.detectChanges();
-    expect((fixture.nativeElement as HTMLElement).textContent).toContain('Integration not found');
+    expect(document.body.textContent).toContain('Integration not found');
   });
 
   it('emits a CreateActionRequest with the correct discriminated union on submit', () => {

--- a/frontend/src/app/features/tasks/task-actions/action-form.component.ts
+++ b/frontend/src/app/features/tasks/task-actions/action-form.component.ts
@@ -7,13 +7,6 @@
 import { Component, OnChanges, SimpleChanges, computed, inject, input, output, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { DialogModule } from 'primeng/dialog';
-import { ButtonModule } from 'primeng/button';
-import { InputTextModule } from 'primeng/inputtext';
-import { SelectModule } from 'primeng/select';
-import { SelectButtonModule } from 'primeng/selectbutton';
-import { CheckboxModule } from 'primeng/checkbox';
-import { TextareaModule } from 'primeng/textarea';
 import { ConfigService } from '@core/services/config.service';
 import {
   Action,
@@ -27,6 +20,7 @@ import {
   UpdateActionRequest,
 } from '@core/models';
 import { ActionEventsComponent } from './action-events.component';
+import { ButtonComponent, CheckboxComponent, DialogComponent, InputDirective, SelectButtonComponent, SelectComponent } from '@shared/ui';
 
 type FormMode = 'create' | 'edit';
 
@@ -41,13 +35,13 @@ interface IntegrationOption {
   imports: [
     CommonModule,
     FormsModule,
-    DialogModule,
-    ButtonModule,
-    InputTextModule,
-    SelectModule,
-    SelectButtonModule,
-    CheckboxModule,
-    TextareaModule,
+    DialogComponent,
+    ButtonComponent,
+    InputDirective,
+    SelectComponent,
+    SelectButtonComponent,
+    CheckboxComponent,
+    InputDirective,
     ActionEventsComponent,
   ],
   templateUrl: './action-form.component.html',

--- a/frontend/src/app/features/tasks/task-actions/action-form.component.ts
+++ b/frontend/src/app/features/tasks/task-actions/action-form.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnChanges, SimpleChanges, computed, inject, input, output, signal } from '@angular/core';
+import { Component, OnChanges, SimpleChanges, computed, inject, input, output, signal, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ConfigService } from '@core/services/config.service';
@@ -45,6 +45,7 @@ interface IntegrationOption {
     ActionEventsComponent,
   ],
   templateUrl: './action-form.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './action-form.component.scss',
 })
 export class ActionFormComponent implements OnChanges {

--- a/frontend/src/app/features/tasks/task-actions/task-actions.component.html
+++ b/frontend/src/app/features/tasks/task-actions/task-actions.component.html
@@ -21,9 +21,9 @@
     </div>
     <button
       *appWritable="access()"
-      pButton
+      grButton
       label="New Action"
-      icon="pi pi-plus"
+      icon="add"
       (click)="startCreate()"
       [appManagedDisable]="access()"
     ></button>
@@ -46,9 +46,9 @@
         <p class="text-secondary">Create an action to send mail, post webhooks, or report build status back to your forge.</p>
         <button
           *appWritable="access()"
-          pButton
+          grButton
           label="New Action"
-          icon="pi pi-plus"
+          icon="add"
           (click)="startCreate()"
           [appManagedDisable]="access()"
         ></button>
@@ -93,9 +93,9 @@
               <div class="action-actions">
                 <button
                   *appWritable="triggerAccess()"
-                  pButton
+                  grButton
                   label="Test"
-                  icon="pi pi-play"
+                  icon="play_arrow"
                   severity="secondary"
                   size="small"
                   [loading]="testingId() === action.id"
@@ -103,18 +103,18 @@
                   (click)="testAction(action.id)"
                 ></button>
                 <button
-                  pButton
+                  grButton
                   label="Deliveries"
-                  icon="pi pi-list"
+                  icon="list"
                   severity="secondary"
                   size="small"
                   (click)="openDeliveries(action.id)"
                 ></button>
                 <button
                   *appWritable="access()"
-                  pButton
+                  grButton
                   label="Edit"
-                  icon="pi pi-pencil"
+                  icon="edit"
                   severity="secondary"
                   size="small"
                   [disabled]="rowDisabled()"
@@ -122,9 +122,9 @@
                 ></button>
                 <button
                   *appWritable="access()"
-                  pButton
+                  grButton
                   label="Delete"
-                  icon="pi pi-trash"
+                  icon="delete"
                   severity="danger"
                   size="small"
                   [loading]="deletingId() === action.id"
@@ -168,34 +168,28 @@
   />
 }
 
-<p-dialog
+<gr-dialog
   header="Delete Action"
   [visible]="confirmDeleteId() !== null"
   (visibleChange)="$event || cancelDelete()"
-  [modal]="true"
-  [style]="{ width: '400px' }"
-  [draggable]="false"
-  [resizable]="false"
+  width="400px"
 >
   <p>Delete this action? This cannot be undone.</p>
-  <ng-template pTemplate="footer">
-    <button pButton label="Cancel" severity="secondary" (click)="cancelDelete()"></button>
-    <button pButton label="Delete" severity="danger" (click)="confirmDelete()"></button>
-  </ng-template>
-</p-dialog>
+  <div grDialogFooter>
+    <button grButton label="Cancel" severity="secondary" (click)="cancelDelete()"></button>
+    <button grButton label="Delete" severity="danger" (click)="confirmDelete()"></button>
+  </div>
+</gr-dialog>
 
-<p-dialog
+<gr-dialog
   header="Save this token now"
   [visible]="revealedToken() !== null"
   (visibleChange)="$event || dismissToken()"
-  [modal]="true"
-  [style]="{ width: '520px' }"
-  [draggable]="false"
-  [resizable]="false"
+  width="520px"
 >
   <p>The action's token is shown below. It will not be displayed again - copy it now and store it somewhere safe.</p>
   <pre class="token-reveal">{{ revealedToken() }}</pre>
-  <ng-template pTemplate="footer">
-    <button pButton label="I've copied it" icon="pi pi-check" (click)="dismissToken()"></button>
-  </ng-template>
-</p-dialog>
+  <div grDialogFooter>
+    <button grButton label="I've copied it" icon="check" (click)="dismissToken()"></button>
+  </div>
+</gr-dialog>

--- a/frontend/src/app/features/tasks/task-actions/task-actions.component.ts
+++ b/frontend/src/app/features/tasks/task-actions/task-actions.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, computed, inject, signal } from '@angular/core';
+import { Component, OnInit, computed, inject, signal, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -46,6 +46,7 @@ interface IntegrationOption {
     ActionDeliveriesComponent,
   ],
   templateUrl: './task-actions.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './task-actions.component.scss',
 })
 export class TaskActionsComponent implements OnInit {

--- a/frontend/src/app/features/tasks/task-actions/task-actions.component.ts
+++ b/frontend/src/app/features/tasks/task-actions/task-actions.component.ts
@@ -8,8 +8,6 @@ import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { DialogModule } from 'primeng/dialog';
-import { ButtonModule } from 'primeng/button';
 import { ActionsService } from '@core/services/actions.service';
 import { IntegrationsService } from '@core/services/integrations.service';
 import { ProjectsService } from '@core/services/projects.service';
@@ -25,6 +23,7 @@ import {
 } from '@core/models';
 import { ActionFormComponent } from './action-form.component';
 import { ActionDeliveriesComponent } from './action-deliveries.component';
+import { ButtonComponent, DialogComponent } from '@shared/ui';
 
 interface IntegrationOption {
   id: string;
@@ -38,8 +37,8 @@ interface IntegrationOption {
     CommonModule,
     RouterModule,
     FormsModule,
-    DialogModule,
-    ButtonModule,
+    DialogComponent,
+    ButtonComponent,
     LoadingSpinnerComponent,
     WritableDirective,
     ManagedDisableDirective,
@@ -251,10 +250,10 @@ export class TaskActionsComponent implements OnInit {
 
   typeIcon(type: ActionType): string {
     switch (type) {
-      case 'send_mail': return 'pi pi-envelope';
-      case 'send_web_request': return 'pi pi-globe';
-      case 'forge_status_report': return 'pi pi-github';
-      case 'open_pr': return 'pi pi-code';
+      case 'send_mail': return 'mail';
+      case 'send_web_request': return 'public';
+      case 'forge_status_report': return 'published_with_changes';
+      case 'open_pr': return 'code';
     }
   }
 

--- a/frontend/src/app/features/tasks/task-detail/task-detail.component.html
+++ b/frontend/src/app/features/tasks/task-detail/task-detail.component.html
@@ -18,18 +18,18 @@
     </div>
     <div class="head-actions">
       @if (authService.isAuthenticated()) {
-        <button *appWritable="triggerAccess()" pButton label="Start Evaluation" icon="pi pi-play"
+        <button *appWritable="triggerAccess()" grButton label="Start Evaluation" icon="play_arrow"
                 (click)="startEvaluation()" [loading]="starting()"
                 [disabled]="starting() || evaluationInProgress()"
-                [pTooltip]="evaluationInProgress() ? 'An evaluation is already in progress' : ''"></button>
-        <button *appWritable="triggerAccess()" pButton label="Restart Failed Builds" icon="pi pi-refresh"
+                [grTooltip]="evaluationInProgress() ? 'An evaluation is already in progress' : ''"></button>
+        <button *appWritable="triggerAccess()" grButton label="Restart Failed Builds" icon="refresh"
                 severity="secondary" (click)="restartFailedBuilds()" [disabled]="starting()"></button>
         @if (proj.name !== 'build-request') {
-          <button pButton label="Settings" icon="pi pi-cog" severity="secondary"
+          <button grButton label="Settings" icon="settings" severity="secondary"
                   [routerLink]="['/project', projectName, 'task', taskName, 'settings']"></button>
         }
       }
-      <button pButton label="Metrics" icon="pi pi-chart-line" severity="secondary"
+      <button grButton label="Metrics" icon="show_chart" severity="secondary"
               [routerLink]="['/project', projectName, 'task', taskName, 'metrics']"></button>
     </div>
   </div>
@@ -116,11 +116,11 @@
               </div>
             </div>
             <div class="panel-actions">
-              <button pButton size="small" icon="pi pi-ellipsis-v" severity="secondary"
+              <button grButton size="small" icon="more_vert" severity="secondary"
                       (click)="panelMenu.toggle($event)" aria-label="More"></button>
-              <p-menu #panelMenu [model]="panelMenuModel()" [popup]="true" appendTo="body" />
+              <gr-menu #panelMenu [model]="panelMenuModel()" />
               @if (isRunning(sel.status)) {
-                <button *appWritable="triggerAccess()" pButton size="small" label="Abort" icon="pi pi-times"
+                <button *appWritable="triggerAccess()" grButton size="small" label="Abort" icon="close"
                         severity="danger" (click)="abortTarget.set(sel.id)"></button>
               }
             </div>
@@ -152,7 +152,7 @@
             <app-empty-state flat icon="package_2" title="No packages"
               message="This evaluation produced no entry-point builds." />
           }
-          <p-menu #pkgMenu [model]="pkgMenuModel()" [popup]="true" appendTo="body" />
+          <gr-menu #pkgMenu [model]="pkgMenuModel()" />
         </div>
       }
     </div>
@@ -165,19 +165,16 @@
     </div>
   }
 
-  <p-dialog
+  <gr-dialog
     header="Abort evaluation"
     [visible]="abortTarget() !== null"
     (visibleChange)="!$event && abortTarget.set(null)"
-    [modal]="true"
-    [style]="{ width: '400px' }"
-    [draggable]="false"
-    [resizable]="false"
+    width="400px"
   >
     <p>Do you really want to abort the eval?</p>
-    <ng-template pTemplate="footer">
-      <button pButton label="Cancel" severity="secondary" (click)="abortTarget.set(null)"></button>
-      <button pButton label="Abort" severity="danger" (click)="confirmAbort()"></button>
-    </ng-template>
-  </p-dialog>
+    <div grDialogFooter>
+      <button grButton label="Cancel" severity="secondary" (click)="abortTarget.set(null)"></button>
+      <button grButton label="Abort" severity="danger" (click)="confirmAbort()"></button>
+    </div>
+  </gr-dialog>
 }

--- a/frontend/src/app/features/tasks/task-detail/task-detail.component.spec.ts
+++ b/frontend/src/app/features/tasks/task-detail/task-detail.component.spec.ts
@@ -281,7 +281,7 @@ describe('TaskDetailComponent - abort modal', () => {
     const spy = vi.spyOn(tasksService, 'abortEvaluation');
     fixture.componentInstance.abortTarget.set('e1');
     fixture.detectChanges();
-    expect(document.querySelector('.p-dialog')).toBeTruthy();
+    expect(document.querySelector('.gr-dialog')).toBeTruthy();
     expect(spy).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/app/features/tasks/task-detail/task-detail.component.ts
+++ b/frontend/src/app/features/tasks/task-detail/task-detail.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, OnDestroy, ElementRef, HostListener, computed, inject, signal } from '@angular/core';
+import { Component, OnInit, OnDestroy, ElementRef, HostListener, computed, inject, signal, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { interval, Subscription } from 'rxjs';
@@ -32,6 +32,7 @@ import { ButtonComponent, DialogComponent, MenuComponent, MenuItem, TooltipDirec
     SegmentedBarComponent, EvalStatusBadgeComponent,
   ],
   templateUrl: './task-detail.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrls: [
     './task-detail.component.scss',
     './task-detail.evaluations.scss',

--- a/frontend/src/app/features/tasks/task-detail/task-detail.component.ts
+++ b/frontend/src/app/features/tasks/task-detail/task-detail.component.ts
@@ -9,11 +9,6 @@ import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { interval, Subscription } from 'rxjs';
 import { auditTime } from 'rxjs/operators';
-import { ButtonModule } from 'primeng/button';
-import { DialogModule } from 'primeng/dialog';
-import { MenuModule } from 'primeng/menu';
-import { TooltipModule } from 'primeng/tooltip';
-import { MenuItem } from 'primeng/api';
 import { LiveService } from '@core/services/live.service';
 import { AuthService } from '@core/services/auth.service';
 import { ProjectsService } from '@core/services/projects.service';
@@ -26,12 +21,13 @@ import { injectTaskAccess } from '@core/resolvers/inject-access';
 import { TaskDetail, EvaluationSummary, EvaluationStatus, EntryPointSummary, BuildStatus, BuildStatusCounts } from '@core/models';
 import { commitLabel, evaluationTitle, formatEvaluationDuration, isRunningEvaluationStatus, parseUtcTimestamp } from '@shared/evaluation';
 import { SegmentedBarComponent } from './segmented-bar/segmented-bar.component';
+import { ButtonComponent, DialogComponent, MenuComponent, MenuItem, TooltipDirective } from '@shared/ui';
 
 @Component({
   selector: 'app-task-detail',
   standalone: true,
   imports: [
-    CommonModule, RouterModule, ButtonModule, DialogModule, MenuModule, TooltipModule,
+    CommonModule, RouterModule, ButtonComponent, DialogComponent, MenuComponent, TooltipDirective,
     LoadingSpinnerComponent, EmptyStateComponent, WritableDirective,
     SegmentedBarComponent, EvalStatusBadgeComponent,
   ],
@@ -354,7 +350,7 @@ export class TaskDetailComponent implements OnInit, OnDestroy {
   pkgMenuModel = signal<MenuItem[]>([]);
 
   panelMenuModel = computed<MenuItem[]>(() => [
-    { label: 'Metrics', icon: 'pi pi-chart-line',
+    { label: 'Metrics', icon: 'show_chart',
       routerLink: ['/project', this.projectName, 'task', this.taskName, 'metrics'] },
   ]);
 
@@ -362,17 +358,17 @@ export class TaskDetailComponent implements OnInit, OnDestroy {
     const canArtefacts = (ep.build_status === 'Completed' || ep.build_status === 'Substituted') && ep.has_artefacts;
     return [
       {
-        label: 'Artefacts', icon: 'pi pi-download', disabled: !canArtefacts,
+        label: 'Artefacts', icon: 'download', disabled: !canArtefacts,
         routerLink: canArtefacts ? ['/project', this.projectName, 'artefacts', ep.build_id] : undefined,
         queryParams: canArtefacts ? { task: this.taskName } : undefined,
       },
       {
-        label: 'Dependency graph', icon: 'pi pi-sitemap',
+        label: 'Dependency graph', icon: 'account_tree',
         routerLink: ['/project', this.projectName, 'graph', ep.build_id],
         queryParams: { evalId: evalId, task: this.taskName },
       },
       {
-        label: 'Entry-point metrics', icon: 'pi pi-chart-line',
+        label: 'Entry-point metrics', icon: 'show_chart',
         routerLink: ['/project', this.projectName, 'task', this.taskName, 'entry-point-metrics'],
         queryParams: { eval: ep.eval },
       },

--- a/frontend/src/app/features/tasks/task-flake-inputs/task-flake-inputs.component.html
+++ b/frontend/src/app/features/tasks/task-flake-inputs/task-flake-inputs.component.html
@@ -4,7 +4,7 @@
   SPDX-License-Identifier: AGPL-3.0-only
 -->
 
-<p-toast />
+<gr-toast />
 
 <div class="container">
   <div class="page-header">
@@ -21,9 +21,9 @@
     </div>
     <button
       *appWritable="access()"
-      pButton
+      grButton
       label="New Override"
-      icon="pi pi-plus"
+      icon="add"
       (click)="startCreate()"
       [appManagedDisable]="access()"
     ></button>
@@ -39,9 +39,9 @@
         <p class="text-secondary">No overrides configured. The task's flake.lock is used as-is.</p>
         <button
           *appWritable="access()"
-          pButton
+          grButton
           label="New Override"
-          icon="pi pi-plus"
+          icon="add"
           (click)="startCreate()"
           [appManagedDisable]="access()"
         ></button>
@@ -70,9 +70,9 @@
               <div class="override-actions">
                 <button
                   *appWritable="access()"
-                  pButton
+                  grButton
                   label="Edit"
-                  icon="pi pi-pencil"
+                  icon="edit"
                   severity="secondary"
                   size="small"
                   [disabled]="rowDisabled()"
@@ -80,9 +80,9 @@
                 ></button>
                 <button
                   *appWritable="access()"
-                  pButton
+                  grButton
                   label="Delete"
-                  icon="pi pi-trash"
+                  icon="delete"
                   severity="danger"
                   size="small"
                   [loading]="deletingId() === override.id"
@@ -99,38 +99,32 @@
 </div>
 
 <!-- Create Dialog -->
-<p-dialog
+<gr-dialog
   header="New Override"
   [(visible)]="showCreateDialog"
-  [modal]="true"
-  [style]="{ width: '520px' }"
-  [draggable]="false"
-  [resizable]="false"
-  (onHide)="cancelEdit()"
+  width="520px"
+  (hide)="cancelEdit()"
 >
   <ng-container *ngTemplateOutlet="overrideForm"></ng-container>
-  <ng-template pTemplate="footer">
-    <button pButton label="Cancel" severity="secondary" (click)="showCreateDialog.set(false)" [disabled]="saving()"></button>
-    <button pButton label="Create" icon="pi pi-check" (click)="saveCreate()" [loading]="saving()" [disabled]="saving()"></button>
-  </ng-template>
-</p-dialog>
+  <div grDialogFooter>
+    <button grButton label="Cancel" severity="secondary" (click)="showCreateDialog.set(false)" [disabled]="saving()"></button>
+    <button grButton label="Create" icon="check" (click)="saveCreate()" [loading]="saving()" [disabled]="saving()"></button>
+  </div>
+</gr-dialog>
 
 <!-- Edit Dialog -->
-<p-dialog
+<gr-dialog
   header="Edit Override"
   [(visible)]="showEditDialog"
-  [modal]="true"
-  [style]="{ width: '520px' }"
-  [draggable]="false"
-  [resizable]="false"
-  (onHide)="cancelEdit()"
+  width="520px"
+  (hide)="cancelEdit()"
 >
   <ng-container *ngTemplateOutlet="overrideForm"></ng-container>
-  <ng-template pTemplate="footer">
-    <button pButton label="Cancel" severity="secondary" (click)="showEditDialog.set(false)" [disabled]="saving()"></button>
-    <button pButton label="Save" icon="pi pi-check" (click)="saveEdit()" [loading]="saving()" [disabled]="saving()"></button>
-  </ng-template>
-</p-dialog>
+  <div grDialogFooter>
+    <button grButton label="Cancel" severity="secondary" (click)="showEditDialog.set(false)" [disabled]="saving()"></button>
+    <button grButton label="Save" icon="check" (click)="saveEdit()" [loading]="saving()" [disabled]="saving()"></button>
+  </div>
+</gr-dialog>
 
 <!-- Shared form template -->
 <ng-template #overrideForm>
@@ -144,7 +138,7 @@
   <div class="form-group">
     <label for="fi-input-name">Input Name</label>
     <input
-      pInputText
+      grInput
       id="fi-input-name"
       [(ngModel)]="form.input_name"
       class="w-full"
@@ -154,7 +148,7 @@
   </div>
 
   <div class="form-group checkbox-group">
-    <p-checkbox
+    <gr-checkbox
       inputId="fi-keep-url"
       [(ngModel)]="form.keepUrl"
       [binary]="true"
@@ -166,7 +160,7 @@
     <div class="form-group">
       <label for="fi-url">URL</label>
       <input
-        pInputText
+        grInput
         id="fi-url"
         [(ngModel)]="form.url"
         class="w-full"

--- a/frontend/src/app/features/tasks/task-flake-inputs/task-flake-inputs.component.ts
+++ b/frontend/src/app/features/tasks/task-flake-inputs/task-flake-inputs.component.ts
@@ -8,18 +8,13 @@ import { Component, OnInit, inject, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { DialogModule } from 'primeng/dialog';
-import { ButtonModule } from 'primeng/button';
-import { InputTextModule } from 'primeng/inputtext';
-import { CheckboxModule } from 'primeng/checkbox';
-import { ToastModule } from 'primeng/toast';
-import { MessageService } from 'primeng/api';
 import { FlakeInputOverridesService } from '@core/services/flake-input-overrides.service';
 import { ProjectsService } from '@core/services/projects.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { WritableDirective, ManagedDisableDirective, AccessService } from '@shared/access';
 import { injectTaskAccess } from '@core/resolvers/inject-access';
 import { FlakeInputOverride, CreateFlakeInputOverrideBody } from '@core/models';
+import { ButtonComponent, CheckboxComponent, DialogComponent, InputDirective, MessageService, ToastComponent } from '@shared/ui';
 
 interface FlakeInputFormState {
   input_name: string;
@@ -40,11 +35,11 @@ const DEFAULT_FORM: FlakeInputFormState = {
     CommonModule,
     RouterModule,
     FormsModule,
-    DialogModule,
-    ButtonModule,
-    InputTextModule,
-    CheckboxModule,
-    ToastModule,
+    DialogComponent,
+    ButtonComponent,
+    InputDirective,
+    CheckboxComponent,
+    ToastComponent,
     LoadingSpinnerComponent,
     WritableDirective,
     ManagedDisableDirective,

--- a/frontend/src/app/features/tasks/task-flake-inputs/task-flake-inputs.component.ts
+++ b/frontend/src/app/features/tasks/task-flake-inputs/task-flake-inputs.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import { Component, OnInit, inject, signal, computed, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -46,6 +46,7 @@ const DEFAULT_FORM: FlakeInputFormState = {
   ],
   providers: [MessageService],
   templateUrl: './task-flake-inputs.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './task-flake-inputs.component.scss',
 })
 export class TaskFlakeInputsComponent implements OnInit {

--- a/frontend/src/app/features/tasks/task-metrics/task-metrics.component.ts
+++ b/frontend/src/app/features/tasks/task-metrics/task-metrics.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import { Component, OnInit, inject, signal, computed, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { MetricChartComponent } from '@shared/components/metric-chart/metric-chart.component';
@@ -26,6 +26,7 @@ const CHART_COLORS = {
   standalone: true,
   imports: [CommonModule, RouterModule, MetricChartComponent, LoadingSpinnerComponent],
   templateUrl: './task-metrics.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './task-metrics.component.scss',
 })
 export class TaskMetricsComponent implements OnInit {

--- a/frontend/src/app/features/tasks/task-settings/task-settings.component.html
+++ b/frontend/src/app/features/tasks/task-settings/task-settings.component.html
@@ -19,7 +19,7 @@
         </div>
         <h1>Task Settings</h1>
       </div>
-      <button pButton label="Project Settings" icon="pi pi-building" severity="secondary" [routerLink]="['/project', projectName, 'settings']"></button>
+      <button grButton label="Project Settings" icon="apartment" severity="secondary" [routerLink]="['/project', projectName, 'settings']"></button>
     </div>
 
     @if (errorMessage()) {
@@ -41,23 +41,23 @@
       <div class="settings-card">
         <div class="form-group">
           <label for="proj-name">Name</label>
-          <input pInputText id="proj-name" [value]="proj.name" disabled class="w-full" />
+          <input grInput id="proj-name" [value]="proj.name" disabled class="w-full" />
           <small class="text-secondary">Task name cannot be changed</small>
         </div>
 
         <div class="form-group">
           <label for="proj-display">Display Name</label>
-          <input pInputText id="proj-display" [(ngModel)]="formData.display_name" class="w-full" [appManagedDisable]="access()" />
+          <input grInput id="proj-display" [(ngModel)]="formData.display_name" class="w-full" [appManagedDisable]="access()" />
         </div>
 
         <div class="form-group">
           <label for="proj-desc">Description</label>
-          <textarea pInputTextarea id="proj-desc" [(ngModel)]="formData.description" rows="3" class="w-full" [appManagedDisable]="access()"></textarea>
+          <textarea grInput id="proj-desc" [(ngModel)]="formData.description" rows="3" class="w-full" [appManagedDisable]="access()"></textarea>
         </div>
 
         <div class="form-group">
           <label for="proj-repo">Repository URL</label>
-          <input pInputText id="proj-repo" [(ngModel)]="formData.repository" class="w-full" [appManagedDisable]="access()" />
+          <input grInput id="proj-repo" [(ngModel)]="formData.repository" class="w-full" [appManagedDisable]="access()" />
         </div>
 
         <div class="form-group">
@@ -67,33 +67,32 @@
               <span class="material-symbols-outlined">help</span>
             </a>
           </label>
-          <input pInputText id="proj-wildcard" [(ngModel)]="formData.wildcard" class="w-full" [appManagedDisable]="access()" />
+          <input grInput id="proj-wildcard" [(ngModel)]="formData.wildcard" class="w-full" [appManagedDisable]="access()" />
           <small class="text-secondary">Pattern for selecting which outputs to evaluate</small>
         </div>
 
         <div class="form-group">
           <label for="proj-keep">Keep Evaluations</label>
-          <input pInputText id="proj-keep" type="number" min="1" [(ngModel)]="formData.keep_evaluations" class="w-full" [appManagedDisable]="access()" />
+          <input grInput id="proj-keep" type="number" min="1" [(ngModel)]="formData.keep_evaluations" class="w-full" [appManagedDisable]="access()" />
           <small class="text-secondary">Number of completed evaluations to retain for metrics and history</small>
         </div>
 
         <div class="form-group">
           <label for="proj-concurrency">Trigger Concurrency</label>
-          <p-select
+          <gr-select
             inputId="proj-concurrency"
             [(ngModel)]="formData.concurrency"
             [options]="concurrencyOptions"
             optionLabel="label"
             optionValue="value"
             optionDisabled="disabled"
-            styleClass="w-full"
             [appManagedDisable]="access()"
           />
           <small class="text-secondary">Determines how this task handles a new trigger event when an evaluation is already running.</small>
         </div>
 
         <div class="form-group checkbox-group">
-          <p-checkbox
+          <gr-checkbox
             inputId="proj-sign-cache"
             [(ngModel)]="formData.sign_cache"
             [binary]="true"
@@ -106,9 +105,9 @@
         <div class="form-actions">
           <button
             *appWritable="access()"
-            pButton
+            grButton
             label="Save Changes"
-            icon="pi pi-check"
+            icon="check"
             (click)="saveSettings()"
             [loading]="saving()"
             [appManagedDisable]="access()"
@@ -125,7 +124,7 @@
           <p class="text-secondary">
             Triggers control how and when evaluations run for this task - polling intervals, forge push and pull-request events, and cron schedules.
           </p>
-          <a pButton label="Manage Triggers" icon="pi pi-clock" severity="secondary" [routerLink]="['/project', projectName, 'task', taskName, 'triggers']"></a>
+          <a grButton label="Manage Triggers" icon="schedule" severity="secondary" [routerLink]="['/project', projectName, 'task', taskName, 'triggers']"></a>
         </div>
       </div>
     </div>
@@ -138,7 +137,7 @@
           <p class="text-secondary">
             Actions react to evaluation and build events - send mail, post webhooks, or report status back to your forge.
           </p>
-          <a pButton label="Manage Actions" icon="pi pi-bolt" severity="secondary" [routerLink]="['/project', projectName, 'task', taskName, 'actions']"></a>
+          <a grButton label="Manage Actions" icon="bolt" severity="secondary" [routerLink]="['/project', projectName, 'task', taskName, 'actions']"></a>
         </div>
       </div>
     </div>
@@ -151,7 +150,7 @@
           <p class="text-secondary">
             Override individual flake inputs with a new git URL, or force an update of an input keeping its original URL. Inputs without an override stay at whatever flake.lock has locked.
           </p>
-          <a pButton label="Manage Flake Inputs" icon="pi pi-share-alt" severity="secondary"
+          <a grButton label="Manage Flake Inputs" icon="share" severity="secondary"
              [routerLink]="['/project', projectName, 'task', taskName, 'flake-inputs']"></a>
         </div>
       </div>
@@ -168,9 +167,9 @@
           </div>
           <button
             *appWritable="access()"
-            pButton
+            grButton
             [label]="proj.active ? 'Deactivate' : 'Activate'"
-            [icon]="proj.active ? 'pi pi-pause' : 'pi pi-play'"
+            [icon]="proj.active ? 'pause' : 'play_arrow'"
             [severity]="proj.active ? 'warn' : 'success'"
             (click)="toggleActive()"
             [loading]="toggling()"
@@ -191,9 +190,9 @@
               <p class="text-secondary">Transfer this task to another project.</p>
             </div>
             <button
-              pButton
+              grButton
               label="Transfer Ownership"
-              icon="pi pi-send"
+              icon="send"
               severity="warn"
               (click)="showTransferDialog.set(true)"
               [appManagedDisable]="access()"
@@ -206,9 +205,9 @@
               <p class="text-secondary">Permanently delete this task and all its evaluations.</p>
             </div>
             <button
-              pButton
+              grButton
               label="Delete Task"
-              icon="pi pi-trash"
+              icon="delete"
               severity="danger"
               (click)="showDeleteDialog.set(true)"
               [appManagedDisable]="access()"
@@ -221,14 +220,11 @@
 </div>
 
 <!-- Transfer Ownership Dialog -->
-<p-dialog
+<gr-dialog
   header="Transfer Ownership"
   [(visible)]="showTransferDialog"
-  [modal]="true"
-  [style]="{ width: '420px' }"
-  [draggable]="false"
-  [resizable]="false"
-  (onHide)="onTransferDialogHide()"
+  width="420px"
+  (hide)="onTransferDialogHide()"
 >
   <div class="dialog-content">
     <p>Transfer <strong>{{ task()?.display_name }}</strong> to another project. This action cannot be undone.</p>
@@ -246,36 +242,31 @@
     }
     <div class="form-group">
       <label>Target Project</label>
-      <p-autoComplete
+      <gr-autocomplete
         [(ngModel)]="transferProjectName"
         [suggestions]="transferProjectSuggestions()"
         (completeMethod)="onTransferProjectSearch($event)"
         placeholder="Project name"
-        styleClass="w-full"
         [forceSelection]="false"
         [disabled]="transferring()"
-        appendTo="body"
       />
     </div>
   </div>
-  <ng-template pTemplate="footer">
-    <button pButton label="Cancel" severity="secondary" (click)="showTransferDialog.set(false)" [disabled]="transferring()"></button>
-    <button pButton label="Transfer" icon="pi pi-send" severity="warn" (click)="transferOwnership()" [loading]="transferring()" [disabled]="transferring() || !transferProjectName.trim()"></button>
-  </ng-template>
-</p-dialog>
+  <div grDialogFooter>
+    <button grButton label="Cancel" severity="secondary" (click)="showTransferDialog.set(false)" [disabled]="transferring()"></button>
+    <button grButton label="Transfer" icon="send" severity="warn" (click)="transferOwnership()" [loading]="transferring()" [disabled]="transferring() || !transferProjectName.trim()"></button>
+  </div>
+</gr-dialog>
 
 <!-- Delete Confirmation Dialog -->
-<p-dialog
+<gr-dialog
   header="Delete Task"
   [(visible)]="showDeleteDialog"
-  [modal]="true"
-  [style]="{ width: '400px' }"
-  [draggable]="false"
-  [resizable]="false"
+  width="400px"
 >
   <p>Are you sure you want to delete <strong>{{ task()?.display_name }}</strong>? This action cannot be undone.</p>
-  <ng-template pTemplate="footer">
-    <button pButton label="Cancel" severity="secondary" (click)="showDeleteDialog.set(false)" [disabled]="deleting()"></button>
-    <button pButton label="Delete" severity="danger" (click)="deleteTask()" [loading]="deleting()" [disabled]="deleting()"></button>
-  </ng-template>
-</p-dialog>
+  <div grDialogFooter>
+    <button grButton label="Cancel" severity="secondary" (click)="showDeleteDialog.set(false)" [disabled]="deleting()"></button>
+    <button grButton label="Delete" severity="danger" (click)="deleteTask()" [loading]="deleting()" [disabled]="deleting()"></button>
+  </div>
+</gr-dialog>

--- a/frontend/src/app/features/tasks/task-settings/task-settings.component.ts
+++ b/frontend/src/app/features/tasks/task-settings/task-settings.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal } from '@angular/core';
+import { Component, OnInit, inject, signal, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -35,6 +35,7 @@ import { AutoCompleteComponent, ButtonComponent, CheckboxComponent, DialogCompon
     ManagedDisableDirective,
   ],
   templateUrl: './task-settings.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './task-settings.component.scss',
 })
 export class TaskSettingsComponent implements OnInit {

--- a/frontend/src/app/features/tasks/task-settings/task-settings.component.ts
+++ b/frontend/src/app/features/tasks/task-settings/task-settings.component.ts
@@ -8,19 +8,13 @@ import { Component, OnInit, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { DialogModule } from 'primeng/dialog';
-import { ButtonModule } from 'primeng/button';
-import { InputTextModule } from 'primeng/inputtext';
-import { TextareaModule } from 'primeng/textarea';
 import { TasksService } from '@core/services/tasks.service';
 import { ProjectsService } from '@core/services/projects.service';
-import { AutoCompleteModule } from 'primeng/autocomplete';
-import { SelectModule } from 'primeng/select';
-import { CheckboxModule } from 'primeng/checkbox';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { WritableDirective, ManagedDisableDirective } from '@shared/access';
 import { ConcurrencyPolicy, Task } from '@core/models';
 import { injectTaskAccess } from '@core/resolvers/inject-access';
+import { AutoCompleteComponent, ButtonComponent, CheckboxComponent, DialogComponent, InputDirective, SelectComponent } from '@shared/ui';
 
 @Component({
   selector: 'app-task-settings',
@@ -29,13 +23,13 @@ import { injectTaskAccess } from '@core/resolvers/inject-access';
     CommonModule,
     RouterModule,
     FormsModule,
-    DialogModule,
-    ButtonModule,
-    InputTextModule,
-    TextareaModule,
-    AutoCompleteModule,
-    SelectModule,
-    CheckboxModule,
+    DialogComponent,
+    ButtonComponent,
+    InputDirective,
+    InputDirective,
+    AutoCompleteComponent,
+    SelectComponent,
+    CheckboxComponent,
     LoadingSpinnerComponent,
     WritableDirective,
     ManagedDisableDirective,

--- a/frontend/src/app/features/tasks/task-triggers/task-triggers.component.html
+++ b/frontend/src/app/features/tasks/task-triggers/task-triggers.component.html
@@ -19,9 +19,9 @@
     </div>
     <button
       *appWritable="access()"
-      pButton
+      grButton
       label="New Trigger"
-      icon="pi pi-plus"
+      icon="add"
       (click)="startCreate()"
       [appManagedDisable]="access()"
     ></button>
@@ -37,9 +37,9 @@
         <p class="text-secondary">Create a trigger to automatically start evaluations on a schedule, push event, or pull request.</p>
         <button
           *appWritable="access()"
-          pButton
+          grButton
           label="New Trigger"
-          icon="pi pi-plus"
+          icon="add"
           (click)="startCreate()"
           [appManagedDisable]="access()"
         ></button>
@@ -70,9 +70,9 @@
               <div class="trigger-actions">
                 <button
                   *appWritable="triggerAccess()"
-                  pButton
+                  grButton
                   label="Fire Now"
-                  icon="pi pi-play"
+                  icon="play_arrow"
                   severity="secondary"
                   size="small"
                   [loading]="firingId() === trigger.id"
@@ -81,9 +81,9 @@
                 ></button>
                 <button
                   *appWritable="access()"
-                  pButton
+                  grButton
                   label="Edit"
-                  icon="pi pi-pencil"
+                  icon="edit"
                   severity="secondary"
                   size="small"
                   [disabled]="rowDisabled()"
@@ -91,9 +91,9 @@
                 ></button>
                 <button
                   *appWritable="access()"
-                  pButton
+                  grButton
                   label="Delete"
-                  icon="pi pi-trash"
+                  icon="delete"
                   severity="danger"
                   size="small"
                   [loading]="deletingId() === trigger.id"
@@ -110,38 +110,32 @@
 </div>
 
 <!-- Create Dialog -->
-<p-dialog
+<gr-dialog
   header="New Trigger"
   [(visible)]="showCreateDialog"
-  [modal]="true"
-  [style]="{ width: '560px' }"
-  [draggable]="false"
-  [resizable]="false"
-  (onHide)="cancelEdit()"
+  width="560px"
+  (hide)="cancelEdit()"
 >
   <ng-container *ngTemplateOutlet="triggerForm; context: { isEdit: false }"></ng-container>
-  <ng-template pTemplate="footer">
-    <button pButton label="Cancel" severity="secondary" (click)="showCreateDialog.set(false)" [disabled]="saving()"></button>
-    <button pButton label="Create" icon="pi pi-check" (click)="saveCreate()" [loading]="saving()" [disabled]="saving()"></button>
-  </ng-template>
-</p-dialog>
+  <div grDialogFooter>
+    <button grButton label="Cancel" severity="secondary" (click)="showCreateDialog.set(false)" [disabled]="saving()"></button>
+    <button grButton label="Create" icon="check" (click)="saveCreate()" [loading]="saving()" [disabled]="saving()"></button>
+  </div>
+</gr-dialog>
 
 <!-- Edit Dialog -->
-<p-dialog
+<gr-dialog
   header="Edit Trigger"
   [(visible)]="showEditDialog"
-  [modal]="true"
-  [style]="{ width: '560px' }"
-  [draggable]="false"
-  [resizable]="false"
-  (onHide)="cancelEdit()"
+  width="560px"
+  (hide)="cancelEdit()"
 >
   <ng-container *ngTemplateOutlet="triggerForm; context: { isEdit: true }"></ng-container>
-  <ng-template pTemplate="footer">
-    <button pButton label="Cancel" severity="secondary" (click)="showEditDialog.set(false)" [disabled]="saving()"></button>
-    <button pButton label="Save" icon="pi pi-check" (click)="saveEdit()" [loading]="saving()" [disabled]="saving()"></button>
-  </ng-template>
-</p-dialog>
+  <div grDialogFooter>
+    <button grButton label="Cancel" severity="secondary" (click)="showEditDialog.set(false)" [disabled]="saving()"></button>
+    <button grButton label="Save" icon="check" (click)="saveEdit()" [loading]="saving()" [disabled]="saving()"></button>
+  </div>
+</gr-dialog>
 
 <!-- Shared form template -->
 <ng-template #triggerForm let-isEdit="isEdit">
@@ -154,13 +148,12 @@
 
   <div class="form-group">
     <label for="trig-type">Type</label>
-    <p-select
+    <gr-select
       inputId="trig-type"
       [(ngModel)]="form.type"
       [options]="typeOptions"
       optionLabel="label"
       optionValue="value"
-      styleClass="w-full"
       [disabled]="isEdit"
     />
     @if (isEdit) {
@@ -172,7 +165,7 @@
     <div class="form-group">
       <label for="trig-interval">Interval (seconds)</label>
       <input
-        pInputText
+        grInput
         id="trig-interval"
         type="number"
         min="10"
@@ -184,7 +177,7 @@
     <div class="form-group">
       <label for="trig-branch">Branch</label>
       <input
-        pInputText
+        grInput
         id="trig-branch"
         [(ngModel)]="form.branch"
         placeholder="HEAD (default branch)"
@@ -197,20 +190,19 @@
   @if (form.type === 'reporter_push' || form.type === 'reporter_pull_request') {
     <div class="form-group">
       <label for="trig-integration">Integration</label>
-      <p-select
+      <gr-select
         inputId="trig-integration"
         [(ngModel)]="form.integration_id"
         [options]="integrationOptions()"
         optionLabel="label"
         optionValue="value"
-        styleClass="w-full"
       />
       <small class="text-secondary">Inbound integration that delivers webhooks for this trigger.</small>
     </div>
     <div class="form-group">
       <label for="trig-branches">Branches</label>
       <input
-        pInputText
+        grInput
         id="trig-branches"
         [(ngModel)]="form.branches"
         class="w-full"
@@ -224,7 +216,7 @@
     <div class="form-group">
       <label for="trig-tags">Tags</label>
       <input
-        pInputText
+        grInput
         id="trig-tags"
         [(ngModel)]="form.tags"
         class="w-full"
@@ -233,7 +225,7 @@
       <small class="text-secondary">Comma-separated tag patterns. Leave blank to match any tag.</small>
     </div>
     <div class="form-group checkbox-group">
-      <p-checkbox
+      <gr-checkbox
         inputId="trig-releases-only"
         [(ngModel)]="form.releases_only"
         [binary]="true"
@@ -246,7 +238,7 @@
     <div class="form-group">
       <label for="trig-actions">Actions</label>
       <input
-        pInputText
+        grInput
         id="trig-actions"
         [(ngModel)]="form.actions"
         class="w-full"
@@ -256,7 +248,7 @@
     </div>
 
     <div class="form-group checkbox-group">
-      <p-checkbox
+      <gr-checkbox
         inputId="trig-require-approval"
         [(ngModel)]="form.require_approval"
         [binary]="true"
@@ -278,7 +270,7 @@
     <div class="form-group">
       <label for="trig-cron">Cron Expression</label>
       <input
-        pInputText
+        grInput
         id="trig-cron"
         [(ngModel)]="form.cron"
         class="w-full"
@@ -291,7 +283,7 @@
   }
 
   <div class="form-group checkbox-group">
-    <p-checkbox
+    <gr-checkbox
       inputId="trig-active"
       [(ngModel)]="form.active"
       [binary]="true"

--- a/frontend/src/app/features/tasks/task-triggers/task-triggers.component.ts
+++ b/frontend/src/app/features/tasks/task-triggers/task-triggers.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import { Component, OnInit, inject, signal, computed, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -75,6 +75,7 @@ const DEFAULT_FORM: TriggerFormState = {
     ManagedDisableDirective,
   ],
   templateUrl: './task-triggers.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './task-triggers.component.scss',
 })
 export class TaskTriggersComponent implements OnInit {

--- a/frontend/src/app/features/tasks/task-triggers/task-triggers.component.ts
+++ b/frontend/src/app/features/tasks/task-triggers/task-triggers.component.ts
@@ -8,11 +8,6 @@ import { Component, OnInit, inject, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { DialogModule } from 'primeng/dialog';
-import { ButtonModule } from 'primeng/button';
-import { InputTextModule } from 'primeng/inputtext';
-import { SelectModule } from 'primeng/select';
-import { CheckboxModule } from 'primeng/checkbox';
 import { TriggersService } from '@core/services/triggers.service';
 import { IntegrationsService } from '@core/services/integrations.service';
 import { ProjectsService } from '@core/services/projects.service';
@@ -27,6 +22,7 @@ import {
   UpdateTriggerBody,
   IntegrationSummary,
 } from '@core/models';
+import { ButtonComponent, CheckboxComponent, DialogComponent, InputDirective, SelectComponent } from '@shared/ui';
 
 interface Option<T> {
   label: string;
@@ -69,11 +65,11 @@ const DEFAULT_FORM: TriggerFormState = {
     CommonModule,
     RouterModule,
     FormsModule,
-    DialogModule,
-    ButtonModule,
-    InputTextModule,
-    SelectModule,
-    CheckboxModule,
+    DialogComponent,
+    ButtonComponent,
+    InputDirective,
+    SelectComponent,
+    CheckboxComponent,
     LoadingSpinnerComponent,
     WritableDirective,
     ManagedDisableDirective,

--- a/frontend/src/app/shared/access/managed-disable.directive.spec.ts
+++ b/frontend/src/app/shared/access/managed-disable.directive.spec.ts
@@ -20,7 +20,7 @@ class HostComponent {
   access = signal<AccessState>({ managed: false, canEdit: true, canTrigger: true });
 }
 
-// Mirrors how PrimeNG inputs implement ControlValueAccessor - the directive
+// Mirrors how a gr-ui control implements ControlValueAccessor - the directive
 // must call `setDisabledState` on them, since setting the DOM `disabled`
 // property on a component host element does not flow into the component's
 // internal state.
@@ -28,10 +28,10 @@ class HostComponent {
   selector: 'fake-input',
   standalone: true,
   providers: [
-    { provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => FakePrimeNgInputDirective), multi: true },
+    { provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => FakeInputDirective), multi: true },
   ],
 })
-class FakePrimeNgInputDirective implements ControlValueAccessor {
+class FakeInputDirective implements ControlValueAccessor {
   isDisabled = false;
   writeValue(): void {}
   registerOnChange(): void {}
@@ -44,7 +44,7 @@ class FakePrimeNgInputDirective implements ControlValueAccessor {
 @Component({
   selector: 'cva-host',
   standalone: true,
-  imports: [FormsModule, ManagedDisableDirective, FakePrimeNgInputDirective],
+  imports: [FormsModule, ManagedDisableDirective, FakeInputDirective],
   template: `<fake-input [(ngModel)]="value" [appManagedDisable]="access()"></fake-input>`,
 })
 class CvaHostComponent {
@@ -112,12 +112,12 @@ describe('ManagedDisableDirective ([appManagedDisable])', () => {
   });
 });
 
-describe('ManagedDisableDirective with a ControlValueAccessor (PrimeNG-like)', () => {
+describe('ManagedDisableDirective with a ControlValueAccessor', () => {
   let fixture: ComponentFixture<CvaHostComponent>;
 
-  function cvaInstance(): FakePrimeNgInputDirective {
+  function cvaInstance(): FakeInputDirective {
     const debugEl = fixture.debugElement.children[0];
-    return debugEl.injector.get(FakePrimeNgInputDirective);
+    return debugEl.injector.get(FakeInputDirective);
   }
 
   beforeEach(() => {

--- a/frontend/src/app/shared/access/managed-disable.directive.spec.ts
+++ b/frontend/src/app/shared/access/managed-disable.directive.spec.ts
@@ -25,7 +25,7 @@ class HostComponent {
 // property on a component host element does not flow into the component's
 // internal state.
 @Directive({
-  selector: 'fake-primeng-input',
+  selector: 'fake-input',
   standalone: true,
   providers: [
     { provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => FakePrimeNgInputDirective), multi: true },
@@ -45,7 +45,7 @@ class FakePrimeNgInputDirective implements ControlValueAccessor {
   selector: 'cva-host',
   standalone: true,
   imports: [FormsModule, ManagedDisableDirective, FakePrimeNgInputDirective],
-  template: `<fake-primeng-input [(ngModel)]="value" [appManagedDisable]="access()"></fake-primeng-input>`,
+  template: `<fake-input [(ngModel)]="value" [appManagedDisable]="access()"></fake-input>`,
 })
 class CvaHostComponent {
   value = '';

--- a/frontend/src/app/shared/components/empty-state/empty-state.component.ts
+++ b/frontend/src/app/shared/components/empty-state/empty-state.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, booleanAttribute, input, output } from '@angular/core';
+import { Component, booleanAttribute, input, output, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 @Component({
@@ -13,6 +13,7 @@ import { CommonModule } from '@angular/common';
   imports: [CommonModule],
   templateUrl: './empty-state.component.html',
   styleUrl: './empty-state.component.scss',
+  changeDetection: ChangeDetectionStrategy.Eager,
   host: { '[class.flat]': 'flat()' },
 })
 export class EmptyStateComponent {

--- a/frontend/src/app/shared/components/eval-status-badge/eval-status-badge.component.ts
+++ b/frontend/src/app/shared/components/eval-status-badge/eval-status-badge.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, computed, input } from '@angular/core';
+import { Component, computed, input, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { EvaluationStatus } from '@core/models/task.model';
 import { isRunningEvaluationStatus } from '@shared/evaluation';
@@ -21,6 +21,7 @@ import { isRunningEvaluationStatus } from '@shared/evaluation';
       {{ label() }}
     </span>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './eval-status-badge.component.scss',
 })
 export class EvalStatusBadgeComponent {

--- a/frontend/src/app/shared/components/footer/footer.component.ts
+++ b/frontend/src/app/shared/components/footer/footer.component.ts
@@ -4,13 +4,14 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, inject } from '@angular/core';
+import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
 import { ConfigService } from '@core/services/config.service';
 
 @Component({
   selector: 'app-footer',
   standalone: true,
   templateUrl: './footer.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './footer.component.scss',
 })
 export class FooterComponent {

--- a/frontend/src/app/shared/components/form/copy-field/copy-field.component.html
+++ b/frontend/src/app/shared/components/form/copy-field/copy-field.component.html
@@ -1,6 +1,6 @@
 <div class="copy-field">
   <input
-    pInputText
+    grInput
     [id]="id() ?? null"
     [value]="value()"
     [class.copy-field__input--mono]="mono()"
@@ -8,9 +8,9 @@
     readonly
   />
   <button
-    pButton
+    grButton
     type="button"
-    [icon]="copied() ? 'pi pi-check' : 'pi pi-copy'"
+    [icon]="copied() ? 'check' : 'content_copy'"
     [severity]="copied() ? 'success' : 'secondary'"
     [attr.aria-label]="copied() ? 'Copied' : 'Copy to clipboard'"
     (click)="copy()"

--- a/frontend/src/app/shared/components/form/copy-field/copy-field.component.ts
+++ b/frontend/src/app/shared/components/form/copy-field/copy-field.component.ts
@@ -6,13 +6,12 @@
 
 import { Component, input, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ButtonModule } from 'primeng/button';
-import { InputTextModule } from 'primeng/inputtext';
+import { ButtonComponent, InputDirective } from '@shared/ui';
 
 @Component({
   selector: 'gr-copy-field',
   standalone: true,
-  imports: [CommonModule, ButtonModule, InputTextModule],
+  imports: [CommonModule, ButtonComponent, InputDirective],
   templateUrl: './copy-field.component.html',
   styleUrl: './copy-field.component.scss',
 })

--- a/frontend/src/app/shared/components/form/copy-field/copy-field.component.ts
+++ b/frontend/src/app/shared/components/form/copy-field/copy-field.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, input, signal } from '@angular/core';
+import { Component, input, signal, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ButtonComponent, InputDirective } from '@shared/ui';
 
@@ -13,6 +13,7 @@ import { ButtonComponent, InputDirective } from '@shared/ui';
   standalone: true,
   imports: [CommonModule, ButtonComponent, InputDirective],
   templateUrl: './copy-field.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './copy-field.component.scss',
 })
 export class CopyFieldComponent {

--- a/frontend/src/app/shared/components/form/form-dialog/form-dialog.component.html
+++ b/frontend/src/app/shared/components/form/form-dialog/form-dialog.component.html
@@ -1,17 +1,14 @@
-<p-dialog
+<gr-dialog
   [header]="title()"
   [(visible)]="visible"
-  [modal]="true"
-  [style]="{ width: width() }"
-  [draggable]="false"
-  [resizable]="false"
+  [width]="width()"
 >
   <div class="form-dialog__content">
     <ng-content></ng-content>
   </div>
-  <ng-template pTemplate="footer">
+  <div grDialogFooter>
     <button
-      pButton
+      grButton
       [label]="cancelLabel()"
       severity="secondary"
       (click)="onCancel()"
@@ -19,7 +16,7 @@
     ></button>
     @if (submitIcon() || submitSeverity()) {
       <button
-        pButton
+        grButton
         [label]="submitLabel()"
         [icon]="submitIcon() ?? ''"
         [severity]="$any(submitSeverity())"
@@ -29,12 +26,12 @@
       ></button>
     } @else {
       <button
-        pButton
+        grButton
         [label]="submitLabel()"
         (click)="onSubmit()"
         [loading]="loading()"
         [disabled]="loading() || disabled()"
       ></button>
     }
-  </ng-template>
-</p-dialog>
+  </div>
+</gr-dialog>

--- a/frontend/src/app/shared/components/form/form-dialog/form-dialog.component.ts
+++ b/frontend/src/app/shared/components/form/form-dialog/form-dialog.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, input, model, output } from '@angular/core';
+import { Component, input, model, output, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ButtonComponent, DialogComponent } from '@shared/ui';
 
@@ -13,6 +13,7 @@ import { ButtonComponent, DialogComponent } from '@shared/ui';
   standalone: true,
   imports: [CommonModule, ButtonComponent, DialogComponent],
   templateUrl: './form-dialog.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './form-dialog.component.scss',
 })
 export class FormDialogComponent {

--- a/frontend/src/app/shared/components/form/form-dialog/form-dialog.component.ts
+++ b/frontend/src/app/shared/components/form/form-dialog/form-dialog.component.ts
@@ -6,13 +6,12 @@
 
 import { Component, input, model, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ButtonModule } from 'primeng/button';
-import { DialogModule } from 'primeng/dialog';
+import { ButtonComponent, DialogComponent } from '@shared/ui';
 
 @Component({
   selector: 'gr-form-dialog',
   standalone: true,
-  imports: [CommonModule, ButtonModule, DialogModule],
+  imports: [CommonModule, ButtonComponent, DialogComponent],
   templateUrl: './form-dialog.component.html',
   styleUrl: './form-dialog.component.scss',
 })

--- a/frontend/src/app/shared/components/form/form-error/form-error.component.ts
+++ b/frontend/src/app/shared/components/form/form-error/form-error.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, computed, input } from '@angular/core';
+import { Component, computed, input, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AbstractControl } from '@angular/forms';
 
@@ -42,6 +42,7 @@ const DEFAULT_MESSAGES: Record<string, (err: unknown) => string> = {
       <span class="form-error" role="alert">{{ msg }}</span>
     }
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './form-error.component.scss',
 })
 export class FormErrorComponent {

--- a/frontend/src/app/shared/components/form/form-field/form-field.component.ts
+++ b/frontend/src/app/shared/components/form/form-field/form-field.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, input } from '@angular/core';
+import { Component, input, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AbstractControl } from '@angular/forms';
 import { FormErrorComponent } from '../form-error/form-error.component';
@@ -14,6 +14,7 @@ import { FormErrorComponent } from '../form-error/form-error.component';
   standalone: true,
   imports: [CommonModule, FormErrorComponent],
   templateUrl: './form-field.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './form-field.component.scss',
 })
 export class FormFieldComponent {

--- a/frontend/src/app/shared/components/form/label-help/label-help.component.ts
+++ b/frontend/src/app/shared/components/form/label-help/label-help.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, input } from '@angular/core';
+import { Component, input, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 @Component({
@@ -23,6 +23,7 @@ import { CommonModule } from '@angular/common';
       <span class="material-symbols-outlined">help</span>
     </a>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './label-help.component.scss',
 })
 export class LabelHelpComponent {

--- a/frontend/src/app/shared/components/form/message-banner/message-banner.component.ts
+++ b/frontend/src/app/shared/components/form/message-banner/message-banner.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, computed, input } from '@angular/core';
+import { Component, computed, input, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 export type MessageBannerType = 'error' | 'success' | 'info' | 'warning';
@@ -21,6 +21,7 @@ const DEFAULT_ICONS: Record<MessageBannerType, string> = {
   standalone: true,
   imports: [CommonModule],
   templateUrl: './message-banner.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './message-banner.component.scss',
 })
 export class MessageBannerComponent {

--- a/frontend/src/app/shared/components/form/password-input/password-input.component.ts
+++ b/frontend/src/app/shared/components/form/password-input/password-input.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, input, signal } from '@angular/core';
+import { Component, input, signal, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
@@ -13,6 +13,7 @@ import { FormControl, ReactiveFormsModule } from '@angular/forms';
   standalone: true,
   imports: [CommonModule, ReactiveFormsModule],
   templateUrl: './password-input.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './password-input.component.scss',
 })
 export class PasswordInputComponent {

--- a/frontend/src/app/shared/components/header/header.component.ts
+++ b/frontend/src/app/shared/components/header/header.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, inject } from '@angular/core';
+import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { AuthService } from '@core/services/auth.service';
@@ -15,6 +15,7 @@ import { ConfigService } from '@core/services/config.service';
   standalone: true,
   imports: [CommonModule, RouterModule],
   templateUrl: './header.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './header.component.scss',
 })
 export class HeaderComponent {

--- a/frontend/src/app/shared/components/layout/page-layout/page-layout.component.ts
+++ b/frontend/src/app/shared/components/layout/page-layout/page-layout.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, input } from '@angular/core';
+import { Component, input, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 @Component({
@@ -12,6 +12,7 @@ import { CommonModule } from '@angular/common';
   standalone: true,
   imports: [CommonModule],
   templateUrl: './page-layout.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './page-layout.component.scss',
 })
 export class PageLayoutComponent {

--- a/frontend/src/app/shared/components/layout/settings-section/settings-section.component.ts
+++ b/frontend/src/app/shared/components/layout/settings-section/settings-section.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, input } from '@angular/core';
+import { Component, input, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 @Component({
@@ -12,6 +12,7 @@ import { CommonModule } from '@angular/common';
   standalone: true,
   imports: [CommonModule],
   templateUrl: './settings-section.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './settings-section.component.scss',
 })
 export class SettingsSectionComponent {

--- a/frontend/src/app/shared/components/loading-spinner/loading-spinner.component.ts
+++ b/frontend/src/app/shared/components/loading-spinner/loading-spinner.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, input } from '@angular/core';
+import { Component, input, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 @Component({
@@ -12,6 +12,7 @@ import { CommonModule } from '@angular/common';
   standalone: true,
   imports: [CommonModule],
   templateUrl: './loading-spinner.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './loading-spinner.component.scss',
 })
 export class LoadingSpinnerComponent {

--- a/frontend/src/app/shared/components/metric-chart/metric-chart.component.ts
+++ b/frontend/src/app/shared/components/metric-chart/metric-chart.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, ElementRef, OnDestroy, afterNextRender, booleanAttribute, effect, input, numberAttribute, viewChild } from '@angular/core';
+import { Component, ElementRef, OnDestroy, afterNextRender, booleanAttribute, effect, input, numberAttribute, viewChild, ChangeDetectionStrategy } from '@angular/core';
 import * as echarts from 'echarts/core';
 import { BarChart, HeatmapChart, LineChart, RadarChart } from 'echarts/charts';
 import { GridComponent, LegendComponent, RadarComponent, TooltipComponent, VisualMapComponent } from 'echarts/components';
@@ -37,6 +37,7 @@ echarts.use([
       <div #host class="metric-chart__plot" [style.height.px]="height()"></div>
     </div>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
   styles: [
     `
       .metric-chart {

--- a/frontend/src/app/shared/components/stat-card/stat-card.component.ts
+++ b/frontend/src/app/shared/components/stat-card/stat-card.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, input } from '@angular/core';
+import { Component, input, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 @Component({
@@ -12,6 +12,7 @@ import { CommonModule } from '@angular/common';
   standalone: true,
   imports: [CommonModule],
   templateUrl: './stat-card.component.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './stat-card.component.scss',
 })
 export class StatCardComponent {

--- a/frontend/src/app/shared/ui/autocomplete.component.html
+++ b/frontend/src/app/shared/ui/autocomplete.component.html
@@ -1,0 +1,31 @@
+<input
+  type="text"
+  class="gr-input gr-autocomplete__input"
+  role="combobox"
+  aria-autocomplete="list"
+  cdkOverlayOrigin
+  #trigger="cdkOverlayOrigin"
+  [id]="inputId()"
+  [value]="value()"
+  [placeholder]="placeholder()"
+  [disabled]="isDisabled()"
+  [attr.aria-expanded]="open()"
+  (input)="onInput($event)"
+  (keyup.enter)="onEnter()"
+  (blur)="onTouched()"
+/>
+
+<ng-template
+  cdkConnectedOverlay
+  [cdkConnectedOverlayOrigin]="trigger"
+  [cdkConnectedOverlayOpen]="open() && suggestions().length > 0"
+  [cdkConnectedOverlayWidth]="panelWidth() || 0"
+  (overlayOutsideClick)="close()"
+  (detach)="close()"
+>
+  <ul class="gr-autocomplete__panel" role="listbox">
+    @for (suggestion of suggestions(); track suggestion) {
+      <li role="option" class="gr-autocomplete__option" (click)="pick(suggestion)">{{ suggestion }}</li>
+    }
+  </ul>
+</ng-template>

--- a/frontend/src/app/shared/ui/autocomplete.component.scss
+++ b/frontend/src/app/shared/ui/autocomplete.component.scss
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+@use '../../styles/variables' as *;
+
+:host { display: block; }
+
+.gr-autocomplete__input { width: 100%; }
+
+.gr-autocomplete__panel {
+  max-height: 16rem;
+  margin: 0;
+  padding: $spacing-xs 0;
+  list-style: none;
+  overflow-y: auto;
+  background: $color-quaternary;
+  border: 1px solid $color-border;
+  border-radius: $border-radius-sm;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.4);
+}
+
+.gr-autocomplete__option {
+  padding: 0.45rem 0.7rem;
+  color: $text-primary;
+  font-size: $font-size-sm;
+  cursor: pointer;
+
+  &:hover { background: $color-hover; }
+}

--- a/frontend/src/app/shared/ui/autocomplete.component.spec.ts
+++ b/frontend/src/app/shared/ui/autocomplete.component.spec.ts
@@ -1,0 +1,92 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Component, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { TestBed } from '@angular/core/testing';
+import { AutoCompleteComponent } from './autocomplete.component';
+
+@Component({
+  standalone: true,
+  imports: [AutoCompleteComponent, FormsModule],
+  template: `
+    <gr-autocomplete
+      inputId="cache-name"
+      placeholder="e.g. my-cache"
+      [suggestions]="suggestions()"
+      (completeMethod)="queries.set(queries().concat($event.query))"
+      (enter)="entered.set(entered() + 1)"
+      [ngModel]="name()"
+      (ngModelChange)="name.set($event)"
+    ></gr-autocomplete>
+  `,
+})
+class HostComponent {
+  suggestions = signal<string[]>([]);
+  queries = signal<string[]>([]);
+  entered = signal(0);
+  name = signal('');
+}
+
+async function render() {
+  TestBed.configureTestingModule({ imports: [HostComponent] });
+  const fixture = TestBed.createComponent(HostComponent);
+  fixture.detectChanges();
+  await fixture.whenStable();
+  fixture.detectChanges();
+  const input = () => fixture.nativeElement.querySelector('input') as HTMLInputElement;
+  const type = (text: string) => {
+    input().value = text;
+    input().dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+  };
+  return { fixture, input, type };
+}
+
+const options = () => Array.from(document.querySelectorAll('.gr-autocomplete__option')) as HTMLElement[];
+
+describe('AutoCompleteComponent', () => {
+  it('asks the caller to complete on every keystroke', async () => {
+    const { fixture, type } = await render();
+    type('my');
+    expect(fixture.componentInstance.queries()).toEqual(['my']);
+  });
+
+  it('writes the typed text back as the model value', async () => {
+    const { fixture, type } = await render();
+    type('my-cache');
+    await fixture.whenStable();
+    expect(fixture.componentInstance.name()).toBe('my-cache');
+  });
+
+  it('shows suggestions only once there are any', async () => {
+    const { fixture, type } = await render();
+    type('my');
+    expect(options()).toHaveLength(0);
+    fixture.componentInstance.suggestions.set(['my-cache', 'my-other']);
+    fixture.detectChanges();
+    expect(options().map((o) => o.textContent!.trim())).toEqual(['my-cache', 'my-other']);
+  });
+
+  it('picks a suggestion into the model and closes the panel', async () => {
+    const { fixture, type, input } = await render();
+    fixture.componentInstance.suggestions.set(['my-cache']);
+    type('my');
+    options()[0].click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(fixture.componentInstance.name()).toBe('my-cache');
+    expect(input().value).toBe('my-cache');
+    expect(options()).toHaveLength(0);
+  });
+
+  it('emits enter for callers that submit from the field', async () => {
+    const { fixture, input } = await render();
+    input().dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter' }));
+    fixture.detectChanges();
+    expect(fixture.componentInstance.entered()).toBe(1);
+  });
+});

--- a/frontend/src/app/shared/ui/autocomplete.component.ts
+++ b/frontend/src/app/shared/ui/autocomplete.component.ts
@@ -1,0 +1,89 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { CdkConnectedOverlay, CdkOverlayOrigin } from '@angular/cdk/overlay';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import {
+  Component,
+  ElementRef,
+  booleanAttribute,
+  computed,
+  forwardRef,
+  inject,
+  input,
+  output,
+  signal,
+} from '@angular/core';
+
+@Component({
+  selector: 'gr-autocomplete',
+  standalone: true,
+  imports: [CdkConnectedOverlay, CdkOverlayOrigin],
+  templateUrl: './autocomplete.component.html',
+  styleUrl: './autocomplete.component.scss',
+  providers: [
+    { provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => AutoCompleteComponent), multi: true },
+  ],
+})
+export class AutoCompleteComponent implements ControlValueAccessor {
+  suggestions = input<readonly string[]>([]);
+  placeholder = input('');
+  inputId = input('');
+  forceSelection = input(false, { transform: booleanAttribute });
+
+  completeMethod = output<{ query: string }>();
+  enter = output<void>();
+
+  protected open = signal(false);
+  protected value = signal('');
+  protected isDisabled = signal(false);
+
+  private host = inject(ElementRef<HTMLElement>);
+  private onChange: (value: string) => void = () => {};
+  protected onTouched: () => void = () => {};
+
+  protected panelWidth = computed(() => this.open() && this.host.nativeElement.offsetWidth);
+
+  writeValue(value: string): void {
+    this.value.set(value ?? '');
+  }
+
+  registerOnChange(fn: (value: string) => void): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(disabled: boolean): void {
+    this.isDisabled.set(disabled);
+  }
+
+  protected onInput(event: Event): void {
+    const query = (event.target as HTMLInputElement).value;
+    this.value.set(query);
+    if (!this.forceSelection()) this.onChange(query);
+    this.completeMethod.emit({ query });
+    this.open.set(true);
+  }
+
+  protected pick(suggestion: string): void {
+    this.value.set(suggestion);
+    this.onChange(suggestion);
+    this.open.set(false);
+  }
+
+  protected close(): void {
+    this.open.set(false);
+    this.onTouched();
+  }
+
+  protected onEnter(): void {
+    this.open.set(false);
+    this.enter.emit();
+  }
+}

--- a/frontend/src/app/shared/ui/autocomplete.component.ts
+++ b/frontend/src/app/shared/ui/autocomplete.component.ts
@@ -16,6 +16,7 @@ import {
   input,
   output,
   signal,
+  ChangeDetectionStrategy
 } from '@angular/core';
 
 @Component({
@@ -24,6 +25,7 @@ import {
   imports: [CdkConnectedOverlay, CdkOverlayOrigin],
   templateUrl: './autocomplete.component.html',
   styleUrl: './autocomplete.component.scss',
+  changeDetection: ChangeDetectionStrategy.Eager,
   providers: [
     { provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => AutoCompleteComponent), multi: true },
   ],

--- a/frontend/src/app/shared/ui/button.component.scss
+++ b/frontend/src/app/shared/ui/button.component.scss
@@ -1,0 +1,119 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+@use '../../styles/variables' as *;
+
+:host {
+  --gr-btn-bg: #{$color-info};
+  --gr-btn-bg-hover: #1391a5;
+  --gr-btn-fg: #{$color-white};
+  --gr-btn-accent: #{$color-info};
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: $spacing-sm;
+  padding: 0.5rem 0.9rem;
+  border: 1px solid var(--gr-btn-bg);
+  border-radius: $border-radius-sm;
+  background: var(--gr-btn-bg);
+  color: var(--gr-btn-fg);
+  font-family: $font-family-base;
+  font-size: $font-size-sm;
+  font-weight: 500;
+  line-height: 1.2;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background-color $transition-fast, border-color $transition-fast, color $transition-fast;
+}
+
+:host(:hover:not(:disabled)) {
+  background: var(--gr-btn-bg-hover);
+  border-color: var(--gr-btn-bg-hover);
+}
+
+:host(:focus-visible) {
+  outline: 2px solid var(--gr-btn-accent);
+  outline-offset: 2px;
+}
+
+:host(:disabled),
+:host(.gr-button--loading) {
+  opacity: 0.6;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+:host(.gr-button--secondary) {
+  --gr-btn-bg: #{$color-tertiary};
+  --gr-btn-bg-hover: #{$color-hover};
+  --gr-btn-fg: #{$text-primary};
+  --gr-btn-accent: #{$text-primary};
+  border-color: $color-border;
+}
+
+:host(.gr-button--success) {
+  --gr-btn-bg: #{$color-success};
+  --gr-btn-bg-hover: #23913d;
+  --gr-btn-accent: #{$color-success};
+}
+
+:host(.gr-button--warn) {
+  --gr-btn-bg: #{$color-warning};
+  --gr-btn-bg-hover: #e6ac06;
+  --gr-btn-fg: #{$color-black};
+  --gr-btn-accent: #{$color-warning};
+}
+
+:host(.gr-button--danger) {
+  --gr-btn-bg: #{$color-danger};
+  --gr-btn-bg-hover: #bd2130;
+  --gr-btn-accent: #{$color-danger};
+}
+
+:host(.gr-button--small) {
+  padding: 0.35rem 0.65rem;
+  font-size: $font-size-xs;
+}
+
+:host(.gr-button--rounded) { border-radius: 999px; }
+:host(.gr-button--icon-only) { padding: 0.45rem; }
+
+:host(.gr-button--text),
+:host(.gr-button--outlined) {
+  background: none;
+  color: var(--gr-btn-accent);
+}
+
+:host(.gr-button--text) { border-color: transparent; }
+:host(.gr-button--outlined) { border-color: var(--gr-btn-accent); }
+
+:host(.gr-button--text:hover:not(:disabled)),
+:host(.gr-button--outlined:hover:not(:disabled)) {
+  background: $color-hover;
+  border-color: var(--gr-btn-accent);
+}
+
+:host(.gr-button--text:hover:not(:disabled)) { border-color: transparent; }
+
+.gr-button__icon {
+  font-family: $font-family-icons;
+  font-size: 1.15em;
+  line-height: 1;
+}
+
+.gr-button__spinner {
+  width: 1em;
+  height: 1em;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: gr-button-spin 0.7s linear infinite;
+}
+
+@keyframes gr-button-spin {
+  to { transform: rotate(360deg); }
+}

--- a/frontend/src/app/shared/ui/button.component.spec.ts
+++ b/frontend/src/app/shared/ui/button.component.spec.ts
@@ -1,0 +1,121 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { ButtonComponent, ButtonSeverity } from './button.component';
+
+@Component({
+  standalone: true,
+  imports: [ButtonComponent],
+  template: `
+    <button
+      grButton
+      [label]="label()"
+      [icon]="icon()"
+      [iconPos]="iconPos()"
+      [severity]="severity()"
+      [loading]="loading()"
+      [disabled]="disabled()"
+      [size]="size()"
+    >{{ projected() }}</button>
+  `,
+})
+class HostComponent {
+  label = signal('Save');
+  icon = signal('');
+  iconPos = signal<'left' | 'right'>('left');
+  severity = signal<ButtonSeverity>('primary');
+  loading = signal(false);
+  disabled = signal(false);
+  size = signal<'small' | 'normal'>('normal');
+  projected = signal('');
+}
+
+function render() {
+  TestBed.configureTestingModule({ imports: [HostComponent] });
+  const fixture = TestBed.createComponent(HostComponent);
+  fixture.detectChanges();
+  return { fixture, btn: () => fixture.nativeElement.querySelector('button') as HTMLButtonElement };
+}
+
+describe('ButtonComponent', () => {
+  it('renders the label', () => {
+    const { btn } = render();
+    expect(btn().textContent).toContain('Save');
+  });
+
+  it('carries the severity class and defaults to primary', () => {
+    const { fixture, btn } = render();
+    expect(btn().classList).toContain('gr-button--primary');
+    fixture.componentInstance.severity.set('danger');
+    fixture.detectChanges();
+    expect(btn().classList).toContain('gr-button--danger');
+    expect(btn().classList).not.toContain('gr-button--primary');
+  });
+
+  it('leaves the native disabled property to the caller', () => {
+    const { fixture, btn } = render();
+    expect(btn().disabled).toBe(false);
+    fixture.componentInstance.disabled.set(true);
+    fixture.detectChanges();
+    expect(btn().disabled).toBe(true);
+  });
+
+  it('renders an icon as a material symbol before the label', () => {
+    const { fixture, btn } = render();
+    fixture.componentInstance.icon.set('add');
+    fixture.detectChanges();
+    const icon = btn().querySelector('.gr-button__icon')!;
+    expect(icon.textContent).toBe('add');
+    expect(icon.classList).toContain('material-symbols-outlined');
+    expect(icon.compareDocumentPosition(btn().querySelector('.gr-button__label')!))
+      .toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it('puts the icon after the label when iconPos is right', () => {
+    const { fixture, btn } = render();
+    fixture.componentInstance.icon.set('arrow_forward');
+    fixture.componentInstance.iconPos.set('right');
+    fixture.detectChanges();
+    expect(btn().querySelector('.gr-button__icon')!.compareDocumentPosition(btn().querySelector('.gr-button__label')!))
+      .toBe(Node.DOCUMENT_POSITION_PRECEDING);
+  });
+
+  it('swaps the icon for a spinner and marks itself busy while loading', () => {
+    const { fixture, btn } = render();
+    fixture.componentInstance.icon.set('add');
+    fixture.componentInstance.loading.set(true);
+    fixture.detectChanges();
+    expect(btn().querySelector('.gr-button__spinner')).toBeTruthy();
+    expect(btn().querySelector('.gr-button__icon')).toBeNull();
+    expect(btn().getAttribute('aria-busy')).toBe('true');
+  });
+
+  it('marks itself icon-only when there is an icon but no label', () => {
+    const { fixture, btn } = render();
+    fixture.componentInstance.icon.set('delete');
+    fixture.componentInstance.label.set('');
+    fixture.detectChanges();
+    expect(btn().classList).toContain('gr-button--icon-only');
+  });
+
+  it('projects content for callers that do not use label', () => {
+    const { fixture, btn } = render();
+    fixture.componentInstance.label.set('');
+    fixture.componentInstance.projected.set('Projected');
+    fixture.detectChanges();
+    expect(btn().textContent).toContain('Projected');
+  });
+
+  it('applies the small size class only when asked', () => {
+    const { fixture, btn } = render();
+    expect(btn().classList).not.toContain('gr-button--small');
+    fixture.componentInstance.size.set('small');
+    fixture.detectChanges();
+    expect(btn().classList).toContain('gr-button--small');
+  });
+});

--- a/frontend/src/app/shared/ui/button.component.ts
+++ b/frontend/src/app/shared/ui/button.component.ts
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Component, booleanAttribute, computed, input } from '@angular/core';
+
+export type ButtonSeverity = 'primary' | 'secondary' | 'success' | 'info' | 'warn' | 'danger';
+
+/// Attribute component on a native <button>/<a>, so callers keep native
+/// `disabled`, `type` and `routerLink` bindings and nothing here fights them.
+@Component({
+  selector: 'button[grButton], a[grButton]',
+  standalone: true,
+  template: `
+    @if (loading()) {
+      <span class="gr-button__spinner" aria-hidden="true"></span>
+    } @else if (icon() && iconPos() === 'left') {
+      <span class="gr-button__icon material-symbols-outlined" aria-hidden="true">{{ icon() }}</span>
+    }
+    @if (label()) {
+      <span class="gr-button__label">{{ label() }}</span>
+    }
+    <ng-content />
+    @if (!loading() && icon() && iconPos() === 'right') {
+      <span class="gr-button__icon material-symbols-outlined" aria-hidden="true">{{ icon() }}</span>
+    }
+  `,
+  host: {
+    class: 'gr-button',
+    '[class]': 'severityClass()',
+    '[class.gr-button--small]': 'size() === "small"',
+    '[class.gr-button--text]': 'text()',
+    '[class.gr-button--outlined]': 'outlined()',
+    '[class.gr-button--rounded]': 'rounded()',
+    '[class.gr-button--icon-only]': '!label() && !!icon()',
+    '[class.gr-button--loading]': 'loading()',
+    '[attr.aria-busy]': 'loading() ? "true" : null',
+  },
+  styleUrl: './button.component.scss',
+})
+export class ButtonComponent {
+  label = input('');
+  icon = input('');
+  iconPos = input<'left' | 'right'>('left');
+  severity = input<ButtonSeverity>('primary');
+  size = input<'small' | 'normal'>('normal');
+  loading = input(false, { transform: booleanAttribute });
+  text = input(false, { transform: booleanAttribute });
+  outlined = input(false, { transform: booleanAttribute });
+  rounded = input(false, { transform: booleanAttribute });
+
+  protected severityClass = computed(() => `gr-button--${this.severity() || 'primary'}`);
+}

--- a/frontend/src/app/shared/ui/button.component.ts
+++ b/frontend/src/app/shared/ui/button.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, booleanAttribute, computed, input } from '@angular/core';
+import { Component, booleanAttribute, computed, input, ChangeDetectionStrategy } from '@angular/core';
 
 export type ButtonSeverity = 'primary' | 'secondary' | 'success' | 'info' | 'warn' | 'danger';
 
@@ -38,6 +38,7 @@ export type ButtonSeverity = 'primary' | 'secondary' | 'success' | 'info' | 'war
     '[class.gr-button--loading]': 'loading()',
     '[attr.aria-busy]': 'loading() ? "true" : null',
   },
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './button.component.scss',
 })
 export class ButtonComponent {

--- a/frontend/src/app/shared/ui/checkbox.component.scss
+++ b/frontend/src/app/shared/ui/checkbox.component.scss
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+@use '../../styles/variables' as *;
+
+:host {
+  display: inline-flex;
+  align-items: center;
+}
+
+.gr-checkbox__input {
+  width: 1.05rem;
+  height: 1.05rem;
+  margin: 0;
+  accent-color: $color-info;
+  cursor: pointer;
+
+  &:disabled { cursor: not-allowed; opacity: 0.5; }
+  &:focus-visible { outline: 2px solid $color-info; outline-offset: 2px; }
+}

--- a/frontend/src/app/shared/ui/checkbox.component.spec.ts
+++ b/frontend/src/app/shared/ui/checkbox.component.spec.ts
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Component, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { TestBed } from '@angular/core/testing';
+import { CheckboxComponent } from './checkbox.component';
+
+@Component({
+  standalone: true,
+  imports: [CheckboxComponent, FormsModule],
+  template: `
+    <gr-checkbox
+      inputId="accept"
+      [binary]="true"
+      [ngModel]="accepted()"
+      (ngModelChange)="accepted.set($event)"
+      [disabled]="disabled()"
+    ></gr-checkbox>
+  `,
+})
+class HostComponent {
+  accepted = signal(false);
+  disabled = signal(false);
+}
+
+async function render() {
+  TestBed.configureTestingModule({ imports: [HostComponent] });
+  const fixture = TestBed.createComponent(HostComponent);
+  fixture.detectChanges();
+  await fixture.whenStable();
+  fixture.detectChanges();
+  const input = () => fixture.nativeElement.querySelector('input') as HTMLInputElement;
+  return { fixture, input };
+}
+
+describe('CheckboxComponent', () => {
+  it('renders a native checkbox carrying the given id', async () => {
+    const { input } = await render();
+    expect(input().type).toBe('checkbox');
+    expect(input().id).toBe('accept');
+  });
+
+  it('reflects the model value', async () => {
+    const { fixture, input } = await render();
+    expect(input().checked).toBe(false);
+    fixture.componentInstance.accepted.set(true);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(input().checked).toBe(true);
+  });
+
+  it('writes the new value back on toggle', async () => {
+    const { fixture, input } = await render();
+    input().click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(fixture.componentInstance.accepted()).toBe(true);
+  });
+
+  it('honours a disabled state pushed in through the form API', async () => {
+    const { fixture, input } = await render();
+    fixture.componentInstance.disabled.set(true);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(input().disabled).toBe(true);
+  });
+});

--- a/frontend/src/app/shared/ui/checkbox.component.ts
+++ b/frontend/src/app/shared/ui/checkbox.component.ts
@@ -5,7 +5,7 @@
  */
 
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
-import { Component, booleanAttribute, forwardRef, input, signal } from '@angular/core';
+import { Component, booleanAttribute, forwardRef, input, signal, ChangeDetectionStrategy } from '@angular/core';
 
 @Component({
   selector: 'gr-checkbox',
@@ -22,6 +22,7 @@ import { Component, booleanAttribute, forwardRef, input, signal } from '@angular
     />
   `,
   styleUrl: './checkbox.component.scss',
+  changeDetection: ChangeDetectionStrategy.Eager,
   providers: [
     { provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => CheckboxComponent), multi: true },
   ],

--- a/frontend/src/app/shared/ui/checkbox.component.ts
+++ b/frontend/src/app/shared/ui/checkbox.component.ts
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
+import { Component, booleanAttribute, forwardRef, input, signal } from '@angular/core';
+
+@Component({
+  selector: 'gr-checkbox',
+  standalone: true,
+  template: `
+    <input
+      type="checkbox"
+      class="gr-checkbox__input"
+      [id]="inputId()"
+      [checked]="checked()"
+      [disabled]="isDisabled()"
+      (change)="onToggle($event)"
+      (blur)="onTouched()"
+    />
+  `,
+  styleUrl: './checkbox.component.scss',
+  providers: [
+    { provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => CheckboxComponent), multi: true },
+  ],
+})
+export class CheckboxComponent implements ControlValueAccessor {
+  inputId = input('');
+  binary = input(true, { transform: booleanAttribute });
+
+  protected checked = signal(false);
+  protected isDisabled = signal(false);
+  private onChange: (value: boolean) => void = () => {};
+  protected onTouched: () => void = () => {};
+
+  writeValue(value: boolean): void {
+    this.checked.set(!!value);
+  }
+
+  registerOnChange(fn: (value: boolean) => void): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(disabled: boolean): void {
+    this.isDisabled.set(disabled);
+  }
+
+  protected onToggle(event: Event): void {
+    const next = (event.target as HTMLInputElement).checked;
+    this.checked.set(next);
+    this.onChange(next);
+  }
+}

--- a/frontend/src/app/shared/ui/confirm-dialog.component.spec.ts
+++ b/frontend/src/app/shared/ui/confirm-dialog.component.spec.ts
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { ConfirmDialogComponent } from './confirm-dialog.component';
+import { ConfirmationService } from './confirmation.service';
+
+function render() {
+  TestBed.configureTestingModule({ imports: [ConfirmDialogComponent], providers: [ConfirmationService] });
+  const fixture = TestBed.createComponent(ConfirmDialogComponent);
+  fixture.detectChanges();
+  return { fixture, service: TestBed.inject(ConfirmationService) };
+}
+
+const panel = () => document.querySelector('.gr-dialog');
+const footerButtons = () =>
+  Array.from(document.querySelectorAll('.gr-dialog__footer button')) as HTMLButtonElement[];
+
+describe('ConfirmDialogComponent', () => {
+  it('stays closed until something is confirmed', () => {
+    render();
+    expect(panel()).toBeNull();
+  });
+
+  it('shows the header, message and button labels from the request', () => {
+    const { fixture, service } = render();
+    service.confirm({
+      message: 'Are you sure you want to delete this item?',
+      header: 'Confirm Delete',
+      acceptButtonProps: { label: 'Delete', severity: 'danger' },
+      rejectButtonProps: { label: 'Cancel', severity: 'secondary' },
+    });
+    fixture.detectChanges();
+    expect(panel()!.textContent).toContain('Confirm Delete');
+    expect(panel()!.textContent).toContain('Are you sure you want to delete this item?');
+    expect(footerButtons().map((b) => b.textContent!.trim())).toEqual(['Cancel', 'Delete']);
+  });
+
+  it('runs accept and closes', () => {
+    const { fixture, service } = render();
+    let accepted = 0;
+    service.confirm({ message: 'sure?', accept: () => accepted++ });
+    fixture.detectChanges();
+    footerButtons()[1].click();
+    fixture.detectChanges();
+    expect(accepted).toBe(1);
+    expect(panel()).toBeNull();
+  });
+
+  it('runs reject and closes', () => {
+    const { fixture, service } = render();
+    let rejected = 0;
+    service.confirm({ message: 'sure?', reject: () => rejected++ });
+    fixture.detectChanges();
+    footerButtons()[0].click();
+    fixture.detectChanges();
+    expect(rejected).toBe(1);
+    expect(panel()).toBeNull();
+  });
+
+  it('falls back to default labels', () => {
+    const { fixture, service } = render();
+    service.confirm({ message: 'sure?' });
+    fixture.detectChanges();
+    expect(footerButtons().map((b) => b.textContent!.trim())).toEqual(['Cancel', 'Yes']);
+  });
+});

--- a/frontend/src/app/shared/ui/confirm-dialog.component.ts
+++ b/frontend/src/app/shared/ui/confirm-dialog.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, computed, inject } from '@angular/core';
+import { Component, computed, inject, ChangeDetectionStrategy } from '@angular/core';
 import { ButtonComponent } from './button.component';
 import { ConfirmationService } from './confirmation.service';
 import { DialogComponent } from './dialog.component';
@@ -42,6 +42,7 @@ import { DialogComponent } from './dialog.component';
       </div>
     </gr-dialog>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
   styles: [
     `
       .gr-confirm { display: flex; align-items: flex-start; gap: 0.75rem; }

--- a/frontend/src/app/shared/ui/confirm-dialog.component.ts
+++ b/frontend/src/app/shared/ui/confirm-dialog.component.ts
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Component, computed, inject } from '@angular/core';
+import { ButtonComponent } from './button.component';
+import { ConfirmationService } from './confirmation.service';
+import { DialogComponent } from './dialog.component';
+
+@Component({
+  selector: 'gr-confirm-dialog',
+  standalone: true,
+  imports: [ButtonComponent, DialogComponent],
+  template: `
+    <gr-dialog
+      [visible]="!!pending()"
+      (visibleChange)="$event || confirmations.reject()"
+      [header]="pending()?.header ?? 'Confirm'"
+      width="420px"
+    >
+      <div class="gr-confirm">
+        @if (pending()?.icon) {
+          <span class="material-symbols-outlined gr-confirm__icon" aria-hidden="true">{{ pending()?.icon }}</span>
+        }
+        <p class="gr-confirm__message">{{ pending()?.message }}</p>
+      </div>
+      <div grDialogFooter>
+        <button
+          grButton
+          [label]="rejectProps().label ?? 'Cancel'"
+          [severity]="rejectProps().severity ?? 'secondary'"
+          (click)="confirmations.reject()"
+        ></button>
+        <button
+          grButton
+          [label]="acceptProps().label ?? 'Yes'"
+          [severity]="acceptProps().severity ?? 'primary'"
+          (click)="confirmations.accept()"
+        ></button>
+      </div>
+    </gr-dialog>
+  `,
+  styles: [
+    `
+      .gr-confirm { display: flex; align-items: flex-start; gap: 0.75rem; }
+      .gr-confirm__icon { color: #ffc107; font-size: 24px; }
+      .gr-confirm__message { margin: 0; }
+    `,
+  ],
+})
+export class ConfirmDialogComponent {
+  protected confirmations = inject(ConfirmationService);
+  protected pending = this.confirmations.pending;
+  protected acceptProps = computed(() => this.pending()?.acceptButtonProps ?? {});
+  protected rejectProps = computed(() => this.pending()?.rejectButtonProps ?? {});
+}

--- a/frontend/src/app/shared/ui/confirmation.service.ts
+++ b/frontend/src/app/shared/ui/confirmation.service.ts
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Injectable, signal } from '@angular/core';
+import { ButtonSeverity } from './button.component';
+
+export interface ConfirmButton {
+  label?: string;
+  severity?: ButtonSeverity;
+}
+
+export interface Confirmation {
+  message?: string;
+  header?: string;
+  icon?: string;
+  acceptButtonProps?: ConfirmButton;
+  rejectButtonProps?: ConfirmButton;
+  accept?: () => void;
+  reject?: () => void;
+}
+
+@Injectable()
+export class ConfirmationService {
+  private current = signal<Confirmation | null>(null);
+  readonly pending = this.current.asReadonly();
+
+  confirm(confirmation: Confirmation): void {
+    this.current.set(confirmation);
+  }
+
+  accept(): void {
+    const c = this.current();
+    this.current.set(null);
+    c?.accept?.();
+  }
+
+  reject(): void {
+    const c = this.current();
+    this.current.set(null);
+    c?.reject?.();
+  }
+}

--- a/frontend/src/app/shared/ui/dialog.component.scss
+++ b/frontend/src/app/shared/ui/dialog.component.scss
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+@use '../../styles/variables' as *;
+
+.gr-dialog {
+  display: flex;
+  flex-direction: column;
+  max-width: calc(100vw - #{$spacing-xl});
+  max-height: calc(100vh - #{$spacing-xl});
+  background: $color-tertiary;
+  border: 1px solid $color-border;
+  border-radius: $border-radius-md;
+  color: $text-primary;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+}
+
+.gr-dialog__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $spacing-md;
+  padding: $spacing-md;
+  background: $color-quaternary;
+  border-bottom: 1px solid $color-border;
+  border-radius: $border-radius-md $border-radius-md 0 0;
+}
+
+.gr-dialog__title {
+  margin: 0;
+  font-size: $font-size-md;
+  font-weight: 600;
+}
+
+.gr-dialog__close {
+  display: inline-flex;
+  padding: $spacing-xs;
+  background: none;
+  border: 0;
+  border-radius: $border-radius-sm;
+  color: $text-secondary;
+  cursor: pointer;
+
+  &:hover { background: $color-hover; color: $text-primary; }
+
+  .material-symbols-outlined { font-size: 20px; }
+}
+
+.gr-dialog__content {
+  flex: 1;
+  padding: $spacing-md;
+  overflow-y: auto;
+}
+
+.gr-dialog__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: $spacing-sm;
+  padding: $spacing-md;
+  border-top: 1px solid $color-border;
+
+  &:empty { display: none; }
+}

--- a/frontend/src/app/shared/ui/dialog.component.spec.ts
+++ b/frontend/src/app/shared/ui/dialog.component.spec.ts
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { DialogComponent } from './dialog.component';
+
+@Component({
+  standalone: true,
+  imports: [DialogComponent],
+  template: `
+    <gr-dialog
+      [(visible)]="open"
+      [header]="header()"
+      [closable]="closable()"
+      width="500px"
+      (hide)="hidden.set(hidden() + 1)"
+    >
+      <p class="body">Are you sure?</p>
+      <div grDialogFooter><button class="confirm">Delete</button></div>
+    </gr-dialog>
+  `,
+})
+class HostComponent {
+  open = signal(false);
+  header = signal('Delete project');
+  closable = signal(true);
+  hidden = signal(0);
+}
+
+function render() {
+  TestBed.configureTestingModule({ imports: [HostComponent] });
+  const fixture = TestBed.createComponent(HostComponent);
+  fixture.detectChanges();
+  return fixture;
+}
+
+const panel = () => document.querySelector('.gr-dialog');
+
+describe('DialogComponent', () => {
+  it('stays out of the DOM until it is made visible', () => {
+    const fixture = render();
+    expect(panel()).toBeNull();
+    fixture.componentInstance.open.set(true);
+    fixture.detectChanges();
+    expect(panel()).toBeTruthy();
+  });
+
+  it('renders the header, the body and the footer slot', () => {
+    const fixture = render();
+    fixture.componentInstance.open.set(true);
+    fixture.detectChanges();
+    expect(panel()!.querySelector('.gr-dialog__title')!.textContent).toContain('Delete project');
+    expect(panel()!.querySelector('.body')!.textContent).toContain('Are you sure?');
+    expect(panel()!.querySelector('.gr-dialog__footer .confirm')).toBeTruthy();
+  });
+
+  it('re-projects its content when reopened', () => {
+    const fixture = render();
+    for (const _ of [0, 1]) {
+      fixture.componentInstance.open.set(true);
+      fixture.detectChanges();
+      expect(panel()!.querySelector('.body')!.textContent).toContain('Are you sure?');
+      expect(panel()!.querySelector('.gr-dialog__footer .confirm')).toBeTruthy();
+      fixture.componentInstance.open.set(false);
+      fixture.detectChanges();
+    }
+  });
+
+  it('closes and reports back through the two-way binding', () => {
+    const fixture = render();
+    fixture.componentInstance.open.set(true);
+    fixture.detectChanges();
+    (panel()!.querySelector('.gr-dialog__close') as HTMLButtonElement).click();
+    fixture.detectChanges();
+    expect(fixture.componentInstance.open()).toBe(false);
+    expect(panel()).toBeNull();
+  });
+
+  it('emits hide when it closes', () => {
+    const fixture = render();
+    fixture.componentInstance.open.set(true);
+    fixture.detectChanges();
+    fixture.componentInstance.open.set(false);
+    fixture.detectChanges();
+    expect(fixture.componentInstance.hidden()).toBe(1);
+  });
+
+  it('hides the close button when it is not closable', () => {
+    const fixture = render();
+    fixture.componentInstance.closable.set(false);
+    fixture.componentInstance.open.set(true);
+    fixture.detectChanges();
+    expect(panel()!.querySelector('.gr-dialog__close')).toBeNull();
+  });
+
+  it('applies the requested width and marks itself a modal dialog', () => {
+    const fixture = render();
+    fixture.componentInstance.open.set(true);
+    fixture.detectChanges();
+    expect((panel() as HTMLElement).style.width).toBe('500px');
+    expect(panel()!.getAttribute('role')).toBe('dialog');
+    expect(panel()!.getAttribute('aria-modal')).toBe('true');
+  });
+});

--- a/frontend/src/app/shared/ui/dialog.component.ts
+++ b/frontend/src/app/shared/ui/dialog.component.ts
@@ -1,0 +1,101 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { CdkTrapFocus } from '@angular/cdk/a11y';
+import { ESCAPE } from '@angular/cdk/keycodes';
+import { Overlay, OverlayRef } from '@angular/cdk/overlay';
+import { TemplatePortal } from '@angular/cdk/portal';
+import {
+  Component,
+  OnDestroy,
+  ViewContainerRef,
+  booleanAttribute,
+  effect,
+  inject,
+  input,
+  model,
+  output,
+  viewChild,
+} from '@angular/core';
+import { TemplateRef } from '@angular/core';
+
+/// Modal dialog on the CDK overlay. Escape closes it, the backdrop does not,
+/// matching what every call site relied on before.
+@Component({
+  selector: 'gr-dialog',
+  standalone: true,
+  imports: [CdkTrapFocus],
+  template: `
+    <ng-template #panel>
+      <div
+        class="gr-dialog"
+        role="dialog"
+        aria-modal="true"
+        [attr.aria-label]="header()"
+        [style.width]="width()"
+        cdkTrapFocus
+        [cdkTrapFocusAutoCapture]="true"
+      >
+        <div class="gr-dialog__header">
+          <h2 class="gr-dialog__title">{{ header() }}</h2>
+          @if (closable()) {
+            <button type="button" class="gr-dialog__close" aria-label="Close" (click)="close()">
+              <span class="material-symbols-outlined" aria-hidden="true">close</span>
+            </button>
+          }
+        </div>
+        <div class="gr-dialog__content"><ng-content /></div>
+        <div class="gr-dialog__footer"><ng-content select="[grDialogFooter]" /></div>
+      </div>
+    </ng-template>
+  `,
+  styleUrl: './dialog.component.scss',
+})
+export class DialogComponent implements OnDestroy {
+  visible = model(false);
+  header = input('');
+  width = input('420px');
+  closable = input(true, { transform: booleanAttribute });
+  hide = output<void>();
+
+  private panel = viewChild.required<TemplateRef<unknown>>('panel');
+  private overlay = inject(Overlay);
+  private vcr = inject(ViewContainerRef);
+  private ref?: OverlayRef;
+
+  constructor() {
+    effect(() => (this.visible() ? this.open() : this.detach()));
+  }
+
+  ngOnDestroy(): void {
+    this.ref?.dispose();
+  }
+
+  close(): void {
+    this.visible.set(false);
+  }
+
+  private open(): void {
+    if (this.ref?.hasAttached()) return;
+    this.ref ??= this.overlay.create({
+      hasBackdrop: true,
+      backdropClass: 'gr-dialog-backdrop',
+      panelClass: 'gr-dialog-panel',
+      scrollStrategy: this.overlay.scrollStrategies.block(),
+      positionStrategy: this.overlay.position().global().centerHorizontally().centerVertically(),
+    });
+    this.ref.keydownEvents().subscribe((e) => {
+      if (e.keyCode === ESCAPE && this.closable()) this.close();
+    });
+    this.ref.attach(new TemplatePortal(this.panel(), this.vcr));
+  }
+
+  private detach(): void {
+    if (!this.ref?.hasAttached()) return;
+    this.ref.detach();
+    this.hide.emit();
+  }
+}

--- a/frontend/src/app/shared/ui/dialog.component.ts
+++ b/frontend/src/app/shared/ui/dialog.component.ts
@@ -19,6 +19,7 @@ import {
   model,
   output,
   viewChild,
+  ChangeDetectionStrategy
 } from '@angular/core';
 import { TemplateRef } from '@angular/core';
 
@@ -52,6 +53,7 @@ import { TemplateRef } from '@angular/core';
       </div>
     </ng-template>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './dialog.component.scss',
 })
 export class DialogComponent implements OnDestroy {

--- a/frontend/src/app/shared/ui/divider.component.ts
+++ b/frontend/src/app/shared/ui/divider.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, input } from '@angular/core';
+import { Component, input, ChangeDetectionStrategy } from '@angular/core';
 
 @Component({
   selector: 'gr-divider',
@@ -15,6 +15,7 @@ import { Component, input } from '@angular/core';
     '[attr.aria-orientation]': 'orientation()',
     '[class.gr-divider--vertical]': 'orientation() === "vertical"',
   },
+  changeDetection: ChangeDetectionStrategy.Eager,
   styles: [
     `
       :host {

--- a/frontend/src/app/shared/ui/divider.component.ts
+++ b/frontend/src/app/shared/ui/divider.component.ts
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Component, input } from '@angular/core';
+
+@Component({
+  selector: 'gr-divider',
+  standalone: true,
+  template: '',
+  host: {
+    role: 'separator',
+    '[attr.aria-orientation]': 'orientation()',
+    '[class.gr-divider--vertical]': 'orientation() === "vertical"',
+  },
+  styles: [
+    `
+      :host {
+        display: block;
+        margin: 1rem 0;
+        border-top: 1px solid #2d333b;
+      }
+      :host(.gr-divider--vertical) {
+        display: inline-block;
+        align-self: stretch;
+        margin: 0 1rem;
+        border-top: 0;
+        border-left: 1px solid #2d333b;
+      }
+    `,
+  ],
+})
+export class DividerComponent {
+  orientation = input<'horizontal' | 'vertical'>('horizontal');
+}

--- a/frontend/src/app/shared/ui/index.ts
+++ b/frontend/src/app/shared/ui/index.ts
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export * from './types';
+export * from './button.component';
+export * from './input.directive';
+export * from './divider.component';
+export * from './dialog.component';
+export * from './checkbox.component';
+export * from './select.component';
+export * from './select-button.component';
+export * from './autocomplete.component';
+export * from './menu.component';
+export * from './popover.component';
+export * from './tooltip.directive';
+export * from './toast.component';
+export * from './message.service';
+export * from './confirm-dialog.component';
+export * from './confirmation.service';

--- a/frontend/src/app/shared/ui/input.directive.ts
+++ b/frontend/src/app/shared/ui/input.directive.ts
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Directive } from '@angular/core';
+
+/// Styling hook only: the element stays a native input/textarea/select so
+/// ngModel, formControlName and appManagedDisable keep working untouched.
+@Directive({
+  selector: 'input[grInput], textarea[grInput], select[grInput]',
+  standalone: true,
+  host: { class: 'gr-input' },
+})
+export class InputDirective {}

--- a/frontend/src/app/shared/ui/menu.component.scss
+++ b/frontend/src/app/shared/ui/menu.component.scss
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+@use '../../styles/variables' as *;
+
+.gr-menu {
+  min-width: 11rem;
+  margin: 0;
+  padding: $spacing-xs 0;
+  list-style: none;
+  background: $color-quaternary;
+  border: 1px solid $color-border;
+  border-radius: $border-radius-sm;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.4);
+}
+
+.gr-menu__separator {
+  height: 1px;
+  margin: $spacing-xs 0;
+  background: $color-border;
+}
+
+.gr-menu__item {
+  display: flex;
+  align-items: center;
+  gap: $spacing-sm;
+  width: 100%;
+  padding: 0.45rem 0.7rem;
+  background: none;
+  border: 0;
+  color: $text-primary;
+  font-family: $font-family-base;
+  font-size: $font-size-sm;
+  text-align: left;
+  cursor: pointer;
+
+  &:hover:not(:disabled) { background: $color-hover; }
+  &:disabled { opacity: 0.5; cursor: not-allowed; }
+}
+
+.gr-menu__icon { font-size: 18px; color: $text-secondary; }

--- a/frontend/src/app/shared/ui/menu.component.spec.ts
+++ b/frontend/src/app/shared/ui/menu.component.spec.ts
@@ -1,0 +1,75 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Component, signal, viewChild } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { MenuComponent } from './menu.component';
+import { MenuItem } from './types';
+
+@Component({
+  standalone: true,
+  imports: [MenuComponent],
+  template: `
+    <button class="anchor" (click)="menu().toggle($event)">Actions</button>
+    <gr-menu [model]="model()"></gr-menu>
+  `,
+})
+class HostComponent {
+  menu = viewChild.required(MenuComponent);
+  ran = signal(0);
+  model = signal<MenuItem[]>([
+    { label: 'Edit', icon: 'edit', command: () => this.ran.set(this.ran() + 1) },
+    { separator: true },
+    { label: 'Delete', icon: 'delete', disabled: true },
+  ]);
+}
+
+function render() {
+  TestBed.configureTestingModule({ imports: [HostComponent] });
+  const fixture = TestBed.createComponent(HostComponent);
+  fixture.detectChanges();
+  const anchor = () => fixture.nativeElement.querySelector('.anchor') as HTMLButtonElement;
+  return { fixture, anchor };
+}
+
+const items = () => Array.from(document.querySelectorAll('.gr-menu__item')) as HTMLButtonElement[];
+
+describe('MenuComponent', () => {
+  it('opens on toggle and closes on a second toggle', () => {
+    const { fixture, anchor } = render();
+    expect(items()).toHaveLength(0);
+    anchor().click();
+    fixture.detectChanges();
+    expect(items().map((i) => i.querySelector('span:last-child')!.textContent)).toEqual(['Edit', 'Delete']);
+    anchor().click();
+    fixture.detectChanges();
+    expect(items()).toHaveLength(0);
+  });
+
+  it('renders separators as their own role', () => {
+    const { fixture, anchor } = render();
+    anchor().click();
+    fixture.detectChanges();
+    expect(document.querySelectorAll('.gr-menu__separator')).toHaveLength(1);
+  });
+
+  it('runs the item command and closes', () => {
+    const { fixture, anchor } = render();
+    anchor().click();
+    fixture.detectChanges();
+    items()[0].click();
+    fixture.detectChanges();
+    expect(fixture.componentInstance.ran()).toBe(1);
+    expect(items()).toHaveLength(0);
+  });
+
+  it('disables the items that ask for it', () => {
+    const { fixture, anchor } = render();
+    anchor().click();
+    fixture.detectChanges();
+    expect(items()[1].disabled).toBe(true);
+  });
+});

--- a/frontend/src/app/shared/ui/menu.component.ts
+++ b/frontend/src/app/shared/ui/menu.component.ts
@@ -15,6 +15,7 @@ import {
   inject,
   input,
   viewChild,
+  ChangeDetectionStrategy
 } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { MenuItem } from './types';
@@ -64,6 +65,7 @@ import { MenuItem } from './types';
       </ul>
     </ng-template>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './menu.component.scss',
 })
 export class MenuComponent implements OnDestroy {

--- a/frontend/src/app/shared/ui/menu.component.ts
+++ b/frontend/src/app/shared/ui/menu.component.ts
@@ -1,0 +1,114 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { ESCAPE } from '@angular/cdk/keycodes';
+import { Overlay, OverlayRef } from '@angular/cdk/overlay';
+import { TemplatePortal } from '@angular/cdk/portal';
+import {
+  Component,
+  OnDestroy,
+  TemplateRef,
+  ViewContainerRef,
+  inject,
+  input,
+  viewChild,
+} from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { MenuItem } from './types';
+
+@Component({
+  selector: 'gr-menu',
+  standalone: true,
+  imports: [RouterLink],
+  template: `
+    <ng-template #panel>
+      <ul class="gr-menu" role="menu">
+        @for (item of model(); track $index) {
+          @if (item.separator) {
+            <li class="gr-menu__separator" role="separator"></li>
+          } @else {
+            <li role="none">
+              @if (item.routerLink && !item.disabled) {
+                <a
+                  role="menuitem"
+                  class="gr-menu__item"
+                  [routerLink]="item.routerLink"
+                  [queryParams]="item.queryParams ?? null"
+                  (click)="run(item)"
+                >
+                  @if (item.icon) {
+                    <span class="material-symbols-outlined gr-menu__icon" aria-hidden="true">{{ item.icon }}</span>
+                  }
+                  <span>{{ item.label }}</span>
+                </a>
+              } @else {
+                <button
+                  type="button"
+                  role="menuitem"
+                  class="gr-menu__item"
+                  [disabled]="item.disabled"
+                  (click)="run(item)"
+                >
+                  @if (item.icon) {
+                    <span class="material-symbols-outlined gr-menu__icon" aria-hidden="true">{{ item.icon }}</span>
+                  }
+                  <span>{{ item.label }}</span>
+                </button>
+              }
+            </li>
+          }
+        }
+      </ul>
+    </ng-template>
+  `,
+  styleUrl: './menu.component.scss',
+})
+export class MenuComponent implements OnDestroy {
+  model = input<readonly MenuItem[]>([]);
+
+  private panel = viewChild.required<TemplateRef<unknown>>('panel');
+  private overlay = inject(Overlay);
+  private vcr = inject(ViewContainerRef);
+  private ref?: OverlayRef;
+
+  ngOnDestroy(): void {
+    this.ref?.dispose();
+  }
+
+  toggle(event: Event): void {
+    if (this.ref?.hasAttached()) return this.hide();
+    this.show((event.currentTarget ?? event.target) as HTMLElement);
+  }
+
+  show(origin: HTMLElement): void {
+    this.hide();
+    this.ref = this.overlay.create({
+      hasBackdrop: true,
+      backdropClass: 'cdk-overlay-transparent-backdrop',
+      scrollStrategy: this.overlay.scrollStrategies.reposition(),
+      positionStrategy: this.overlay
+        .position()
+        .flexibleConnectedTo(origin)
+        .withPositions([
+          { originX: 'end', originY: 'bottom', overlayX: 'end', overlayY: 'top', offsetY: 4 },
+          { originX: 'end', originY: 'top', overlayX: 'end', overlayY: 'bottom', offsetY: -4 },
+        ]),
+    });
+    this.ref.backdropClick().subscribe(() => this.hide());
+    this.ref.keydownEvents().subscribe((e) => e.keyCode === ESCAPE && this.hide());
+    this.ref.attach(new TemplatePortal(this.panel(), this.vcr));
+  }
+
+  hide(): void {
+    this.ref?.dispose();
+    this.ref = undefined;
+  }
+
+  protected run(item: MenuItem): void {
+    this.hide();
+    item.command?.();
+  }
+}

--- a/frontend/src/app/shared/ui/message.service.ts
+++ b/frontend/src/app/shared/ui/message.service.ts
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Injectable, signal } from '@angular/core';
+import { Message } from './types';
+
+export interface ToastMessage extends Message {
+  id: number;
+}
+
+const DEFAULT_LIFE = 3000;
+
+@Injectable()
+export class MessageService {
+  private next = 0;
+  private queue = signal<ToastMessage[]>([]);
+  readonly messages = this.queue.asReadonly();
+
+  add(message: Message): void {
+    const entry: ToastMessage = { severity: 'info', ...message, id: this.next++ };
+    this.queue.update((all) => [...all, entry]);
+    const life = message.life ?? DEFAULT_LIFE;
+    if (life > 0) setTimeout(() => this.remove(entry.id), life);
+  }
+
+  remove(id: number): void {
+    this.queue.update((all) => all.filter((m) => m.id !== id));
+  }
+
+  clear(): void {
+    this.queue.set([]);
+  }
+}

--- a/frontend/src/app/shared/ui/popover.component.scss
+++ b/frontend/src/app/shared/ui/popover.component.scss
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+@use '../../styles/variables' as *;
+
+.gr-popover {
+  max-width: 22rem;
+  padding: $spacing-md;
+  background: $color-quaternary;
+  border: 1px solid $color-border;
+  border-radius: $border-radius-md;
+  color: $text-primary;
+  font-size: $font-size-sm;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.4);
+}

--- a/frontend/src/app/shared/ui/popover.component.spec.ts
+++ b/frontend/src/app/shared/ui/popover.component.spec.ts
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Component, viewChild } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { PopoverComponent } from './popover.component';
+
+@Component({
+  standalone: true,
+  imports: [PopoverComponent],
+  template: `
+    <button class="anchor" (click)="pop().toggle($event)">Why?</button>
+    <gr-popover><p class="detail">Scoring rules</p></gr-popover>
+  `,
+})
+class HostComponent {
+  pop = viewChild.required(PopoverComponent);
+}
+
+function render() {
+  TestBed.configureTestingModule({ imports: [HostComponent] });
+  const fixture = TestBed.createComponent(HostComponent);
+  fixture.detectChanges();
+  return { fixture, anchor: () => fixture.nativeElement.querySelector('.anchor') as HTMLButtonElement };
+}
+
+const panel = () => document.querySelector('.gr-popover');
+
+describe('PopoverComponent', () => {
+  it('projects its content only once opened', () => {
+    const { fixture, anchor } = render();
+    expect(panel()).toBeNull();
+    anchor().click();
+    fixture.detectChanges();
+    expect(panel()!.querySelector('.detail')!.textContent).toContain('Scoring rules');
+  });
+
+  it('closes on a second toggle', () => {
+    const { fixture, anchor } = render();
+    anchor().click();
+    fixture.detectChanges();
+    anchor().click();
+    fixture.detectChanges();
+    expect(panel()).toBeNull();
+  });
+
+  it('re-projects its content when reopened', () => {
+    const { fixture, anchor } = render();
+    for (const _ of [0, 1]) {
+      anchor().click();
+      fixture.detectChanges();
+      expect(panel()!.querySelector('.detail')).toBeTruthy();
+      anchor().click();
+      fixture.detectChanges();
+    }
+  });
+
+  it('tears the overlay down with the host', () => {
+    const { fixture, anchor } = render();
+    anchor().click();
+    fixture.detectChanges();
+    fixture.destroy();
+    expect(panel()).toBeNull();
+  });
+});

--- a/frontend/src/app/shared/ui/popover.component.ts
+++ b/frontend/src/app/shared/ui/popover.component.ts
@@ -14,10 +14,11 @@ import {
   ViewContainerRef,
   inject,
   viewChild,
+  ChangeDetectionStrategy
 } from '@angular/core';
 
 /// Click-anchored overlay. Callers keep a template reference and call
-/// `toggle($event)`, the same shape the PrimeNG popover used.
+/// `toggle($event)` from the element the panel should hang off.
 @Component({
   selector: 'gr-popover',
   standalone: true,
@@ -26,6 +27,7 @@ import {
       <div class="gr-popover" role="dialog"><ng-content /></div>
     </ng-template>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './popover.component.scss',
 })
 export class PopoverComponent implements OnDestroy {

--- a/frontend/src/app/shared/ui/popover.component.ts
+++ b/frontend/src/app/shared/ui/popover.component.ts
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { ESCAPE } from '@angular/cdk/keycodes';
+import { Overlay, OverlayRef } from '@angular/cdk/overlay';
+import { TemplatePortal } from '@angular/cdk/portal';
+import {
+  Component,
+  OnDestroy,
+  TemplateRef,
+  ViewContainerRef,
+  inject,
+  viewChild,
+} from '@angular/core';
+
+/// Click-anchored overlay. Callers keep a template reference and call
+/// `toggle($event)`, the same shape the PrimeNG popover used.
+@Component({
+  selector: 'gr-popover',
+  standalone: true,
+  template: `
+    <ng-template #panel>
+      <div class="gr-popover" role="dialog"><ng-content /></div>
+    </ng-template>
+  `,
+  styleUrl: './popover.component.scss',
+})
+export class PopoverComponent implements OnDestroy {
+  private panel = viewChild.required<TemplateRef<unknown>>('panel');
+  private overlay = inject(Overlay);
+  private vcr = inject(ViewContainerRef);
+  private ref?: OverlayRef;
+
+  ngOnDestroy(): void {
+    this.ref?.dispose();
+  }
+
+  toggle(event: Event): void {
+    if (this.ref?.hasAttached()) return this.hide();
+    this.show((event.currentTarget ?? event.target) as HTMLElement);
+  }
+
+  show(origin: HTMLElement): void {
+    this.hide();
+    this.ref = this.overlay.create({
+      hasBackdrop: true,
+      backdropClass: 'cdk-overlay-transparent-backdrop',
+      scrollStrategy: this.overlay.scrollStrategies.reposition(),
+      positionStrategy: this.overlay
+        .position()
+        .flexibleConnectedTo(origin)
+        .withPositions([
+          { originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4 },
+          { originX: 'start', originY: 'top', overlayX: 'start', overlayY: 'bottom', offsetY: -4 },
+        ]),
+    });
+    this.ref.backdropClick().subscribe(() => this.hide());
+    this.ref.keydownEvents().subscribe((e) => e.keyCode === ESCAPE && this.hide());
+    this.ref.attach(new TemplatePortal(this.panel(), this.vcr));
+  }
+
+  hide(): void {
+    this.ref?.dispose();
+    this.ref = undefined;
+  }
+}

--- a/frontend/src/app/shared/ui/select-button.component.scss
+++ b/frontend/src/app/shared/ui/select-button.component.scss
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+@use '../../styles/variables' as *;
+
+.gr-select-button {
+  display: inline-flex;
+  border: 1px solid $color-border;
+  border-radius: $border-radius-sm;
+  overflow: hidden;
+}
+
+.gr-select-button__item {
+  padding: 0.4rem 0.8rem;
+  background: $color-quaternary;
+  border: 0;
+  border-right: 1px solid $color-border;
+  color: $text-secondary;
+  font-family: $font-family-base;
+  font-size: $font-size-sm;
+  cursor: pointer;
+
+  &:last-child { border-right: 0; }
+  &:hover:not(:disabled) { background: $color-hover; color: $text-primary; }
+  &:disabled { cursor: not-allowed; opacity: 0.5; }
+  &--selected { background: $color-info; color: $color-white; }
+}

--- a/frontend/src/app/shared/ui/select-button.component.spec.ts
+++ b/frontend/src/app/shared/ui/select-button.component.spec.ts
@@ -1,0 +1,78 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Component, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { TestBed } from '@angular/core/testing';
+import { SelectButtonComponent } from './select-button.component';
+
+@Component({
+  standalone: true,
+  imports: [SelectButtonComponent, FormsModule],
+  template: `
+    <gr-select-button
+      [options]="options"
+      optionLabel="label"
+      optionValue="value"
+      [allowEmpty]="allowEmpty()"
+      [ngModel]="scope()"
+      (ngModelChange)="scope.set($event)"
+    ></gr-select-button>
+  `,
+})
+class HostComponent {
+  options = [
+    { label: 'Mine', value: 'mine' },
+    { label: 'All', value: 'all' },
+  ];
+  scope = signal<string | null>('mine');
+  allowEmpty = signal(false);
+}
+
+async function render() {
+  TestBed.configureTestingModule({ imports: [HostComponent] });
+  const fixture = TestBed.createComponent(HostComponent);
+  fixture.detectChanges();
+  await fixture.whenStable();
+  fixture.detectChanges();
+  const items = () => Array.from(fixture.nativeElement.querySelectorAll('.gr-select-button__item')) as HTMLButtonElement[];
+  return { fixture, items };
+}
+
+describe('SelectButtonComponent', () => {
+  it('renders one radio per option and marks the selected one', async () => {
+    const { items } = await render();
+    expect(items().map((i) => i.textContent!.trim())).toEqual(['Mine', 'All']);
+    expect(items()[0].getAttribute('aria-checked')).toBe('true');
+    expect(items()[1].getAttribute('aria-checked')).toBe('false');
+  });
+
+  it('writes the picked option value back', async () => {
+    const { fixture, items } = await render();
+    items()[1].click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(fixture.componentInstance.scope()).toBe('all');
+  });
+
+  it('keeps the selection when re-clicked and empty is not allowed', async () => {
+    const { fixture, items } = await render();
+    items()[0].click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(fixture.componentInstance.scope()).toBe('mine');
+  });
+
+  it('clears the selection when re-clicked and empty is allowed', async () => {
+    const { fixture, items } = await render();
+    fixture.componentInstance.allowEmpty.set(true);
+    fixture.detectChanges();
+    items()[0].click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(fixture.componentInstance.scope()).toBeNull();
+  });
+});

--- a/frontend/src/app/shared/ui/select-button.component.ts
+++ b/frontend/src/app/shared/ui/select-button.component.ts
@@ -1,0 +1,85 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { Component, booleanAttribute, forwardRef, input, signal } from '@angular/core';
+
+@Component({
+  selector: 'gr-select-button',
+  standalone: true,
+  template: `
+    <div class="gr-select-button" role="radiogroup">
+      @for (option of options(); track $index) {
+        <button
+          type="button"
+          role="radio"
+          class="gr-select-button__item"
+          [class.gr-select-button__item--selected]="isSelected(option)"
+          [attr.aria-checked]="isSelected(option)"
+          [disabled]="isDisabled()"
+          (click)="pick(option)"
+        >
+          {{ labelOf(option) }}
+        </button>
+      }
+    </div>
+  `,
+  styleUrl: './select-button.component.scss',
+  providers: [
+    { provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => SelectButtonComponent), multi: true },
+  ],
+})
+export class SelectButtonComponent implements ControlValueAccessor {
+  options = input<readonly unknown[]>([]);
+  optionLabel = input('label');
+  optionValue = input('value');
+  allowEmpty = input(true, { transform: booleanAttribute });
+
+  protected value = signal<unknown>(null);
+  protected isDisabled = signal(false);
+  private onChange: (value: unknown) => void = () => {};
+  private onTouched: () => void = () => {};
+
+  writeValue(value: unknown): void {
+    this.value.set(value ?? null);
+  }
+
+  registerOnChange(fn: (value: unknown) => void): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(disabled: boolean): void {
+    this.isDisabled.set(disabled);
+  }
+
+  protected labelOf(option: unknown): string {
+    const key = this.optionLabel();
+    if (option && typeof option === 'object' && key) return String((option as never)[key] ?? '');
+    return String(option ?? '');
+  }
+
+  protected valueOf(option: unknown): unknown {
+    const key = this.optionValue();
+    if (option && typeof option === 'object' && key) return (option as never)[key];
+    return option;
+  }
+
+  protected isSelected(option: unknown): boolean {
+    return this.valueOf(option) === this.value();
+  }
+
+  protected pick(option: unknown): void {
+    const next = this.valueOf(option);
+    if (next === this.value() && !this.allowEmpty()) return;
+    this.value.set(next === this.value() && this.allowEmpty() ? null : next);
+    this.onChange(this.value());
+    this.onTouched();
+  }
+}

--- a/frontend/src/app/shared/ui/select-button.component.ts
+++ b/frontend/src/app/shared/ui/select-button.component.ts
@@ -5,7 +5,7 @@
  */
 
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { Component, booleanAttribute, forwardRef, input, signal } from '@angular/core';
+import { Component, booleanAttribute, forwardRef, input, signal, ChangeDetectionStrategy } from '@angular/core';
 
 @Component({
   selector: 'gr-select-button',
@@ -28,6 +28,7 @@ import { Component, booleanAttribute, forwardRef, input, signal } from '@angular
     </div>
   `,
   styleUrl: './select-button.component.scss',
+  changeDetection: ChangeDetectionStrategy.Eager,
   providers: [
     { provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => SelectButtonComponent), multi: true },
   ],

--- a/frontend/src/app/shared/ui/select.component.html
+++ b/frontend/src/app/shared/ui/select.component.html
@@ -1,0 +1,45 @@
+<button
+  type="button"
+  class="gr-select__trigger"
+  role="combobox"
+  aria-haspopup="listbox"
+  cdkOverlayOrigin
+  #trigger="cdkOverlayOrigin"
+  [id]="inputId()"
+  [disabled]="isDisabled()"
+  [attr.aria-expanded]="open()"
+  (click)="toggle()"
+  (keydown)="onKeydown($event)"
+  (blur)="onTouched()"
+>
+  <span class="gr-select__value" [class.gr-select__value--placeholder]="!selectedLabel()">
+    {{ selectedLabel() || placeholder() }}
+  </span>
+  <span class="material-symbols-outlined gr-select__arrow" aria-hidden="true">expand_more</span>
+</button>
+
+<ng-template
+  cdkConnectedOverlay
+  [cdkConnectedOverlayOrigin]="trigger"
+  [cdkConnectedOverlayOpen]="open()"
+  [cdkConnectedOverlayWidth]="triggerWidth() || 0"
+  (overlayOutsideClick)="close()"
+  (detach)="close()"
+>
+  <ul class="gr-select__panel" role="listbox">
+    @for (option of options(); track $index) {
+      <li
+        role="option"
+        class="gr-select__option"
+        [attr.aria-selected]="isSelected(option)"
+        [attr.aria-disabled]="isDisabledOption(option)"
+        [class.gr-select__option--selected]="isSelected(option)"
+        [class.gr-select__option--active]="$index === activeIndex()"
+        [class.gr-select__option--disabled]="isDisabledOption(option)"
+        (click)="pick(option)"
+      >
+        {{ labelOf(option) }}
+      </li>
+    }
+  </ul>
+</ng-template>

--- a/frontend/src/app/shared/ui/select.component.scss
+++ b/frontend/src/app/shared/ui/select.component.scss
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+@use '../../styles/variables' as *;
+
+:host { display: block; }
+
+.gr-select__trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $spacing-sm;
+  width: 100%;
+  padding: 0.5rem 0.7rem;
+  background: $color-quaternary;
+  border: 1px solid $color-border;
+  border-radius: $border-radius-sm;
+  color: $text-primary;
+  font-family: $font-family-base;
+  font-size: $font-size-sm;
+  text-align: left;
+  cursor: pointer;
+
+  &:focus-visible { outline: 2px solid $color-info; outline-offset: 2px; }
+  &:disabled { cursor: not-allowed; opacity: 0.5; }
+}
+
+.gr-select__value {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gr-select__value--placeholder { color: $text-light; }
+
+.gr-select__arrow { font-size: 20px; color: $text-secondary; }
+
+.gr-select__panel {
+  max-height: 16rem;
+  margin: 0;
+  padding: $spacing-xs 0;
+  list-style: none;
+  overflow-y: auto;
+  background: $color-quaternary;
+  border: 1px solid $color-border;
+  border-radius: $border-radius-sm;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.4);
+}
+
+.gr-select__option {
+  padding: 0.45rem 0.7rem;
+  color: $text-primary;
+  font-size: $font-size-sm;
+  cursor: pointer;
+
+  &:hover, &--active { background: $color-hover; }
+  &--selected { background: $color-hover; font-weight: 600; }
+  &--disabled { opacity: 0.5; cursor: not-allowed; }
+}

--- a/frontend/src/app/shared/ui/select.component.spec.ts
+++ b/frontend/src/app/shared/ui/select.component.spec.ts
@@ -1,0 +1,137 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Component, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { TestBed } from '@angular/core/testing';
+import { SelectComponent } from './select.component';
+
+@Component({
+  standalone: true,
+  imports: [SelectComponent, FormsModule],
+  template: `
+    <gr-select
+      inputId="pick"
+      [options]="options()"
+      optionLabel="label"
+      optionValue="value"
+      [optionDisabled]="'inactive'"
+      placeholder="Any project"
+      [ngModel]="chosen()"
+      (ngModelChange)="chosen.set($event)"
+      [disabled]="disabled()"
+    ></gr-select>
+  `,
+})
+class HostComponent {
+  options = signal([
+    { label: 'Alpha', value: 'a' },
+    { label: 'Beta', value: 'b' },
+    { label: 'Gone', value: 'c', inactive: true },
+  ]);
+  chosen = signal<string | null>(null);
+  disabled = signal(false);
+}
+
+async function render() {
+  TestBed.configureTestingModule({ imports: [HostComponent] });
+  const fixture = TestBed.createComponent(HostComponent);
+  fixture.detectChanges();
+  await fixture.whenStable();
+  fixture.detectChanges();
+  return fixture;
+}
+
+const trigger = (f: { nativeElement: HTMLElement }) =>
+  f.nativeElement.querySelector('.gr-select__trigger') as HTMLButtonElement;
+const optionEls = () => Array.from(document.querySelectorAll('.gr-select__option')) as HTMLElement[];
+
+describe('SelectComponent', () => {
+  it('shows the placeholder until something is chosen', async () => {
+    const fixture = await render();
+    expect(trigger(fixture).textContent).toContain('Any project');
+  });
+
+  it('opens a listbox of the options on click', async () => {
+    const fixture = await render();
+    expect(optionEls()).toHaveLength(0);
+    trigger(fixture).click();
+    fixture.detectChanges();
+    expect(optionEls().map((o) => o.textContent!.trim())).toEqual(['Alpha', 'Beta', 'Gone']);
+  });
+
+  it('writes the option value back through ngModel and closes', async () => {
+    const fixture = await render();
+    trigger(fixture).click();
+    fixture.detectChanges();
+    optionEls()[1].click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(fixture.componentInstance.chosen()).toBe('b');
+    expect(optionEls()).toHaveLength(0);
+    expect(trigger(fixture).textContent).toContain('Beta');
+  });
+
+  it('renders the label of a value pushed in from the model', async () => {
+    const fixture = await render();
+    fixture.componentInstance.chosen.set('a');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(trigger(fixture).textContent).toContain('Alpha');
+  });
+
+  it('ignores clicks on a disabled option', async () => {
+    const fixture = await render();
+    trigger(fixture).click();
+    fixture.detectChanges();
+    optionEls()[2].click();
+    fixture.detectChanges();
+    expect(fixture.componentInstance.chosen()).toBeNull();
+  });
+
+  it('does not open while disabled', async () => {
+    const fixture = await render();
+    fixture.componentInstance.disabled.set(true);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(trigger(fixture).disabled).toBe(true);
+    trigger(fixture).click();
+    fixture.detectChanges();
+    expect(optionEls()).toHaveLength(0);
+  });
+
+  it('closes on Escape', async () => {
+    const fixture = await render();
+    trigger(fixture).click();
+    fixture.detectChanges();
+    trigger(fixture).dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    fixture.detectChanges();
+    expect(optionEls()).toHaveLength(0);
+  });
+
+  it('selects the active option with the keyboard', async () => {
+    const fixture = await render();
+    trigger(fixture).dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    fixture.detectChanges();
+    trigger(fixture).dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    fixture.detectChanges();
+    trigger(fixture).dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(fixture.componentInstance.chosen()).toBe('b');
+  });
+
+  it('marks itself a combobox and tracks its expanded state', async () => {
+    const fixture = await render();
+    expect(trigger(fixture).getAttribute('role')).toBe('combobox');
+    expect(trigger(fixture).getAttribute('aria-expanded')).toBe('false');
+    trigger(fixture).click();
+    fixture.detectChanges();
+    expect(trigger(fixture).getAttribute('aria-expanded')).toBe('true');
+  });
+});

--- a/frontend/src/app/shared/ui/select.component.ts
+++ b/frontend/src/app/shared/ui/select.component.ts
@@ -14,16 +14,18 @@ import {
   inject,
   input,
   signal,
+  ChangeDetectionStrategy
 } from '@angular/core';
 
 /// Single-select dropdown on the CDK connected overlay. `optionLabel` and
-/// `optionValue` keep the PrimeNG-shaped option arrays the call sites already build.
+/// `optionValue` read plain `{ label, value }` option arrays straight from callers.
 @Component({
   selector: 'gr-select',
   standalone: true,
   imports: [CdkConnectedOverlay, CdkOverlayOrigin],
   templateUrl: './select.component.html',
   styleUrl: './select.component.scss',
+  changeDetection: ChangeDetectionStrategy.Eager,
   providers: [
     { provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => SelectComponent), multi: true },
   ],

--- a/frontend/src/app/shared/ui/select.component.ts
+++ b/frontend/src/app/shared/ui/select.component.ts
@@ -1,0 +1,130 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { CdkConnectedOverlay, CdkOverlayOrigin } from '@angular/cdk/overlay';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import {
+  Component,
+  ElementRef,
+  computed,
+  forwardRef,
+  inject,
+  input,
+  signal,
+} from '@angular/core';
+
+/// Single-select dropdown on the CDK connected overlay. `optionLabel` and
+/// `optionValue` keep the PrimeNG-shaped option arrays the call sites already build.
+@Component({
+  selector: 'gr-select',
+  standalone: true,
+  imports: [CdkConnectedOverlay, CdkOverlayOrigin],
+  templateUrl: './select.component.html',
+  styleUrl: './select.component.scss',
+  providers: [
+    { provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => SelectComponent), multi: true },
+  ],
+})
+export class SelectComponent implements ControlValueAccessor {
+  options = input<readonly unknown[]>([]);
+  optionLabel = input('label');
+  optionValue = input('value');
+  optionDisabled = input('');
+  placeholder = input('');
+  inputId = input('');
+
+  protected open = signal(false);
+  protected value = signal<unknown>(null);
+  protected isDisabled = signal(false);
+  protected activeIndex = signal(-1);
+
+  private host = inject(ElementRef<HTMLElement>);
+  private onChange: (value: unknown) => void = () => {};
+  protected onTouched: () => void = () => {};
+
+  protected triggerWidth = computed(() => this.open() && this.host.nativeElement.offsetWidth);
+
+  protected selectedLabel = computed(() => {
+    const match = this.options().find((o) => this.valueOf(o) === this.value());
+    return match === undefined ? '' : this.labelOf(match);
+  });
+
+  writeValue(value: unknown): void {
+    this.value.set(value ?? null);
+  }
+
+  registerOnChange(fn: (value: unknown) => void): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(disabled: boolean): void {
+    this.isDisabled.set(disabled);
+    if (disabled) this.open.set(false);
+  }
+
+  protected labelOf(option: unknown): string {
+    const key = this.optionLabel();
+    if (option && typeof option === 'object' && key) return String((option as never)[key] ?? '');
+    return String(option ?? '');
+  }
+
+  protected valueOf(option: unknown): unknown {
+    const key = this.optionValue();
+    if (option && typeof option === 'object' && key) return (option as never)[key];
+    return option;
+  }
+
+  protected isDisabledOption(option: unknown): boolean {
+    const key = this.optionDisabled();
+    return !!key && !!option && typeof option === 'object' && !!(option as never)[key];
+  }
+
+  protected isSelected(option: unknown): boolean {
+    return this.valueOf(option) === this.value();
+  }
+
+  protected toggle(): void {
+    if (this.isDisabled()) return;
+    this.open.update((o) => !o);
+    if (this.open()) this.activeIndex.set(Math.max(0, this.options().findIndex((o) => this.isSelected(o))));
+  }
+
+  protected close(): void {
+    this.open.set(false);
+    this.onTouched();
+  }
+
+  protected pick(option: unknown): void {
+    if (this.isDisabledOption(option)) return;
+    this.value.set(this.valueOf(option));
+    this.onChange(this.value());
+    this.close();
+  }
+
+  protected onKeydown(event: KeyboardEvent): void {
+    if (this.isDisabled()) return;
+    const items = this.options();
+    if (event.key === 'Escape') return this.close();
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      if (!this.open()) return this.toggle();
+      const step = event.key === 'ArrowDown' ? 1 : -1;
+      const next = Math.min(items.length - 1, Math.max(0, this.activeIndex() + step));
+      this.activeIndex.set(next);
+      return;
+    }
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      if (!this.open()) return this.toggle();
+      const active = items[this.activeIndex()];
+      if (active !== undefined) this.pick(active);
+    }
+  }
+}

--- a/frontend/src/app/shared/ui/toast.component.scss
+++ b/frontend/src/app/shared/ui/toast.component.scss
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+@use '../../styles/variables' as *;
+
+.gr-toast {
+  position: fixed;
+  top: $spacing-md;
+  right: $spacing-md;
+  z-index: $z-tooltip;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-sm;
+
+  &:empty { display: none; }
+}
+
+.gr-toast__item {
+  display: flex;
+  align-items: flex-start;
+  gap: $spacing-sm;
+  min-width: 18rem;
+  max-width: 26rem;
+  padding: $spacing-sm $spacing-md;
+  background: $color-quaternary;
+  border: 1px solid $color-border;
+  border-left: 3px solid $color-info;
+  border-radius: $border-radius-sm;
+  color: $text-primary;
+  font-size: $font-size-sm;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.4);
+
+  &--success { border-left-color: $color-success; }
+  &--warn { border-left-color: $color-warning; }
+  &--error { border-left-color: $color-danger; }
+
+  .material-symbols-outlined { font-size: 20px; }
+}
+
+.gr-toast__text {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 2px;
+
+  span { color: $text-secondary; }
+}
+
+.gr-toast__close {
+  padding: 0;
+  background: none;
+  border: 0;
+  color: $text-secondary;
+  cursor: pointer;
+
+  &:hover { color: $text-primary; }
+}

--- a/frontend/src/app/shared/ui/toast.component.spec.ts
+++ b/frontend/src/app/shared/ui/toast.component.spec.ts
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { MessageService } from './message.service';
+import { ToastComponent } from './toast.component';
+
+function render() {
+  TestBed.configureTestingModule({ imports: [ToastComponent], providers: [MessageService] });
+  const fixture = TestBed.createComponent(ToastComponent);
+  fixture.detectChanges();
+  const service = TestBed.inject(MessageService);
+  const items = () => Array.from(fixture.nativeElement.querySelectorAll('.gr-toast__item')) as HTMLElement[];
+  return { fixture, service, items };
+}
+
+describe('MessageService and ToastComponent', () => {
+  it('renders nothing until a message arrives', () => {
+    const { items } = render();
+    expect(items()).toHaveLength(0);
+  });
+
+  it('renders the summary and detail of a message', () => {
+    const { fixture, service, items } = render();
+    service.add({ severity: 'success', summary: 'Saved', detail: 'Worker updated.', life: 0 });
+    fixture.detectChanges();
+    expect(items()).toHaveLength(1);
+    expect(items()[0].textContent).toContain('Saved');
+    expect(items()[0].textContent).toContain('Worker updated.');
+  });
+
+  it('classes the item by severity and defaults to info', () => {
+    const { fixture, service, items } = render();
+    service.add({ severity: 'error', summary: 'Boom', life: 0 });
+    service.add({ summary: 'Plain', life: 0 });
+    fixture.detectChanges();
+    expect(items()[0].classList).toContain('gr-toast__item--error');
+    expect(items()[1].classList).toContain('gr-toast__item--info');
+  });
+
+  it('dismisses a message when its close button is used', () => {
+    const { fixture, service, items } = render();
+    service.add({ summary: 'Saved', life: 0 });
+    fixture.detectChanges();
+    (items()[0].querySelector('.gr-toast__close') as HTMLButtonElement).click();
+    fixture.detectChanges();
+    expect(items()).toHaveLength(0);
+  });
+
+  it('expires a message after its life elapses', async () => {
+    const { fixture, service, items } = render();
+    service.add({ summary: 'Transient', life: 10 });
+    fixture.detectChanges();
+    expect(items()).toHaveLength(1);
+    await new Promise((r) => setTimeout(r, 30));
+    fixture.detectChanges();
+    expect(items()).toHaveLength(0);
+  });
+
+  it('keeps a message with life 0 until dismissed', async () => {
+    const { fixture, service, items } = render();
+    service.add({ summary: 'Sticky', life: 0 });
+    fixture.detectChanges();
+    await new Promise((r) => setTimeout(r, 30));
+    fixture.detectChanges();
+    expect(items()).toHaveLength(1);
+  });
+});

--- a/frontend/src/app/shared/ui/toast.component.ts
+++ b/frontend/src/app/shared/ui/toast.component.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Component, inject } from '@angular/core';
+import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
 import { MessageService } from './message.service';
 import { MessageSeverity } from './types';
 
@@ -34,6 +34,7 @@ const ICONS: Record<MessageSeverity, string> = {
       }
     </div>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './toast.component.scss',
 })
 export class ToastComponent {

--- a/frontend/src/app/shared/ui/toast.component.ts
+++ b/frontend/src/app/shared/ui/toast.component.ts
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Component, inject } from '@angular/core';
+import { MessageService } from './message.service';
+import { MessageSeverity } from './types';
+
+const ICONS: Record<MessageSeverity, string> = {
+  success: 'check_circle',
+  info: 'info',
+  warn: 'warning',
+  error: 'error',
+};
+
+@Component({
+  selector: 'gr-toast',
+  standalone: true,
+  template: `
+    <div class="gr-toast" role="status" aria-live="polite">
+      @for (message of messages(); track message.id) {
+        <div class="gr-toast__item gr-toast__item--{{ message.severity }}">
+          <span class="material-symbols-outlined" aria-hidden="true">{{ iconFor(message.severity) }}</span>
+          <div class="gr-toast__text">
+            <strong>{{ message.summary }}</strong>
+            @if (message.detail) { <span>{{ message.detail }}</span> }
+          </div>
+          <button type="button" class="gr-toast__close" aria-label="Dismiss" (click)="messageService.remove(message.id)">
+            <span class="material-symbols-outlined" aria-hidden="true">close</span>
+          </button>
+        </div>
+      }
+    </div>
+  `,
+  styleUrl: './toast.component.scss',
+})
+export class ToastComponent {
+  protected messageService = inject(MessageService);
+  protected messages = this.messageService.messages;
+
+  protected iconFor(severity: MessageSeverity | undefined): string {
+    return ICONS[severity ?? 'info'];
+  }
+}

--- a/frontend/src/app/shared/ui/tooltip.directive.spec.ts
+++ b/frontend/src/app/shared/ui/tooltip.directive.spec.ts
@@ -1,0 +1,72 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { TooltipDirective } from './tooltip.directive';
+
+@Component({
+  standalone: true,
+  imports: [TooltipDirective],
+  template: `<button class="target" [grTooltip]="text()" tooltipPosition="bottom">Run</button>`,
+})
+class HostComponent {
+  text = signal('Re-run this evaluation');
+}
+
+function render() {
+  TestBed.configureTestingModule({ imports: [HostComponent] });
+  const fixture = TestBed.createComponent(HostComponent);
+  fixture.detectChanges();
+  return { fixture, target: () => fixture.nativeElement.querySelector('.target') as HTMLElement };
+}
+
+const tip = () => document.querySelector('.gr-tooltip');
+
+describe('TooltipDirective', () => {
+  it('shows the text on hover and hides it again on leave', () => {
+    const { fixture, target } = render();
+    expect(tip()).toBeNull();
+    target().dispatchEvent(new MouseEvent('mouseenter'));
+    fixture.detectChanges();
+    expect(tip()!.textContent).toContain('Re-run this evaluation');
+    target().dispatchEvent(new MouseEvent('mouseleave'));
+    fixture.detectChanges();
+    expect(tip()).toBeNull();
+  });
+
+  it('also opens on keyboard focus', () => {
+    const { fixture, target } = render();
+    target().dispatchEvent(new FocusEvent('focus'));
+    fixture.detectChanges();
+    expect(tip()).toBeTruthy();
+  });
+
+  it('stays away when there is no text', () => {
+    const { fixture, target } = render();
+    fixture.componentInstance.text.set('');
+    fixture.detectChanges();
+    target().dispatchEvent(new MouseEvent('mouseenter'));
+    fixture.detectChanges();
+    expect(tip()).toBeNull();
+  });
+
+  it('does not stack overlays when hover fires twice', () => {
+    const { fixture, target } = render();
+    target().dispatchEvent(new MouseEvent('mouseenter'));
+    target().dispatchEvent(new MouseEvent('mouseenter'));
+    fixture.detectChanges();
+    expect(document.querySelectorAll('.gr-tooltip')).toHaveLength(1);
+  });
+
+  it('is torn down with the host', () => {
+    const { fixture, target } = render();
+    target().dispatchEvent(new MouseEvent('mouseenter'));
+    fixture.detectChanges();
+    fixture.destroy();
+    expect(tip()).toBeNull();
+  });
+});

--- a/frontend/src/app/shared/ui/tooltip.directive.ts
+++ b/frontend/src/app/shared/ui/tooltip.directive.ts
@@ -11,7 +11,7 @@ import {
   OverlayRef,
 } from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
-import { Component, Directive, ElementRef, OnDestroy, inject, input } from '@angular/core';
+import { Component, Directive, ElementRef, OnDestroy, inject, input, ChangeDetectionStrategy } from '@angular/core';
 
 export type TooltipPosition = 'top' | 'bottom' | 'left' | 'right';
 
@@ -26,6 +26,7 @@ const POSITIONS: Record<TooltipPosition, ConnectedPosition> = {
   selector: 'gr-tooltip-panel',
   standalone: true,
   template: '<div class="gr-tooltip">{{ text }}</div>',
+  changeDetection: ChangeDetectionStrategy.Eager,
   styles: [
     `
       .gr-tooltip {

--- a/frontend/src/app/shared/ui/tooltip.directive.ts
+++ b/frontend/src/app/shared/ui/tooltip.directive.ts
@@ -1,0 +1,88 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import {
+  ConnectedPosition,
+  Overlay,
+  OverlayPositionBuilder,
+  OverlayRef,
+} from '@angular/cdk/overlay';
+import { ComponentPortal } from '@angular/cdk/portal';
+import { Component, Directive, ElementRef, OnDestroy, inject, input } from '@angular/core';
+
+export type TooltipPosition = 'top' | 'bottom' | 'left' | 'right';
+
+const POSITIONS: Record<TooltipPosition, ConnectedPosition> = {
+  top: { originX: 'center', originY: 'top', overlayX: 'center', overlayY: 'bottom', offsetY: -6 },
+  bottom: { originX: 'center', originY: 'bottom', overlayX: 'center', overlayY: 'top', offsetY: 6 },
+  left: { originX: 'start', originY: 'center', overlayX: 'end', overlayY: 'center', offsetX: -6 },
+  right: { originX: 'end', originY: 'center', overlayX: 'start', overlayY: 'center', offsetX: 6 },
+};
+
+@Component({
+  selector: 'gr-tooltip-panel',
+  standalone: true,
+  template: '<div class="gr-tooltip">{{ text }}</div>',
+  styles: [
+    `
+      .gr-tooltip {
+        max-width: 18rem;
+        padding: 0.35rem 0.55rem;
+        background: #050708;
+        border: 1px solid #2d333b;
+        border-radius: 5px;
+        color: #fff;
+        font-size: 0.75rem;
+        line-height: 1.3;
+      }
+    `,
+  ],
+})
+export class TooltipPanelComponent {
+  text = '';
+}
+
+@Directive({
+  selector: '[grTooltip]',
+  standalone: true,
+  host: {
+    '(mouseenter)': 'show()',
+    '(mouseleave)': 'hide()',
+    '(focus)': 'show()',
+    '(blur)': 'hide()',
+  },
+})
+export class TooltipDirective implements OnDestroy {
+  grTooltip = input('');
+  tooltipPosition = input<TooltipPosition>('top');
+
+  private overlay = inject(Overlay);
+  private positions = inject(OverlayPositionBuilder);
+  private host = inject(ElementRef<HTMLElement>);
+  private ref?: OverlayRef;
+
+  ngOnDestroy(): void {
+    this.hide();
+  }
+
+  show(): void {
+    if (!this.grTooltip() || this.ref) return;
+    this.ref = this.overlay.create({
+      positionStrategy: this.positions
+        .flexibleConnectedTo(this.host)
+        .withPositions([POSITIONS[this.tooltipPosition()], POSITIONS.bottom]),
+      scrollStrategy: this.overlay.scrollStrategies.close(),
+    });
+    const panel = this.ref.attach(new ComponentPortal(TooltipPanelComponent));
+    panel.instance.text = this.grTooltip();
+    panel.changeDetectorRef.detectChanges();
+  }
+
+  hide(): void {
+    this.ref?.dispose();
+    this.ref = undefined;
+  }
+}

--- a/frontend/src/app/shared/ui/types.ts
+++ b/frontend/src/app/shared/ui/types.ts
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export interface SelectOption {
+  [key: string]: unknown;
+}
+
+export interface MenuItem {
+  label?: string;
+  icon?: string;
+  disabled?: boolean;
+  separator?: boolean;
+  command?: () => void;
+  routerLink?: string | unknown[];
+  queryParams?: Record<string, unknown>;
+}
+
+export type MessageSeverity = 'success' | 'info' | 'warn' | 'error';
+
+export interface Message {
+  severity?: MessageSeverity;
+  summary?: string;
+  detail?: string;
+  life?: number;
+}

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -7,31 +7,7 @@
 @use 'app/styles/variables' as *;
 @use 'app/styles/grids';
 
-// PrimeNG Imports
-// Note: PrimeNG 21+ requires separate theme package installation
-// For now, using custom dark theme only
-// @import 'primeng/resources/primeng.min.css';
-@import 'primeicons/primeicons.css';
-
 // Fonts are loaded via <link> tags in index.html
-
-// PrimeNG Dark Theme Customization
-:root {
-  // Override PrimeNG CSS variables with Gradient's dark theme
-  --primary-color: #{$color-primary};
-  --surface-ground: #{$color-primary};
-  --surface-section: #{$color-tertiary};
-  --surface-card: #{$color-tertiary};
-  --surface-overlay: #{$color-quaternary};
-  --surface-border: #{$color-border};
-  --text-color: #{$text-primary};
-  --text-color-secondary: #{$text-secondary};
-  --content-padding: #{$spacing-md};
-  --inline-spacing: #{$spacing-sm};
-  --border-radius: #{$border-radius-md};
-  --surface-hover: #{$color-hover};
-  --focus-ring: 0 0 0 0.2rem rgba(255, 255, 255, 0.2);
-}
 
 // Global Styles
 html, body {
@@ -115,46 +91,33 @@ a {
   direction: ltr;
 }
 
-// PrimeNG Component Overrides
-.p-component {
-  font-family: $font-family-base;
-}
-
-// PrimeNG button loading spinner animation (theme CSS is not imported)
-.p-button-loading-icon {
-  animation: fa-spin 2s infinite linear;
-}
-
-.p-button {
-  background: $color-tertiary;
-  border: 1px solid $color-border;
-  color: $text-primary;
-
-  &:hover {
-    background: $color-hover;
-    border-color: $text-secondary;
-  }
-
-  &:disabled {
-    cursor: not-allowed;
-    opacity: 0.5;
-    pointer-events: none;
-  }
-}
-
-.p-inputtext {
+// Shared form-control styling for the gr-ui input directive
+.gr-input {
+  padding: 0.5rem 0.7rem;
   background: $color-quaternary;
   border: 1px solid $color-border;
+  border-radius: $border-radius-sm;
   color: $text-primary;
+  font-family: $font-family-base;
+  font-size: $font-size-sm;
 
   &:focus {
     border-color: $text-secondary;
+    outline: none;
   }
 
   &:disabled {
     cursor: not-allowed;
     opacity: 0.5;
   }
+}
+
+.gr-spin {
+  animation: gr-spin 1.2s linear infinite;
+}
+
+@keyframes gr-spin {
+  to { transform: rotate(360deg); }
 }
 
 input[type="radio"] {
@@ -173,43 +136,4 @@ select:disabled,
 textarea:disabled {
   cursor: not-allowed;
   opacity: 0.5;
-}
-
-.p-dialog {
-  background: $color-tertiary;
-  border: 1px solid $color-border;
-  color: $text-primary;
-
-  .p-dialog-header {
-    background: $color-quaternary;
-    border-bottom: 1px solid $color-border;
-  }
-
-  .p-dialog-content {
-    padding: $spacing-md;
-  }
-}
-
-.p-table {
-  background: $color-tertiary;
-  color: $text-primary;
-
-  .p-datatable-thead > tr > th {
-    background: $color-quaternary;
-    border: 1px solid $color-border;
-    color: $text-primary;
-  }
-
-  .p-datatable-tbody > tr {
-    background: $color-tertiary;
-    color: $text-primary;
-
-    &:hover {
-      background: $color-hover;
-    }
-
-    > td {
-      border: 1px solid $color-border;
-    }
-  }
 }

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -5,13 +5,12 @@
   "compilerOptions": {
     "outDir": "./out-tsc/app",
     "types": [],
-    "baseUrl": "./",
     "paths": {
-      "@app/*": ["src/app/*"],
-      "@core/*": ["src/app/core/*"],
-      "@shared/*": ["src/app/shared/*"],
-      "@features/*": ["src/app/features/*"],
-      "@environments/*": ["src/environments/*"]
+      "@app/*": ["./src/app/*"],
+      "@core/*": ["./src/app/core/*"],
+      "@shared/*": ["./src/app/shared/*"],
+      "@features/*": ["./src/app/features/*"],
+      "@environments/*": ["./src/environments/*"]
     }
   },
   "include": [
@@ -19,5 +18,12 @@
   ],
   "exclude": [
     "src/**/*.spec.ts"
-  ]
+  ],
+  "angularCompilerOptions": {
+    "extendedDiagnostics": {
+      "checks": {
+        "optionalChainNotNullable": "suppress"
+      }
+    }
+  }
 }

--- a/nix/packages/gradient-frontend.nix
+++ b/nix/packages/gradient-frontend.nix
@@ -22,7 +22,7 @@
   pnpmDeps = fetchPnpmDeps {
     inherit pnpm pname version src;
     fetcherVersion = 4;
-    hash = "sha256-DM7iK9mjaIEc08fMdAIg5l+LQ5glnRfkbgsSaK8E3nI=";
+    hash = "sha256-+HrqxlQBI7sxgvpe/IQUIZXDyz0ksQoiWM74yUkr9sY=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
PrimeNG v22 is closed source (compiled-only, no-reverse-engineering, licence key), so it cannot ship in an AGPL-3.0 bundle at any price, and v21 was the last MIT line, which pinned us to Angular 21. The ten components actually in use are now bespoke in `src/app/shared/ui/` on `@angular/cdk`, which unblocked Angular 22, TypeScript 6 and the rest of the dependency refresh.

Initial bundle drops 174kB (583 to 409), the shipped licence manifest is now only MIT / BSD-3-Clause / Apache-2.0 / 0BSD, and 62 new specs cover the layer.

Stacked on #574; retarget to main once that merges.