### PR TITLE
worker: fix: report a server abort as its own failure kind

### DIFF
--- a/backend/gradient-proto/src/messages/mod.rs
+++ b/backend/gradient-proto/src/messages/mod.rs
@@ -26,7 +26,9 @@ pub use wire::{decode_client_message, decode_server_message};
 /// v5: dropped `PresignedUpload`/`PresignedDownload` and `AssignJob.timeout_secs`.
 /// v7: `CacheQuery`/`CacheStatus`/`CacheError` carry a per-query `query_id`;
 ///     `NarUploaded` carries the path's content address (`ca`).
-pub const PROTO_VERSION: u16 = 7;
+/// v8: `BuildFailureKind::Aborted` distinguishes a server-ordered abort from a
+///     deterministic build failure.
+pub const PROTO_VERSION: u16 = 8;
 
 pub use gradient_types::constants::{NAR_ZSTD_LEVEL, PRESIGN_TTL};
 

--- a/backend/gradient-scheduler/src/build/lifecycle.rs
+++ b/backend/gradient-scheduler/src/build/lifecycle.rs
@@ -67,6 +67,10 @@ pub(crate) enum FailureOutcome {
     /// Penalty-free re-queue (substitute miss): back to `Queued` without
     /// bumping `attempt`. Escalation to a real build is decided at dispatch.
     Requeue,
+    /// The server ordered the job stopped. Terminal for this evaluation but not
+    /// a verdict on the derivation, so the anchor lands on the requeueable
+    /// `Aborted` rather than `FailedPermanent`.
+    Aborted,
 }
 
 /// Decide what to do with a failed build given its classification and how many
@@ -79,6 +83,7 @@ pub(crate) fn decide_failure_outcome(
     match kind {
         BuildFailureKind::Timeout => FailureOutcome::Timeout,
         BuildFailureKind::Permanent => FailureOutcome::Permanent,
+        BuildFailureKind::Aborted => FailureOutcome::Aborted,
         BuildFailureKind::SubstituteUnavailable => FailureOutcome::Requeue,
         // A missing input self-heals: its producer is re-queued and rebuilds, so
         // the build retries in-eval like a transient failure and succeeds once
@@ -113,7 +118,8 @@ pub(crate) fn terminal_success_status(outputs_already_valid: bool) -> BuildStatu
 }
 
 /// Best-effort mapping from the worker's failure classification to a stored
-/// `build_attempt.reason`. `Transient` has no single cause, so it stays `None`.
+/// `build_attempt.reason`. `Transient` has no single cause, so it stays `None`;
+/// an abort is not a failure of the derivation and carries no reason at all.
 fn attempt_reason(kind: BuildFailureKind) -> Option<AttemptFailureReason> {
     match kind {
         BuildFailureKind::SubstituteUnavailable => {
@@ -122,7 +128,21 @@ fn attempt_reason(kind: BuildFailureKind) -> Option<AttemptFailureReason> {
         BuildFailureKind::InputsUnavailable => Some(AttemptFailureReason::InputsUnavailable),
         BuildFailureKind::Permanent => Some(AttemptFailureReason::BuilderNonzero),
         BuildFailureKind::Timeout => Some(AttemptFailureReason::WallClockTimeout),
-        BuildFailureKind::Transient | BuildFailureKind::CorruptEvalCache => None,
+        BuildFailureKind::Transient
+        | BuildFailureKind::CorruptEvalCache
+        | BuildFailureKind::Aborted => None,
+    }
+}
+
+/// How the attempt row is closed out. An abort is recorded as `Aborted`, so the
+/// `deterministic_build_failure` predicate (`outcome = Failed AND reason =
+/// BuilderNonzero`) cannot match it: stamping a user abort as a reproducible
+/// builder exit excluded the anchor from `requeue_failed_anchors` forever, so no
+/// later evaluation could ever rebuild it (#572).
+fn attempt_outcome(kind: BuildFailureKind) -> AttemptOutcome {
+    match kind {
+        BuildFailureKind::Aborted => AttemptOutcome::Aborted,
+        _ => AttemptOutcome::Failed,
     }
 }
 
@@ -431,7 +451,7 @@ pub async fn handle_build_job_failed(
     if let Err(e) = fail_latest_attempt(
         &state.worker_db,
         derivation_build,
-        AttemptOutcome::Failed,
+        attempt_outcome(kind),
         attempt_reason(kind),
         Some(truncate_failure_message(error)),
     )
@@ -491,6 +511,15 @@ pub async fn handle_build_job_failed(
             update_derivation_build_status(&state.db(), anchor, BuildStatus::Queued).await;
             info!(%derivation_build, "substitute unavailable; re-queued for re-dispatch/escalation");
             return Ok(());
+        }
+        FailureOutcome::Aborted => {
+            // The eval-abort path has usually already parked the anchor here (a
+            // no-op re-transition); this covers the anchor the worker gave up on
+            // before that write landed. No dependency cascade: nothing about the
+            // derivation failed, and the abort already settled the evaluation.
+            update_derivation_build_status(&state.db(), anchor, BuildStatus::Aborted).await;
+            info!(%derivation_build, "build aborted by server; anchor left requeueable");
+            return check_referencing_evals_done(state, derivation_id).await;
         }
         FailureOutcome::Permanent => {
             update_derivation_build_status(&state.db(), anchor, BuildStatus::FailedPermanent).await;
@@ -650,10 +679,62 @@ mod orphaned_eval_tests {
 #[cfg(test)]
 mod retry_tests {
     use super::{
-        FailureOutcome, decide_failure_outcome, inputs_unavailable_circuit_open,
-        retry_backoff_elapsed, truncate_failure_message,
+        FailureOutcome, attempt_outcome, attempt_reason, decide_failure_outcome,
+        inputs_unavailable_circuit_open, retry_backoff_elapsed, truncate_failure_message,
     };
+    use gradient_entity::build_attempt::{AttemptFailureReason, AttemptOutcome};
     use gradient_types::proto::BuildFailureKind;
+
+    /// The user pressed Abort: the worker stopped nix, nothing about the
+    /// derivation failed. Reporting it as `Permanent` landed the anchor on
+    /// `FailedPermanent` with `reason = BuilderNonzero`, which
+    /// `deterministic_build_failure` reads as a reproducible builder exit and
+    /// excludes from every requeue - the derivation could never be built again
+    /// (#572).
+    #[test]
+    fn abort_is_not_a_deterministic_build_failure() {
+        for attempt in [0, 1, 99] {
+            assert_eq!(
+                decide_failure_outcome(BuildFailureKind::Aborted, attempt, 3),
+                FailureOutcome::Aborted,
+                "an abort is never a build verdict, at any attempt count"
+            );
+        }
+        assert_eq!(
+            attempt_outcome(BuildFailureKind::Aborted),
+            AttemptOutcome::Aborted
+        );
+        assert_eq!(attempt_reason(BuildFailureKind::Aborted), None);
+    }
+
+    /// The exception exists for a real reason: a builder that exited non-zero
+    /// reproduces on rebuild, so thawing it loops the fleet. It must stay
+    /// attached to that one case.
+    #[test]
+    fn only_a_real_builder_exit_records_builder_nonzero() {
+        assert_eq!(
+            attempt_reason(BuildFailureKind::Permanent),
+            Some(AttemptFailureReason::BuilderNonzero)
+        );
+        assert_eq!(
+            attempt_outcome(BuildFailureKind::Permanent),
+            AttemptOutcome::Failed
+        );
+        for kind in [
+            BuildFailureKind::Transient,
+            BuildFailureKind::Timeout,
+            BuildFailureKind::SubstituteUnavailable,
+            BuildFailureKind::InputsUnavailable,
+            BuildFailureKind::CorruptEvalCache,
+            BuildFailureKind::Aborted,
+        ] {
+            assert_ne!(
+                attempt_reason(kind),
+                Some(AttemptFailureReason::BuilderNonzero),
+                "{kind:?} must not poison the anchor as a deterministic failure"
+            );
+        }
+    }
 
     #[test]
     fn permanent_is_terminal_regardless_of_attempt() {

--- a/backend/gradient-scheduler/src/eval.rs
+++ b/backend/gradient-scheduler/src/eval.rs
@@ -1310,6 +1310,15 @@ pub async fn handle_eval_job_failed(
             EvaluationStatus::Completed | EvaluationStatus::Failed | EvaluationStatus::Aborted
         )
     {
+        // The API writes `Aborted` before `AbortJob` goes out, so the guard above
+        // normally catches this. If that write was lost, settle the evaluation
+        // where the abort meant to put it rather than reporting a failure the
+        // user did not cause.
+        if kind == BuildFailureKind::Aborted {
+            update_evaluation_status(&state.db(), eval, EvaluationStatus::Aborted).await;
+            return Ok(());
+        }
+
         update_evaluation_status_with_error(
             &state.db(),
             eval,

--- a/backend/gradient-types/src/proto.rs
+++ b/backend/gradient-types/src/proto.rs
@@ -567,4 +567,10 @@ pub enum BuildFailureKind {
     /// the evaluation so it re-evaluates cache-less. Carries the corrupt blob's
     /// fingerprint on `ClientMessage::JobFailed.missing_paths`.
     CorruptEvalCache,
+    /// The server sent `AbortJob` and the worker stopped. Not a failure of the
+    /// derivation: it is recorded as `AttemptOutcome::Aborted` with no reason,
+    /// so a later evaluation can thaw the anchor. Reporting an abort as
+    /// `Permanent` stamped `AttemptFailureReason::BuilderNonzero` on the
+    /// attempt, which permanently blocks every requeue (#572).
+    Aborted,
 }

--- a/backend/gradient-worker/src/executor/eval.rs
+++ b/backend/gradient-worker/src/executor/eval.rs
@@ -31,10 +31,11 @@ use tracing::{debug, info, warn};
 
 /// Abort error returned from the eval pipeline when the dispatch loop fires
 /// the watch signal in response to a server-side `AbortJob`. Bubbles up as a
-/// regular `Err`, which the worker translates into `JobFailed` - the server's
-/// `handle_eval_job_failed` then no-ops because the eval is already
-/// `Aborted` from the API call.
-const ABORT_ERR: &str = "evaluation aborted by server";
+/// regular `Err`, which the worker reports as `BuildFailureKind::Aborted` so the
+/// server holds the evaluation at `Aborted` instead of failing it.
+fn abort_err() -> anyhow::Error {
+    crate::executor::failure::JobAborted("evaluation aborted by server".to_owned()).into()
+}
 
 /// Returns true if the dispatch loop has flipped the abort watch to `true`.
 fn is_aborted(abort: &mut watch::Receiver<bool>) -> bool {
@@ -699,7 +700,7 @@ impl<'a> ClosureWalker<'a> {
         while !self.queue.is_empty() {
             // Honour AbortJob at every wave boundary.
             if is_aborted(abort) {
-                anyhow::bail!(ABORT_ERR);
+                return Err(abort_err());
             }
             self.process_wave(updater).await?;
         }
@@ -934,7 +935,7 @@ pub async fn evaluate_derivations_with(
     abort: &mut watch::Receiver<bool>,
 ) -> Result<EvalOutcome> {
     if is_aborted(abort) {
-        anyhow::bail!(ABORT_ERR);
+        return Err(abort_err());
     }
     updater.report_evaluating_derivations().await?;
 
@@ -986,7 +987,7 @@ pub async fn evaluate_derivations_with(
     }
 
     if is_aborted(abort) {
-        anyhow::bail!(ABORT_ERR);
+        return Err(abort_err());
     }
 
     // ── Step 2: resolve attr paths → drv paths ───────────────────────────────

--- a/backend/gradient-worker/src/executor/failure.rs
+++ b/backend/gradient-worker/src/executor/failure.rs
@@ -68,15 +68,33 @@ impl BuildError {
             missing_paths,
         }
     }
-    /// The server sent `AbortJob` while the daemon was building. Terminal: the
-    /// build is already in a terminal state server-side, so retrying is wrong.
+    /// The server sent `AbortJob` while the daemon was building. Reported as
+    /// its own kind, never `Permanent`: a `Permanent` build failure is recorded
+    /// as `BuilderNonzero`, which permanently excludes the anchor from every
+    /// requeue even though `Aborted` is a requeueable status (#572).
     pub(crate) fn aborted(drv_path: &str) -> Self {
         Self::new(
-            BuildFailureKind::Permanent,
-            anyhow::anyhow!("build aborted by server: {}", drv_path),
+            BuildFailureKind::Aborted,
+            JobAborted(format!("build aborted by server: {drv_path}")).into(),
         )
     }
 }
+
+// ── JobAborted ────────────────────────────────────────────────────────────────
+
+/// The job stopped because the server ordered it to. Carried as a typed error so
+/// [`wire_failure`] classifies it wherever the abort is noticed - inside the
+/// daemon log drain, at a NAR-push checkpoint, or between eval waves - instead of
+/// falling through to the unclassified-`Permanent` branch.
+#[derive(Debug)]
+pub struct JobAborted(pub String);
+
+impl std::fmt::Display for JobAborted {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+impl std::error::Error for JobAborted {}
 
 // ── Builder-message classification ────────────────────────────────────────────
 
@@ -174,6 +192,11 @@ pub(crate) fn wire_failure(e: &anyhow::Error) -> (BuildFailureKind, Vec<String>)
             BuildFailureKind::CorruptEvalCache,
             vec![c.fingerprint.clone()],
         );
+    }
+    // An abort noticed outside the build itself (NAR push checkpoints, eval wave
+    // boundaries) arrives as a bare `JobAborted`, not wrapped in a `BuildError`.
+    if e.chain().any(|s| s.is::<JobAborted>()) {
+        return (BuildFailureKind::Aborted, Vec::new());
     }
     match e.downcast_ref::<BuildError>() {
         Some(be) => (be.kind, be.missing_paths.clone()),
@@ -277,6 +300,21 @@ mod tests {
             vec!["abc123".to_owned()],
             "the fingerprint rides missing_paths so the server can purge the blob"
         );
+    }
+
+    /// An abort must never reach the server as `Permanent`: that is stored as
+    /// `BuilderNonzero` and permanently blocks the anchor from being requeued
+    /// (#572). Both shapes are covered - the `BuildError` raised inside the
+    /// daemon log drain, and the bare `JobAborted` raised at a NAR-push
+    /// checkpoint or an eval wave boundary.
+    #[test]
+    fn an_abort_is_reported_as_aborted_not_permanent() {
+        let from_build: anyhow::Error = BuildError::aborted("/nix/store/x.drv").into();
+        assert_eq!(wire_failure(&from_build).0, BuildFailureKind::Aborted);
+
+        let from_checkpoint = anyhow::Error::new(JobAborted("job aborted by server".into()))
+            .context("compress and push NARs");
+        assert_eq!(wire_failure(&from_checkpoint).0, BuildFailureKind::Aborted);
     }
 
     #[test]

--- a/backend/gradient-worker/src/executor/mod.rs
+++ b/backend/gradient-worker/src/executor/mod.rs
@@ -462,10 +462,12 @@ impl JobExecutor {
 }
 
 /// Propagate a server-side `AbortJob` as an error so the surrounding job
-/// resolves to `JobFailed` instead of `JobCompleted`.
+/// resolves to `JobFailed` instead of `JobCompleted`. Typed so the failure
+/// classifier reports `BuildFailureKind::Aborted` rather than treating it as an
+/// unclassified `Permanent` failure.
 pub(crate) fn check_abort(abort: &mut watch::Receiver<bool>) -> Result<()> {
     if *abort.borrow() {
-        anyhow::bail!("job aborted by server");
+        return Err(failure::JobAborted("job aborted by server".to_owned()).into());
     }
     Ok(())
 }

--- a/docs/src/development/proto.md
+++ b/docs/src/development/proto.md
@@ -1320,7 +1320,7 @@ Credentials are encrypted in transit (TLS). Workers MUST:
 
 Either side can abort a job:
 
-**Server-initiated:** `AbortJob { job_id, reason }` → worker stops current step, cleans up, responds `JobFailed` with the abort reason. The server sends `AbortJob` when an evaluation is aborted via the API (`POST /evals/{id}` with `method: "abort"`). The scheduler finds which worker holds the active job and delivers the message through a per-worker channel. Pending (unassigned) jobs for the aborted evaluation are removed from the in-memory tracker.
+**Server-initiated:** `AbortJob { job_id, reason }` -> worker stops current step, cleans up, responds `JobFailed { kind: Aborted }` with the abort reason. The abort is its own `BuildFailureKind`: a `Permanent` build failure is stored as `build_attempt.reason = BuilderNonzero`, which the requeue predicate reads as a reproducible builder exit and excludes from every future thaw, so an aborted derivation could never be rebuilt. `Aborted` is recorded as `AttemptOutcome::Aborted` with no reason, leaves the anchor on the requeueable `Aborted` status, and cascades no `DependencyFailed`. The server sends `AbortJob` when an evaluation is aborted via the API (`POST /evals/{id}` with `method: "abort"`). The scheduler finds which worker holds the active job and delivers the message through a per-worker channel. Pending (unassigned) jobs for the aborted evaluation are removed from the in-memory tracker.
 
 **Worker-initiated:** worker sends `JobFailed` at any time.
 
@@ -1443,13 +1443,16 @@ On receiving `ServerMessage::Draining`, workers:
 
 ## Versioning
 
- - `PROTO_VERSION` (currently `5`) is incremented on breaking wire changes.
+ - `PROTO_VERSION` (currently `8`) is incremented on breaking wire changes.
  - Server accepts any `client_version == PROTO_VERSION`; the check lives once, in
    `session::handshake::on_init_connection`, and every session flavor (worker,
    cache-scoped, outbound) goes through it.
  - v5 dropped the dead `PresignedUpload`/`PresignedDownload` messages and
    `AssignJob.timeout_secs`; presigned URLs travel exclusively in `CacheQuery`
    replies (`CachedPath.url`).
+ - v7 gave `CacheQuery`/`CacheStatus`/`CacheError` a per-query `query_id` and
+   `NarUploaded` the path's content address (`ca`).
+ - v8 added `BuildFailureKind::Aborted`.
  - New capabilities are gated by `GradientCapabilities` flags, not version numbers.
 
 ---

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -798,6 +798,7 @@ carries a scope (from the newest source bucket) rather than dropping the column.
 Migration `m20260827_000000_metric_rollup_scope_project` re-keys the historical
 rows in place - `scope` is not part of `idx-metric_rollup-unique` and
 `scope_hash` is unchanged, so no merge is needed.
+
 ## NAR packing reads store files, never maps them (#573)
 
 `harmonia-file-nar`'s dumper branches at 256 KiB and used to `mmap` everything
@@ -821,6 +822,32 @@ nor drop content across several large files in one archive. The SIGKILL itself
 is macOS-only and not reproducible on the Linux CI runners; what is testable, and
 what these pin, is that the route the dumper picks for a large file yields that
 file's real bytes.
+
+## Aborting a build no longer poisons its derivation (#572)
+
+Pressing Abort made the server send `AbortJob`, the worker stop nix, and the
+worker report `JobFailed { kind: Permanent }`. The scheduler stores `Permanent`
+as `build_attempt` `outcome = Failed, reason = BuilderNonzero`, which is exactly
+the `deterministic_build_failure` predicate that `requeue_failed_anchors` and
+`requeue_failed_closure_for_eval` use to exclude reproducible builder exits from
+every thaw - so a user abort permanently blocked the derivation (and its whole
+dependent subtree) from ever being built again, even though `Aborted` is itself a
+requeueable status. The exception on `BuilderNonzero` is correct and stays: an
+identical rebuild reproduces a non-zero exit, and thawing it loops the fleet
+(the retry-storm fix). What was wrong is calling an abort one.
+
+`BuildFailureKind::Aborted` is now its own wire kind (`PROTO_VERSION` 7 -> 8;
+the handshake rejects any mismatched peer, so there is no mixed-version decode
+path). `backend/gradient-worker/src/executor/failure.rs`:
+`an_abort_is_reported_as_aborted_not_permanent` covers both shapes the abort
+takes - the `BuildError` raised inside the daemon log drain, and the bare
+`JobAborted` raised at a NAR-push checkpoint or an eval wave boundary, which
+previously fell through `wire_failure`'s unclassified-`Permanent` branch.
+`backend/gradient-scheduler/src/build/lifecycle.rs`:
+`abort_is_not_a_deterministic_build_failure` pins the anchor to
+`FailureOutcome::Aborted` at any attempt count with `AttemptOutcome::Aborted` and
+no reason, and `only_a_real_builder_exit_records_builder_nonzero` pins that
+`BuilderNonzero` is reachable from `Permanent` alone.
 
 ## PostgreSQL minimum-version guard (#387)
 


### PR DESCRIPTION
Fixes #572.

Abort sent `JobFailed { kind: Permanent }`, which the scheduler stores as `build_attempt` `outcome = Failed, reason = BuilderNonzero` - exactly the `deterministic_build_failure` predicate that excludes an anchor from every requeue. A user abort therefore poisoned the derivation and its dependent subtree permanently.

On the issue's question: the `BuilderNonzero` exception is correct and stays. An identical rebuild reproduces a non-zero builder exit, so thawing it loops the fleet (the retry-storm fix). What was wrong is classifying an abort as one. `BuildFailureKind::Aborted` is now its own kind (`PROTO_VERSION` 7 -> 8), recorded as `AttemptOutcome::Aborted` with no reason, leaving the anchor on the requeueable `Aborted` status and cascading no `DependencyFailed`.