### PR TITLE
Feat/eval search and entry point outputs 564

### DIFF
--- a/backend/gradient-entity/src/derivation_output.rs
+++ b/backend/gradient-entity/src/derivation_output.rs
@@ -18,6 +18,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::ids::{CachedPathId, DerivationId, DerivationOutputId};
 
+/// `hash` sentinel written when the evaluator could not parse an output's store
+/// path (floating CA outputs have none until built). Nothing ever rewrites it,
+/// so a row carrying it has no usable store path.
+pub const UNKNOWN_OUTPUT_HASH: &str = "unknown";
+
 #[derive(Clone, Debug, Default, PartialEq, DeriveEntityModel, Deserialize, Serialize)]
 #[sea_orm(table_name = "derivation_output")]
 pub struct Model {

--- a/backend/gradient-migration/src/lib.rs
+++ b/backend/gradient-migration/src/lib.rs
@@ -37,6 +37,7 @@ mod m20260821_000000_debug_info;
 mod m20260822_000000_rename_project_to_task;
 mod m20260822_000001_rename_organization_to_project;
 mod m20260827_000000_metric_rollup_scope_project;
+mod m20260827_000001_commit_hash_index;
 
 pub struct Migrator;
 
@@ -75,6 +76,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260822_000000_rename_project_to_task::Migration),
             Box::new(m20260822_000001_rename_organization_to_project::Migration),
             Box::new(m20260827_000000_metric_rollup_scope_project::Migration),
+            Box::new(m20260827_000001_commit_hash_index::Migration),
         ]
     }
 }

--- a/backend/gradient-migration/src/m20260827_000001_commit_hash_index.rs
+++ b/backend/gradient-migration/src/m20260827_000001_commit_hash_index.rs
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Index `commit.hash` so `GET /tasks/{project}/{task}/evaluations?commit=` can
+//! resolve a hash without a sequential scan. The table carried only its primary
+//! key, and a fresh row is written per evaluation, so it grows with evaluation
+//! history and one hash maps to many ids.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared("CREATE INDEX \"idx-commit-hash\" ON public.commit (hash)")
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared("DROP INDEX IF EXISTS \"idx-commit-hash\"")
+            .await?;
+
+        Ok(())
+    }
+}

--- a/backend/gradient-scheduler/src/eval.rs
+++ b/backend/gradient-scheduler/src/eval.rs
@@ -74,8 +74,13 @@ impl DerivationInsertBatch {
                 .into_active_model(),
             );
             for output in &d.outputs {
-                let (hash, package) = get_hash_from_path(output.path.clone())
-                    .unwrap_or_else(|_| ("unknown".to_owned(), output.name.clone()));
+                let (hash, package) =
+                    get_hash_from_path(output.path.clone()).unwrap_or_else(|_| {
+                        (
+                            gradient_entity::derivation_output::UNKNOWN_OUTPUT_HASH.to_owned(),
+                            output.name.clone(),
+                        )
+                    });
                 new_outputs.push(
                     MDerivationOutput {
                         id: DerivationOutputId::now_v7(),

--- a/backend/gradient-sources/src/git/mod.rs
+++ b/backend/gradient-sources/src/git/mod.rs
@@ -66,5 +66,44 @@ pub async fn resolve_head(
     Ok((commit_hash, msg, author))
 }
 
+/// Resolve a ref on an arbitrary remote repository to its commit hash, without
+/// a task to hang it off. `branch = None` resolves the remote HEAD (the default
+/// branch). SSH URLs are authenticated with `project`'s deploy key, the same key
+/// the worker later uses to fetch the flake.
+#[instrument(skip(ctx, project), fields(project_id = %project.id, repository = %url))]
+pub async fn resolve_remote_ref(
+    ctx: &DbContext,
+    project: &MProject,
+    url: &str,
+    branch: Option<&str>,
+) -> Result<Vec<u8>, SourceError> {
+    let ssh_creds = if gradient_types::input::check_repository_url_is_ssh(url) {
+        Some(crate::ssh_key::decrypt_ssh_private_key(
+            &ctx.config.secrets.crypt_secret_file,
+            project.clone(),
+            &ctx.config.server.serve_url,
+        )?)
+    } else {
+        None
+    };
+
+    let url = url.to_owned();
+    let branch = branch.map(|b| b.to_owned());
+
+    tokio::task::spawn_blocking(move || match ssh_creds {
+        Some((private_key, public_key)) => remote::ls_remote_head(
+            &url,
+            Some(&private_key),
+            Some(&public_key),
+            branch.as_deref(),
+        ),
+        None => remote::ls_remote_head(&url, None, None, branch.as_deref()),
+    })
+    .await
+    .map_err(|e| SourceError::GitExecution {
+        error: e.to_string(),
+    })?
+}
+
 #[cfg(test)]
 mod tests;

--- a/backend/gradient-sources/src/git/remote/mod.rs
+++ b/backend/gradient-sources/src/git/remote/mod.rs
@@ -49,7 +49,7 @@ pub fn fetch_options_with_ssh(ssh_key: Option<&str>) -> git2::FetchOptions<'stat
     fo
 }
 
-pub(super) fn ls_remote_head(
+pub(in crate::git) fn ls_remote_head(
     url: &str,
     private_key: Option<&str>,
     public_key: Option<&str>,

--- a/backend/gradient-sources/src/git/tests/mod.rs
+++ b/backend/gradient-sources/src/git/tests/mod.rs
@@ -39,6 +39,24 @@ fn git_transport_url_passes_through_bare_schemes_and_scp() {
 
 // ── parse_nix_git_url ────────────────────────────────────────────────────
 
+/// `POST /build-requests/url` builds an evaluation's source string with
+/// `repository_url_to_nix` and the worker reads it back with
+/// `parse_nix_git_url`. Pin that round trip, in both URL shapes, so a change to
+/// either side cannot silently strand remote build requests (#564).
+#[test]
+fn repository_url_to_nix_round_trips_through_parse_nix_git_url() {
+    for url in [
+        "https://example.com/repo.git",
+        "ssh://git@example.com/org/repo.git",
+    ] {
+        let nix_url = gradient_types::input::repository_url_to_nix(url, FAKE_SHA).unwrap();
+        let (parsed_url, parsed_rev) = parse_nix_git_url(&nix_url).unwrap();
+
+        assert_eq!(parsed_url, url, "url round trip for {url}");
+        assert_eq!(parsed_rev, FAKE_SHA, "rev round trip for {url}");
+    }
+}
+
 #[test]
 fn parse_nix_git_url_strips_git_plus_prefix() {
     let (url, rev) = parse_nix_git_url("git+https://example.com/repo.git?rev=deadbeef").unwrap();

--- a/backend/gradient-sources/src/lib.rs
+++ b/backend/gradient-sources/src/lib.rs
@@ -15,7 +15,7 @@ pub use self::build_log::strip_nix_log_tail;
 pub use self::cache_key::*;
 pub use self::git::{
     Libgit2Prefetcher, accept_cert, check_task_updates, fetch_options_with_ssh, get_commit_info,
-    resolve_head,
+    resolve_head, resolve_remote_ref,
 };
 pub use self::nar_path::*;
 pub use self::secret::{decrypt_secret, encrypt_secret};

--- a/backend/gradient-types/src/wildcard.rs
+++ b/backend/gradient-types/src/wildcard.rs
@@ -118,6 +118,118 @@ impl Wildcard {
             excludes.join(" "),
         )
     }
+
+    /// Whether this wildcard's scope covers the concrete attribute path `attr`.
+    ///
+    /// Mirrors the evaluator's segment rules: a literal segment compares by
+    /// inner content (quotes unwrapped on both sides, so a dotted attribute
+    /// name must be quoted on the attr side too), `#` matches exactly one
+    /// segment, and `*` matches one segment - or one *or two* as the final
+    /// segment, since the walk descends one extra level there. An exclusion
+    /// pattern, always an exact path, removes a path the includes matched.
+    ///
+    /// This answers "was this attr in scope", not "was it built": the attr may
+    /// not exist in the flake at all.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use gradient_types::wildcard::Wildcard;
+    ///
+    /// let w: Wildcard = "packages.*.*,!packages.x86_64-linux.broken".parse().unwrap();
+    /// assert!(w.matches("packages.x86_64-linux.hello"));
+    /// assert!(!w.matches("packages.x86_64-linux.broken"));
+    /// ```
+    pub fn matches(&self, attr: &str) -> bool {
+        if attr.is_empty() {
+            return false;
+        }
+
+        let path = unquote_segments(attr);
+        let mut included = false;
+
+        for pattern in &self.patterns {
+            match pattern.strip_prefix('!') {
+                Some(body) => {
+                    if unquote_segments(body) == path {
+                        return false;
+                    }
+                }
+                None => included = included || pattern_covers(pattern, &path),
+            }
+        }
+
+        included
+    }
+}
+
+/// One parsed segment of an include pattern.
+enum Seg {
+    Star,
+    Hash,
+    Lit(String),
+}
+
+/// Splits a concrete attribute path into its segments, unwrapping quotes.
+fn unquote_segments(path: &str) -> Vec<String> {
+    split_segments(path)
+        .into_iter()
+        .map(|(seg, is_quoted)| {
+            if is_quoted {
+                seg.trim_matches('"').to_string()
+            } else {
+                seg
+            }
+        })
+        .collect()
+}
+
+/// Parses an include pattern into segments, collapsing consecutive `*` the same
+/// way [`path_to_nix_list`] does.
+fn pattern_segments(body: &str) -> Vec<Seg> {
+    let mut out: Vec<Seg> = Vec::new();
+
+    for (seg, is_quoted) in split_segments(body) {
+        let next = if is_quoted {
+            Seg::Lit(seg.trim_matches('"').to_string())
+        } else {
+            match seg.as_str() {
+                "*" => Seg::Star,
+                "#" => Seg::Hash,
+                _ => Seg::Lit(seg),
+            }
+        };
+
+        if matches!(next, Seg::Star) && matches!(out.last(), Some(Seg::Star)) {
+            continue;
+        }
+
+        out.push(next);
+    }
+
+    out
+}
+
+/// Whether a single include pattern covers `path`. Every segment consumes
+/// exactly one path element except a trailing `*`, which consumes one or two.
+fn pattern_covers(pattern: &str, path: &[String]) -> bool {
+    let segs = pattern_segments(pattern);
+    let Some(last) = segs.last() else {
+        return false;
+    };
+
+    if matches!(last, Seg::Star) {
+        if path.len() != segs.len() && path.len() != segs.len() + 1 {
+            return false;
+        }
+    } else if path.len() != segs.len() {
+        return false;
+    }
+
+    segs.iter().enumerate().all(|(i, seg)| match seg {
+        Seg::Star | Seg::Hash => true,
+        Seg::Lit(lit) => path[i] == *lit,
+    })
 }
 
 /// Splits a Nix attribute-path pattern on `.`, respecting double-quoted
@@ -509,5 +621,120 @@ mod tests {
             "packages.*.*,!.packages".parse::<Wildcard>().unwrap_err(),
             InputError::EvaluationWildcardStartsWithPeriod,
         );
+    }
+}
+
+#[cfg(test)]
+mod matches_tests {
+    use super::*;
+
+    fn m(pattern: &str, attr: &str) -> bool {
+        pattern.parse::<Wildcard>().unwrap().matches(attr)
+    }
+
+    #[test]
+    fn exact_path_matches_itself_only() {
+        assert!(m(
+            "packages.x86_64-linux.hello",
+            "packages.x86_64-linux.hello"
+        ));
+        assert!(!m(
+            "packages.x86_64-linux.hello",
+            "packages.x86_64-linux.world"
+        ));
+        assert!(!m("packages.x86_64-linux.hello", "packages.x86_64-linux"));
+    }
+
+    #[test]
+    fn star_mid_pattern_matches_exactly_one_segment() {
+        assert!(m("my.*.test", "my.foo.test"));
+        assert!(!m("my.*.test", "my.test"));
+        assert!(!m("my.*.test", "my.foo.bar.test"));
+    }
+
+    #[test]
+    fn hash_matches_exactly_one_segment_and_does_not_descend() {
+        assert!(m("packages.x86_64-linux.#", "packages.x86_64-linux.hello"));
+        assert!(!m(
+            "packages.x86_64-linux.#",
+            "packages.x86_64-linux.py.hello"
+        ));
+        assert!(!m("packages.x86_64-linux.#", "packages.x86_64-linux"));
+    }
+
+    /// A trailing `*` descends one extra level, so it covers both the attr at
+    /// that position and derivations one level below it.
+    #[test]
+    fn trailing_star_matches_one_or_two_segments() {
+        assert!(m("packages.*", "packages.x86_64-linux"));
+        assert!(m("packages.*", "packages.x86_64-linux.hello"));
+        assert!(!m("packages.*", "packages"));
+        assert!(!m("packages.*", "packages.x86_64-linux.py.hello"));
+    }
+
+    /// `packages.*.*` and `packages.*` are the same pattern - consecutive stars
+    /// collapse before evaluation, so they must match the same set here too.
+    #[test]
+    fn consecutive_stars_collapse() {
+        for attr in ["packages.x86_64-linux", "packages.x86_64-linux.hello"] {
+            assert_eq!(m("packages.*.*", attr), m("packages.*", attr), "{attr}");
+        }
+        assert!(m("packages.*.*", "packages.x86_64-linux.hello"));
+        assert!(!m("packages.*.*", "packages.x86_64-linux.py.hello"));
+    }
+
+    #[test]
+    fn bare_star_matches_top_two_levels() {
+        assert!(m("*", "hello"));
+        assert!(m("*", "packages.hello"));
+        assert!(!m("*", "packages.x86_64-linux.hello"));
+    }
+
+    #[test]
+    fn any_include_pattern_may_match() {
+        let w: Wildcard = "packages.*.*,checks.*.*".parse().unwrap();
+        assert!(w.matches("packages.x86_64-linux.hello"));
+        assert!(w.matches("checks.x86_64-linux.fmt"));
+        assert!(!w.matches("devShells.x86_64-linux.default"));
+    }
+
+    #[test]
+    fn exclusion_removes_an_otherwise_matching_path() {
+        let w: Wildcard = "packages.*.*,!packages.x86_64-linux.broken"
+            .parse()
+            .unwrap();
+        assert!(w.matches("packages.x86_64-linux.hello"));
+        assert!(!w.matches("packages.x86_64-linux.broken"));
+        assert!(w.matches("packages.aarch64-linux.broken"));
+    }
+
+    /// Both sides are split on unquoted `.` and compared by inner content, so a
+    /// dotted attribute name must be quoted on the attr side too - `a."b.c".d`
+    /// is three segments and is NOT the same path as the four-segment `a.b.c.d`.
+    #[test]
+    fn quoted_segments_compare_by_inner_content() {
+        assert!(m(
+            r#"packages.*."python3.12""#,
+            r#"packages.x86_64-linux."python3.12""#
+        ));
+        assert!(!m(
+            r#"packages.*."python3.12""#,
+            "packages.x86_64-linux.python3.12"
+        ));
+        assert!(m(r#"my."wild.card".test"#, r#"my."wild.card".test"#));
+        assert!(!m(r#"my."wild.card".test"#, "my.wild.card.test"));
+    }
+
+    /// The attr side is a concrete path, so a caller may quote segments that
+    /// contain dots exactly as they would in the wildcard.
+    #[test]
+    fn quoted_attr_segments_are_unwrapped_too() {
+        assert!(m("packages.*.*", r#"packages."x86_64-linux".hello"#));
+    }
+
+    #[test]
+    fn empty_attr_never_matches() {
+        assert!(!m("*", ""));
+        assert!(!m("packages.*.*", ""));
     }
 }

--- a/backend/gradient-web/src/endpoints/build_requests/dispatch.rs
+++ b/backend/gradient-web/src/endpoints/build_requests/dispatch.rs
@@ -217,48 +217,98 @@ pub(super) async fn finalize_build_request(
 
     let cached_path = ensure_cached_path(&tx, nar).await?;
     queue_signature_placeholders(&tx, &cached_path, &project).await?;
-    let task = ensure_build_request_task(
+
+    let response = queue_build_request(
         &tx,
+        state,
+        project,
+        user,
+        BuildRequestSource {
+            repository: nar.store_path.clone(),
+            commit_hash: vec![0; 20],
+            commit_message: format!("Build request {}", nar.store_hash),
+            target,
+            input_overrides,
+        },
+    )
+    .await?;
+
+    tx.commit().await?;
+
+    Ok(response)
+}
+
+/// What the evaluator should read, and how to label it. `repository` is either a
+/// `/nix/store/<hash>-source` path for an uploaded source or a `git+…?rev=` URL
+/// for a remote one; the evaluator treats both as flake sources.
+pub(super) struct BuildRequestSource {
+    pub repository: String,
+    /// Real commit hash for a remote source; the upload path has no commit and
+    /// passes a zero placeholder.
+    pub commit_hash: Vec<u8>,
+    pub commit_message: String,
+    pub target: Option<String>,
+    pub input_overrides: Vec<(String, String)>,
+}
+
+/// Queues one evaluation on the project's reserved `build-request` task,
+/// creating that task on first use. Shared by every build-request entry point.
+///
+/// Evaluations are marked `concurrent`: build requests are independent one-shot
+/// jobs, so they must not serialise behind each other on
+/// `uq_evaluation_one_active_per_task`, nor abort one another.
+pub(super) async fn queue_build_request<C: ConnectionTrait>(
+    tx: &C,
+    state: &ServerState,
+    project: gradient_types::ids::ProjectId,
+    user: &MUser,
+    source: BuildRequestSource,
+) -> WebResult<DispatchResponse> {
+    let task = ensure_build_request_task(
+        tx,
         project,
         user.id,
         state.config.storage.default_keep_evaluations(),
     )
     .await?;
 
-    let target = target
+    let target = source
+        .target
         .map(|t| t.trim().to_string())
         .filter(|t| !t.is_empty())
         .unwrap_or_else(|| task.wildcard.clone());
 
     let commit = MCommit {
         id: CommitId::now_v7(),
-        message: format!("Build request {}", nar.store_hash),
-        hash: vec![0; 20],
+        message: source.commit_message,
+        hash: source.commit_hash,
         author: Some(user.id),
         author_name: user.name.clone(),
     }
     .into_active_model()
-    .insert(&tx)
+    .insert(tx)
     .await?;
 
     let now_ts = now();
     let evaluation = MEvaluation {
         id: EvaluationId::now_v7(),
         task: Some(task.id),
-        repository: nar.store_path.clone(),
+        repository: source.repository,
         commit: commit.id,
         wildcard: target,
         status: gradient_entity::evaluation::EvaluationStatus::Queued,
+        concurrent: true,
         created_at: now_ts,
         updated_at: now_ts,
         ..Default::default()
     }
     .into_active_model()
-    .insert(&tx)
+    .insert(tx)
     .await?;
 
-    if !input_overrides.is_empty() {
-        let rows: Vec<AEvaluationFlakeInputOverride> = input_overrides
+    if !source.input_overrides.is_empty() {
+        let rows: Vec<AEvaluationFlakeInputOverride> = source
+            .input_overrides
             .into_iter()
             .map(|(input_name, url)| {
                 MEvaluationFlakeInputOverride {
@@ -271,13 +321,11 @@ pub(super) async fn finalize_build_request(
             })
             .collect();
         EEvaluationFlakeInputOverride::insert_many(rows)
-            .exec(&tx)
+            .exec(tx)
             .await?;
     }
 
-    let cache = resolve_project_cache_name(&tx, project).await?;
-
-    tx.commit().await?;
+    let cache = resolve_project_cache_name(tx, project).await?;
 
     Ok(DispatchResponse {
         evaluation: evaluation.id,
@@ -453,7 +501,7 @@ async fn ensure_build_request_task<C: ConnectionTrait>(
         created_at: now(),
         managed: true,
         keep_evaluations,
-        concurrency: ConcurrencyPolicy::SoftAbort,
+        concurrency: ConcurrencyPolicy::All,
         sign_cache: true,
         ..Default::default()
     }

--- a/backend/gradient-web/src/endpoints/build_requests/mod.rs
+++ b/backend/gradient-web/src/endpoints/build_requests/mod.rs
@@ -9,10 +9,14 @@
 //! Two-phase upload + dispatch: the client posts a manifest of source paths
 //! to learn which BLAKE3 blobs the server is missing, streams those blobs
 //! one at a time, then dispatches the request to the scheduler.
+//!
+//! [`url`] is the no-upload variant: the source is already published at a
+//! remote URL, so only the URL and a revision are posted (#564).
 
 pub mod blobs;
 pub mod dispatch;
 pub mod manifest;
 pub mod source;
 pub mod types;
+pub mod url;
 mod validation;

--- a/backend/gradient-web/src/endpoints/build_requests/url.rs
+++ b/backend/gradient-web/src/endpoints/build_requests/url.rs
@@ -1,0 +1,146 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! `POST /build-requests/url` - queue a build request against a remote
+//! repository instead of an uploaded source tree (#564).
+//!
+//! The upload flows exist so `gradient build` can ship a dirty working tree. A
+//! deployment tool already has the source published at a URL and only needs
+//! Gradient to evaluate one attribute of it, so there is nothing to upload:
+//! `repository_url_to_nix` turns the URL and revision into exactly the source
+//! string an evaluation carries, and the worker fetches it directly.
+//!
+//! Like the upload flows this runs on the project's reserved `build-request`
+//! task, so a caller never has to create a task per job.
+
+use super::dispatch::{
+    BuildRequestSource, DispatchResponse, InputOverrideBody, queue_build_request,
+    validate_remote_override,
+};
+use crate::access::{Caller, ProjectAccess, load_project};
+use crate::authorization::MaybeApiKey;
+use crate::error::{ErrorCode, WebError, WebResult};
+use crate::helpers::ok_json;
+use crate::permissions::Permission;
+use axum::extract::State;
+use axum::{Extension, Json};
+use gradient_core::ServerState;
+use gradient_sources::resolve_remote_ref;
+use gradient_types::input::{hex_to_vec, repository_url_to_nix, vec_to_hex};
+use gradient_types::{BaseResponse, MUser};
+use sea_orm::TransactionTrait;
+use serde::Deserialize;
+use std::sync::Arc;
+
+/// A git commit hash is 40 hex characters, so 20 bytes once decoded.
+const COMMIT_HASH_BYTES: usize = 20;
+
+#[derive(Deserialize, Debug)]
+pub struct UrlRequest {
+    /// Project the build runs under; supplies the cache, the workers, and the
+    /// deploy key used to reach a private repository.
+    pub project: String,
+    pub url: String,
+    /// Branch or tag to resolve. Omit both this and `rev` to take the
+    /// repository's default branch.
+    #[serde(default, rename = "ref")]
+    pub git_ref: Option<String>,
+    /// Exact commit to build, 40 hex characters. Mutually exclusive with `ref`.
+    #[serde(default)]
+    pub rev: Option<String>,
+    /// Attribute path or wildcard to evaluate. Defaults to everything.
+    #[serde(default)]
+    pub target: Option<String>,
+    #[serde(default)]
+    pub input_overrides: Vec<InputOverrideBody>,
+}
+
+pub async fn post_url(
+    state: State<Arc<ServerState>>,
+    Extension(user): Extension<MUser>,
+    Extension(api_key): Extension<MaybeApiKey>,
+    Json(body): Json<UrlRequest>,
+) -> WebResult<Json<BaseResponse<DispatchResponse>>> {
+    let project = load_project(
+        &state.0,
+        Caller::User(&user),
+        api_key.as_ref(),
+        body.project,
+        ProjectAccess::Require {
+            permission: Permission::TriggerEvaluation,
+            reject_managed: false,
+        },
+    )
+    .await?;
+
+    if body.git_ref.is_some() && body.rev.is_some() {
+        return Err(WebError::bad_request(
+            "Specify at most one of `ref` and `rev`",
+        ));
+    }
+
+    let url = body.url.trim();
+    if url.is_empty() {
+        return Err(WebError::bad_request("`url` must not be empty"));
+    }
+
+    let input_overrides: Vec<(String, String)> = body
+        .input_overrides
+        .into_iter()
+        .map(|o| (o.input_name, o.url))
+        .collect();
+    for (input_name, override_url) in &input_overrides {
+        validate_remote_override(input_name, override_url)?;
+    }
+
+    let (commit_hash, label) = match body.rev.as_deref() {
+        Some(rev) => {
+            let hash = hex_to_vec(rev)
+                .ok()
+                .filter(|h| h.len() == COMMIT_HASH_BYTES)
+                .ok_or_else(|| WebError::bad_request("`rev` must be a 40-character hex hash"))?;
+            (hash, rev.to_string())
+        }
+        None => {
+            let git_ref = body.git_ref.as_deref();
+            let hash = resolve_remote_ref(&state.db(), &project, url, git_ref)
+                .await
+                .map_err(|e| {
+                    WebError::bad_request_with(
+                        ErrorCode::REPOSITORY_UNREACHABLE,
+                        format!("Failed to resolve repository state: {}", e),
+                    )
+                })?;
+            (hash, git_ref.unwrap_or("HEAD").to_string())
+        }
+    };
+
+    // Rejects local paths, and is the same shape `parse_nix_git_url` reads back
+    // on the worker.
+    let repository = repository_url_to_nix(url, &vec_to_hex(&commit_hash))
+        .map_err(|e| WebError::bad_request(format!("Invalid repository URL: {}", e)))?;
+
+    let tx = state.web_db.inner().begin().await?;
+
+    let response = queue_build_request(
+        &tx,
+        &state.0,
+        project.id,
+        &user,
+        BuildRequestSource {
+            repository,
+            commit_hash,
+            commit_message: format!("Build request {url}@{label}"),
+            target: body.target,
+            input_overrides,
+        },
+    )
+    .await?;
+
+    tx.commit().await?;
+
+    Ok(ok_json(response))
+}

--- a/backend/gradient-web/src/endpoints/tasks/evaluations.rs
+++ b/backend/gradient-web/src/endpoints/tasks/evaluations.rs
@@ -41,6 +41,11 @@ pub struct EvaluateRequest {
     /// `"restart_failed"` skips fetch+eval and re-queues failed builds from the
     /// most recent evaluation. Omit or `null` for a normal evaluation.
     pub mode: Option<String>,
+    /// Exact commit to evaluate, 40 hex characters. Omit to take the branch
+    /// head, which is what a normal CI run does.
+    pub commit: Option<String>,
+    /// Attribute path or wildcard to evaluate instead of the task's own.
+    pub attr: Option<String>,
 }
 
 /// Builds one [`EvaluationSummary`] per evaluation using grouped DB rollups
@@ -214,33 +219,85 @@ pub async fn post_task_evaluate(
         return Ok(ok_json(eval.id.to_string()));
     }
 
-    let mut task_for_check = task.clone();
-    task_for_check.force_evaluation = true;
-    let (_has_updates, commit_hash) = check_task_updates(&state.db(), &task_for_check, None)
-        .await
-        .map_err(|e| {
-            WebError::bad_request_with(
-                ErrorCode::REPOSITORY_UNREACHABLE,
-                format!("Failed to fetch repository state: {}", e),
+    let pinned = body
+        .as_ref()
+        .and_then(|b| b.commit.as_deref())
+        .map(|commit| {
+            hex_to_vec(commit)
+                .ok()
+                .filter(|h| h.len() == COMMIT_HASH_BYTES)
+                .ok_or_else(|| WebError::bad_request("`commit` must be a 40-character hex hash"))
+        })
+        .transpose()?;
+
+    let attr = body
+        .as_ref()
+        .and_then(|b| b.attr.as_deref())
+        .map(|a| {
+            a.parse::<Wildcard>()
+                .map(|w| w.to_string())
+                .map_err(|e| WebError::bad_request(format!("Invalid `attr`: {}", e)))
+        })
+        .transpose()?;
+
+    let pinned_run = pinned.is_some();
+
+    // A pinned commit skips the branch-head lookup entirely; the clone inside
+    // `get_commit_info` is what proves the commit is actually reachable, so an
+    // unknown one is refused here instead of queueing an evaluation that dies
+    // fetching.
+    let (commit_hash, commit_message, author_name) = match pinned {
+        Some(commit_hash) => {
+            let (message, _email, author) = get_commit_info(&state.db(), &task, &commit_hash)
+                .await
+                .map_err(|e| {
+                    WebError::bad_request_with(
+                        ErrorCode::REPOSITORY_UNREACHABLE,
+                        format!("Commit not found in repository: {}", e),
+                    )
+                })?;
+            (commit_hash, message, author)
+        }
+        None => {
+            let mut task_for_check = task.clone();
+            task_for_check.force_evaluation = true;
+            let (_has_updates, commit_hash) =
+                check_task_updates(&state.db(), &task_for_check, None)
+                    .await
+                    .map_err(|e| {
+                        WebError::bad_request_with(
+                            ErrorCode::REPOSITORY_UNREACHABLE,
+                            format!("Failed to fetch repository state: {}", e),
+                        )
+                    })?;
+
+            let (message, _email, author) = get_commit_info(&state.db(), &task, &commit_hash)
+                .await
+                .unwrap_or_else(|_| (String::new(), None, String::new()));
+
+            // A manual evaluation also bumps tracked flake inputs (OpenPr
+            // action). Self-gated: no-ops unless the task qualifies. A pinned
+            // run is deliberately excluded - it asks for one exact revision,
+            // not for the newest inputs.
+            if let Err(e) = gradient_ci::trigger::maybe_trigger_input_update(
+                &state.web_db,
+                &task,
+                commit_hash.clone(),
+                None,
             )
-        })?;
+            .await
+            {
+                tracing::warn!(error = %e, task = %task.name, "manual input_update trigger failed");
+            }
 
-    let (commit_message, _email, author_name) = get_commit_info(&state.db(), &task, &commit_hash)
-        .await
-        .unwrap_or_else(|_| (String::new(), None, String::new()));
+            (commit_hash, message, author)
+        }
+    };
 
-    // A manual evaluation also bumps tracked flake inputs (OpenPr action).
-    // Self-gated: no-ops unless the task qualifies.
-    if let Err(e) = gradient_ci::trigger::maybe_trigger_input_update(
-        &state.web_db,
-        &task,
-        commit_hash.clone(),
-        None,
-    )
-    .await
-    {
-        tracing::warn!(error = %e, task = %task.name, "manual input_update trigger failed");
-    }
+    // A pinned run is an out-of-band request, typically from a deployment tool.
+    // Marking it concurrent keeps it from queueing behind - or aborting - the
+    // task's own CI run, which owns the single non-concurrent slot.
+    let concurrent = pinned_run;
 
     let eval = gradient_ci::trigger_evaluation(
         &state.web_db,
@@ -249,9 +306,9 @@ pub async fn post_task_evaluate(
         Some(commit_message),
         Some(author_name),
         None,
-        false,
+        concurrent,
         None,
-        None,
+        attr,
         None,
         Some(user.id),
     )

--- a/backend/gradient-web/src/endpoints/tasks/evaluations.rs
+++ b/backend/gradient-web/src/endpoints/tasks/evaluations.rs
@@ -21,16 +21,18 @@ use axum::{Extension, Json};
 use gradient_core::ServerState;
 use gradient_db::get_any_project_by_name;
 use gradient_entity::build::BuildStatus;
+use gradient_entity::derivation_output::UNKNOWN_OUTPUT_HASH;
+use gradient_entity::evaluation::EvaluationStatus;
 use gradient_entity::evaluation_message::MessageLevel;
 use gradient_sources::{check_task_updates, get_commit_info, get_path_from_derivation_output};
 use gradient_storage::nar_extract::{
     ExtractError, Extracted, extract_path_from_reader, nar_reader_from_stream,
 };
-use gradient_types::input::vec_to_hex;
+use gradient_types::input::{hex_to_vec, vec_to_hex};
 use gradient_types::*;
-use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect};
+use sea_orm::{ColumnTrait, EntityTrait, Iterable, QueryFilter, QueryOrder, QuerySelect};
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
 #[derive(Deserialize, Default)]
@@ -146,6 +148,7 @@ pub(super) async fn evaluations_to_summaries(
             commit: commit_hash,
             commit_message,
             status: evaluation.status,
+            wildcard: evaluation.wildcard.clone(),
             trigger,
             triggered_by,
             pr_number,
@@ -196,7 +199,7 @@ pub async fn post_task_evaluate(
     let mode = body.as_ref().and_then(|b| b.mode.as_deref());
 
     if mode == Some("restart_failed") {
-        gradient_ci::trigger_restart_builds(&state.web_db, &task)
+        let eval = gradient_ci::trigger_restart_builds(&state.web_db, &task)
             .await
             .map_err(|e| match e {
                 gradient_ci::TriggerError::AlreadyInProgress => {
@@ -208,7 +211,7 @@ pub async fn post_task_evaluate(
                 gradient_ci::TriggerError::Db(db_err) => WebError::from(db_err),
             })?;
 
-        return Ok(ok_json("Restarting failed builds".to_string()));
+        return Ok(ok_json(eval.id.to_string()));
     }
 
     let mut task_for_check = task.clone();
@@ -272,7 +275,7 @@ pub async fn post_task_evaluate(
     let eval = gradient_ci::park_if_no_workers(&state.web_db, eval, task.project).await?;
     gradient_ci::actions::dispatch_evaluation_created(&state.ci(), &eval).await;
 
-    Ok(ok_json("Evaluation started".to_string()))
+    Ok(ok_json(eval.id.to_string()))
 }
 
 /// `GET /tasks/{project}/{task}/evaluations`
@@ -297,12 +300,56 @@ pub async fn get_task_evaluations(
     .await?;
 
     let limit = params.limit.unwrap_or(task.keep_evaluations as u64);
-    let evaluations = EEvaluation::find()
-        .filter(CEvaluation::Task.eq(task.id))
-        .order_by_desc(CEvaluation::CreatedAt)
-        .limit(limit)
-        .all(&state.web_db)
-        .await?;
+    let attr = params.attr.as_deref().map(parse_attr_filter).transpose()?;
+
+    let mut query = EEvaluation::find().filter(CEvaluation::Task.eq(task.id));
+
+    if let Some(commit) = params.commit.as_deref() {
+        let hash = hex_to_vec(commit)
+            .ok()
+            .filter(|h| h.len() == COMMIT_HASH_BYTES)
+            .ok_or_else(|| WebError::bad_request("`commit` must be a 40-character hex hash"))?;
+
+        // A fresh `commit` row is written per evaluation, so one hash maps to
+        // many ids; resolve them first rather than joining on every scan.
+        let commit_ids: Vec<CommitId> = ECommit::find()
+            .filter(CCommit::Hash.eq(hash))
+            .all(&state.web_db)
+            .await?
+            .into_iter()
+            .map(|c| c.id)
+            .collect();
+
+        if commit_ids.is_empty() {
+            return Ok(ok_json(vec![]));
+        }
+
+        query = query.filter(CEvaluation::Commit.is_in(commit_ids));
+    }
+
+    if let Some(status) = params.status.as_deref() {
+        query = query.filter(CEvaluation::Status.is_in(parse_status_filter(status)?));
+    }
+
+    let query = query.order_by_desc(CEvaluation::CreatedAt);
+
+    // Wildcard coverage cannot be expressed in SQL, so an `attr` search reads a
+    // bounded window of the SQL-filtered rows and matches them here.
+    let evaluations = match attr {
+        Some(attr) => query
+            .limit(ATTR_SCAN_LIMIT)
+            .all(&state.web_db)
+            .await?
+            .into_iter()
+            .filter(|e| {
+                e.wildcard
+                    .parse::<Wildcard>()
+                    .is_ok_and(|w| w.matches(attr))
+            })
+            .take(limit as usize)
+            .collect(),
+        None => query.limit(limit).all(&state.web_db).await?,
+    };
 
     let summaries = evaluations_to_summaries(&state.0, evaluations).await?;
 
@@ -388,6 +435,53 @@ pub async fn get_task_details(
 #[derive(Deserialize, Debug, Default)]
 pub struct EvaluationsQuery {
     pub limit: Option<u64>,
+    /// Full 40-character commit hash, hex.
+    pub commit: Option<String>,
+    /// `active`, `terminal`, or one exact status name (`Building`, `Failed`, ...).
+    pub status: Option<String>,
+    /// Concrete attribute path. Matches evaluations whose *wildcard* covers it,
+    /// which is set when the row is created and so answers at every status -
+    /// unlike entry points, which only exist once derivations have resolved.
+    pub attr: Option<String>,
+}
+
+/// A git commit hash is 40 hex characters, so 20 bytes once decoded.
+const COMMIT_HASH_BYTES: usize = 20;
+
+/// How many rows an `attr` search reads before matching in Rust. Evaluations are
+/// GC-bounded per task by `keep_evaluations`, so this only truncates a task
+/// configured to retain more than this, and only for the oldest of them.
+const ATTR_SCAN_LIMIT: u64 = 1000;
+
+/// Validates the `attr` filter as a concrete attribute path: one of the paths a
+/// wildcard may cover, carrying no pattern syntax of its own. Segments inside
+/// double quotes are left alone so an attribute genuinely named `*` still works.
+fn parse_attr_filter(attr: &str) -> WebResult<&str> {
+    let unquoted_has = |c: char| attr.split('"').step_by(2).any(|part| part.contains(c));
+
+    if attr.is_empty() || attr.contains(',') || unquoted_has('*') || unquoted_has('#') {
+        return Err(WebError::bad_request(
+            "`attr` must be a concrete attribute path, without wildcard syntax",
+        ));
+    }
+
+    Ok(attr)
+}
+
+/// Resolves the `status` filter to the set of statuses it names.
+fn parse_status_filter(raw: &str) -> WebResult<Vec<EvaluationStatus>> {
+    match raw {
+        "active" => Ok(EvaluationStatus::ACTIVE.to_vec()),
+        "terminal" => Ok(EvaluationStatus::TERMINAL.to_vec()),
+        name => EvaluationStatus::iter()
+            .find(|s| format!("{s:?}").eq_ignore_ascii_case(name))
+            .map(|s| vec![s])
+            .ok_or_else(|| {
+                WebError::bad_request(format!(
+                    "Unknown evaluation status `{name}`; expected `active`, `terminal`, or a status name"
+                ))
+            }),
+    }
 }
 
 #[derive(Deserialize, Debug)]
@@ -456,8 +550,30 @@ struct EntryPointRelatedData {
     build_jobs: HashMap<DerivationId, BuildJobId>,
     derivations: HashMap<DerivationId, MDerivation>,
     has_products: HashMap<DerivationId, bool>,
+    outputs: HashMap<DerivationId, BTreeMap<String, String>>,
     build_time_ms: HashMap<DerivationId, Option<i64>>,
     deps: HashMap<EntryPointId, BuildStatusCounts>,
+}
+
+/// Groups output rows into `output name -> full /nix/store path` per derivation.
+/// Rows whose store path the evaluator never resolved carry the
+/// [`UNKNOWN_OUTPUT_HASH`] sentinel and are dropped: there is no path to report.
+fn output_paths_by_derivation(
+    rows: &[MDerivationOutput],
+) -> HashMap<DerivationId, BTreeMap<String, String>> {
+    let mut out: HashMap<DerivationId, BTreeMap<String, String>> = HashMap::new();
+
+    for row in rows {
+        if row.hash == UNKNOWN_OUTPUT_HASH {
+            continue;
+        }
+        out.entry(row.derivation).or_default().insert(
+            row.name.clone(),
+            get_path_from_derivation_output(row.clone()).full(),
+        );
+    }
+
+    out
 }
 
 impl EntryPointRelatedData {
@@ -516,25 +632,37 @@ impl EntryPointRelatedData {
             .map(|j| (j.derivation, j.id))
             .collect();
 
-        let completed_drv_ids: Vec<DerivationId> = anchors
+        let completed_drv_ids: HashSet<DerivationId> = anchors
             .values()
             .filter(|a| a.status == BuildStatus::Completed || a.status == BuildStatus::Substituted)
             .map(|a| a.derivation)
             .collect();
 
-        // Determine which derivations have at least one build_product by looking
-        // at their outputs.
-        let has_products: HashMap<DerivationId, bool> = if completed_drv_ids.is_empty() {
-            HashMap::new()
-        } else {
-            let outputs = gradient_db::fetch_in_chunks(&completed_drv_ids, |chunk| async move {
-                EDerivationOutput::find()
-                    .filter(CDerivationOutput::Derivation.is_in(chunk))
-                    .all(db)
-                    .await
-            })
-            .await?;
-            let output_ids: Vec<DerivationOutputId> = outputs.iter().map(|o| o.id).collect();
+        // Output rows are written at eval time from the resolved `.drv`, so they
+        // exist regardless of build status; `build_status` is what tells a caller
+        // whether the path is realised. `hash` falls back to the literal
+        // "unknown" when the evaluator could not parse the output path (floating
+        // CA outputs), and nothing ever rewrites it - skip those rather than
+        // hand out a path that cannot exist.
+        let output_rows = gradient_db::fetch_in_chunks(&drv_ids, |chunk| async move {
+            EDerivationOutput::find()
+                .filter(CDerivationOutput::Derivation.is_in(chunk))
+                .all(db)
+                .await
+        })
+        .await?;
+
+        let outputs = output_paths_by_derivation(&output_rows);
+
+        // Determine which derivations have at least one build_product. Only
+        // built derivations can have products, so the product lookup stays
+        // scoped to their outputs.
+        let has_products: HashMap<DerivationId, bool> = {
+            let built: Vec<&MDerivationOutput> = output_rows
+                .iter()
+                .filter(|o| completed_drv_ids.contains(&o.derivation))
+                .collect();
+            let output_ids: Vec<DerivationOutputId> = built.iter().map(|o| o.id).collect();
             let mut m: HashMap<DerivationId, bool> = HashMap::new();
             if !output_ids.is_empty() {
                 let products = gradient_db::fetch_in_chunks(&output_ids, |chunk| async move {
@@ -546,7 +674,7 @@ impl EntryPointRelatedData {
                 .await?;
                 for bp in products {
                     // Map back from output → derivation.
-                    if let Some(output) = outputs.iter().find(|o| o.id == bp.derivation_output) {
+                    if let Some(output) = built.iter().find(|o| o.id == bp.derivation_output) {
                         m.insert(output.derivation, true);
                     }
                 }
@@ -620,6 +748,7 @@ impl EntryPointRelatedData {
             build_jobs,
             derivations,
             has_products,
+            outputs,
             build_time_ms,
             deps,
         })
@@ -647,6 +776,11 @@ impl EntryPointRelatedData {
                 eval: ep.eval.clone(),
                 build_status,
                 has_artefacts: *self.has_products.get(&ep.derivation).unwrap_or(&false),
+                outputs: self
+                    .outputs
+                    .get(&ep.derivation)
+                    .cloned()
+                    .unwrap_or_default(),
                 architecture: drv.architecture.clone(),
                 build_time_ms: self.build_time_ms.get(&ep.derivation).copied().flatten(),
                 deps: self.deps.get(&ep.id).copied().unwrap_or_default(),
@@ -926,5 +1060,113 @@ mod tests {
                 .count(),
             100
         );
+    }
+}
+
+#[cfg(test)]
+mod search_tests {
+    use super::*;
+    use gradient_entity::ids::DerivationOutputId;
+
+    fn output_row(drv: DerivationId, name: &str, hash: &str, package: &str) -> MDerivationOutput {
+        MDerivationOutput {
+            id: DerivationOutputId::now_v7(),
+            derivation: drv,
+            name: name.into(),
+            hash: hash.into(),
+            package: package.into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn output_paths_are_absolute_store_paths_grouped_per_derivation() {
+        let a = DerivationId::now_v7();
+        let b = DerivationId::now_v7();
+        let rows = vec![
+            output_row(a, "out", "aaaa", "hello-1.0"),
+            output_row(a, "dev", "bbbb", "hello-1.0-dev"),
+            output_row(b, "out", "cccc", "world-2.0"),
+        ];
+
+        let grouped = output_paths_by_derivation(&rows);
+
+        assert_eq!(grouped[&a]["out"], "/nix/store/aaaa-hello-1.0");
+        assert_eq!(grouped[&a]["dev"], "/nix/store/bbbb-hello-1.0-dev");
+        assert_eq!(grouped[&b]["out"], "/nix/store/cccc-world-2.0");
+        assert_eq!(grouped.len(), 2);
+    }
+
+    /// The evaluator writes the sentinel when an output has no resolvable path
+    /// and nothing ever rewrites it, so reporting one would hand a deployment
+    /// tool `/nix/store/unknown-...`, which cannot exist.
+    #[test]
+    fn unresolved_output_paths_are_omitted() {
+        let drv = DerivationId::now_v7();
+        let rows = vec![
+            output_row(drv, "out", UNKNOWN_OUTPUT_HASH, "hello"),
+            output_row(drv, "dev", "bbbb", "hello-dev"),
+        ];
+
+        let grouped = output_paths_by_derivation(&rows);
+
+        assert!(!grouped[&drv].contains_key("out"));
+        assert_eq!(grouped[&drv]["dev"], "/nix/store/bbbb-hello-dev");
+    }
+
+    #[test]
+    fn derivation_with_no_resolvable_output_is_absent_entirely() {
+        let drv = DerivationId::now_v7();
+        let rows = vec![output_row(drv, "out", UNKNOWN_OUTPUT_HASH, "hello")];
+
+        assert!(output_paths_by_derivation(&rows).is_empty());
+    }
+
+    #[test]
+    fn attr_filter_accepts_a_concrete_path() {
+        assert!(parse_attr_filter("packages.x86_64-linux.hello").is_ok());
+        assert!(parse_attr_filter(r#"packages."x86_64-linux".hello"#).is_ok());
+    }
+
+    #[test]
+    fn attr_filter_rejects_pattern_syntax() {
+        for bad in ["", "packages.*.hello", "packages.x86_64-linux.#", "a.b,c.d"] {
+            assert!(parse_attr_filter(bad).is_err(), "should reject {bad:?}");
+        }
+    }
+
+    /// A `*` inside quotes is an attribute literally named `*`, not a pattern.
+    #[test]
+    fn attr_filter_allows_a_quoted_star_segment() {
+        assert!(parse_attr_filter(r#"packages.x86_64-linux."*""#).is_ok());
+    }
+
+    #[test]
+    fn status_filter_expands_the_named_groups() {
+        assert_eq!(
+            parse_status_filter("active").unwrap(),
+            EvaluationStatus::ACTIVE.to_vec()
+        );
+        assert_eq!(
+            parse_status_filter("terminal").unwrap(),
+            EvaluationStatus::TERMINAL.to_vec()
+        );
+    }
+
+    #[test]
+    fn status_filter_takes_one_status_by_name_case_insensitively() {
+        assert_eq!(
+            parse_status_filter("building").unwrap(),
+            vec![EvaluationStatus::Building]
+        );
+        assert_eq!(
+            parse_status_filter("Completed").unwrap(),
+            vec![EvaluationStatus::Completed]
+        );
+    }
+
+    #[test]
+    fn status_filter_rejects_an_unknown_name() {
+        assert!(parse_status_filter("Exploded").is_err());
     }
 }

--- a/backend/gradient-web/src/endpoints/tasks/mod.rs
+++ b/backend/gradient-web/src/endpoints/tasks/mod.rs
@@ -71,6 +71,10 @@ pub struct EntryPointSummary {
     pub eval: String,
     pub build_status: gradient_entity::build::BuildStatus,
     pub has_artefacts: bool,
+    /// Output name to full `/nix/store` path, from the resolved `.drv`. Present
+    /// before the build runs; `build_status` is what says whether the path is
+    /// realised. Outputs whose path the evaluator could not resolve are omitted.
+    pub outputs: std::collections::BTreeMap<String, String>,
     pub architecture: gradient_entity::server::Architecture,
     pub build_time_ms: Option<i64>,
     pub deps: BuildStatusCounts,
@@ -94,6 +98,9 @@ pub struct EvaluationSummary {
     pub commit: String,
     pub commit_message: Option<String>,
     pub status: EvaluationStatus,
+    /// Attribute-path scope this evaluation ran with. Lets a caller tell what an
+    /// evaluation covered without waiting for its entry points to resolve.
+    pub wildcard: String,
     pub trigger: Option<EvaluationTriggerSummary>,
     pub triggered_by: Option<String>,
     /// PR/MR number for pull-request-triggered evaluations, for the "PR #42"

--- a/backend/gradient-web/src/lib.rs
+++ b/backend/gradient-web/src/lib.rs
@@ -354,6 +354,7 @@ pub fn create_router(state: Arc<ServerState>) -> Result<Router, InitError> {
             "/build-requests/{session}/dispatch",
             post(build_requests::dispatch::post_dispatch),
         )
+        .route("/build-requests/url", post(build_requests::url::post_url))
         .route(
             "/build-requests/source",
             post(build_requests::source::post_source).layer(DefaultBodyLimit::max(

--- a/backend/gradient-web/tests/build_requests_url.rs
+++ b/backend/gradient-web/tests/build_requests_url.rs
@@ -1,0 +1,268 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Integration tests for `POST /api/v1/build-requests/url` (#564).
+//!
+//! The no-upload build request: the source is already published at a URL, so a
+//! deployment tool posts the URL and a revision instead of shipping a source
+//! tree. Every test here pins an explicit `rev`, which is the branch that does
+//! no network work - resolving a `ref` needs a real remote.
+//!
+//! Query sequence: session, session update, user (authorize), project by name,
+//! membership, role (TriggerEvaluation), then the queueing transaction.
+
+use gradient_db::permissions::PermissionMask;
+use gradient_entity::{ids::*, project, project_user, role, task};
+use gradient_test_support::fixtures::{project_id, task_id, test_date, user, user_id};
+use gradient_test_support::web::{live_session, make_test_server, make_token};
+use gradient_types::consts::BASE_ROLE_WRITE_ID;
+use gradient_types::{ConcurrencyPolicy, SessionId};
+use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
+use serde_json::{Value, json};
+use uuid::Uuid;
+
+const URL: &str = "/api/v1/build-requests/url";
+const REV: &str = "9c1a2b3c4d5e6f708192a3b4c5d6e7f809a1b2c3";
+const REPO: &str = "https://example.com/org/repo.git";
+
+fn write_role() -> role::Model {
+    role::Model {
+        id: BASE_ROLE_WRITE_ID,
+        name: "write".into(),
+        permission: gradient_db::permissions::write_mask() as PermissionMask,
+        ..Default::default()
+    }
+}
+
+fn membership() -> project_user::Model {
+    project_user::Model {
+        id: ProjectUserId::new(Uuid::parse_str("00000000-0000-0000-0000-0000000000bb").unwrap()),
+        project: project_id(),
+        user: user_id(),
+        role: BASE_ROLE_WRITE_ID,
+    }
+}
+
+fn project_row() -> project::Model {
+    project::Model {
+        id: project_id(),
+        name: "test-project".into(),
+        display_name: "Test Project".into(),
+        public_key: "ssh-ed25519 AAAA test".into(),
+        private_key: "encrypted".into(),
+        created_by: user_id(),
+        created_at: test_date(),
+        ..Default::default()
+    }
+}
+
+fn reserved_task() -> task::Model {
+    task::Model {
+        id: task_id(),
+        project: project_id(),
+        name: "build-request".into(),
+        active: true,
+        display_name: "Build Requests".into(),
+        repository: "build-request".into(),
+        wildcard: "*".into(),
+        last_check_at: test_date(),
+        created_by: user_id(),
+        created_at: test_date(),
+        managed: true,
+        keep_evaluations: 10,
+        concurrency: ConcurrencyPolicy::All,
+        ..Default::default()
+    }
+}
+
+fn base_db(session_id: SessionId) -> MockDatabase {
+    let session = live_session(session_id);
+    MockDatabase::new(DatabaseBackend::Postgres)
+        .append_query_results([vec![session.clone()]])
+        .append_query_results([vec![session]])
+        .append_query_results([vec![user()]])
+        .append_query_results([vec![project_row()]])
+        .append_query_results([vec![membership()]])
+        .append_query_results([vec![write_role()]])
+}
+
+fn run<F: std::future::Future>(fut: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(fut)
+}
+
+async fn post(db: MockDatabase, session_id: SessionId, body: Value) -> axum_test::TestResponse {
+    make_test_server(db.into_connection())
+        .post(URL)
+        .add_header(
+            "Authorization",
+            format!("Bearer {}", make_token(session_id)),
+        )
+        .json(&body)
+        .await
+}
+
+#[test]
+fn queues_an_evaluation_against_the_remote_url() {
+    run(async {
+        let session_id = SessionId::now_v7();
+        let commit = CommitId::now_v7();
+        let evaluation = EvaluationId::now_v7();
+
+        let db = base_db(session_id)
+            // reserved build-request task already exists
+            .append_query_results([vec![reserved_task()]])
+            // INSERT commit, INSERT evaluation
+            .append_query_results([vec![gradient_entity::commit::Model {
+                id: commit,
+                message: format!("Build request {REPO}@{REV}"),
+                hash: vec![0x9c; 20],
+                author: Some(user_id()),
+                author_name: user().name,
+            }]])
+            .append_query_results([vec![gradient_entity::evaluation::Model {
+                id: evaluation,
+                task: Some(task_id()),
+                repository: format!("git+{REPO}?rev={REV}"),
+                commit,
+                wildcard: "packages.x86_64-linux.hello".into(),
+                concurrent: true,
+                created_at: test_date(),
+                updated_at: test_date(),
+                ..Default::default()
+            }]])
+            // no cache linked to the project
+            .append_query_results([Vec::<gradient_entity::project_cache::Model>::new()])
+            .append_exec_results([MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }]);
+
+        let res = post(
+            db,
+            session_id,
+            json!({
+                "project": "test-project",
+                "url": REPO,
+                "rev": REV,
+                "target": "packages.x86_64-linux.hello",
+            }),
+        )
+        .await;
+
+        res.assert_status_ok();
+        let body: Value = res.json();
+        assert_eq!(body["error"], false);
+        assert_eq!(body["message"]["evaluation"], evaluation.to_string());
+        assert_eq!(body["message"]["task"], task_id().to_string());
+        assert_eq!(body["message"]["commit"], commit.to_string());
+    });
+}
+
+#[test]
+fn rejects_ref_and_rev_together() {
+    run(async {
+        let session_id = SessionId::now_v7();
+        let res = post(
+            base_db(session_id),
+            session_id,
+            json!({"project": "test-project", "url": REPO, "rev": REV, "ref": "main"}),
+        )
+        .await;
+
+        res.assert_status_bad_request();
+        let body: Value = res.json();
+        assert!(
+            body["message"].as_str().unwrap().contains("at most one"),
+            "unexpected message: {}",
+            body["message"]
+        );
+    });
+}
+
+#[test]
+fn rejects_a_rev_that_is_not_a_full_hash() {
+    run(async {
+        let session_id = SessionId::now_v7();
+        let res = post(
+            base_db(session_id),
+            session_id,
+            json!({"project": "test-project", "url": REPO, "rev": "9c1a2b3"}),
+        )
+        .await;
+
+        res.assert_status_bad_request();
+        let body: Value = res.json();
+        assert!(
+            body["message"].as_str().unwrap().contains("40-character"),
+            "unexpected message: {}",
+            body["message"]
+        );
+    });
+}
+
+#[test]
+fn rejects_an_empty_url() {
+    run(async {
+        let session_id = SessionId::now_v7();
+        let res = post(
+            base_db(session_id),
+            session_id,
+            json!({"project": "test-project", "url": "   ", "rev": REV}),
+        )
+        .await;
+
+        res.assert_status_bad_request();
+    });
+}
+
+/// `repository_url_to_nix` refuses local paths, so a build request cannot make
+/// the server read a flake off its own disk.
+#[test]
+fn rejects_a_local_file_url() {
+    run(async {
+        let session_id = SessionId::now_v7();
+        let res = post(
+            base_db(session_id),
+            session_id,
+            json!({"project": "test-project", "url": "file:///etc", "rev": REV}),
+        )
+        .await;
+
+        res.assert_status_bad_request();
+        let body: Value = res.json();
+        assert!(
+            body["message"].as_str().unwrap().contains("repository URL"),
+            "unexpected message: {}",
+            body["message"]
+        );
+    });
+}
+
+/// Same defence in depth the upload dispatch applies: an override must name a
+/// remote flake ref, never a local path.
+#[test]
+fn rejects_a_local_input_override() {
+    run(async {
+        let session_id = SessionId::now_v7();
+        let res = post(
+            base_db(session_id),
+            session_id,
+            json!({
+                "project": "test-project",
+                "url": REPO,
+                "rev": REV,
+                "input_overrides": [{"input_name": "nixpkgs", "url": "/home/me/nixpkgs"}],
+            }),
+        )
+        .await;
+
+        res.assert_status_bad_request();
+    });
+}

--- a/backend/gradient-web/tests/evaluations_search.rs
+++ b/backend/gradient-web/tests/evaluations_search.rs
@@ -1,0 +1,261 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Integration tests for the `GET /api/v1/tasks/{project}/{task}/evaluations`
+//! search filters (#564).
+//!
+//! The `attr` filter matches an evaluation's *wildcard*, set when the row is
+//! created, so it answers while an evaluation is still `Queued` - unlike entry
+//! points, which only exist once derivations have resolved. That is the
+//! behaviour `attr_filter_matches_queued_evaluation` pins.
+//!
+//! Every request (public project, so no membership check) consumes these
+//! mocked reads before the handler's own: session by jti, session update, user,
+//! project by name, task by project and name.
+
+use gradient_entity::evaluation::EvaluationStatus;
+use gradient_entity::{commit, evaluation, ids::*, project, task};
+use gradient_test_support::fixtures::{commit_id, project_id, task_id, test_date, user, user_id};
+use gradient_test_support::web::{live_session, make_test_server, make_token};
+use gradient_types::{ConcurrencyPolicy, SessionId};
+use sea_orm::{DatabaseBackend, MockDatabase};
+use serde_json::Value;
+
+const COMMIT_HEX: &str = "1111111111111111111111111111111111111111";
+
+fn public_project() -> project::Model {
+    project::Model {
+        id: project_id(),
+        name: "test-project".into(),
+        display_name: "Test Project".into(),
+        public: true,
+        public_key: "ssh-ed25519 AAAA test".into(),
+        private_key: "encrypted".into(),
+        created_by: user_id(),
+        created_at: test_date(),
+        ..Default::default()
+    }
+}
+
+fn task_row() -> task::Model {
+    task::Model {
+        id: task_id(),
+        project: project_id(),
+        name: "test-task".into(),
+        active: true,
+        display_name: "Test Task".into(),
+        repository: "https://github.com/test/repo".into(),
+        wildcard: "*".into(),
+        last_check_at: test_date(),
+        created_by: user_id(),
+        created_at: test_date(),
+        keep_evaluations: 10,
+        concurrency: ConcurrencyPolicy::Skip,
+        ..Default::default()
+    }
+}
+
+fn commit_row() -> commit::Model {
+    commit::Model {
+        id: commit_id(),
+        message: "test commit".into(),
+        hash: vec![0x11; 20],
+        author: None,
+        author_name: "Tester".into(),
+    }
+}
+
+fn eval_row(id: EvaluationId, wildcard: &str, status: EvaluationStatus) -> evaluation::Model {
+    evaluation::Model {
+        id,
+        task: Some(task_id()),
+        repository: "https://github.com/test/repo".into(),
+        commit: commit_id(),
+        wildcard: wildcard.into(),
+        status,
+        created_at: test_date(),
+        updated_at: test_date(),
+        ..Default::default()
+    }
+}
+
+fn with_auth(db: MockDatabase, session_id: SessionId) -> MockDatabase {
+    let session = live_session(session_id);
+    db.append_query_results([vec![session.clone()]])
+        .append_query_results([vec![session]])
+        .append_query_results([vec![user()]])
+}
+
+fn with_task(db: MockDatabase) -> MockDatabase {
+    db.append_query_results([vec![public_project()]])
+        .append_query_results([vec![task_row()]])
+}
+
+/// The two grouped rollups `evaluations_to_summaries` runs after loading
+/// commits. Empty is a valid result set for both.
+fn with_summary_rollups(db: MockDatabase) -> MockDatabase {
+    db.append_query_results([Vec::<commit::Model>::new()])
+        .append_query_results([Vec::<commit::Model>::new()])
+}
+
+fn run<F: std::future::Future>(fut: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(fut)
+}
+
+fn base_db(session_id: SessionId) -> MockDatabase {
+    with_task(with_auth(
+        MockDatabase::new(DatabaseBackend::Postgres),
+        session_id,
+    ))
+}
+
+const URL: &str = "/api/v1/tasks/test-project/test-task/evaluations";
+
+#[test]
+fn rejects_commit_that_is_not_a_full_hash() {
+    run(async {
+        let session_id = SessionId::now_v7();
+        let server = make_test_server(base_db(session_id).into_connection());
+
+        let res = server
+            .get(&format!("{URL}?commit=1111"))
+            .add_header(
+                "Authorization",
+                format!("Bearer {}", make_token(session_id)),
+            )
+            .await;
+
+        res.assert_status_bad_request();
+        let body: Value = res.json();
+        assert_eq!(body["error"], true);
+        assert!(
+            body["message"].as_str().unwrap().contains("40-character"),
+            "unexpected message: {}",
+            body["message"]
+        );
+    });
+}
+
+#[test]
+fn rejects_unknown_status() {
+    run(async {
+        let session_id = SessionId::now_v7();
+        let server = make_test_server(base_db(session_id).into_connection());
+
+        let res = server
+            .get(&format!("{URL}?status=Exploded"))
+            .add_header(
+                "Authorization",
+                format!("Bearer {}", make_token(session_id)),
+            )
+            .await;
+
+        res.assert_status_bad_request();
+        let body: Value = res.json();
+        assert!(
+            body["message"].as_str().unwrap().contains("Exploded"),
+            "unexpected message: {}",
+            body["message"]
+        );
+    });
+}
+
+/// `attr` names one concrete attribute path; wildcard syntax there would make
+/// "does this evaluation cover my attr" ambiguous in both directions.
+#[test]
+fn rejects_wildcard_syntax_in_attr() {
+    run(async {
+        let session_id = SessionId::now_v7();
+        let server = make_test_server(base_db(session_id).into_connection());
+
+        let res = server
+            .get(&format!("{URL}?attr=packages.*.hello"))
+            .add_header(
+                "Authorization",
+                format!("Bearer {}", make_token(session_id)),
+            )
+            .await;
+
+        res.assert_status_bad_request();
+        let body: Value = res.json();
+        assert!(
+            body["message"].as_str().unwrap().contains("concrete"),
+            "unexpected message: {}",
+            body["message"]
+        );
+    });
+}
+
+/// A hash nothing was ever evaluated at is an empty result, not a 404 - the
+/// caller is asking whether an evaluation exists.
+#[test]
+fn unknown_commit_returns_empty_list() {
+    run(async {
+        let session_id = SessionId::now_v7();
+        let db = base_db(session_id).append_query_results([Vec::<commit::Model>::new()]);
+        let server = make_test_server(db.into_connection());
+
+        let res = server
+            .get(&format!("{URL}?commit={COMMIT_HEX}"))
+            .add_header(
+                "Authorization",
+                format!("Bearer {}", make_token(session_id)),
+            )
+            .await;
+
+        res.assert_status_ok();
+        let body: Value = res.json();
+        assert_eq!(body["error"], false);
+        assert_eq!(body["message"].as_array().unwrap().len(), 0);
+    });
+}
+
+/// The core of #564: an evaluation that has not produced a single entry point
+/// yet still answers "yes, this attr is in flight", because the match is on the
+/// wildcard it was created with.
+#[test]
+fn attr_filter_matches_queued_evaluation() {
+    run(async {
+        let session_id = SessionId::now_v7();
+        let queued = EvaluationId::now_v7();
+
+        let db = base_db(session_id)
+            .append_query_results([vec![commit_row()]])
+            .append_query_results([vec![
+                eval_row(queued, "packages.*.*", EvaluationStatus::Queued),
+                eval_row(
+                    EvaluationId::now_v7(),
+                    "checks.*.*",
+                    EvaluationStatus::Completed,
+                ),
+            ]])
+            .append_query_results([vec![commit_row()]]);
+        let server = make_test_server(with_summary_rollups(db).into_connection());
+
+        let res = server
+            .get(&format!(
+                "{URL}?commit={COMMIT_HEX}&attr=packages.x86_64-linux.hello"
+            ))
+            .add_header(
+                "Authorization",
+                format!("Bearer {}", make_token(session_id)),
+            )
+            .await;
+
+        res.assert_status_ok();
+        let body: Value = res.json();
+        let rows = body["message"].as_array().unwrap();
+        assert_eq!(rows.len(), 1, "checks.*.* must be filtered out: {body}");
+        assert_eq!(rows[0]["id"], queued.to_string());
+        assert_eq!(rows[0]["status"], "Queued");
+        assert_eq!(rows[0]["wildcard"], "packages.*.*");
+        assert_eq!(rows[0]["commit"], COMMIT_HEX);
+    });
+}

--- a/backend/gradient-web/tests/task_evaluate_response.rs
+++ b/backend/gradient-web/tests/task_evaluate_response.rs
@@ -1,0 +1,150 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Regression test for `POST /api/v1/tasks/{project}/{task}/evaluate` (#564).
+//!
+//! The endpoint used to answer with the prose `"Evaluation started"` while both
+//! its OpenAPI contract and the CLI (`gradient task evaluate` prints
+//! `{"evaluation_id": <message>}`) expected the new evaluation's UUID, leaving
+//! every API-driven caller unable to follow the run it had just started.
+//!
+//! `restart_failed` is the path exercised here because the normal path resolves
+//! the branch head over git first; both return the same thing.
+
+use gradient_entity::evaluation::EvaluationStatus;
+use gradient_entity::{entry_point, evaluation, ids::*, project, project_user, role, task};
+use gradient_test_support::fixtures::{commit_id, project_id, task_id, test_date, user, user_id};
+use gradient_test_support::web::{live_session, make_test_server, make_token};
+use gradient_types::consts::BASE_ROLE_ADMIN_ID;
+use gradient_types::{ConcurrencyPolicy, SessionId};
+use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
+use serde_json::{Value, json};
+use uuid::Uuid;
+
+fn task_row() -> task::Model {
+    task::Model {
+        id: task_id(),
+        project: project_id(),
+        name: "test-task".into(),
+        active: true,
+        display_name: "Test Task".into(),
+        repository: "https://github.com/test/repo".into(),
+        wildcard: "*".into(),
+        last_check_at: test_date(),
+        created_by: user_id(),
+        created_at: test_date(),
+        keep_evaluations: 10,
+        concurrency: ConcurrencyPolicy::Skip,
+        ..Default::default()
+    }
+}
+
+fn admin_membership() -> project_user::Model {
+    project_user::Model {
+        id: ProjectUserId::new(Uuid::parse_str("00000000-0000-0000-0000-0000000000aa").unwrap()),
+        project: project_id(),
+        user: user_id(),
+        role: BASE_ROLE_ADMIN_ID,
+    }
+}
+
+fn admin_role() -> role::Model {
+    role::Model {
+        id: BASE_ROLE_ADMIN_ID,
+        name: "Admin".into(),
+        permission: gradient_db::permissions::admin_mask(),
+        ..Default::default()
+    }
+}
+
+fn eval_row(id: EvaluationId, status: EvaluationStatus) -> evaluation::Model {
+    evaluation::Model {
+        id,
+        task: Some(task_id()),
+        repository: "https://github.com/test/repo".into(),
+        commit: commit_id(),
+        wildcard: "*".into(),
+        status,
+        created_at: test_date(),
+        updated_at: test_date(),
+        ..Default::default()
+    }
+}
+
+fn run<F: std::future::Future>(fut: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(fut)
+}
+
+#[test]
+fn restart_failed_answers_with_the_new_evaluation_id() {
+    run(async {
+        let session_id = SessionId::now_v7();
+        let session = live_session(session_id);
+        let previous = eval_row(EvaluationId::now_v7(), EvaluationStatus::Failed);
+        let restarted = eval_row(EvaluationId::now_v7(), EvaluationStatus::Completed);
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            // authorize middleware
+            .append_query_results([vec![session.clone()]])
+            .append_query_results([vec![session]])
+            .append_query_results([vec![user()]])
+            // load_task + TriggerEvaluation permission
+            .append_query_results([vec![project::Model {
+                id: project_id(),
+                name: "test-project".into(),
+                display_name: "Test Project".into(),
+                public_key: "ssh-ed25519 AAAA test".into(),
+                private_key: "encrypted".into(),
+                created_by: user_id(),
+                created_at: test_date(),
+                ..Default::default()
+            }]])
+            .append_query_results([vec![task_row()]])
+            .append_query_results([vec![admin_membership()]])
+            .append_query_results([vec![admin_role()]])
+            // no evaluation currently active
+            .append_query_results([Vec::<evaluation::Model>::new()])
+            // previous evaluation, and its (absent) entry points
+            .append_query_results([vec![previous]])
+            .append_query_results([Vec::<entry_point::Model>::new()])
+            // INSERT ... RETURNING the new evaluation
+            .append_query_results([vec![restarted.clone()]])
+            // no task-level flake input overrides to snapshot
+            .append_query_results([Vec::<gradient_entity::task_flake_input_override::Model>::new()])
+            // task.last_evaluation update
+            .append_exec_results([MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }])
+            .append_query_results([vec![task_row()]]);
+
+        let server = make_test_server(db.into_connection());
+
+        let res = server
+            .post("/api/v1/tasks/test-project/test-task/evaluate")
+            .add_header(
+                "Authorization",
+                format!("Bearer {}", make_token(session_id)),
+            )
+            .json(&json!({ "mode": "restart_failed" }))
+            .await;
+
+        res.assert_status_ok();
+        let body: Value = res.json();
+        assert_eq!(body["error"], false);
+        assert_eq!(
+            body["message"],
+            restarted.id.to_string(),
+            "expected the new evaluation id, got {}",
+            body["message"]
+        );
+        Uuid::parse_str(body["message"].as_str().unwrap()).expect("message must be a UUID");
+    });
+}

--- a/backend/gradient-web/tests/task_evaluate_response.rs
+++ b/backend/gradient-web/tests/task_evaluate_response.rs
@@ -148,3 +148,81 @@ fn restart_failed_answers_with_the_new_evaluation_id() {
         Uuid::parse_str(body["message"].as_str().unwrap()).expect("message must be a UUID");
     });
 }
+
+/// Sequence up to the point the pinned-commit validation runs: authorize, then
+/// `load_task` with the TriggerEvaluation permission.
+fn authorized_db(session_id: SessionId) -> MockDatabase {
+    let session = live_session(session_id);
+    MockDatabase::new(DatabaseBackend::Postgres)
+        .append_query_results([vec![session.clone()]])
+        .append_query_results([vec![session]])
+        .append_query_results([vec![user()]])
+        .append_query_results([vec![project::Model {
+            id: project_id(),
+            name: "test-project".into(),
+            display_name: "Test Project".into(),
+            public_key: "ssh-ed25519 AAAA test".into(),
+            private_key: "encrypted".into(),
+            created_by: user_id(),
+            created_at: test_date(),
+            ..Default::default()
+        }]])
+        .append_query_results([vec![task_row()]])
+        .append_query_results([vec![admin_membership()]])
+        .append_query_results([vec![admin_role()]])
+}
+
+async fn evaluate(db: MockDatabase, session_id: SessionId, body: Value) -> axum_test::TestResponse {
+    make_test_server(db.into_connection())
+        .post("/api/v1/tasks/test-project/test-task/evaluate")
+        .add_header(
+            "Authorization",
+            format!("Bearer {}", make_token(session_id)),
+        )
+        .json(&body)
+        .await
+}
+
+/// A pinned commit must be exact: a prefix would make the evaluation ambiguous,
+/// and both validations run before any git work so a bad request costs nothing.
+#[test]
+fn rejects_a_commit_that_is_not_a_full_hash() {
+    run(async {
+        let session_id = SessionId::now_v7();
+        let res = evaluate(
+            authorized_db(session_id),
+            session_id,
+            json!({ "commit": "9c1a2b3" }),
+        )
+        .await;
+
+        res.assert_status_bad_request();
+        let body: Value = res.json();
+        assert!(
+            body["message"].as_str().unwrap().contains("40-character"),
+            "unexpected message: {}",
+            body["message"]
+        );
+    });
+}
+
+#[test]
+fn rejects_an_unparsable_attr() {
+    run(async {
+        let session_id = SessionId::now_v7();
+        let res = evaluate(
+            authorized_db(session_id),
+            session_id,
+            json!({ "attr": ".packages" }),
+        )
+        .await;
+
+        res.assert_status_bad_request();
+        let body: Value = res.json();
+        assert!(
+            body["message"].as_str().unwrap().contains("attr"),
+            "unexpected message: {}",
+            body["message"]
+        );
+    });
+}

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -1784,8 +1784,19 @@ paths:
       - $ref: '#/components/parameters/TaskSlug'
     get:
       tags: [tasks]
-      summary: List recent evaluations
-      description: Returns the `keep_evaluations` most recent evaluations for the task, newest first.
+      summary: List and search evaluations
+      description: |-
+        Returns the `keep_evaluations` most recent evaluations for the task,
+        newest first. The `commit`, `status` and `attr` filters combine (AND) to
+        answer "has this attribute at this commit been evaluated, and is it still
+        running?" without walking the whole history.
+
+        `attr` matches an evaluation's **wildcard**, not its entry points. The
+        wildcard is set when the evaluation row is created, so the filter answers
+        while the evaluation is still `Queued` or `EvaluatingFlake`; entry points
+        do not exist until derivations have resolved. The flip side is that a
+        match means the attribute was *in scope*, not that it exists in the flake
+        or that it built - read `/tasks/{project}/{task}/entry-points` for that.
       operationId: getTaskEvaluations
       security:
         - {}
@@ -1799,6 +1810,40 @@ paths:
           schema:
             type: integer
             minimum: 1
+        - name: commit
+          in: query
+          required: false
+          description: >-
+            Full 40-character hex commit hash. Short prefixes are rejected. A
+            hash with no evaluations returns an empty list, not `404`.
+          schema:
+            type: string
+            pattern: '^[0-9a-fA-F]{40}$'
+            example: "9c1a2b3c4d5e6f708192a3b4c5d6e7f809a1b2c3"
+        - name: status
+          in: query
+          required: false
+          description: >-
+            `active` (Queued, Fetching, EvaluatingFlake, EvaluatingDerivation,
+            Building, Waiting), `terminal` (Completed, Failed, Aborted), or one
+            exact status name, case-insensitive.
+          schema:
+            type: string
+            example: active
+        - name: attr
+          in: query
+          required: false
+          description: |-
+            Concrete Nix attribute path. Returns evaluations whose wildcard
+            covers it. Must not itself contain wildcard syntax (`*`, `#`, `,`);
+            double-quote segments containing dots, exactly as in a wildcard
+            (`packages."x86_64-linux".hello`), and URL-encode `"` as `%22`.
+
+            Matching runs in the server over at most the 1000 most recent
+            evaluations that pass the other filters.
+          schema:
+            type: string
+            example: "packages.x86_64-linux.hello"
       responses:
         '200':
           description: List of evaluation summaries
@@ -1814,6 +1859,14 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/EvaluationSummary'
+        '400':
+          description: >-
+            `commit` is not a 40-character hex hash, `status` is not a known
+            status or group, or `attr` carries wildcard syntax.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StringResponse'
         '404':
           $ref: '#/components/responses/NotFound'
 
@@ -1925,13 +1978,29 @@ paths:
     post:
       tags: [tasks]
       summary: Trigger evaluation
-      description: >-
-        Queues a new evaluation for the task. Returns the new evaluation UUID.
+      description: |-
+        Queues a new evaluation for the task and returns its UUID in `message`,
+        so a caller can follow the run it just started (`GET /evals/{id}`, or the
+        `GET /evals/{id}/live` stream). `mode: "restart_failed"` returns the UUID
+        of the evaluation created to re-run the previous one's failed builds.
 
         Returns `400` with `code: "repository_unreachable"` when the repository
         cannot be fetched (DNS failure, authentication failure, unreachable host,
         bad URL, …) - the message includes the underlying git error.
       operationId: triggerEvaluation
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                mode:
+                  type: string
+                  enum: [restart_failed]
+                  description: >-
+                    Skip fetch and evaluation and re-queue the failed builds of
+                    the most recent evaluation. Omit for a normal evaluation.
       responses:
         '200':
           description: Evaluation UUID
@@ -8141,7 +8210,7 @@ components:
 
     EntryPointSummary:
       type: object
-      required: [id, build_id, derivation_path, eval, build_status, has_artefacts, architecture, deps, created_at]
+      required: [id, build_id, derivation_path, eval, build_status, has_artefacts, outputs, architecture, deps, created_at]
       properties:
         id: { type: string, format: uuid }
         build_id: { type: string, format: uuid }
@@ -8152,6 +8221,23 @@ components:
         build_status:
           $ref: '#/components/schemas/BuildStatus'
         has_artefacts: { type: boolean }
+        outputs:
+          type: object
+          additionalProperties:
+            type: string
+          description: |-
+            Map of output name to **full** `/nix/store` path (e.g.
+            `{"out": "/nix/store/xyz-hello-2.12.1"}`). Written at evaluation time
+            from the resolved `.drv`, so it is populated before the build runs -
+            `build_status` is what says whether the path is realised. Outputs
+            whose store path the evaluator could not resolve are omitted rather
+            than reported with a placeholder, so this map can be empty or miss
+            individual outputs.
+
+            Note this differs from `BuildWithOutputs.output`, which is
+            prefix-free for historical reasons.
+          example:
+            out: "/nix/store/7g0q1x3j6v8k4z5y9b1c2d3e4f5g6h7i-hello-2.12.1"
         architecture:
           type: string
           description: Nix system string, e.g. x86_64-linux
@@ -8195,7 +8281,7 @@ components:
 
     EvaluationSummary:
       type: object
-      required: [id, commit, status, total_builds, builds, errors, warnings, created_at, updated_at]
+      required: [id, commit, status, wildcard, total_builds, builds, errors, warnings, created_at, updated_at]
       properties:
         id:
           type: string
@@ -8211,6 +8297,13 @@ components:
           $ref: '#/components/schemas/EvaluationKind'
         status:
           $ref: '#/components/schemas/EvaluationStatus'
+        wildcard:
+          type: string
+          description: >-
+            Attribute-path scope the evaluation ran with. Set when the row is
+            created, so it says what an evaluation covers before its entry
+            points exist. This is what the `attr` search filter matches.
+          example: "packages.*.*"
         trigger:
           allOf:
             - $ref: '#/components/schemas/EvaluationTriggerSummary'

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -2001,6 +2001,27 @@ paths:
                   description: >-
                     Skip fetch and evaluation and re-queue the failed builds of
                     the most recent evaluation. Omit for a normal evaluation.
+                commit:
+                  type: string
+                  pattern: '^[0-9a-fA-F]{40}$'
+                  description: |-
+                    Exact commit to evaluate. Omit to take the branch head, which
+                    is what a normal CI run does. The commit must be reachable in
+                    the task's repository or the request is refused with
+                    `code: "repository_unreachable"` rather than queueing an
+                    evaluation that fails fetching.
+
+                    A pinned run is marked `concurrent`, so it neither queues
+                    behind nor aborts the task's own CI run, and it does not bump
+                    tracked flake inputs - it asks for one exact revision.
+                  example: "9c1a2b3c4d5e6f708192a3b4c5d6e7f809a1b2c3"
+                attr:
+                  type: string
+                  description: >-
+                    Attribute path or wildcard to evaluate instead of the task's
+                    own, e.g. `packages.x86_64-linux.hello`. Narrowing the scope
+                    is what makes a per-deployment evaluation cheap.
+                  example: "packages.x86_64-linux.hello"
       responses:
         '200':
           description: Evaluation UUID
@@ -3366,6 +3387,93 @@ paths:
           description: Session already dispatched or has blobs still missing.
         '410':
           description: Session expired.
+
+  /build-requests/url:
+    post:
+      tags: [build-requests]
+      summary: Queue a build request against a remote repository
+      description: |-
+        The no-upload build request: the source is already published at a URL, so
+        only the URL and a revision are posted and the worker fetches the flake
+        itself. Use this to build one attribute of a repository on demand -
+        a deployment tool resolving a commit, for instance - without creating a
+        task for it.
+
+        Runs on the project's reserved `build-request` task, created lazily on
+        first use and shared by every build request in the project, so no task is
+        created per job. Evaluations queued here are `concurrent`: build requests
+        are independent one-shot jobs and never queue behind or abort each other.
+
+        Supply `rev` for an exact commit, `ref` for a branch or tag the server
+        resolves first, or neither to take the repository's default branch. SSH
+        URLs are authenticated with the project's deploy key. Local paths
+        (`file://`) are rejected.
+
+        Requires the `TriggerEvaluation` permission on the project. This lets a
+        caller have Gradient fetch and evaluate an arbitrary remote flake on the
+        build fleet - the same capability the source-upload flows already grant.
+      operationId: postBuildRequestUrl
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [project, url]
+              properties:
+                project:
+                  type: string
+                  description: Project the build runs under; supplies the cache, the workers, and the deploy key.
+                url:
+                  type: string
+                  description: Repository URL, `https://`, `ssh://`, or SCP-style.
+                  example: "ssh://git@github.com/org/repo.git"
+                ref:
+                  type: string
+                  description: Branch or tag to resolve. Mutually exclusive with `rev`.
+                  example: main
+                rev:
+                  type: string
+                  pattern: '^[0-9a-fA-F]{40}$'
+                  description: Exact commit to build. Mutually exclusive with `ref`.
+                  example: "9c1a2b3c4d5e6f708192a3b4c5d6e7f809a1b2c3"
+                target:
+                  type: string
+                  description: Attribute path or wildcard to evaluate. Defaults to the reserved task's wildcard.
+                  example: "packages.x86_64-linux.k8s-resources"
+                input_overrides:
+                  type: array
+                  description: Per-run flake input overrides; only remote flake refs are accepted.
+                  items:
+                    $ref: '#/components/schemas/InputOverride'
+      responses:
+        '200':
+          description: Evaluation queued
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BaseResponse'
+                  - type: object
+                    properties:
+                      message:
+                        $ref: '#/components/schemas/DispatchResponse'
+        '400':
+          description: >-
+            Empty `url`, a local `file://` URL, `ref` and `rev` given together,
+            `rev` that is not a 40-character hex hash, an input override that is
+            not a remote flake ref, or (`code: "repository_unreachable"`) a `ref`
+            the server could not resolve.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StringResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
 
   /build-requests/source:
     post:

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -7106,3 +7106,54 @@ follow the run it had just started.
 id of the evaluation the trigger created, and parses it as a UUID. It exercises
 the `restart_failed` path because the normal path resolves the branch head over
 git first; both return the same thing.
+
+## Building a remote repository without uploading it (#564)
+
+The source-upload flows exist so `gradient build` can ship a dirty working tree.
+A deployment tool already has its source published at a URL and only needs one
+attribute of it evaluated, so `POST /build-requests/url` takes the URL and a
+revision instead. It runs on the same lazily-created reserved `build-request`
+task, so no task is created per job.
+
+`backend/gradient-sources/src/git/tests/mod.rs`
+`repository_url_to_nix_round_trips_through_parse_nix_git_url` pins the contract
+the endpoint depends on: the web side writes the evaluation's source string with
+`repository_url_to_nix` and the worker reads it back with `parse_nix_git_url`, so
+a change to either side would otherwise silently strand every remote build
+request.
+
+`backend/gradient-web/tests/build_requests_url.rs`
+`queues_an_evaluation_against_the_remote_url` covers the happy path with an
+explicit `rev`, the branch that does no network work. The rejections pin the
+input contract: `ref` and `rev` together are ambiguous, a short `rev` is refused
+rather than guessed, and `rejects_a_local_file_url` covers `repository_url_to_nix`
+refusing local paths, which is what stops a build request from making the server
+read a flake off its own disk. `rejects_a_local_input_override` is the same
+defence in depth the upload dispatch already applies to `--override-input`.
+
+Build-request evaluations are inserted `concurrent`. They are independent
+one-shot jobs sharing one reserved task, so without that flag
+`uq_evaluation_one_active_per_task` would admit exactly one in flight per
+project - a latent collision between two parallel `gradient build` runs, and a
+hard blocker for a deployment tool firing one job per application. The reserved
+task's own policy moved from `SoftAbort` to `All` for the same reason: one build
+request must never abort an unrelated one.
+
+## Evaluating a task at a pinned commit (#564)
+
+`POST /tasks/{project}/{task}/evaluate` resolved the branch head and could not be
+asked for a specific revision, so a caller that knew exactly which commit it
+wanted deployed could only trigger the head and hope it had not moved.
+
+`backend/gradient-web/tests/task_evaluate_response.rs`
+`rejects_a_commit_that_is_not_a_full_hash` and `rejects_an_unparsable_attr` pin
+that both inputs are validated before any git work, so a malformed request costs
+nothing. Reachability is proved by the clone inside `get_commit_info`, which the
+pinned path now treats as fatal (`code: "repository_unreachable"`) instead of
+falling back to empty metadata - queueing an evaluation for a commit that is not
+in the repository only produces a run that dies fetching.
+
+A pinned run is marked `concurrent` and skips the flake-input bump that a manual
+head evaluation performs: it is an out-of-band request for one exact revision, so
+it must not contend for the task's single non-concurrent slot against CI, and it
+must not quietly move the inputs it was asked to pin.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -7041,3 +7041,68 @@ value.
 default, and phase 4 asserts a freshly created task reports `5`, that echoing
 that value straight back in a `PATCH` succeeds, and that `6` (over the maximum)
 and `0` (under the floor) are still refused.
+
+## Finding an evaluation by commit and attribute, before it has entry points (#564)
+
+The reported gap: no way to ask "is `packages.x86_64-linux.my-package` at commit
+XY built, or being built?" without paging every evaluation and opening each one.
+The obvious filter, matching on the entry point, cannot answer it: `entry_point`
+rows are written only once the evaluation resolves its derivations, so the filter
+returns nothing during `Queued`, `Fetching` and `EvaluatingFlake` - exactly the
+window in which "is it already running?" decides whether a caller triggers a
+duplicate. `evaluation.wildcard` is set when the row is created, so the `attr`
+filter matches against that instead.
+
+`backend/gradient-types/src/wildcard.rs` `matches_tests` pins the matcher the
+filter is built on, against the evaluator's own segment rules:
+`trailing_star_matches_one_or_two_segments` and `consecutive_stars_collapse`
+cover `*` being recursive - `packages.*.*` and `packages.*` are the same pattern
+and both reach one level below the system attribute;
+`hash_matches_exactly_one_segment_and_does_not_descend` covers `#` being the
+non-recursive form; `quoted_segments_compare_by_inner_content` pins that both
+sides split on unquoted `.` only, so `a."b.c".d` is three segments and is not the
+four-segment `a.b.c.d`; and `exclusion_removes_an_otherwise_matching_path` covers
+`!` patterns subtracting from what the includes matched.
+
+`backend/gradient-web/tests/evaluations_search.rs`
+`attr_filter_matches_queued_evaluation` is the regression that matters: a
+`Queued` evaluation with no entry points at all is still returned for an `attr`
+its wildcard covers, while a sibling evaluation scoped to `checks.*.*` is not.
+`unknown_commit_returns_empty_list` pins that a commit nothing was evaluated at
+is an empty list rather than a `404`, since the caller is asking whether an
+evaluation exists. The three rejection cases pin the filters' contracts: a short
+commit prefix, an unknown status name, and wildcard syntax inside `attr`, which
+would make "does this evaluation cover my attr" ambiguous in both directions.
+`search_tests` in `endpoints/tasks/evaluations.rs` covers the validators and the
+status-group expansion directly.
+
+## Entry points report their output store paths (#564)
+
+Reading the store path for a built entry point meant a second hop to
+`GET /builds/{build}`, whose `output` map is prefix-free (`<hash>-<name>`), while
+the entry point itself exposed only the `.drv`. `EntryPointSummary.outputs` now
+carries the full `/nix/store` paths.
+
+`search_tests::output_paths_are_absolute_store_paths_grouped_per_derivation`
+pins the `/nix/store/` prefix and the per-derivation grouping.
+`unresolved_output_paths_are_omitted` and
+`derivation_with_no_resolvable_output_is_absent_entirely` cover the sentinel
+case: the evaluator writes the literal hash `unknown` when an output has no
+resolvable store path, nothing ever rewrites that column, so reporting one would
+hand a deployment tool `/nix/store/unknown-...`. Those outputs are dropped
+instead. Outputs are read from the resolved `.drv`, so they are present before
+the build runs - `build_status` is what says whether the path is realised.
+
+## `POST /tasks/{project}/{task}/evaluate` answers with the evaluation id (#564)
+
+The endpoint returned the prose `"Evaluation started"` while its OpenAPI
+contract, the documented example, and the CLI all expected the new evaluation's
+UUID - `gradient task evaluate` printed
+`{"evaluation_id": "Evaluation started"}` - so an API-driven caller could not
+follow the run it had just started.
+
+`backend/gradient-web/tests/task_evaluate_response.rs`
+`restart_failed_answers_with_the_new_evaluation_id` asserts the response is the
+id of the evaluation the trigger created, and parses it as a UUID. It exercises
+the `restart_failed` path because the normal path resolves the branch head over
+git first; both return the same thing.

--- a/docs/src/usage/api.md
+++ b/docs/src/usage/api.md
@@ -258,6 +258,19 @@ Set `GRADIENT_WORKER_PEERS_FILE` (or the NixOS `peersFile` option) to this path.
 | `POST` | `/tasks/{project}/{task}/evaluate` | Trigger evaluation |
 | `POST/DELETE` | `/tasks/{project}/{task}/active` | Enable / disable |
 
+### Build requests
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/build-requests/url` | Build a remote repository at a ref or commit (no upload) |
+| `POST` | `/build-requests/manifest` | Start a source upload session |
+| `POST` | `/build-requests/{session}/blobs` | Upload missing blobs |
+| `POST` | `/build-requests/{session}/dispatch` | Finalise and queue |
+| `POST` | `/build-requests/source` | Upload a packed source NAR and queue |
+
+All of these run on the project's reserved `build-request` task, created lazily
+on first use, so no task is created per job.
+
 ### Evaluations
 
 | Method | Path | Description |
@@ -441,3 +454,30 @@ curl -s -G "https://gradient.example.com/api/v1/tasks/my-project/my-task/entry-p
 finishes; `build_status` is what tells you whether that path is realised and
 fetchable from the cache. To wait rather than poll, attach to
 `GET /evals/{id}/live`.
+
+If no evaluation covers the commit yet, ask for one. There are two ways:
+
+```sh
+# On the task, so the run appears in its evaluation history.
+curl -X POST "https://gradient.example.com/api/v1/tasks/my-project/my-task/evaluate" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"commit":"9c1a2b3c4d5e6f708192a3b4c5d6e7f809a1b2c3",
+       "attr":"packages.x86_64-linux.my-package"}'
+```
+
+A pinned run is `concurrent`, so it neither queues behind nor aborts the task's
+own CI run, and it does not bump tracked flake inputs.
+
+```sh
+# Without a task at all: point Gradient at any repository URL.
+curl -X POST "https://gradient.example.com/api/v1/build-requests/url" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"project":"my-project",
+       "url":"ssh://git@github.com/org/repo.git",
+       "rev":"9c1a2b3c4d5e6f708192a3b4c5d6e7f809a1b2c3",
+       "target":"packages.x86_64-linux.my-package"}'
+```
+
+Send `ref` instead of `rev` to have the server resolve a branch or tag, or
+neither to take the repository's default branch. Both forms answer with the new
+evaluation's id, so the wait-and-read steps above are identical afterwards.

--- a/docs/src/usage/api.md
+++ b/docs/src/usage/api.md
@@ -252,7 +252,7 @@ Set `GRADIENT_WORKER_PEERS_FILE` (or the NixOS `peersFile` option) to this path.
 | `PUT` | `/tasks/{project}` | Create task |
 | `GET/PATCH/DELETE` | `/tasks/{project}/{task}` | Get / update / delete |
 | `GET` | `/tasks/{project}/{task}/details` | Aggregated task data |
-| `GET` | `/tasks/{project}/{task}/evaluations` | List recent evaluations (optional `?limit=`) |
+| `GET` | `/tasks/{project}/{task}/evaluations` | List / search evaluations (`?limit=`, `?commit=`, `?status=`, `?attr=`) |
 | `GET` | `/tasks/{project}/{task}/entry-points` | Root builds |
 | `POST` | `/tasks/{project}/{task}/check-repository` | Test repo access |
 | `POST` | `/tasks/{project}/{task}/evaluate` | Trigger evaluation |
@@ -393,3 +393,51 @@ Response:
 ```json
 { "error": false, "message": "3fa85f64-5717-4562-b3fc-2c963f66afa6" }
 ```
+
+The `message` is the new evaluation's UUID, so you can follow the run you just
+started with `GET /evals/{id}` or the `GET /evals/{id}/live` stream.
+
+## Example: Has this attribute at this commit been built?
+
+For pull-based deployment tools that follow a branch and need the store path for
+one flake output at one commit. Search the evaluations first:
+
+```sh
+curl -s -G "https://gradient.example.com/api/v1/tasks/my-project/my-task/evaluations" \
+  -H "Authorization: Bearer $TOKEN" \
+  --data-urlencode "commit=9c1a2b3c4d5e6f708192a3b4c5d6e7f809a1b2c3" \
+  --data-urlencode "attr=packages.x86_64-linux.my-package"
+```
+
+`attr` matches the evaluation's *wildcard*, which is set the moment the
+evaluation row is created. That means an evaluation still `Queued` or
+`EvaluatingFlake` is found too, so a caller can wait for a run already in flight
+instead of triggering a duplicate. An empty list means no evaluation covers that
+attribute at that commit; trigger one with `POST .../evaluate`.
+
+A match means the attribute was *in scope*, not that it exists in the flake or
+that it built. Confirm and read the store path from the entry points:
+
+```sh
+curl -s -G "https://gradient.example.com/api/v1/tasks/my-project/my-task/entry-points" \
+  -H "Authorization: Bearer $TOKEN" \
+  --data-urlencode "evaluation_id=$EVAL_ID"
+```
+
+```json
+{
+  "error": false,
+  "message": [
+    {
+      "eval": "packages.x86_64-linux.my-package",
+      "build_status": "Completed",
+      "outputs": { "out": "/nix/store/7g0q1x3j...-my-package-1.0.0" }
+    }
+  ]
+}
+```
+
+`outputs` comes from the resolved `.drv`, so it is populated before the build
+finishes; `build_status` is what tells you whether that path is realised and
+fetchable from the cache. To wait rather than poll, attach to
+`GET /evals/{id}/live`.

--- a/frontend/src/app/core/models/task.model.ts
+++ b/frontend/src/app/core/models/task.model.ts
@@ -49,6 +49,7 @@ export interface EvaluationSummary {
   commit: string;
   commit_message: string | null;
   status: EvaluationStatus;
+  wildcard: string;
   trigger: { id: string; type: TriggerType } | null;
   triggered_by: string | null;
   pr_number: number | null;
@@ -67,6 +68,8 @@ export interface EntryPointSummary {
   eval: string;
   build_status: BuildStatus;
   has_artefacts: boolean;
+  /** Output name to full `/nix/store` path; empty until the evaluator resolves them. */
+  outputs: Record<string, string>;
   architecture: Architecture;
   build_time_ms: number | null;
   deps: BuildStatusCounts;


### PR DESCRIPTION
Closes #564 

This PR adds new Endpoints for triggering Evaluations:

- Adds `POST /build-requests/url` for remote sources with no upload, and lets `POST`
evaluate pin a commit and attr. Build-request evals are now concurrent so they
no longer serialise on the shared reserved task.
- Entry points now carry their output store paths and `POST` evaluate answers with
the new `evaluation id`, so a deployment client can resolve an attr at a commit
without paging every evaluation.