### PR TITLE
deps: fix: update harmonia past the mmap NAR dumper

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1051,7 +1051,22 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto 0.3.0",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -1309,7 +1324,7 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "signature",
+ "signature 2.2.0",
  "spki",
 ]
 
@@ -1319,8 +1334,16 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "signature",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
+dependencies = [
+ "signature 3.0.0",
 ]
 
 [[package]]
@@ -1338,10 +1361,21 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
- "serde",
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
  "sha2 0.10.9",
+ "subtle",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "ed25519 3.0.0",
+ "sha2 0.11.0",
  "subtle",
  "zeroize",
 ]
@@ -1426,7 +1460,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1501,6 +1535,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filetime"
@@ -2538,8 +2578,8 @@ dependencies = [
 
 [[package]]
 name = "harmonia-file-core"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "serde",
  "serde_json",
@@ -2548,8 +2588,8 @@ dependencies = [
 
 [[package]]
 name = "harmonia-file-nar"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "bstr",
  "bytes",
@@ -2572,8 +2612,8 @@ dependencies = [
 
 [[package]]
 name = "harmonia-protocol"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "async-stream",
  "bstr",
@@ -2606,18 +2646,18 @@ dependencies = [
 
 [[package]]
 name = "harmonia-protocol-derive"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "harmonia-store-aterm"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "bytes",
  "harmonia-store-content-address",
@@ -2632,8 +2672,8 @@ dependencies = [
 
 [[package]]
 name = "harmonia-store-build-result"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "harmonia-store-derivation",
  "num_enum",
@@ -2643,8 +2683,8 @@ dependencies = [
 
 [[package]]
 name = "harmonia-store-content-address"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "derive_more",
  "harmonia-store-path",
@@ -2656,7 +2696,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-derivation"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -2674,8 +2714,8 @@ dependencies = [
 
 [[package]]
 name = "harmonia-store-path"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "derive_more",
  "harmonia-utils-base-encoding",
@@ -2687,8 +2727,8 @@ dependencies = [
 
 [[package]]
 name = "harmonia-store-path-info"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "harmonia-store-content-address",
  "harmonia-store-path",
@@ -2699,8 +2739,8 @@ dependencies = [
 
 [[package]]
 name = "harmonia-store-remote"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "async-stream",
  "futures-core",
@@ -2720,7 +2760,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-base-encoding"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "data-encoding",
  "derive_more",
@@ -2730,7 +2770,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-hash"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "blake3",
  "data-encoding",
@@ -2748,7 +2788,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-io"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "bytes",
  "futures-util",
@@ -2760,11 +2800,11 @@ dependencies = [
 
 [[package]]
 name = "harmonia-utils-signature"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "data-encoding",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0",
  "getrandom 0.4.3",
  "harmonia-utils-base-encoding",
  "serde",
@@ -3306,7 +3346,7 @@ dependencies = [
  "js-sys",
  "serde",
  "serde_json",
- "signature",
+ "signature 2.2.0",
  "zeroize",
 ]
 
@@ -4787,7 +4827,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5097,7 +5137,7 @@ dependencies = [
  "pkcs8",
  "rand_core 0.6.4",
  "sha2 0.10.9",
- "signature",
+ "signature 2.2.0",
  "spki",
  "subtle",
  "zeroize",
@@ -5161,7 +5201,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5174,7 +5214,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5233,7 +5273,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5752,6 +5792,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6063,7 +6109,7 @@ version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3"
 dependencies = [
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "p256",
  "p384",
  "p521",
@@ -6071,7 +6117,7 @@ dependencies = [
  "rsa",
  "sec1",
  "sha2 0.10.9",
- "signature",
+ "signature 2.2.0",
  "ssh-cipher",
  "ssh-encoding",
  "subtle",
@@ -6204,10 +6250,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7003,7 +7049,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7127,15 +7173,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/backend/gradient-core/tests/nar_pack.rs
+++ b/backend/gradient-core/tests/nar_pack.rs
@@ -1,0 +1,151 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! On-disk NAR packing (`harmonia_file_nar::NarByteStream`), the path the worker
+//! uses to upload every build output.
+//!
+//! The dumper splits on a 256 KiB threshold and takes a different route for
+//! anything above it. That large-file route used to be an mmap of the store
+//! file, which macOS validates the code signature of on every page fault: a
+//! mach-o with an invalid signature SIGKILLs the packing process outright and
+//! takes every in-progress build on that worker with it (#573). On Linux the
+//! same mapping served uprobe breakpoint bytes instead of the file's real
+//! contents (harmonia #1140). The tests below pack a real tree straight off disk
+//! and compare it to `write_nar`, the reference encoder, so a large file's bytes
+//! must survive the route the dumper picks for it.
+
+use bytes::Bytes;
+use futures::StreamExt as _;
+use harmonia_file_nar::NarByteStream;
+use harmonia_file_nar::archive::test_data::{TestNarEvent, TestNarEvents};
+use harmonia_file_nar::archive::write_nar;
+use std::io::Write as _;
+use std::path::Path;
+
+/// The dumper's small-file threshold. Anything above it takes the other route.
+const SMALL_FILE_THRESHOLD: usize = 256 * 1024;
+
+fn block_on<F: std::future::Future>(f: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(f)
+}
+
+/// Deterministic, incompressible-ish filler: a repeating byte pattern would
+/// still compare equal after a whole chunk was dropped or duplicated.
+fn filler(len: usize) -> Vec<u8> {
+    let mut state = 0x2545_f491_4f6c_dd1du64;
+    (0..len)
+        .map(|_| {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            (state >> 24) as u8
+        })
+        .collect()
+}
+
+fn pack(path: &Path) -> Vec<u8> {
+    block_on(async {
+        let mut stream = NarByteStream::new(path.to_path_buf());
+        let mut out = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            out.extend_from_slice(&chunk.expect("NAR stream error"));
+        }
+        out
+    })
+}
+
+fn expected_dir_with_file(name: &str, contents: &[u8], executable: bool) -> Vec<u8> {
+    let events: TestNarEvents = vec![
+        TestNarEvent::StartDirectory { name: Bytes::new() },
+        TestNarEvent::File {
+            name: Bytes::from(name.to_owned().into_bytes()),
+            executable,
+            size: contents.len() as u64,
+            reader: std::io::Cursor::new(Bytes::from(contents.to_vec())),
+        },
+        TestNarEvent::EndDirectory,
+    ];
+    write_nar(&events).to_vec()
+}
+
+fn write_tree(dir: &Path, name: &str, contents: &[u8]) {
+    let mut f = std::fs::File::create(dir.join(name)).unwrap();
+    f.write_all(contents).unwrap();
+    f.sync_all().unwrap();
+}
+
+/// A file over the threshold must serialize to exactly its own bytes. This is
+/// the regression guard for #573: the large-file route must read the file, not
+/// map it.
+#[test]
+fn a_file_over_the_dumper_threshold_packs_its_real_bytes() {
+    let contents = filler(SMALL_FILE_THRESHOLD * 4 + 7);
+    let tmp = tempfile::tempdir().unwrap();
+    write_tree(tmp.path(), "big", &contents);
+
+    assert_eq!(
+        pack(tmp.path()),
+        expected_dir_with_file("big", &contents, false),
+        "large-file NAR bytes diverged from the reference encoding"
+    );
+}
+
+/// The threshold itself is a boundary the dumper branches on, so pin both sides
+/// of it plus the exact boundary value.
+#[test]
+fn packing_is_byte_exact_across_the_threshold_boundary() {
+    for size in [
+        0,
+        1,
+        SMALL_FILE_THRESHOLD - 1,
+        SMALL_FILE_THRESHOLD,
+        SMALL_FILE_THRESHOLD + 1,
+    ] {
+        let contents = filler(size);
+        let tmp = tempfile::tempdir().unwrap();
+        write_tree(tmp.path(), "f", &contents);
+
+        assert_eq!(
+            pack(tmp.path()),
+            expected_dir_with_file("f", &contents, false),
+            "NAR bytes diverged at size {size}"
+        );
+    }
+}
+
+/// A multi-gigabyte store path is streamed, not buffered: chunk boundaries must
+/// not reorder or drop content across several large files in one archive.
+#[test]
+fn several_large_files_pack_in_order() {
+    let tmp = tempfile::tempdir().unwrap();
+    let a = filler(SMALL_FILE_THRESHOLD * 2);
+    let b = filler(SMALL_FILE_THRESHOLD * 3 + 11);
+    write_tree(tmp.path(), "a", &a);
+    write_tree(tmp.path(), "b", &b);
+
+    let events: TestNarEvents = vec![
+        TestNarEvent::StartDirectory { name: Bytes::new() },
+        TestNarEvent::File {
+            name: Bytes::from_static(b"a"),
+            executable: false,
+            size: a.len() as u64,
+            reader: std::io::Cursor::new(Bytes::from(a.clone())),
+        },
+        TestNarEvent::File {
+            name: Bytes::from_static(b"b"),
+            executable: false,
+            size: b.len() as u64,
+            reader: std::io::Cursor::new(Bytes::from(b.clone())),
+        },
+        TestNarEvent::EndDirectory,
+    ];
+
+    assert_eq!(pack(tmp.path()), write_nar(&events).to_vec());
+}

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -511,7 +511,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -554,12 +554,6 @@ dependencies = [
  "webpki-roots",
  "wiremock",
 ]
-
-[[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-oid"
@@ -690,14 +684,14 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.3"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
- "digest 0.10.7",
+ "digest 0.11.3",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -780,16 +774,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid 0.9.6",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,7 +826,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid 0.10.2",
+ "const-oid",
  "crypto-common 0.2.2",
 ]
 
@@ -864,7 +848,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -904,24 +888,22 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ed25519"
-version = "2.2.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
- "pkcs8",
  "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "serde",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "subtle",
  "zeroize",
 ]
@@ -954,7 +936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -990,9 +972,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filedescriptor"
@@ -1284,8 +1266,8 @@ dependencies = [
 
 [[package]]
 name = "harmonia-file-core"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1294,8 +1276,8 @@ dependencies = [
 
 [[package]]
 name = "harmonia-file-nar"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "bstr",
  "bytes",
@@ -1318,8 +1300,8 @@ dependencies = [
 
 [[package]]
 name = "harmonia-protocol"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "async-stream",
  "bstr",
@@ -1352,18 +1334,18 @@ dependencies = [
 
 [[package]]
 name = "harmonia-protocol-derive"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "harmonia-store-aterm"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "bytes",
  "harmonia-store-content-address",
@@ -1378,8 +1360,8 @@ dependencies = [
 
 [[package]]
 name = "harmonia-store-build-result"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "harmonia-store-derivation",
  "num_enum",
@@ -1389,8 +1371,8 @@ dependencies = [
 
 [[package]]
 name = "harmonia-store-content-address"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "derive_more",
  "harmonia-store-path",
@@ -1402,7 +1384,7 @@ dependencies = [
 [[package]]
 name = "harmonia-store-derivation"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -1420,8 +1402,8 @@ dependencies = [
 
 [[package]]
 name = "harmonia-store-path"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "derive_more",
  "harmonia-utils-base-encoding",
@@ -1433,8 +1415,8 @@ dependencies = [
 
 [[package]]
 name = "harmonia-store-path-info"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "harmonia-store-content-address",
  "harmonia-store-path",
@@ -1445,8 +1427,8 @@ dependencies = [
 
 [[package]]
 name = "harmonia-store-remote"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "async-stream",
  "futures-core",
@@ -1466,7 +1448,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-base-encoding"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "data-encoding",
  "derive_more",
@@ -1476,7 +1458,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-hash"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "blake3",
  "data-encoding",
@@ -1494,7 +1476,7 @@ dependencies = [
 [[package]]
 name = "harmonia-utils-io"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "bytes",
  "futures-util",
@@ -1506,8 +1488,8 @@ dependencies = [
 
 [[package]]
 name = "harmonia-utils-signature"
-version = "3.1.0"
-source = "git+https://github.com/nix-community/harmonia.git#be940def673a5a2da6aa51be8dc8fd8600cfcbf9"
+version = "3.2.0"
+source = "git+https://github.com/nix-community/harmonia.git#7c1ef262e324bbf61201fe92a73849eb3d6fd9e2"
 dependencies = [
  "data-encoding",
  "ed25519-dalek",
@@ -1828,7 +1810,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82cb6a9f675da968c63b6208c641b9dca58fc0133ae53375736b1767b0cab8bd"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2495,16 +2477,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2667,7 +2639,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3051,7 +3023,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3108,7 +3080,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3336,12 +3308,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "rand_core 0.6.4",
-]
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 
 [[package]]
 name = "simd_cesu8"
@@ -3385,16 +3354,6 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
 ]
 
 [[package]]
@@ -3465,6 +3424,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3512,10 +3482,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4228,7 +4198,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -798,6 +798,29 @@ carries a scope (from the newest source bucket) rather than dropping the column.
 Migration `m20260827_000000_metric_rollup_scope_project` re-keys the historical
 rows in place - `scope` is not part of `idx-metric_rollup-unique` and
 `scope_hash` is unchanged, so no merge is needed.
+## NAR packing reads store files, never maps them (#573)
+
+`harmonia-file-nar`'s dumper branches at 256 KiB and used to `mmap` everything
+above it. macOS validates a mach-o's code signature on every page fault from a
+mapped file, so packing a store path containing a binary with an invalid
+signature SIGKILL'd `gradient-worker` outright and took every build in progress
+on that worker with it; on Linux the same mapping served uprobe breakpoint bytes
+rather than the file's real contents, producing NARs that failed signature
+verification (harmonia #1140). Upstream replaced the mapping with bounded
+`read()` chunks in `be87963`; gradient's lockfiles sat 132 commits behind it, so
+the worker kept shipping the mmap dumper. Both workspaces now lock `7c1ef26`.
+
+`backend/gradient-core/tests/nar_pack.rs` packs a real tree off disk with
+`NarByteStream` (the worker's own upload path) and compares it byte-for-byte
+against `write_nar`, the reference encoder:
+`a_file_over_the_dumper_threshold_packs_its_real_bytes` covers the large-file
+route, `packing_is_byte_exact_across_the_threshold_boundary` pins both sides of
+the 256 KiB branch plus the boundary value itself, and
+`several_large_files_pack_in_order` pins that chunk boundaries neither reorder
+nor drop content across several large files in one archive. The SIGKILL itself
+is macOS-only and not reproducible on the Linux CI runners; what is testable, and
+what these pin, is that the route the dumper picks for a large file yields that
+file's real bytes.
 
 ## PostgreSQL minimum-version guard (#387)
 


### PR DESCRIPTION
Fixes #573.

macOS validates a mach-o's code signature on every page fault from a mapped file, so `harmonia-file-nar`'s mmap-based NAR dumper SIGKILL'd `gradient-worker` the moment it packed a store path containing a binary with an invalid signature, taking every in-progress build with it.

Upstream already replaced the mapping with bounded `read()` chunks (harmonia `be87963`, #1140 - the same mapping served uprobe breakpoint bytes on Linux). Gradient's lockfiles sat 132 commits behind it. `cargo update -p harmonia-file-nar` in both workspaces, nothing else in the tree needed changing.