### PR TITLE
server: refactor: run every server loop under a ractor supervision tree

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -769,6 +769,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3fac94a66da67200398458a25412bcc3f9b6443b5119a6cad9cf3ccfcd8cc6"
+dependencies = [
+ "bon-macros",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4654961ad0494e4774c5c60b4cb4cd0ae9b9d92d039d901638b1dba97ebebf5"
+dependencies = [
+ "darling 0.24.1",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "borsh"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2551,6 +2574,7 @@ dependencies = [
  "gradient-test-support",
  "gradient-types",
  "gradient-util",
+ "ractor",
  "reqwest",
  "sea-orm",
  "serde",
@@ -2738,6 +2762,7 @@ version = "1.3.0"
 dependencies = [
  "base64 0.23.1",
  "hex",
+ "ractor",
  "reqwest",
  "rustls",
  "rustls-native-certs",
@@ -4998,6 +5023,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
+dependencies = [
+ "proc-macro2",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5246,6 +5281,26 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "ractor"
+version = "0.16.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac09d231cc3efcabd2e9ddb085d71ce90fe5725a18ec7b9aad8347aa33c5ab0"
+dependencies = [
+ "bon",
+ "dashmap",
+ "futures",
+ "js-sys",
+ "once_cell",
+ "strum",
+ "tokio",
+ "tokio_with_wasm",
+ "tracing",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-time",
+]
 
 [[package]]
 name = "radium"
@@ -6648,6 +6703,21 @@ name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "subtle"
@@ -6883,6 +6953,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -6970,6 +7041,30 @@ dependencies = [
  "libc",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio_with_wasm"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef3ce6a8f5b5190dfe4851db6c969e8360a262759e16a0b75dfc43af19d97a86"
+dependencies = [
+ "js-sys",
+ "tokio",
+ "tokio_with_wasm_proc",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "tokio_with_wasm_proc"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8aa1d26c1550eef93cfb2dafadc145b3220432dae8d156b5ba485880594ffe"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2226,7 +2226,6 @@ dependencies = [
  "mockall",
  "ring",
  "sea-orm",
- "sentry",
  "serde",
  "serde_json",
  "tempfile",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -50,6 +50,7 @@ gradient-worker       = { path = "gradient-worker" }
 # Async / runtime
 async-stream = { version = "0.3", default-features = false }
 async-trait  = { version = "0.1", default-features = false }
+ractor       = { version = "0.16", default-features = false, features = ["tokio_runtime"] }
 futures      = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 tokio        = { version = "1.50", default-features = false, features = ["rt-multi-thread"] }
 tokio-test   = { version = "0.4", default-features = false }

--- a/backend/clippy.toml
+++ b/backend/clippy.toml
@@ -1,0 +1,3 @@
+disallowed-methods = [
+    { path = "tokio::task::spawn", reason = "use Shutdown::spawn for a tracked task or Shutdown::supervise for a loop" },
+]

--- a/backend/gradient-cache/Cargo.toml
+++ b/backend/gradient-cache/Cargo.toml
@@ -32,7 +32,6 @@ chrono              = { workspace = true }
 futures             = { workspace = true }
 ring                = { workspace = true }
 sea-orm             = { workspace = true }
-sentry              = { workspace = true }
 serde               = { workspace = true }
 serde_json          = { workspace = true }
 thiserror           = { workspace = true }

--- a/backend/gradient-cache/src/cacher/eval_cache_sweep.rs
+++ b/backend/gradient-cache/src/cacher/eval_cache_sweep.rs
@@ -16,7 +16,7 @@ use gradient_core::ServerState;
 use gradient_types::*;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QuerySelect};
 use std::sync::Arc;
-use tracing::{debug, error, info, warn};
+use tracing::{error, info, warn};
 
 /// Rows are `(id, size_bytes, updated_at)`. Returns the ids to evict: every row
 /// older than `max_age`, plus - oldest-`updated_at` first - enough additional
@@ -122,36 +122,6 @@ pub async fn evict_eval_cache(state: Arc<ServerState>) -> anyhow::Result<()> {
     }
 
     Ok(())
-}
-
-/// Periodic eval-cache eviction sweep; interval from
-/// `storage.eval_cache_sweep_interval_secs`.
-pub async fn eval_cache_sweep_loop(state: Arc<ServerState>) {
-    let _guard = if state.config.registration.report_errors {
-        Some(sentry::init(
-            gradient_types::cli::effective_sentry_dsn(&state.config.registration).to_string(),
-        ))
-    } else {
-        None
-    };
-
-    let mut interval = tokio::time::interval(std::time::Duration::from_secs(
-        state.config.storage.eval_cache_sweep_interval_secs.max(1),
-    ));
-    let cancel = state.shutdown.token();
-    loop {
-        tokio::select! {
-            _ = cancel.cancelled() => {
-                debug!("eval-cache sweep loop shutting down");
-                return;
-            }
-            _ = interval.tick() => {}
-        }
-
-        if let Err(e) = evict_eval_cache(Arc::clone(&state)).await {
-            error!(error = ?e, "eval-cache sweep failed");
-        }
-    }
 }
 
 #[cfg(test)]

--- a/backend/gradient-cache/src/cacher/mod.rs
+++ b/backend/gradient-cache/src/cacher/mod.rs
@@ -22,7 +22,7 @@ pub(crate) mod test_support;
 
 pub use self::debug_index::index_pending_debug_info;
 pub use self::deep_gc::{DeepGcReport, run_deep_gc};
-pub use self::eval_cache_sweep::{eval_cache_sweep_loop, evict_eval_cache};
+pub use self::eval_cache_sweep::evict_eval_cache;
 
 pub use self::cleanup::{
     CleanupReport, cleanup_expired_upload_sessions, cleanup_old_evaluations,
@@ -33,21 +33,22 @@ pub use self::sign_sweep::sign_missing_signatures;
 
 use futures::future::BoxFuture;
 use gradient_core::ServerState;
+use gradient_util::supervision::ChildSpec;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
-use tokio::time;
+use std::time::Duration;
 use tracing::{error, info};
 
-/// One periodic background pass: a name (for logs), a tick interval, and the
-/// async fn to run. Registered in [`sweeps`] and driven by [`run_sweep`].
+/// One periodic pass: a name (logs and health), a tick interval, the budget
+/// past which a pass is cancelled, and the async fn to run.
 struct Sweep {
     name: &'static str,
     interval_secs: u64,
+    budget_secs: u64,
     run: Box<dyn Fn(Arc<ServerState>) -> BoxFuture<'static, anyhow::Result<()>> + Send + Sync>,
 }
 
 impl Sweep {
-    fn new<F, Fut>(name: &'static str, interval_secs: u64, run: F) -> Self
+    fn new<F, Fut>(name: &'static str, interval_secs: u64, budget_secs: u64, run: F) -> Self
     where
         F: Fn(Arc<ServerState>) -> Fut + Send + Sync + 'static,
         Fut: std::future::Future<Output = anyhow::Result<()>> + Send + 'static,
@@ -55,82 +56,63 @@ impl Sweep {
         Sweep {
             name,
             interval_secs,
+            budget_secs,
             run: Box::new(move |state| Box::pin(run(state))),
         }
     }
 }
 
 /// The registered sweeps. "cache-maintenance" bundles the 9 order-sensitive
-/// GC/reconcile steps that used to live in the monolithic `cache_loop`
-/// (orphan-files, eval GC, derivation GC, NAR TTL, demote-unbacked,
-/// unpark-storage-full, build-request blobs, upload sessions, partial-store
-/// GC); "sign-sweep" is the signature backfill and "debug-index" the build-id
-/// backfill. Each runs on its own interval and its own spawned loop.
+/// GC/reconcile steps; "sign-sweep" is the signature backfill, "debug-index"
+/// the build-id backfill, "eval-cache-sweep" the eval-cache eviction.
 fn sweeps(state: &ServerState) -> Vec<Sweep> {
+    let storage = &state.config.storage;
     vec![
         Sweep::new(
             "cache-maintenance",
-            state.config.storage.cache_maintenance_interval_secs.max(1),
-            |state| Box::pin(run_cache_maintenance(state)),
+            storage.cache_maintenance_interval_secs.max(1),
+            1800,
+            run_cache_maintenance,
         ),
         Sweep::new(
             "sign-sweep",
-            state.config.storage.sign_sweep_interval_secs.max(1),
-            |state| Box::pin(sign_missing_signatures(state)),
+            storage.sign_sweep_interval_secs.max(1),
+            300,
+            sign_missing_signatures,
         ),
         Sweep::new(
             "debug-index",
-            state.config.storage.debug_index_interval_secs.max(1),
-            |state| Box::pin(index_pending_debug_info(state)),
+            storage.debug_index_interval_secs.max(1),
+            600,
+            index_pending_debug_info,
+        ),
+        Sweep::new(
+            "eval-cache-sweep",
+            storage.eval_cache_sweep_interval_secs.max(1),
+            600,
+            evict_eval_cache,
         ),
     ]
 }
 
-/// Drives one [`Sweep`] on its own interval until shutdown. Errors from a
-/// single run are logged and never abort the loop.
-async fn run_sweep(state: Arc<ServerState>, sweep: Sweep) {
-    let _guard = if state.config.registration.report_errors {
-        Some(sentry::init(
-            gradient_types::cli::effective_sentry_dsn(&state.config.registration).to_string(),
-        ))
-    } else {
-        None
-    };
-
-    let mut interval = time::interval(Duration::from_secs(sweep.interval_secs));
-    let cancel = state.shutdown.token();
-
-    loop {
-        tokio::select! {
-            _ = cancel.cancelled() => {
-                info!(sweep = sweep.name, "sweep loop shutting down");
-                return;
-            }
-            _ = interval.tick() => {}
-        }
-
-        let started = Instant::now();
-        match (sweep.run)(Arc::clone(&state)).await {
-            Ok(()) => info!(
-                sweep = sweep.name,
-                elapsed_ms = started.elapsed().as_millis() as u64,
-                "sweep completed"
-            ),
-            Err(e) => error!(
-                sweep = sweep.name,
-                elapsed_ms = started.elapsed().as_millis() as u64,
-                error = ?e,
-                "sweep failed"
-            ),
-        }
-    }
-}
-
-/// Spawns every registered sweep as its own long-lived task.
-pub fn spawn_sweeps(state: &Arc<ServerState>) {
-    for sweep in sweeps(state) {
-        state.shutdown.spawn(run_sweep(Arc::clone(state), sweep));
-    }
+/// Every registered sweep as a supervised periodic child.
+pub fn child_specs(state: &Arc<ServerState>) -> Vec<ChildSpec> {
+    sweeps(state)
+        .into_iter()
+        .map(|sweep| {
+            let state = Arc::clone(state);
+            let run = sweep.run;
+            ChildSpec::periodic(
+                sweep.name,
+                Duration::from_secs(sweep.interval_secs),
+                Duration::from_secs(sweep.budget_secs),
+                move || {
+                    let fut = run(Arc::clone(&state));
+                    async move { fut.await.map_err(Into::into) }
+                },
+            )
+        })
+        .collect()
 }
 
 /// The 9 order-sensitive cache-maintenance steps, run sequentially every

--- a/backend/gradient-cache/src/lib.rs
+++ b/backend/gradient-cache/src/lib.rs
@@ -10,9 +10,12 @@ use gradient_core::ServerState;
 use std::sync::Arc;
 
 pub async fn start_cache(state: Arc<ServerState>) -> std::io::Result<()> {
-    cacher::spawn_sweeps(&state);
-    state
-        .shutdown
-        .spawn(cacher::eval_cache_sweep_loop(Arc::clone(&state)));
+    for spec in cacher::child_specs(&state) {
+        state
+            .shutdown
+            .supervise_now(spec)
+            .await
+            .map_err(std::io::Error::other)?;
+    }
     Ok(())
 }

--- a/backend/gradient-ci/src/actions/mod.rs
+++ b/backend/gradient-ci/src/actions/mod.rs
@@ -174,7 +174,8 @@ async fn dispatch_event(ctx: &CiContext, task_id: TaskId, event: &str, payload: 
         let ctx = ctx.clone();
         let payload = payload.clone();
         let event = event.to_string();
-        tokio::spawn(async move {
+        let shutdown = ctx.db.shutdown.clone();
+        shutdown.spawn(async move {
             // A mass status-transition wave (promotion, thaw, requeue) fires
             // one event per anchor; unbounded execution exhausted the DB pool
             // and convoyed on the per-action bookkeeping row.

--- a/backend/gradient-db/src/retention.rs
+++ b/backend/gradient-db/src/retention.rs
@@ -14,6 +14,7 @@
 use std::time::Duration;
 
 use gradient_entity::metric_rollup::RollupGranularity;
+use gradient_util::supervision::ChildSpec;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use tracing::{debug, warn};
 
@@ -21,17 +22,20 @@ use super::DbContext;
 
 const RETENTION_INTERVAL_SECS: u64 = 3600;
 
-pub fn start_retention_loop(ctx: DbContext) {
-    let shutdown = ctx.shutdown.clone();
-    shutdown.spawn(async move { retention_loop(ctx).await });
-}
-
-async fn retention_loop(ctx: DbContext) {
-    let mut interval = tokio::time::interval(Duration::from_secs(RETENTION_INTERVAL_SECS));
-    loop {
-        interval.tick().await;
-        run_retention(&ctx).await;
-    }
+/// The hourly pruning pass as a supervised child.
+pub fn child_spec(ctx: DbContext) -> ChildSpec {
+    ChildSpec::periodic(
+        "retention",
+        Duration::from_secs(RETENTION_INTERVAL_SECS),
+        Duration::from_secs(600),
+        move || {
+            let ctx = ctx.clone();
+            async move {
+                run_retention(&ctx).await;
+                Ok(())
+            }
+        },
+    )
 }
 
 async fn run_retention(ctx: &DbContext) {

--- a/backend/gradient-db/src/rollup.rs
+++ b/backend/gradient-db/src/rollup.rs
@@ -15,6 +15,7 @@
 use std::time::Duration;
 
 use gradient_entity::metric_rollup::RollupGranularity;
+use gradient_util::supervision::ChildSpec;
 use sea_orm::ConnectionTrait;
 use tracing::{debug, warn};
 
@@ -226,18 +227,21 @@ fn upstream_misses_sql() -> String {
     )
 }
 
-pub fn start_rollup_loop(ctx: DbContext) {
-    let shutdown = ctx.shutdown.clone();
-    shutdown.spawn(async move { rollup_loop(ctx).await });
-}
-
-async fn rollup_loop(ctx: DbContext) {
+/// The rollup aggregation pass as a supervised child.
+pub fn child_spec(ctx: DbContext) -> ChildSpec {
     let secs = ctx.config.metrics_args.metrics_rollup_interval_secs.max(1);
-    let mut interval = tokio::time::interval(Duration::from_secs(secs));
-    loop {
-        interval.tick().await;
-        run_rollup(&ctx).await;
-    }
+    ChildSpec::periodic(
+        "rollup",
+        Duration::from_secs(secs),
+        Duration::from_secs(300),
+        move || {
+            let ctx = ctx.clone();
+            async move {
+                run_rollup(&ctx).await;
+                Ok(())
+            }
+        },
+    )
 }
 
 async fn run_rollup(ctx: &DbContext) {

--- a/backend/gradient-proto/src/handler/cache_session.rs
+++ b/backend/gradient-proto/src/handler/cache_session.rs
@@ -98,7 +98,7 @@ pub async fn handle_cache_socket(
     }
 
     let send_chunk_timeout = Duration::from_secs(state.config.proto.nar_send_chunk_timeout_secs);
-    let (mut reader, writer) = socket.split(send_chunk_timeout);
+    let (mut reader, writer) = socket.split(send_chunk_timeout, &state.shutdown);
     let max_serves = state.config.proto.max_concurrent_nar_serves;
     let nar_serve_semaphore = Arc::new(Semaphore::new(max_serves));
     let idle = Duration::from_secs(CACHE_SESSION_IDLE_TIMEOUT_SECS);
@@ -177,7 +177,8 @@ pub async fn handle_cache_socket(
                     let state = Arc::clone(&state);
                     let writer = writer.clone();
                     let job_id = job_id.clone();
-                    tokio::spawn(async move {
+                    let shutdown = state.shutdown.clone();
+                    shutdown.spawn(async move {
                         let _permit = permit;
                         if let Err(e) = super::nar_transfer::serve_nar_request(
                             &state,

--- a/backend/gradient-proto/src/handler/cache_session.rs
+++ b/backend/gradient-proto/src/handler/cache_session.rs
@@ -102,25 +102,31 @@ pub async fn handle_cache_socket(
     let max_serves = state.config.proto.max_concurrent_nar_serves;
     let nar_serve_semaphore = Arc::new(Semaphore::new(max_serves));
     let idle = Duration::from_secs(CACHE_SESSION_IDLE_TIMEOUT_SECS);
+    let cancel = state.shutdown.token();
 
     loop {
         // Only enforce the idle timeout while no NAR transfer is in flight, so
         // a client that batches its NarRequests and then quietly receives a
         // large download is not disconnected mid-transfer.
-        let msg = if nar_serve_semaphore.available_permits() == max_serves {
-            match tokio::time::timeout(idle, recv_client_msg(&mut reader)).await {
-                Ok(Some(m)) => m,
-                Ok(None) => break,
-                Err(_) => {
-                    debug!(%cache_id, "cache websocket idle timeout; closing");
-                    break;
+        let next = async {
+            if nar_serve_semaphore.available_permits() == max_serves {
+                match tokio::time::timeout(idle, recv_client_msg(&mut reader)).await {
+                    Ok(m) => m,
+                    Err(_) => {
+                        debug!(%cache_id, "cache websocket idle timeout; closing");
+                        None
+                    }
                 }
+            } else {
+                recv_client_msg(&mut reader).await
             }
-        } else {
-            match recv_client_msg(&mut reader).await {
+        };
+        let msg = tokio::select! {
+            _ = cancel.cancelled() => break,
+            m = next => match m {
                 Some(m) => m,
                 None => break,
-            }
+            },
         };
 
         if let Some(reason) = reject_reason(&msg) {

--- a/backend/gradient-proto/src/handler/dispatch.rs
+++ b/backend/gradient-proto/src/handler/dispatch.rs
@@ -288,7 +288,7 @@ impl<'a> DispatchContext<'a> {
         network_speed_mbps: Option<f32>,
     ) {
         let rpc = self.rpc();
-        tokio::spawn(async move {
+        self.state.shutdown.spawn(async move {
             rpc.on_worker_metrics(
                 cpu_usage_pct,
                 ram_free_mb,
@@ -307,12 +307,16 @@ impl<'a> DispatchContext<'a> {
         mode: QueryMode,
     ) {
         let rpc = self.rpc();
-        tokio::spawn(async move { rpc.on_cache_query(job_id, query_id, paths, mode).await });
+        self.state
+            .shutdown
+            .spawn(async move { rpc.on_cache_query(job_id, query_id, paths, mode).await });
     }
 
     fn spawn_query_known_derivations(&self, job_id: String, drv_paths: Vec<String>) {
         let rpc = self.rpc();
-        tokio::spawn(async move { rpc.on_query_known_derivations(job_id, drv_paths).await });
+        self.state
+            .shutdown
+            .spawn(async move { rpc.on_query_known_derivations(job_id, drv_paths).await });
     }
 
     // ── Eval cache ────────────────────────────────────────────────────────────
@@ -712,13 +716,14 @@ impl<'a> DispatchContext<'a> {
         // serialise paths[1..]. The shared `nar_serve_semaphore` caps fan-out
         // per connection, and the cloneable `ProtoWriter` interleaves chunks
         // safely on the wire (the worker keys NarPush by store_path).
+        let shutdown = self.state.shutdown.clone();
         for store_path in paths {
             let state = Arc::clone(self.state);
             let writer = self.writer.clone();
             let permit = Arc::clone(self.nar_serve_semaphore);
             let peer_id = self.peer_id.to_owned();
             let job_id = job_id.clone();
-            tokio::spawn(async move {
+            shutdown.spawn(async move {
                 let _guard = match permit.acquire_owned().await {
                     Ok(g) => g,
                     Err(_) => return, // semaphore closed (shutdown)
@@ -746,7 +751,8 @@ impl<'a> DispatchContext<'a> {
         let writer = self.writer.clone();
         let permit = Arc::clone(self.nar_serve_semaphore);
         let peer_id = self.peer_id.to_owned();
-        tokio::spawn(async move {
+        let shutdown = self.state.shutdown.clone();
+        shutdown.spawn(async move {
             let _guard = match permit.acquire_owned().await {
                 Ok(g) => g,
                 Err(_) => return,

--- a/backend/gradient-proto/src/handler/mod.rs
+++ b/backend/gradient-proto/src/handler/mod.rs
@@ -66,16 +66,21 @@ async fn ws_upgrade(
             .into_response();
     };
 
+    let shutdown = state.shutdown.clone();
     ws.max_message_size(MAX_PROTO_MESSAGE_SIZE)
         .max_frame_size(MAX_PROTO_MESSAGE_SIZE)
         .on_upgrade(move |sock| async move {
-            let _permit = permit;
-            session::handle_socket(
-                socket::ProtoSocket::Axum(Box::new(sock)),
-                state,
-                scheduler,
-                false,
-            )
-            .await;
+            let _ = shutdown
+                .spawn(async move {
+                    let _permit = permit;
+                    session::handle_socket(
+                        socket::ProtoSocket::Axum(Box::new(sock)),
+                        state,
+                        scheduler,
+                        false,
+                    )
+                    .await;
+                })
+                .await;
         })
 }

--- a/backend/gradient-proto/src/handler/nar_transfer.rs
+++ b/backend/gradient-proto/src/handler/nar_transfer.rs
@@ -382,7 +382,8 @@ impl<'a> DispatchContext<'a> {
         let peer_id = self.peer_id.to_owned();
         let semaphore = Arc::clone(self.nar_commit_semaphore);
         let hash = hash.to_owned();
-        tokio::spawn(async move {
+        let shutdown = state.shutdown.clone();
+        shutdown.spawn(async move {
             let Ok(_permit) = semaphore.acquire_owned().await else {
                 return;
             };

--- a/backend/gradient-proto/src/handler/session.rs
+++ b/backend/gradient-proto/src/handler/session.rs
@@ -299,9 +299,15 @@ impl ProtoSession<Registered> {
         // inbound frame so the liveness watchdog can spot a worker that died
         // without a clean TCP close.
         let last_seen = scheduler.worker_last_seen(&peer_id).await;
+        let cancel = state.shutdown.token();
 
         loop {
             let msg = tokio::select! {
+                _ = cancel.cancelled() => {
+                    info!(%peer_id, "server shutting down; sending Draining and closing");
+                    let _ = send_server_msg(&writer, &ServerMessage::Draining).await;
+                    break;
+                }
                 msg = recv_client_msg(&mut reader) => match msg {
                     Some(m) => m,
                     None => break,

--- a/backend/gradient-proto/src/handler/session.rs
+++ b/backend/gradient-proto/src/handler/session.rs
@@ -274,7 +274,7 @@ impl ProtoSession<Registered> {
 
         let proto_cfg = &state.config.proto;
         let send_chunk_timeout = Duration::from_secs(proto_cfg.nar_send_chunk_timeout_secs);
-        let (mut reader, writer) = socket.split(send_chunk_timeout);
+        let (mut reader, writer) = socket.split(send_chunk_timeout, &state.shutdown);
 
         let partial_root =
             std::path::PathBuf::from(format!("{}/nar-partial", state.config.storage.base_path));

--- a/backend/gradient-proto/src/outbound.rs
+++ b/backend/gradient-proto/src/outbound.rs
@@ -16,6 +16,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
+use gradient_util::supervision::ChildSpec;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use tokio::sync::Mutex;
 use tokio_tungstenite::connect_async_with_config;
@@ -27,26 +28,24 @@ use gradient_entity::worker_registration::{Column, Entity as EWorkerRegistration
 use crate::handler::{MAX_PROTO_MESSAGE_SIZE, ProtoSocket, handle_socket};
 use gradient_scheduler::Scheduler;
 
-/// Spawn the outbound connection loop on the shared shutdown tracker so it
-/// drains cleanly on SIGTERM.
+/// The outbound connection pass as a supervised child; each connection it
+/// opens is a tracked task of its own.
 pub fn start_outbound_loop(scheduler: Arc<Scheduler>) {
-    let shutdown = scheduler.state.shutdown.clone();
-    let cancel = shutdown.token();
-    shutdown.spawn(async move {
-        let mut interval = tokio::time::interval(Duration::from_secs(15));
-        let connecting: Arc<Mutex<HashSet<String>>> = Arc::default();
-        info!("outbound worker connection loop started");
-        loop {
-            tokio::select! {
-                _ = cancel.cancelled() => {
-                    info!("outbound worker connection loop shutting down");
-                    return;
-                }
-                _ = interval.tick() => {}
+    let connecting: Arc<Mutex<HashSet<String>>> = Arc::default();
+    let pass_scheduler = Arc::clone(&scheduler);
+    scheduler.state.shutdown.supervise(ChildSpec::periodic(
+        "outbound-connect",
+        Duration::from_secs(15),
+        Duration::from_secs(60),
+        move || {
+            let scheduler = Arc::clone(&pass_scheduler);
+            let connecting = Arc::clone(&connecting);
+            async move {
+                connect_to_registered_workers(&scheduler, &connecting).await;
+                Ok(())
             }
-            connect_to_registered_workers(&scheduler, &connecting).await;
-        }
-    });
+        },
+    ));
 }
 
 async fn connect_to_registered_workers(

--- a/backend/gradient-proto/src/session/frame.rs
+++ b/backend/gradient-proto/src/session/frame.rs
@@ -25,7 +25,11 @@ use tokio_tungstenite::{
 };
 use tracing::{debug, trace, warn};
 
+use gradient_util::shutdown::Shutdown;
+
 use crate::messages::{ClientMessage, ServerMessage, decode_client_message, decode_server_message};
+
+type WriterTask = std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>;
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -269,19 +273,33 @@ impl ProtoSocket {
     /// by a spawned task that owns the WebSocket sink. `send_chunk_timeout`
     /// bounds how long each producer `send` may wait when the queue is full -
     /// exceeding it indicates the peer's TCP receive side is stalled.
-    pub fn split(self, send_chunk_timeout: Duration) -> (ProtoReader, ProtoWriter) {
-        self.split_typed(send_chunk_timeout)
+    pub fn split(
+        self,
+        send_chunk_timeout: Duration,
+        shutdown: &Shutdown,
+    ) -> (ProtoReader, ProtoWriter) {
+        self.split_typed(send_chunk_timeout, |task| {
+            shutdown.spawn(task);
+        })
     }
 
     /// Peer-role counterpart of [`Self::split`]: read `ServerMessage`, write
-    /// `ClientMessage`. Used by the worker after its handshake.
+    /// `ClientMessage`. Used by the worker after its handshake, which owns
+    /// its own runtime and has no shutdown tracker to register against.
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "no shutdown tracker on the peer side"
+    )]
     pub fn split_peer(self, send_chunk_timeout: Duration) -> (ServerReader, ClientWriter) {
-        self.split_typed(send_chunk_timeout)
+        self.split_typed(send_chunk_timeout, |task| {
+            tokio::spawn(task);
+        })
     }
 
     fn split_typed<In: WireMessage, Out: WireMessage>(
         self,
         send_chunk_timeout: Duration,
+        spawn: impl FnOnce(WriterTask),
     ) -> (MsgReader<In>, MsgWriter<Out>) {
         let (tx, bulk_rx) = mpsc::channel::<Vec<u8>>(WRITER_QUEUE_DEPTH);
         let (control_tx, control_rx) = mpsc::channel::<Vec<u8>>(CONTROL_QUEUE_DEPTH);
@@ -295,12 +313,12 @@ impl ProtoSocket {
         let inner = match self {
             Self::Axum(ws) => {
                 let (sink, stream) = (*ws).split();
-                tokio::spawn(axum_writer_task(lanes, sink));
+                spawn(Box::pin(axum_writer_task(lanes, sink)));
                 ReaderInner::Axum(stream)
             }
             Self::Tungstenite(ws) => {
                 let (sink, stream) = (*ws).split();
-                tokio::spawn(tungstenite_writer_task(lanes, sink));
+                spawn(Box::pin(tungstenite_writer_task(lanes, sink)));
                 ReaderInner::Tungstenite(stream)
             }
         };

--- a/backend/gradient-scheduler/Cargo.toml
+++ b/backend/gradient-scheduler/Cargo.toml
@@ -24,6 +24,7 @@ gradient-types = { workspace = true }
 gradient-entity = { workspace = true }
 gradient-score = { workspace = true }
 gradient-util = { workspace = true }
+ractor        = { workspace = true }
 
 anyhow     = { workspace = true }
 arc-swap   = { workspace = true }

--- a/backend/gradient-scheduler/src/build/lifecycle.rs
+++ b/backend/gradient-scheduler/src/build/lifecycle.rs
@@ -315,7 +315,8 @@ pub async fn handle_build_job_completed(
 
     if was_external_cached {
         let state = Arc::clone(state);
-        tokio::spawn(async move {
+        let shutdown = state.shutdown.clone();
+        shutdown.spawn(async move {
             let drv_path = match EDerivation::find_by_id(derivation_id)
                 .one(&state.worker_db)
                 .await

--- a/backend/gradient-scheduler/src/dispatch/background.rs
+++ b/backend/gradient-scheduler/src/dispatch/background.rs
@@ -7,48 +7,39 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use tracing::{debug, error, info, warn};
+use tracing::{debug, warn};
 
 use crate::Scheduler;
 
 /// Poll ~3x per heartbeat deadline so worst-case detection latency is timeout + tick.
 const LIVENESS_POLLS_PER_DEADLINE: u64 = 3;
 
-/// Periodic read-only invariant check: counts stale gate flags, unpromoted-ready
+/// Liveness poll period, or `None` when the watchdog is disabled by config.
+pub(super) fn liveness_period(scheduler: &Scheduler) -> Option<Duration> {
+    let timeout_secs = scheduler.state.config.proto.worker_heartbeat_timeout_secs;
+    (timeout_secs != 0)
+        .then(|| Duration::from_secs((timeout_secs / LIVENESS_POLLS_PER_DEADLINE).max(5)))
+}
+
+/// Read-only invariant check: counts stale gate flags, unpromoted-ready
 /// anchors, unbacked trusted outputs, and wedged Building evals so a dead zone
 /// becomes a warning long before a user reports a stuck evaluation. Transient
 /// non-zero counts right after a transition are normal; persistent ones are not.
-pub(super) async fn consistency_sweep_loop(scheduler: Arc<Scheduler>) {
-    let secs = scheduler
-        .state
-        .config
-        .metrics_args
-        .graph_consistency_interval_secs;
-    if secs == 0 {
-        info!("graph consistency sweep disabled (graph_consistency_interval_secs = 0)");
-        return;
+pub(super) async fn consistency_sweep_pass(scheduler: Arc<Scheduler>) -> anyhow::Result<()> {
+    let report = gradient_db::graph_consistency_report(&scheduler.state.worker_db).await?;
+    if report.total() > 0 {
+        warn!(
+            stale_closure_complete = report.stale_closure_complete,
+            stale_drv_closure_cached = report.stale_drv_closure_cached,
+            unpromoted_ready = report.unpromoted_ready,
+            unbacked_trusted_outputs = report.unbacked_trusted_outputs,
+            wedged_building_evals = report.wedged_building_evals,
+            "graph consistency sweep found invariant violations"
+        );
+    } else {
+        debug!("graph consistency sweep clean");
     }
-
-    let mut interval = tokio::time::interval(Duration::from_secs(secs.max(1)));
-    let cancel = scheduler.state.shutdown.token();
-    loop {
-        tokio::select! {
-            _ = cancel.cancelled() => return,
-            _ = interval.tick() => {}
-        }
-        match gradient_db::graph_consistency_report(&scheduler.state.worker_db).await {
-            Ok(report) if report.total() > 0 => warn!(
-                stale_closure_complete = report.stale_closure_complete,
-                stale_drv_closure_cached = report.stale_drv_closure_cached,
-                unpromoted_ready = report.unpromoted_ready,
-                unbacked_trusted_outputs = report.unbacked_trusted_outputs,
-                wedged_building_evals = report.wedged_building_evals,
-                "graph consistency sweep found invariant violations"
-            ),
-            Ok(_) => debug!("graph consistency sweep clean"),
-            Err(e) => error!(error = %e, "graph consistency sweep failed"),
-        }
-    }
+    Ok(())
 }
 
 /// Unregister workers that have gone silent past the heartbeat deadline.
@@ -57,108 +48,66 @@ pub(super) async fn consistency_sweep_loop(scheduler: Arc<Scheduler>) {
 /// only when the TCP connection closes. A hard OOM-kill, a frozen host, or a
 /// network partition can leave the socket half-open with no clean close, so the
 /// worker stays "connected" and its in-flight eval/build jobs sit non-terminal
-/// forever. This watchdog stamps each worker's `last_seen` (in the session loop)
-/// and reuses [`Scheduler::unregister_worker`] - which re-queues the orphaned
-/// jobs and resets their DB rows - the moment a worker exceeds the deadline.
-pub(super) async fn worker_liveness_loop(scheduler: Arc<Scheduler>) {
+/// forever. This pass reads each worker's `last_seen` (stamped in the session
+/// loop) and reuses [`Scheduler::unregister_worker`] - which re-queues the
+/// orphaned jobs and resets their DB rows - the moment a worker exceeds the deadline.
+pub(super) async fn worker_liveness_pass(scheduler: Arc<Scheduler>) -> anyhow::Result<()> {
     let timeout_secs = scheduler.state.config.proto.worker_heartbeat_timeout_secs;
-    if timeout_secs == 0 {
-        info!("worker liveness watchdog disabled (worker_heartbeat_timeout_secs = 0)");
-        return;
-    }
-
     let timeout_ms = (timeout_secs as i64) * 1000;
-    // Poll ~3x per deadline so worst-case detection latency is timeout + tick.
-    let tick = (timeout_secs / LIVENESS_POLLS_PER_DEADLINE).max(5);
-    let mut interval = tokio::time::interval(Duration::from_secs(tick));
-    let cancel = scheduler.state.shutdown.token();
-    loop {
-        tokio::select! {
-            _ = cancel.cancelled() => return,
-            _ = interval.tick() => {}
-        }
-        let now_ms = gradient_types::now().and_utc().timestamp_millis();
-        for worker_id in scheduler.stale_workers(now_ms, timeout_ms).await {
-            warn!(
-                %worker_id,
-                timeout_secs,
-                "worker silent past heartbeat deadline - presumed dead (OOM-kill / frozen \
-                 host / network partition); unregistering and re-queuing its jobs"
-            );
-            scheduler.unregister_worker(&worker_id).await;
-        }
+    let now_ms = gradient_types::now().and_utc().timestamp_millis();
+    for worker_id in scheduler.stale_workers(now_ms, timeout_ms).await {
+        warn!(
+            %worker_id,
+            timeout_secs,
+            "worker silent past heartbeat deadline - presumed dead (OOM-kill / frozen \
+             host / network partition); unregistering and re-queuing its jobs"
+        );
+        scheduler.unregister_worker(&worker_id).await;
     }
+    Ok(())
 }
 
-/// Periodically recompute the windowed [`gradient_score::InstanceContext`] snapshot
-/// consumed by resource-aware scoring and publish it lock-free.
-pub(super) async fn instance_metrics_loop(scheduler: Arc<Scheduler>) {
-    let secs = scheduler
-        .state
-        .config
-        .metrics_args
-        .instance_metrics_interval_secs
-        .max(1);
-    let mut interval = tokio::time::interval(Duration::from_secs(secs));
-    let cancel = scheduler.state.shutdown.token();
-    loop {
-        tokio::select! {
-            _ = cancel.cancelled() => return,
-            _ = interval.tick() => {}
-        }
-        let (active_builds, pending_builds) = scheduler.job_tracker.read().await.instance_counts();
-        let (total_workers, idle_workers) = scheduler.worker_pool.read().await.worker_counts();
-        let counts = crate::instance::InstanceCounts {
-            active_builds,
-            pending_builds,
-            total_workers,
-            idle_workers,
-        };
-        let ctx = crate::instance::compute_instance_context(
-            &scheduler.state.worker_db,
-            counts,
-            gradient_types::now(),
-        )
-        .await;
-        scheduler.instance.store(Arc::new(ctx));
+/// Recompute the windowed [`gradient_score::InstanceContext`] snapshot consumed
+/// by resource-aware scoring and publish it lock-free.
+pub(super) async fn instance_metrics_pass(scheduler: Arc<Scheduler>) -> anyhow::Result<()> {
+    let (active_builds, pending_builds) = scheduler.job_tracker.read().await.instance_counts();
+    let (total_workers, idle_workers) = scheduler.worker_pool.read().await.worker_counts();
+    let counts = crate::instance::InstanceCounts {
+        active_builds,
+        pending_builds,
+        total_workers,
+        idle_workers,
+    };
+    let ctx = crate::instance::compute_instance_context(
+        &scheduler.state.worker_db,
+        counts,
+        gradient_types::now(),
+    )
+    .await;
+    scheduler.instance.store(Arc::new(ctx));
 
-        let eval_history = crate::instance::compute_eval_history(
-            &scheduler.state.worker_db,
-            gradient_types::now(),
-        )
-        .await;
-        scheduler.eval_history.store(Arc::new(eval_history));
-    }
+    let eval_history =
+        crate::instance::compute_eval_history(&scheduler.state.worker_db, gradient_types::now())
+            .await;
+    scheduler.eval_history.store(Arc::new(eval_history));
+    Ok(())
 }
 
-/// Periodically snapshot every connected worker's live metrics into
-/// `worker_sample` for the Job Board's worker statistics.
-pub(super) async fn worker_sample_loop(scheduler: Arc<Scheduler>) {
-    let secs = scheduler
-        .state
-        .config
-        .metrics_args
-        .worker_sample_interval_secs
-        .max(1);
-    let mut interval = tokio::time::interval(Duration::from_secs(secs));
-    let cancel = scheduler.state.shutdown.token();
-    loop {
-        tokio::select! {
-            _ = cancel.cancelled() => return,
-            _ = interval.tick() => {}
-        }
-        let workers = scheduler.worker_pool.read().await.all_workers();
-        for info in &workers {
-            crate::worker_lifecycle::record_worker_sample(&scheduler.state.worker_db, info).await;
-        }
-        let (workers, pending, active) = scheduler.metrics_snapshot().await;
-        let _ = scheduler
-            .state
-            .board_events
-            .send(crate::BoardEvent::QueueDepth {
-                workers,
-                pending,
-                active,
-            });
+/// Snapshot every connected worker's live metrics into `worker_sample` for the
+/// Job Board's worker statistics.
+pub(super) async fn worker_sample_pass(scheduler: Arc<Scheduler>) -> anyhow::Result<()> {
+    let workers = scheduler.worker_pool.read().await.all_workers();
+    for info in &workers {
+        crate::worker_lifecycle::record_worker_sample(&scheduler.state.worker_db, info).await;
     }
+    let (workers, pending, active) = scheduler.metrics_snapshot().await;
+    let _ = scheduler
+        .state
+        .board_events
+        .send(crate::BoardEvent::QueueDepth {
+            workers,
+            pending,
+            active,
+        });
+    Ok(())
 }

--- a/backend/gradient-scheduler/src/dispatch/build.rs
+++ b/backend/gradient-scheduler/src/dispatch/build.rs
@@ -7,7 +7,6 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
-use std::time::Duration;
 
 use crate::dispatch_mode::{BuildDispatchMode, arch_available, decide_dispatch_mode};
 use gradient_core::ServerState;
@@ -17,13 +16,15 @@ use gradient_sources::get_path_from_derivation_output;
 use gradient_types::*;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 
-use tracing::{debug, error, info};
+use gradient_util::supervision::{ChildCtx, ChildSpec, run_pass};
+use ractor::{Actor, ActorProcessingErr, ActorRef};
+use tracing::{debug, error};
 
 use crate::Scheduler;
 use crate::jobs::PendingBuildJob;
 use gradient_types::proto::{BuildJob, BuildSpec, CacheInfo, DerivationOutput, RequiredPath};
 
-use super::DISPATCH_TICK_SECS;
+use super::{DISPATCH_BUDGET, DISPATCH_TICK};
 
 /// Full-backstop (Global) reconcile cadence, in dispatch ticks: 6 x 5s = 30s.
 const GLOBAL_RECONCILE_TICKS: u64 = 6;
@@ -32,71 +33,155 @@ const GLOBAL_RECONCILE_TICKS: u64 = 6;
 /// tens of seconds on a large cache): 720 x 5s = 1h.
 const DEEP_RECONCILE_TICKS: u64 = 720;
 
-pub(super) async fn build_dispatch_loop(scheduler: Arc<Scheduler>) {
-    let mut interval = tokio::time::interval(Duration::from_secs(DISPATCH_TICK_SECS));
-    let cancel = scheduler.state.shutdown.token();
-    let mut tick_count: u64 = 0;
-    info!("build dispatch loop started");
-    loop {
-        let timer_tick = tokio::select! {
-            _ = cancel.cancelled() => {
-                info!("build dispatch loop shutting down");
-                return;
-            }
-            _ = interval.tick() => true,
-            _ = scheduler.dispatch_kick.notified() => false,
+/// One dispatch pass. A timer tick also advances the rescore clock and runs
+/// the reconcile scope for `tick_count`; a kick runs only the dispatch half.
+pub(crate) async fn build_dispatch_pass(scheduler: &Scheduler, timer_tick: bool, tick_count: u64) {
+    // rescore_count is an anti-starvation timeout measured in dispatch
+    // intervals, so only the timer advances it - reactive kicks (which can
+    // fire many times per interval) just run an extra dispatch pass.
+    if timer_tick {
+        scheduler.job_tracker.write().await.bump_rescore_counts();
+
+        // Every timer tick runs promotion (Tick); the anchor-side flag
+        // fixpoints, unbacked-output demote, and failure sweep (Global) run
+        // every GLOBAL_RECONCILE_TICKS, and the cached_path-side fixpoint
+        // (Deep) hourly - their full-table scans saturated Postgres when
+        // re-run every 5s on a large graph. Active evals keep their flags
+        // fresh via reactive completion propagation and per-flush Eval passes.
+        let scope = if tick_count.is_multiple_of(DEEP_RECONCILE_TICKS) {
+            gradient_db::ReconcileScope::Deep
+        } else if tick_count.is_multiple_of(GLOBAL_RECONCILE_TICKS) {
+            gradient_db::ReconcileScope::Global
+        } else {
+            gradient_db::ReconcileScope::Tick
         };
-        // rescore_count is an anti-starvation timeout measured in dispatch
-        // intervals, so only the timer advances it - reactive kicks (which can
-        // fire many times per interval) just run an extra dispatch pass.
+        gradient_db::reconcile_build_graph(&scheduler.state.db(), scope).await;
+    }
+
+    if let Err(e) = requeue_transient_failures(scheduler).await {
+        error!(error = %e, "requeue_transient_failures error");
+    }
+    if let Err(e) = dispatch_ready_builds(scheduler).await {
+        error!(error = %e, "build dispatch error");
+    }
+    // After dispatching, reconcile each in-flight evaluation's
+    // Building/Waiting state so the UI reflects "no worker can pick this
+    // up" (or recovers when a worker comes back online). Cheap when
+    // there are no in-flight evals.
+    if let Err(e) = scheduler.reconcile_waiting_state().await {
+        error!(error = %e, "reconcile_waiting_state in dispatch loop failed");
+    }
+    // A `.drv` our cache lost has no producer; the only recovery is a fresh
+    // evaluation of the same commit. Runs after the waiting-state reconcile
+    // has settled `graph_stuck`.
+    if let Err(e) = crate::waiting_state::recover_drv_stuck_evals(&scheduler.state).await {
+        error!(error = %e, "recover_drv_stuck_evals in dispatch loop failed");
+    }
+
+    // Re-offer still-pending jobs to all sessions each pass. A build
+    // re-queued after a failed/rejected dispatch had its sent-flag cleared,
+    // so this re-offers it (workers score it a second time) - including to a
+    // worker that just freed capacity via the kick. Sessions ignore an empty
+    // delta, so this is cheap when nothing changed.
+    if scheduler.job_tracker.read().await.has_pending() {
+        scheduler.job_notify.send_modify(|g| *g = g.wrapping_add(1));
+    }
+}
+
+pub(crate) enum BuildMsg {
+    Tick,
+    Kick,
+}
+
+/// The build dispatcher as a supervised actor: a timer tick every
+/// `DISPATCH_TICK`, plus edge-triggered kicks coalesced by generation so a
+/// burst of kicks queued during one pass is serviced by a single extra pass.
+pub(crate) struct BuildDispatch;
+
+pub(crate) struct BuildDispatchState {
+    scheduler: Arc<Scheduler>,
+    ctx: ChildCtx,
+    tick_count: u64,
+    kicks_seen: u64,
+}
+
+impl Actor for BuildDispatch {
+    type Msg = BuildMsg;
+    type State = BuildDispatchState;
+    type Arguments = (Arc<Scheduler>, ChildCtx);
+
+    async fn pre_start(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        (scheduler, ctx): Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        myself.send_after(DISPATCH_TICK, || BuildMsg::Tick);
+        Ok(BuildDispatchState {
+            scheduler,
+            ctx,
+            tick_count: 0,
+            kicks_seen: 0,
+        })
+    }
+
+    async fn handle(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        msg: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        let timer_tick = matches!(msg, BuildMsg::Tick);
+        let kick_gen = state.scheduler.kick_gen.load(Ordering::Relaxed);
+        if !timer_tick && kick_gen == state.kicks_seen {
+            return Ok(());
+        }
         if timer_tick {
-            scheduler.job_tracker.write().await.bump_rescore_counts();
-
-            // Every timer tick runs promotion (Tick); the anchor-side flag
-            // fixpoints, unbacked-output demote, and failure sweep (Global) run
-            // every GLOBAL_RECONCILE_TICKS, and the cached_path-side fixpoint
-            // (Deep) hourly - their full-table scans saturated Postgres when
-            // re-run every 5s on a large graph. Active evals keep their flags
-            // fresh via reactive completion propagation and per-flush Eval passes.
-            tick_count = tick_count.wrapping_add(1);
-            let scope = if tick_count.is_multiple_of(DEEP_RECONCILE_TICKS) {
-                gradient_db::ReconcileScope::Deep
-            } else if tick_count.is_multiple_of(GLOBAL_RECONCILE_TICKS) {
-                gradient_db::ReconcileScope::Global
-            } else {
-                gradient_db::ReconcileScope::Tick
-            };
-            gradient_db::reconcile_build_graph(&scheduler.state.db(), scope).await;
+            state.tick_count = state.tick_count.wrapping_add(1);
         }
 
-        if let Err(e) = requeue_transient_failures(&scheduler).await {
-            error!(error = %e, "requeue_transient_failures error");
-        }
-        if let Err(e) = dispatch_ready_builds(&scheduler).await {
-            error!(error = %e, "build dispatch error");
-        }
-        // After dispatching, reconcile each in-flight evaluation's
-        // Building/Waiting state so the UI reflects "no worker can pick this
-        // up" (or recovers when a worker comes back online). Cheap when
-        // there are no in-flight evals.
-        if let Err(e) = scheduler.reconcile_waiting_state().await {
-            error!(error = %e, "reconcile_waiting_state in dispatch loop failed");
-        }
-        // A `.drv` our cache lost has no producer; the only recovery is a fresh
-        // evaluation of the same commit. Runs after the waiting-state reconcile
-        // has settled `graph_stuck`.
-        if let Err(e) = crate::waiting_state::recover_drv_stuck_evals(&scheduler.state).await {
-            error!(error = %e, "recover_drv_stuck_evals in dispatch loop failed");
-        }
+        let scheduler = Arc::clone(&state.scheduler);
+        let tick_count = state.tick_count;
+        let alive = run_pass(
+            "build-dispatch",
+            DISPATCH_BUDGET,
+            &state.ctx.cancel,
+            &state.ctx.health,
+            Box::pin(async move {
+                build_dispatch_pass(&scheduler, timer_tick, tick_count).await;
+                Ok(())
+            }),
+        )
+        .await;
+        state.kicks_seen = kick_gen;
 
-        // Re-offer still-pending jobs to all sessions each pass. A build
-        // re-queued after a failed/rejected dispatch had its sent-flag cleared,
-        // so this re-offers it (workers score it a second time) - including to a
-        // worker that just freed capacity via the kick. Sessions ignore an empty
-        // delta, so this is cheap when nothing changed.
-        if scheduler.job_tracker.read().await.has_pending() {
-            scheduler.job_notify.send_modify(|g| *g = g.wrapping_add(1));
+        if !alive {
+            myself.stop(Some("shutdown".into()));
+        } else if timer_tick {
+            myself.send_after(DISPATCH_TICK, || BuildMsg::Tick);
         }
+        Ok(())
+    }
+}
+
+/// The build dispatcher as a supervised child. The factory re-publishes the
+/// actor ref on every (re)spawn so `kick_dispatch` always reaches the live one.
+pub(super) fn child_spec(scheduler: &Arc<Scheduler>) -> ChildSpec {
+    let scheduler = Arc::clone(scheduler);
+    ChildSpec::Custom {
+        name: "build-dispatch",
+        spawn: Arc::new(move |ctx: ChildCtx| {
+            let scheduler = Arc::clone(&scheduler);
+            Box::pin(async move {
+                let parent = ctx.parent.clone();
+                let (actor, _) =
+                    Actor::spawn_linked(None, BuildDispatch, (Arc::clone(&scheduler), ctx), parent)
+                        .await?;
+                scheduler
+                    .build_dispatch
+                    .store(Some(Arc::new(actor.clone())));
+                Ok(actor.get_cell())
+            })
+        }),
     }
 }
 

--- a/backend/gradient-scheduler/src/dispatch/eval.rs
+++ b/backend/gradient-scheduler/src/dispatch/eval.rs
@@ -7,7 +7,6 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
-use std::time::Duration;
 
 use gradient_core::ServerState;
 use gradient_entity::evaluation::EvaluationStatus;
@@ -16,31 +15,11 @@ use gradient_types::wildcard::Wildcard;
 use gradient_types::*;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 
-use tracing::{debug, error, info};
+use tracing::{debug, error};
 
 use crate::Scheduler;
 use crate::jobs::PendingEvalJob;
 use gradient_types::proto::{FlakeJob, FlakeStep, RequiredPath};
-
-use super::DISPATCH_TICK_SECS;
-
-pub(super) async fn eval_dispatch_loop(scheduler: Arc<Scheduler>) {
-    let mut interval = tokio::time::interval(Duration::from_secs(DISPATCH_TICK_SECS));
-    let cancel = scheduler.state.shutdown.token();
-    info!("eval dispatch loop started");
-    loop {
-        tokio::select! {
-            _ = cancel.cancelled() => {
-                info!("eval dispatch loop shutting down");
-                return;
-            }
-            _ = interval.tick() => {}
-        }
-        if let Err(e) = dispatch_queued_evals(&scheduler).await {
-            error!(error = %e, "eval dispatch error");
-        }
-    }
-}
 
 pub(crate) async fn dispatch_queued_evals(scheduler: &Scheduler) -> anyhow::Result<()> {
     if scheduler.draining.load(Ordering::Relaxed) {

--- a/backend/gradient-scheduler/src/dispatch/mod.rs
+++ b/backend/gradient-scheduler/src/dispatch/mod.rs
@@ -6,17 +6,26 @@
 
 //! Background loops that poll the DB and enqueue jobs into the in-memory scheduler.
 //!
+//! Every loop is a child of one supervision tree (`gradient_util::supervision`):
+//! a pass that panics or errors is logged and the loop restarts with backoff, a
+//! pass past its budget is cancelled in place, and shutdown stops the tree.
+//!
 //! Split across submodules by concern:
-//! - [`background`] - consistency sweep, worker liveness, and metrics loops
-//! - [`eval`] - `eval_dispatch_loop`: finds `Queued` evaluations → enqueues `FlakeJob`s
-//! - [`build`] - `build_dispatch_loop`: finds ready `Queued` `derivation_build` anchors → enqueues `BuildJob`s
+//! - [`background`] - consistency sweep, worker liveness, and metrics passes
+//! - [`eval`] - `dispatch_queued_evals`: finds `Queued` evaluations and enqueues `FlakeJob`s
+//! - [`build`] - the build dispatch actor: finds ready `Queued` `derivation_build` anchors and enqueues `BuildJob`s
 //!
-//! `trigger_dispatch::trigger_dispatch_loop` fires polling/time triggers → creates evaluations.
+//! `trigger_dispatch::dispatch_once` fires polling/time triggers and creates evaluations.
 //!
-//! The eval/build loops are idempotent: re-enqueueing the same job_id overwrites
+//! The eval/build passes are idempotent: re-enqueueing the same job_id overwrites
 //! the existing entry in the `JobTracker` without harm.
 
+use std::future::Future;
 use std::sync::Arc;
+use std::time::Duration;
+
+use gradient_util::supervision::{ChildSpec, Supervisor};
+use tracing::{error, info};
 
 use super::Scheduler;
 
@@ -24,29 +33,107 @@ mod background;
 mod build;
 mod eval;
 
-pub(crate) use build::dispatch_ready_builds;
+pub(crate) use build::{BuildMsg, dispatch_ready_builds};
 #[cfg(test)]
 pub(crate) use eval::dispatch_queued_evals;
 pub(crate) use eval::project_id_for_eval;
 
 /// Tick interval shared by the eval and build dispatch loops.
 pub(crate) const DISPATCH_TICK_SECS: u64 = 5;
+pub(super) const DISPATCH_TICK: Duration = Duration::from_secs(DISPATCH_TICK_SECS);
+/// A dispatch pass past this is cancelled and retried on the next tick.
+pub(super) const DISPATCH_BUDGET: Duration = Duration::from_secs(120);
+const METRICS_BUDGET: Duration = Duration::from_secs(60);
+const CONSISTENCY_BUDGET: Duration = Duration::from_secs(600);
 
-/// Spawns all dispatch loops on the shared shutdown tracker so they drain on SIGTERM.
+/// Starts every dispatch loop under one supervision tree tied to shutdown.
 pub fn start_dispatch_loops(scheduler: Arc<Scheduler>) {
     let shutdown = scheduler.state.shutdown.clone();
-    let s1 = Arc::clone(&scheduler);
-    let s2 = Arc::clone(&scheduler);
-    let s3 = Arc::clone(&scheduler);
-    let s4 = Arc::clone(&scheduler);
-    let s5 = Arc::clone(&scheduler);
-    shutdown.spawn(async move { super::trigger_dispatch::trigger_dispatch_loop(s3).await });
-    shutdown.spawn(async move { eval::eval_dispatch_loop(s1).await });
-    shutdown.spawn(async move { build::build_dispatch_loop(s2).await });
-    shutdown.spawn(async move { background::worker_sample_loop(s4).await });
-    shutdown.spawn(async move { background::instance_metrics_loop(s5).await });
-    let s6 = Arc::clone(&scheduler);
-    shutdown.spawn(async move { background::worker_liveness_loop(s6).await });
-    let s7 = Arc::clone(&scheduler);
-    shutdown.spawn(async move { background::consistency_sweep_loop(s7).await });
+    shutdown.spawn(async move {
+        let children = child_specs(&scheduler);
+        match Supervisor::start(&scheduler.state.shutdown, children).await {
+            Ok(sup) => {
+                info!("dispatch supervision tree started");
+                let _ = scheduler.supervisor.set(sup);
+            }
+            Err(e) => error!(error = %e, "failed to start the dispatch supervision tree"),
+        }
+    });
+}
+
+fn child_specs(scheduler: &Arc<Scheduler>) -> Vec<ChildSpec> {
+    let metrics = &scheduler.state.config.metrics_args;
+    let mut children = vec![
+        periodic(
+            scheduler,
+            "trigger-dispatch",
+            DISPATCH_TICK,
+            DISPATCH_BUDGET,
+            |s| async move { crate::trigger_dispatch::dispatch_once(&s).await },
+        ),
+        periodic(
+            scheduler,
+            "eval-dispatch",
+            DISPATCH_TICK,
+            DISPATCH_BUDGET,
+            |s| async move { eval::dispatch_queued_evals(&s).await },
+        ),
+        build::child_spec(scheduler),
+        periodic(
+            scheduler,
+            "worker-sample",
+            Duration::from_secs(metrics.worker_sample_interval_secs.max(1)),
+            METRICS_BUDGET,
+            background::worker_sample_pass,
+        ),
+        periodic(
+            scheduler,
+            "instance-metrics",
+            Duration::from_secs(metrics.instance_metrics_interval_secs.max(1)),
+            METRICS_BUDGET,
+            background::instance_metrics_pass,
+        ),
+    ];
+
+    match background::liveness_period(scheduler) {
+        Some(period) => children.push(periodic(
+            scheduler,
+            "worker-liveness",
+            period,
+            METRICS_BUDGET,
+            background::worker_liveness_pass,
+        )),
+        None => info!("worker liveness watchdog disabled (worker_heartbeat_timeout_secs = 0)"),
+    }
+
+    match metrics.graph_consistency_interval_secs {
+        0 => info!("graph consistency sweep disabled (graph_consistency_interval_secs = 0)"),
+        secs => children.push(periodic(
+            scheduler,
+            "graph-consistency",
+            Duration::from_secs(secs),
+            CONSISTENCY_BUDGET,
+            background::consistency_sweep_pass,
+        )),
+    }
+
+    children
+}
+
+fn periodic<F, Fut>(
+    scheduler: &Arc<Scheduler>,
+    name: &'static str,
+    period: Duration,
+    budget: Duration,
+    pass: F,
+) -> ChildSpec
+where
+    F: Fn(Arc<Scheduler>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = anyhow::Result<()>> + Send + 'static,
+{
+    let scheduler = Arc::clone(scheduler);
+    ChildSpec::periodic(name, period, budget, move || {
+        let fut = pass(Arc::clone(&scheduler));
+        async move { fut.await.map_err(Into::into) }
+    })
 }

--- a/backend/gradient-scheduler/src/dispatch/mod.rs
+++ b/backend/gradient-scheduler/src/dispatch/mod.rs
@@ -24,8 +24,8 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
-use gradient_util::supervision::{ChildSpec, Supervisor};
-use tracing::{error, info};
+use gradient_util::supervision::ChildSpec;
+use tracing::info;
 
 use super::Scheduler;
 
@@ -46,19 +46,11 @@ pub(super) const DISPATCH_BUDGET: Duration = Duration::from_secs(120);
 const METRICS_BUDGET: Duration = Duration::from_secs(60);
 const CONSISTENCY_BUDGET: Duration = Duration::from_secs(600);
 
-/// Starts every dispatch loop under one supervision tree tied to shutdown.
+/// Registers every dispatch loop on the process supervision tree.
 pub fn start_dispatch_loops(scheduler: Arc<Scheduler>) {
-    let shutdown = scheduler.state.shutdown.clone();
-    shutdown.spawn(async move {
-        let children = child_specs(&scheduler);
-        match Supervisor::start(&scheduler.state.shutdown, children).await {
-            Ok(sup) => {
-                info!("dispatch supervision tree started");
-                let _ = scheduler.supervisor.set(sup);
-            }
-            Err(e) => error!(error = %e, "failed to start the dispatch supervision tree"),
-        }
-    });
+    for spec in child_specs(&scheduler) {
+        scheduler.state.shutdown.supervise(spec);
+    }
 }
 
 fn child_specs(scheduler: &Arc<Scheduler>) -> Vec<ChildSpec> {

--- a/backend/gradient-scheduler/src/job_handlers/queue.rs
+++ b/backend/gradient-scheduler/src/job_handlers/queue.rs
@@ -49,12 +49,16 @@ impl Scheduler {
         self.job_notify.subscribe()
     }
 
-    /// Wake `build_dispatch_loop` now instead of waiting for its 5s tick. Called
+    /// Wake the build dispatcher now instead of waiting for its 5s tick. Called
     /// when a job completes and leaves its worker idle, so the dependents it just
     /// unblocked are enqueued and offered immediately - collapsing per-level
     /// latency on serial chains without kicking while the worker is still busy.
     pub(crate) fn kick_dispatch(&self) {
-        self.dispatch_kick.notify_one();
+        self.kick_gen
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if let Some(actor) = self.build_dispatch.load_full() {
+            let _ = actor.send_message(crate::dispatch::BuildMsg::Kick);
+        }
     }
 
     /// Returns ALL pending job candidates visible to the given worker.

--- a/backend/gradient-scheduler/src/lib.rs
+++ b/backend/gradient-scheduler/src/lib.rs
@@ -38,7 +38,7 @@ mod worker_lifecycle;
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicU64};
 
 use gradient_core::ServerState;
 use gradient_types::*;
@@ -75,11 +75,14 @@ pub struct Scheduler {
     /// (not `Notify`) so a bump fired while a session is busy is still observed
     /// on its next loop iteration instead of being a lost edge-triggered wakeup.
     pub(crate) job_notify: Arc<tokio::sync::watch::Sender<u64>>,
-    /// Kicks `build_dispatch_loop` to run a dispatch pass immediately instead of
-    /// waiting for its 5s tick, so a serial dependency chain advances at
-    /// completion speed rather than one level per interval. `notify_one` keeps a
-    /// single permit, so a kick fired mid-pass is still serviced next iteration.
-    pub(crate) dispatch_kick: Arc<tokio::sync::Notify>,
+    /// The live build-dispatch actor, re-published by its factory on every
+    /// (re)spawn, so `kick_dispatch` always reaches the current instance.
+    pub(crate) build_dispatch: Arc<arc_swap::ArcSwapOption<ractor::ActorRef<dispatch::BuildMsg>>>,
+    /// Edge-trigger generation for `kick_dispatch`: the dispatcher services a
+    /// burst of kicks with one pass by comparing against the generation it saw.
+    pub(crate) kick_gen: Arc<AtomicU64>,
+    /// The supervision tree owning every dispatch loop; set by `start`.
+    pub(crate) supervisor: Arc<std::sync::OnceLock<gradient_util::supervision::Supervisor>>,
     /// Per-evaluation accumulator of discovered dependency edges, flushed when
     /// the eval stream completes. Promotion itself is graph-driven (see
     /// `gradient_db::promotion`), not tied to this map.
@@ -120,7 +123,9 @@ impl Scheduler {
             worker_pool: Arc::new(RwLock::new(WorkerPool::new())),
             job_tracker: Arc::new(RwLock::new(JobTracker::new())),
             job_notify: Arc::new(tokio::sync::watch::channel(0u64).0),
-            dispatch_kick: Arc::new(tokio::sync::Notify::new()),
+            build_dispatch: Arc::new(arc_swap::ArcSwapOption::empty()),
+            kick_gen: Arc::new(AtomicU64::new(0)),
+            supervisor: Arc::new(std::sync::OnceLock::new()),
             eval_edges: Arc::new(RwLock::new(HashMap::new())),
             policy,
             instance: Arc::new(arc_swap::ArcSwap::from_pointee(
@@ -156,6 +161,14 @@ impl Scheduler {
     /// Call once after creating the scheduler, before serving requests.
     pub fn start(self: &Arc<Self>) {
         dispatch::start_dispatch_loops(Arc::clone(self));
+    }
+
+    /// Per-loop supervision health (restarts, pass errors, timeouts, last ok).
+    pub fn loop_health(&self) -> Vec<(&'static str, gradient_util::supervision::LoopHealth)> {
+        self.supervisor
+            .get()
+            .map(|s| s.health().snapshot())
+            .unwrap_or_default()
     }
 
     /// Snapshot of in-memory scheduler counts used by the metrics endpoint.

--- a/backend/gradient-scheduler/src/lib.rs
+++ b/backend/gradient-scheduler/src/lib.rs
@@ -81,8 +81,6 @@ pub struct Scheduler {
     /// Edge-trigger generation for `kick_dispatch`: the dispatcher services a
     /// burst of kicks with one pass by comparing against the generation it saw.
     pub(crate) kick_gen: Arc<AtomicU64>,
-    /// The supervision tree owning every dispatch loop; set by `start`.
-    pub(crate) supervisor: Arc<std::sync::OnceLock<gradient_util::supervision::Supervisor>>,
     /// Per-evaluation accumulator of discovered dependency edges, flushed when
     /// the eval stream completes. Promotion itself is graph-driven (see
     /// `gradient_db::promotion`), not tied to this map.
@@ -125,7 +123,6 @@ impl Scheduler {
             job_notify: Arc::new(tokio::sync::watch::channel(0u64).0),
             build_dispatch: Arc::new(arc_swap::ArcSwapOption::empty()),
             kick_gen: Arc::new(AtomicU64::new(0)),
-            supervisor: Arc::new(std::sync::OnceLock::new()),
             eval_edges: Arc::new(RwLock::new(HashMap::new())),
             policy,
             instance: Arc::new(arc_swap::ArcSwap::from_pointee(
@@ -165,9 +162,10 @@ impl Scheduler {
 
     /// Per-loop supervision health (restarts, pass errors, timeouts, last ok).
     pub fn loop_health(&self) -> Vec<(&'static str, gradient_util::supervision::LoopHealth)> {
-        self.supervisor
-            .get()
-            .map(|s| s.health().snapshot())
+        self.state
+            .shutdown
+            .supervision_health()
+            .map(|h| h.snapshot())
             .unwrap_or_default()
     }
 

--- a/backend/gradient-scheduler/src/scheduler_tests.rs
+++ b/backend/gradient-scheduler/src/scheduler_tests.rs
@@ -124,22 +124,19 @@ async fn job_notify_bump_is_not_lost_when_not_awaiting() {
     );
 }
 
-/// Reactive dispatch (#359): a kick fired while the dispatch loop is mid-pass
-/// (not awaiting) is retained - `notify_one` stores one permit - and serviced on
-/// the loop's next iteration, so a serial dependency chain advances at
-/// completion speed instead of one level per 5s tick.
+/// Reactive dispatch (#359): a kick advances the edge-trigger generation even
+/// when no dispatcher is running yet, so the actor services it on its next
+/// pass instead of losing the wakeup.
 #[tokio::test]
 async fn dispatch_kick_is_retained_when_not_awaiting() {
+    use std::sync::atomic::Ordering;
     let scheduler = test_scheduler();
+    let before = scheduler.kick_gen.load(Ordering::Relaxed);
     scheduler.kick_dispatch();
-    let woke = tokio::time::timeout(
-        std::time::Duration::from_secs(1),
-        scheduler.dispatch_kick.notified(),
-    )
-    .await;
-    assert!(
-        woke.is_ok(),
-        "kick fired while not awaiting must still wake the dispatch loop"
+    assert_eq!(
+        scheduler.kick_gen.load(Ordering::Relaxed),
+        before + 1,
+        "a kick must advance the generation the dispatcher compares against"
     );
 }
 
@@ -154,13 +151,11 @@ async fn capability_update_kicks_dispatch_instead_of_reconciling_inline() {
     scheduler
         .update_worker_capabilities("peer-x", vec![], vec![], 4, 8, 16_000, 100)
         .await;
-    let woke = tokio::time::timeout(
-        std::time::Duration::from_secs(1),
-        scheduler.dispatch_kick.notified(),
-    )
-    .await;
-    assert!(
-        woke.is_ok(),
+    assert_eq!(
+        scheduler
+            .kick_gen
+            .load(std::sync::atomic::Ordering::Relaxed),
+        1,
         "capability update must kick the dispatch loop, not reconcile inline"
     );
 }

--- a/backend/gradient-scheduler/src/trigger_dispatch.rs
+++ b/backend/gradient-scheduler/src/trigger_dispatch.rs
@@ -88,7 +88,6 @@ pub(crate) fn cron_due(
 }
 
 use std::sync::Arc;
-use std::time::Duration;
 
 use gradient_ci::{ApplyInput, ApplyOutcome, apply_trigger, trigger::maybe_trigger_input_update};
 use gradient_core::ServerState;
@@ -100,23 +99,6 @@ use sea_orm::{ActiveModelTrait as _, ColumnTrait, Condition, EntityTrait, QueryF
 use tracing::{debug, error, info, warn};
 
 use super::Scheduler;
-
-/// Spawned by `dispatch::start_dispatch_loops`; ticks every 5 s and processes
-/// every active polling/time trigger via `dispatch_once`.
-pub async fn trigger_dispatch_loop(scheduler: Arc<Scheduler>) {
-    let mut interval = tokio::time::interval(Duration::from_secs(5));
-    let cancel = scheduler.state.shutdown.token();
-    info!("trigger dispatch loop started");
-    loop {
-        tokio::select! {
-            _ = cancel.cancelled() => { info!("trigger dispatch loop shutting down"); return; }
-            _ = interval.tick() => {}
-        }
-        if let Err(e) = dispatch_once(&scheduler).await {
-            error!(error = %e, "trigger dispatch error");
-        }
-    }
-}
 
 /// One pass through all active polling+time triggers. Public for tests.
 pub(crate) async fn dispatch_once(scheduler: &Scheduler) -> anyhow::Result<()> {

--- a/backend/gradient-util/Cargo.toml
+++ b/backend/gradient-util/Cargo.toml
@@ -20,6 +20,7 @@ workspace = true
 [dependencies]
 base64              = { workspace = true }
 hex                 = { workspace = true }
+ractor              = { workspace = true }
 reqwest             = { workspace = true }
 rustls              = { workspace = true }
 rustls-native-certs = { workspace = true }

--- a/backend/gradient-util/src/lib.rs
+++ b/backend/gradient-util/src/lib.rs
@@ -10,3 +10,4 @@ pub mod http_validation;
 pub mod hydra;
 pub mod nix_hash;
 pub mod shutdown;
+pub mod supervision;

--- a/backend/gradient-util/src/shutdown.rs
+++ b/backend/gradient-util/src/shutdown.rs
@@ -27,11 +27,14 @@ use std::time::Duration;
 
 use tokio::sync::OnceCell;
 use tokio::task::JoinHandle;
-use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 use tracing::{Instrument, error, info, warn};
 
 use crate::supervision::{ChildSpec, Supervisor, SupervisorHealth};
+
+/// Re-exported so callers observing shutdown do not need `tokio-util` as a
+/// direct dependency.
+pub use tokio_util::sync::CancellationToken;
 
 #[derive(Clone, Debug)]
 pub struct Shutdown {

--- a/backend/gradient-util/src/shutdown.rs
+++ b/backend/gradient-util/src/shutdown.rs
@@ -13,8 +13,8 @@
 //!
 //! # Rules
 //!
-//! - Anything outliving a single request goes through `Shutdown::spawn`,
-//!   never bare `tokio::spawn`.
+//! - A loop goes through `Shutdown::supervise`; a task that outlives one
+//!   request goes through `Shutdown::spawn`; never bare `tokio::spawn`.
 //! - Loops that sleep (`interval.tick`, `sleep`) must `select!` on
 //!   `cancelled()` so SIGTERM doesn't have to wait a full poll cycle.
 //! - Per-connection / per-job tasks derive a child token via
@@ -22,17 +22,22 @@
 //!   transitively.
 
 use std::future::Future;
+use std::sync::Arc;
 use std::time::Duration;
 
+use tokio::sync::OnceCell;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
-use tracing::{Instrument, info, warn};
+use tracing::{Instrument, error, info, warn};
+
+use crate::supervision::{ChildSpec, Supervisor, SupervisorHealth};
 
 #[derive(Clone, Debug)]
 pub struct Shutdown {
     token: CancellationToken,
     tracker: TaskTracker,
+    tree: Arc<OnceCell<Supervisor>>,
 }
 
 impl Default for Shutdown {
@@ -46,6 +51,7 @@ impl Shutdown {
         Self {
             token: CancellationToken::new(),
             tracker: TaskTracker::new(),
+            tree: Arc::new(OnceCell::new()),
         }
     }
 
@@ -85,6 +91,43 @@ impl Shutdown {
         F::Output: Send + 'static,
     {
         self.tracker.spawn(future.in_current_span())
+    }
+
+    /// The process supervision tree, started on first use.
+    pub async fn supervisor(&self) -> Result<&Supervisor, String> {
+        self.tree
+            .get_or_try_init(|| async {
+                Supervisor::start(self.token.clone(), self.tracker.clone())
+                    .await
+                    .map_err(|e| e.to_string())
+            })
+            .await
+    }
+
+    /// The tree, if one has been started.
+    pub fn tree(&self) -> Option<&Supervisor> {
+        self.tree.get()
+    }
+
+    pub fn supervision_health(&self) -> Option<Arc<SupervisorHealth>> {
+        self.tree.get().map(Supervisor::health)
+    }
+
+    /// Add `spec` to the tree and wait until its first instance runs.
+    pub async fn supervise_now(&self, spec: ChildSpec) -> Result<(), String> {
+        self.supervisor().await?.add(spec).await
+    }
+
+    /// Add `spec` from a sync context. A loop that cannot start is logged and
+    /// stays absent from the health registry, which is how it is noticed.
+    pub fn supervise(&self, spec: ChildSpec) {
+        let this = self.clone();
+        let name = spec.name();
+        self.spawn(async move {
+            if let Err(error) = this.supervise_now(spec).await {
+                error!(loop_name = name, %error, "failed to start supervised loop");
+            }
+        });
     }
 
     /// Trigger shutdown. Idempotent.

--- a/backend/gradient-util/src/supervision.rs
+++ b/backend/gradient-util/src/supervision.rs
@@ -1,0 +1,553 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Supervision tree for the server's long-lived loops.
+//!
+//! A `Root` actor owns every loop as a linked child. A child that panics or
+//! exits unexpectedly is respawned after an exponential backoff; a child whose
+//! pass exceeds its budget is cancelled in place and ticks again. Shutdown stops
+//! the whole tree through the shared [`Shutdown`] token.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use ractor::{Actor, ActorCell, ActorId, ActorProcessingErr, ActorRef, SpawnErr, SupervisionEvent};
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
+
+use crate::shutdown::Shutdown;
+
+pub type PassError = Box<dyn std::error::Error + Send + Sync + 'static>;
+pub type PassFuture = Pin<Box<dyn Future<Output = Result<(), PassError>> + Send>>;
+pub type PassFn = Arc<dyn Fn() -> PassFuture + Send + Sync>;
+pub type SpawnFuture = Pin<Box<dyn Future<Output = Result<ActorCell, SpawnErr>> + Send>>;
+pub type SpawnFn = Arc<dyn Fn(ChildCtx) -> SpawnFuture + Send + Sync>;
+
+const BACKOFF_BASE: Duration = Duration::from_secs(1);
+const BACKOFF_MAX: Duration = Duration::from_secs(60);
+const HEALTHY_RESET: Duration = Duration::from_secs(300);
+const STOP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// A pass that runs every `period`, cancelled in place past `budget`.
+#[derive(Clone)]
+pub struct PeriodicSpec {
+    pub name: &'static str,
+    pub period: Duration,
+    pub budget: Duration,
+    pub run: PassFn,
+}
+
+/// What the root supervises: a periodic pass, or any actor spawned by a factory.
+#[derive(Clone)]
+pub enum ChildSpec {
+    Periodic(PeriodicSpec),
+    Custom { name: &'static str, spawn: SpawnFn },
+}
+
+impl ChildSpec {
+    pub fn periodic<F, Fut>(name: &'static str, period: Duration, budget: Duration, run: F) -> Self
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<(), PassError>> + Send + 'static,
+    {
+        Self::Periodic(PeriodicSpec {
+            name,
+            period,
+            budget,
+            run: Arc::new(move || Box::pin(run())),
+        })
+    }
+
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Periodic(p) => p.name,
+            Self::Custom { name, .. } => name,
+        }
+    }
+}
+
+/// Everything a child needs from the tree: its parent cell, the shared health
+/// registry and the shutdown token.
+#[derive(Clone)]
+pub struct ChildCtx {
+    pub parent: ActorCell,
+    pub health: Arc<SupervisorHealth>,
+    pub cancel: CancellationToken,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct LoopHealth {
+    pub restarts: u32,
+    pub pass_errors: u64,
+    pub pass_timeouts: u64,
+    pub last_ok_at: Option<Instant>,
+    pub last_error: Option<String>,
+}
+
+#[derive(Default)]
+pub struct SupervisorHealth {
+    loops: Mutex<HashMap<&'static str, LoopHealth>>,
+}
+
+impl SupervisorHealth {
+    pub fn with(&self, name: &'static str, f: impl FnOnce(&mut LoopHealth)) {
+        let mut map = self.loops.lock().unwrap_or_else(|e| e.into_inner());
+        f(map.entry(name).or_default());
+    }
+
+    pub fn snapshot(&self) -> Vec<(&'static str, LoopHealth)> {
+        let map = self.loops.lock().unwrap_or_else(|e| e.into_inner());
+        let mut rows: Vec<_> = map.iter().map(|(k, v)| (*k, v.clone())).collect();
+        rows.sort_by_key(|(k, _)| *k);
+        rows
+    }
+
+    pub fn get(&self, name: &str) -> LoopHealth {
+        let map = self.loops.lock().unwrap_or_else(|e| e.into_inner());
+        map.get(name).cloned().unwrap_or_default()
+    }
+}
+
+/// Run one pass under the shutdown token and the budget, recording the outcome.
+/// Returns `false` when shutdown was observed, so the caller stops instead of rescheduling.
+pub async fn run_pass(
+    name: &'static str,
+    budget: Duration,
+    cancel: &CancellationToken,
+    health: &SupervisorHealth,
+    pass: PassFuture,
+) -> bool {
+    let started = Instant::now();
+    let outcome = tokio::select! {
+        _ = cancel.cancelled() => return false,
+        r = tokio::time::timeout(budget, pass) => r,
+    };
+    let elapsed_ms = started.elapsed().as_millis() as u64;
+    match outcome {
+        Ok(Ok(())) => health.with(name, |h| h.last_ok_at = Some(Instant::now())),
+        Ok(Err(e)) => {
+            warn!(loop_name = name, elapsed_ms, error = %e, "pass failed");
+            health.with(name, |h| {
+                h.pass_errors += 1;
+                h.last_error = Some(e.to_string());
+            });
+        }
+        Err(_) => {
+            warn!(
+                loop_name = name,
+                elapsed_ms, "pass exceeded its budget and was cancelled"
+            );
+            health.with(name, |h| h.pass_timeouts += 1);
+        }
+    }
+    true
+}
+
+pub struct Periodic;
+
+pub enum PeriodicMsg {
+    Tick,
+}
+
+pub struct PeriodicArgs {
+    pub spec: PeriodicSpec,
+    pub ctx: ChildCtx,
+}
+
+impl Actor for Periodic {
+    type Msg = PeriodicMsg;
+    type State = PeriodicArgs;
+    type Arguments = PeriodicArgs;
+
+    async fn pre_start(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        args: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        myself.send_after(args.spec.period, || PeriodicMsg::Tick);
+        Ok(args)
+    }
+
+    async fn handle(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        PeriodicMsg::Tick: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        let spec = &state.spec;
+        let alive = run_pass(
+            spec.name,
+            spec.budget,
+            &state.ctx.cancel,
+            &state.ctx.health,
+            (spec.run)(),
+        )
+        .await;
+        if alive {
+            myself.send_after(spec.period, || PeriodicMsg::Tick);
+        } else {
+            myself.stop(Some("shutdown".into()));
+        }
+        Ok(())
+    }
+}
+
+pub struct Root;
+
+pub enum RootMsg {
+    Respawn(&'static str),
+}
+
+pub struct RootArgs {
+    pub children: Vec<ChildSpec>,
+    pub health: Arc<SupervisorHealth>,
+    pub cancel: CancellationToken,
+}
+
+pub struct RootState {
+    args: RootArgs,
+    live: HashMap<ActorId, &'static str>,
+    failures: HashMap<&'static str, (u32, Instant)>,
+}
+
+impl RootState {
+    fn spec(&self, name: &str) -> Option<ChildSpec> {
+        self.args
+            .children
+            .iter()
+            .find(|c| c.name() == name)
+            .cloned()
+    }
+
+    fn backoff(&mut self, name: &'static str) -> Duration {
+        let now = Instant::now();
+        let entry = self.failures.entry(name).or_insert((0, now));
+        if now.duration_since(entry.1) > HEALTHY_RESET {
+            entry.0 = 0;
+        }
+        let delay = BACKOFF_BASE
+            .saturating_mul(1u32 << entry.0.min(6))
+            .min(BACKOFF_MAX);
+        *entry = (entry.0.saturating_add(1), now);
+        delay
+    }
+}
+
+async fn spawn_child(
+    myself: &ActorRef<RootMsg>,
+    spec: &ChildSpec,
+    state: &mut RootState,
+) -> Result<(), SpawnErr> {
+    let ctx = ChildCtx {
+        parent: myself.get_cell(),
+        health: Arc::clone(&state.args.health),
+        cancel: state.args.cancel.clone(),
+    };
+    let cell = match spec {
+        ChildSpec::Periodic(p) => {
+            let args = PeriodicArgs {
+                spec: p.clone(),
+                ctx: ctx.clone(),
+            };
+            let (child, _) = Actor::spawn_linked(None, Periodic, args, ctx.parent).await?;
+            child.get_cell()
+        }
+        ChildSpec::Custom { spawn, .. } => spawn(ctx).await?,
+    };
+    state.live.insert(cell.get_id(), spec.name());
+    info!(loop_name = spec.name(), "supervised loop started");
+    Ok(())
+}
+
+impl Actor for Root {
+    type Msg = RootMsg;
+    type State = RootState;
+    type Arguments = RootArgs;
+
+    async fn pre_start(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        args: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        let mut state = RootState {
+            args,
+            live: HashMap::new(),
+            failures: HashMap::new(),
+        };
+        for spec in state.args.children.clone() {
+            spawn_child(&myself, &spec, &mut state).await?;
+        }
+        Ok(state)
+    }
+
+    async fn handle(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        RootMsg::Respawn(name): Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        if state.args.cancel.is_cancelled() {
+            return Ok(());
+        }
+        if let Some(spec) = state.spec(name) {
+            spawn_child(&myself, &spec, state).await?;
+        }
+        Ok(())
+    }
+
+    async fn handle_supervisor_evt(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        event: SupervisionEvent,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        let (cell, reason) = match event {
+            SupervisionEvent::ActorFailed(cell, err) => (cell, err.to_string()),
+            SupervisionEvent::ActorTerminated(cell, _, reason) => {
+                (cell, reason.unwrap_or_else(|| "exited".into()))
+            }
+            _ => return Ok(()),
+        };
+        let Some(name) = state.live.remove(&cell.get_id()) else {
+            return Ok(());
+        };
+        if state.args.cancel.is_cancelled() {
+            return Ok(());
+        }
+        let delay = state.backoff(name);
+        warn!(loop_name = name, %reason, restart_in_ms = delay.as_millis() as u64, "supervised loop died; restarting");
+        state.args.health.with(name, |h| {
+            h.restarts += 1;
+            h.last_error = Some(reason);
+        });
+        myself.send_after(delay, move || RootMsg::Respawn(name));
+        Ok(())
+    }
+
+    async fn post_stop(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        _state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        myself
+            .get_cell()
+            .stop_children_and_wait(Some("shutdown".into()), Some(STOP_TIMEOUT))
+            .await;
+        Ok(())
+    }
+}
+
+/// Handle to a running tree: the root and its health registry.
+#[derive(Clone)]
+pub struct Supervisor {
+    root: ActorRef<RootMsg>,
+    health: Arc<SupervisorHealth>,
+}
+
+impl Supervisor {
+    /// Spawn the root with `children` and tie its lifetime to `shutdown`.
+    pub async fn start(shutdown: &Shutdown, children: Vec<ChildSpec>) -> Result<Self, SpawnErr> {
+        let health = Arc::new(SupervisorHealth::default());
+        let args = RootArgs {
+            children,
+            health: Arc::clone(&health),
+            cancel: shutdown.token(),
+        };
+        let (root, _) = Actor::spawn(None, Root, args).await?;
+        let cancel = shutdown.token();
+        let stop = root.clone();
+        shutdown.spawn(async move {
+            cancel.cancelled().await;
+            if let Err(e) = stop
+                .stop_and_wait(Some("shutdown".into()), Some(STOP_TIMEOUT))
+                .await
+            {
+                warn!(error = %e, "supervision tree did not stop cleanly");
+            }
+        });
+        Ok(Self { root, health })
+    }
+
+    pub fn health(&self) -> Arc<SupervisorHealth> {
+        Arc::clone(&self.health)
+    }
+
+    pub fn root(&self) -> ActorCell {
+        self.root.get_cell()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+
+    fn counting_pass(calls: Arc<AtomicU32>, panic_on: Option<u32>) -> ChildSpec {
+        ChildSpec::periodic(
+            "t",
+            Duration::from_millis(10),
+            Duration::from_millis(50),
+            move || {
+                let calls = Arc::clone(&calls);
+                async move {
+                    let n = calls.fetch_add(1, Ordering::SeqCst) + 1;
+                    if panic_on == Some(n) {
+                        panic!("boom on call {n}");
+                    }
+                    Ok(())
+                }
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn a_panicking_pass_is_restarted_and_keeps_ticking() {
+        let shutdown = Shutdown::new();
+        let calls = Arc::new(AtomicU32::new(0));
+        let sup = Supervisor::start(&shutdown, vec![counting_pass(Arc::clone(&calls), Some(2))])
+            .await
+            .expect("spawn");
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+        let h = sup.health().get("t");
+        assert_eq!(h.restarts, 1, "one restart after the panic: {h:?}");
+        assert!(
+            calls.load(Ordering::SeqCst) > 3,
+            "ticking resumed after the restart"
+        );
+        assert!(h.last_ok_at.is_some());
+        shutdown.cancel_and_drain(Duration::from_secs(2)).await;
+    }
+
+    #[tokio::test]
+    async fn a_pass_past_its_budget_is_cancelled_and_counted() {
+        let shutdown = Shutdown::new();
+        let spec = ChildSpec::periodic(
+            "slow",
+            Duration::from_millis(10),
+            Duration::from_millis(20),
+            || async {
+                tokio::time::sleep(Duration::from_secs(5)).await;
+                Ok(())
+            },
+        );
+        let sup = Supervisor::start(&shutdown, vec![spec])
+            .await
+            .expect("spawn");
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let h = sup.health().get("slow");
+        assert!(h.pass_timeouts >= 2, "{h:?}");
+        assert_eq!(h.restarts, 0);
+        shutdown.cancel_and_drain(Duration::from_secs(2)).await;
+    }
+
+    #[tokio::test]
+    async fn shutdown_stops_the_tree_and_never_restarts() {
+        let shutdown = Shutdown::new();
+        let calls = Arc::new(AtomicU32::new(0));
+        let sup = Supervisor::start(&shutdown, vec![counting_pass(Arc::clone(&calls), None)])
+            .await
+            .expect("spawn");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(shutdown.cancel_and_drain(Duration::from_secs(2)).await);
+        let after = calls.load(Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            after,
+            "no ticks after shutdown"
+        );
+        assert_eq!(sup.root().get_status(), ractor::ActorStatus::Stopped);
+    }
+
+    struct Slow;
+
+    enum SlowMsg {
+        Work,
+        Ping(ractor::RpcReplyPort<u64>),
+    }
+
+    impl Actor for Slow {
+        type Msg = SlowMsg;
+        type State = Arc<AtomicU64>;
+        type Arguments = Arc<AtomicU64>;
+
+        async fn pre_start(
+            &self,
+            _: ActorRef<Self::Msg>,
+            done: Self::Arguments,
+        ) -> Result<Self::State, ActorProcessingErr> {
+            Ok(done)
+        }
+
+        async fn handle(
+            &self,
+            _: ActorRef<Self::Msg>,
+            msg: Self::Msg,
+            done: &mut Self::State,
+        ) -> Result<(), ActorProcessingErr> {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+            let n = done.fetch_add(1, Ordering::SeqCst) + 1;
+            if let SlowMsg::Ping(reply) = msg {
+                let _ = reply.send(n);
+            }
+            Ok(())
+        }
+    }
+
+    /// The mailbox is unbounded: a burst of casts is accepted instantly and a
+    /// later call waits behind the whole backlog (FIFO, no priority lanes).
+    #[tokio::test]
+    async fn casts_queue_without_bound_and_a_call_waits_behind_them() {
+        let done = Arc::new(AtomicU64::new(0));
+        let (actor, _) = Actor::spawn(None, Slow, Arc::clone(&done))
+            .await
+            .expect("spawn");
+        let burst = 2000u64;
+        let started = Instant::now();
+        for _ in 0..burst {
+            actor.send_message(SlowMsg::Work).expect("cast");
+        }
+        assert!(
+            started.elapsed() < Duration::from_millis(100),
+            "casts never wait"
+        );
+        let queued = burst - done.load(Ordering::SeqCst);
+        assert!(
+            queued > burst / 2,
+            "{queued} of {burst} still queued after the burst"
+        );
+        let processed = ractor::call!(actor, SlowMsg::Ping).expect("call");
+        assert_eq!(
+            processed,
+            burst + 1,
+            "the call was answered only after the backlog"
+        );
+        assert!(
+            started.elapsed() >= Duration::from_millis(1000),
+            "head-of-line wait behind the burst"
+        );
+        actor.stop(None);
+    }
+
+    #[tokio::test]
+    async fn backoff_grows_and_caps() {
+        let cancel = CancellationToken::new();
+        let mut st = RootState {
+            args: RootArgs {
+                children: vec![],
+                health: Arc::default(),
+                cancel,
+            },
+            live: HashMap::new(),
+            failures: HashMap::new(),
+        };
+        let delays: Vec<u64> = (0..8).map(|_| st.backoff("x").as_secs()).collect();
+        assert_eq!(delays, vec![1, 2, 4, 8, 16, 32, 60, 60]);
+    }
+}

--- a/backend/gradient-util/src/supervision.rs
+++ b/backend/gradient-util/src/supervision.rs
@@ -17,7 +17,10 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use ractor::{Actor, ActorCell, ActorId, ActorProcessingErr, ActorRef, RpcReplyPort, SpawnErr, SupervisionEvent};
+use ractor::{
+    Actor, ActorCell, ActorId, ActorProcessingErr, ActorRef, RpcReplyPort, SpawnErr,
+    SupervisionEvent,
+};
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 use tracing::{info, warn};
@@ -383,7 +386,10 @@ impl Supervisor {
         let stop = root.clone();
         tracker.spawn(async move {
             token.cancelled().await;
-            if let Err(e) = stop.stop_and_wait(Some("shutdown".into()), Some(STOP_TIMEOUT)).await {
+            if let Err(e) = stop
+                .stop_and_wait(Some("shutdown".into()), Some(STOP_TIMEOUT))
+                .await
+            {
                 warn!(error = %e, "supervision tree did not stop cleanly");
             }
         });
@@ -501,7 +507,11 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(200)).await;
         assert!(calls.load(Ordering::SeqCst) > 0, "the loop ticked");
         assert_eq!(
-            shutdown.supervision_health().expect("tree").snapshot().len(),
+            shutdown
+                .supervision_health()
+                .expect("tree")
+                .snapshot()
+                .len(),
             1
         );
         shutdown.cancel_and_drain(Duration::from_secs(2)).await;

--- a/backend/gradient-util/src/supervision.rs
+++ b/backend/gradient-util/src/supervision.rs
@@ -98,6 +98,11 @@ pub struct SupervisorHealth {
 }
 
 impl SupervisorHealth {
+    /// Give `name` a row so the snapshot lists a child before its first pass.
+    pub fn register(&self, name: &'static str) {
+        self.with(name, |_| {});
+    }
+
     pub fn with(&self, name: &'static str, f: impl FnOnce(&mut LoopHealth)) {
         let mut map = self.loops.lock().unwrap_or_else(|e| e.into_inner());
         f(map.entry(name).or_default());
@@ -264,6 +269,7 @@ async fn spawn_child(
         ChildSpec::Custom { spawn, .. } => spawn(ctx).await?,
     };
     state.live.insert(cell.get_id(), spec.name());
+    state.args.health.register(spec.name());
     info!(loop_name = spec.name(), "supervised loop started");
     Ok(())
 }
@@ -453,6 +459,24 @@ mod tests {
             "ticking resumed after the restart"
         );
         assert!(h.last_ok_at.is_some());
+        shutdown.cancel_and_drain(Duration::from_secs(2)).await;
+    }
+
+    #[tokio::test]
+    async fn a_child_is_listed_in_health_before_its_first_pass() {
+        let shutdown = Shutdown::new();
+        let spec = ChildSpec::periodic(
+            "hourly",
+            Duration::from_secs(3600),
+            Duration::from_secs(60),
+            || async { Ok(()) },
+        );
+        shutdown.supervise_now(spec).await.expect("supervise");
+        let health = shutdown.supervision_health().expect("tree");
+        let names: Vec<_> = health.snapshot().into_iter().map(|(n, _)| n).collect();
+        assert_eq!(names, vec!["hourly"]);
+        let h = health.get("hourly");
+        assert!(h.last_ok_at.is_none() && h.restarts == 0, "{h:?}");
         shutdown.cancel_and_drain(Duration::from_secs(2)).await;
     }
 

--- a/backend/gradient-util/src/supervision.rs
+++ b/backend/gradient-util/src/supervision.rs
@@ -17,11 +17,10 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use ractor::{Actor, ActorCell, ActorId, ActorProcessingErr, ActorRef, SpawnErr, SupervisionEvent};
+use ractor::{Actor, ActorCell, ActorId, ActorProcessingErr, ActorRef, RpcReplyPort, SpawnErr, SupervisionEvent};
 use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
 use tracing::{info, warn};
-
-use crate::shutdown::Shutdown;
 
 pub type PassError = Box<dyn std::error::Error + Send + Sync + 'static>;
 pub type PassFuture = Pin<Box<dyn Future<Output = Result<(), PassError>> + Send>>;
@@ -64,7 +63,7 @@ impl ChildSpec {
         })
     }
 
-    fn name(&self) -> &'static str {
+    pub fn name(&self) -> &'static str {
         match self {
             Self::Periodic(p) => p.name,
             Self::Custom { name, .. } => name,
@@ -201,6 +200,7 @@ impl Actor for Periodic {
 pub struct Root;
 
 pub enum RootMsg {
+    Add(ChildSpec, RpcReplyPort<Result<(), String>>),
     Respawn(&'static str),
 }
 
@@ -289,14 +289,27 @@ impl Actor for Root {
     async fn handle(
         &self,
         myself: ActorRef<Self::Msg>,
-        RootMsg::Respawn(name): Self::Msg,
+        msg: Self::Msg,
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
-        if state.args.cancel.is_cancelled() {
-            return Ok(());
-        }
-        if let Some(spec) = state.spec(name) {
-            spawn_child(&myself, &spec, state).await?;
+        match msg {
+            RootMsg::Add(spec, reply) => {
+                let result = spawn_child(&myself, &spec, state)
+                    .await
+                    .map_err(|e| e.to_string());
+                if result.is_ok() {
+                    state.args.children.push(spec);
+                }
+                let _ = reply.send(result);
+            }
+            RootMsg::Respawn(name) => {
+                if state.args.cancel.is_cancelled() {
+                    return Ok(());
+                }
+                if let Some(spec) = state.spec(name) {
+                    spawn_child(&myself, &spec, state).await?;
+                }
+            }
         }
         Ok(())
     }
@@ -350,42 +363,54 @@ pub struct Supervisor {
     health: Arc<SupervisorHealth>,
 }
 
+impl std::fmt::Debug for Supervisor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Supervisor").finish_non_exhaustive()
+    }
+}
+
 impl Supervisor {
-    /// Spawn the root with `children` and tie its lifetime to `shutdown`.
-    pub async fn start(shutdown: &Shutdown, children: Vec<ChildSpec>) -> Result<Self, SpawnErr> {
+    /// Spawn an empty root that stops when `token` is cancelled. The stop task
+    /// is tracked so a drain waits for the tree.
+    pub async fn start(token: CancellationToken, tracker: TaskTracker) -> Result<Self, SpawnErr> {
         let health = Arc::new(SupervisorHealth::default());
         let args = RootArgs {
-            children,
+            children: Vec::new(),
             health: Arc::clone(&health),
-            cancel: shutdown.token(),
+            cancel: token.clone(),
         };
         let (root, _) = Actor::spawn(None, Root, args).await?;
-        let cancel = shutdown.token();
         let stop = root.clone();
-        shutdown.spawn(async move {
-            cancel.cancelled().await;
-            if let Err(e) = stop
-                .stop_and_wait(Some("shutdown".into()), Some(STOP_TIMEOUT))
-                .await
-            {
+        tracker.spawn(async move {
+            token.cancelled().await;
+            if let Err(e) = stop.stop_and_wait(Some("shutdown".into()), Some(STOP_TIMEOUT)).await {
                 warn!(error = %e, "supervision tree did not stop cleanly");
             }
         });
         Ok(Self { root, health })
     }
 
+    /// Add a child and wait until its first instance is running.
+    pub async fn add(&self, spec: ChildSpec) -> Result<(), String> {
+        match ractor::call!(self.root, RootMsg::Add, spec) {
+            Ok(result) => result,
+            Err(e) => Err(e.to_string()),
+        }
+    }
+
     pub fn health(&self) -> Arc<SupervisorHealth> {
         Arc::clone(&self.health)
     }
 
-    pub fn root(&self) -> ActorCell {
-        self.root.get_cell()
+    pub fn root_status(&self) -> ractor::ActorStatus {
+        self.root.get_cell().get_status()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::shutdown::Shutdown;
     use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
     fn counting_pass(calls: Arc<AtomicU32>, panic_on: Option<u32>) -> ChildSpec {
@@ -410,11 +435,12 @@ mod tests {
     async fn a_panicking_pass_is_restarted_and_keeps_ticking() {
         let shutdown = Shutdown::new();
         let calls = Arc::new(AtomicU32::new(0));
-        let sup = Supervisor::start(&shutdown, vec![counting_pass(Arc::clone(&calls), Some(2))])
+        shutdown
+            .supervise_now(counting_pass(Arc::clone(&calls), Some(2)))
             .await
-            .expect("spawn");
+            .expect("supervise");
         tokio::time::sleep(Duration::from_millis(1500)).await;
-        let h = sup.health().get("t");
+        let h = shutdown.supervision_health().expect("tree").get("t");
         assert_eq!(h.restarts, 1, "one restart after the panic: {h:?}");
         assert!(
             calls.load(Ordering::SeqCst) > 3,
@@ -436,11 +462,9 @@ mod tests {
                 Ok(())
             },
         );
-        let sup = Supervisor::start(&shutdown, vec![spec])
-            .await
-            .expect("spawn");
+        shutdown.supervise_now(spec).await.expect("supervise");
         tokio::time::sleep(Duration::from_millis(200)).await;
-        let h = sup.health().get("slow");
+        let h = shutdown.supervision_health().expect("tree").get("slow");
         assert!(h.pass_timeouts >= 2, "{h:?}");
         assert_eq!(h.restarts, 0);
         shutdown.cancel_and_drain(Duration::from_secs(2)).await;
@@ -450,9 +474,10 @@ mod tests {
     async fn shutdown_stops_the_tree_and_never_restarts() {
         let shutdown = Shutdown::new();
         let calls = Arc::new(AtomicU32::new(0));
-        let sup = Supervisor::start(&shutdown, vec![counting_pass(Arc::clone(&calls), None)])
+        shutdown
+            .supervise_now(counting_pass(Arc::clone(&calls), None))
             .await
-            .expect("spawn");
+            .expect("supervise");
         tokio::time::sleep(Duration::from_millis(50)).await;
         assert!(shutdown.cancel_and_drain(Duration::from_secs(2)).await);
         let after = calls.load(Ordering::SeqCst);
@@ -462,7 +487,24 @@ mod tests {
             after,
             "no ticks after shutdown"
         );
-        assert_eq!(sup.root().get_status(), ractor::ActorStatus::Stopped);
+        assert_eq!(
+            shutdown.tree().expect("tree").root_status(),
+            ractor::ActorStatus::Stopped
+        );
+    }
+
+    #[tokio::test]
+    async fn supervise_from_a_sync_context_lands_in_the_tree() {
+        let shutdown = Shutdown::new();
+        let calls = Arc::new(AtomicU32::new(0));
+        shutdown.supervise(counting_pass(Arc::clone(&calls), None));
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert!(calls.load(Ordering::SeqCst) > 0, "the loop ticked");
+        assert_eq!(
+            shutdown.supervision_health().expect("tree").snapshot().len(),
+            1
+        );
+        shutdown.cancel_and_drain(Duration::from_secs(2)).await;
     }
 
     struct Slow;

--- a/backend/gradient-web/src/endpoints/board.rs
+++ b/backend/gradient-web/src/endpoints/board.rs
@@ -23,6 +23,7 @@ use gradient_entity::{build_attempt, flake_output_node};
 use gradient_scheduler::{BoardEvent, Scheduler};
 use gradient_types::ids::DispatchedJobId;
 use gradient_types::*;
+use gradient_util::shutdown::CancellationToken;
 use sea_orm::{
     ColumnTrait, ConnectionTrait, DatabaseBackend, EntityTrait, QueryFilter, QueryOrder,
     QuerySelect, Statement,
@@ -1119,7 +1120,13 @@ pub async fn board_live_ws(
         pending,
         active,
     };
-    ws.on_upgrade(move |socket| board_live_loop(socket, rx, scope, initial))
+    let cancel = state.shutdown.token();
+    let shutdown = state.shutdown.clone();
+    ws.on_upgrade(move |socket| async move {
+        let _ = shutdown
+            .spawn(board_live_loop(socket, rx, scope, initial, cancel))
+            .await;
+    })
 }
 
 async fn board_live_loop(
@@ -1127,6 +1134,7 @@ async fn board_live_loop(
     mut rx: tokio::sync::broadcast::Receiver<BoardEvent>,
     scope: MetricsScope,
     initial: BoardEvent,
+    cancel: CancellationToken,
 ) {
     // Send a queue-depth snapshot immediately so freshly-opened boards show
     // live counts without waiting for the next periodic broadcast.
@@ -1137,7 +1145,11 @@ async fn board_live_loop(
     }
 
     loop {
-        match rx.recv().await {
+        let event = tokio::select! {
+            _ = cancel.cancelled() => break,
+            event = rx.recv() => event,
+        };
+        match event {
             Ok(ev) => {
                 if let Some(text) = mask_event(&ev, &scope)
                     && socket.send(Message::Text(text.into())).await.is_err()

--- a/backend/gradient-web/src/endpoints/board_metrics.rs
+++ b/backend/gradient-web/src/endpoints/board_metrics.rs
@@ -538,6 +538,34 @@ pub async fn get_board_durations_heatmap(
 }
 
 #[derive(Serialize)]
+pub struct SupervisedLoop {
+    pub name: String,
+    pub restarts: u32,
+    pub pass_errors: u64,
+    pub pass_timeouts: u64,
+    pub last_ok_seconds_ago: Option<f64>,
+    pub last_error: Option<String>,
+}
+
+/// Render the supervision tree's raw health rows for the API, expressing
+/// `last_ok_at` as seconds elapsed rather than an opaque `Instant`.
+fn loops_view(
+    rows: Vec<(&'static str, gradient_util::supervision::LoopHealth)>,
+    now: std::time::Instant,
+) -> Vec<SupervisedLoop> {
+    rows.into_iter()
+        .map(|(name, h)| SupervisedLoop {
+            name: name.to_string(),
+            restarts: h.restarts,
+            pass_errors: h.pass_errors,
+            pass_timeouts: h.pass_timeouts,
+            last_ok_seconds_ago: h.last_ok_at.map(|t| now.duration_since(t).as_secs_f64()),
+            last_error: h.last_error,
+        })
+        .collect()
+}
+
+#[derive(Serialize)]
 pub struct BoardHealth {
     pub version: String,
     pub uptime_seconds: f64,
@@ -551,12 +579,15 @@ pub struct BoardHealth {
     pub rollup_lag_seconds: Option<f64>,
     pub latest_rollup_bucket: Option<String>,
     pub draining: bool,
+    pub supervised: Vec<SupervisedLoop>,
+    pub proto_sessions: usize,
 }
 
 pub async fn get_board_health(
     State(state): State<Arc<ServerState>>,
     Extension(user): Extension<MUser>,
     Extension(scheduler): Extension<Arc<Scheduler>>,
+    Extension(limiter): Extension<Arc<gradient_proto::ProtoLimiter>>,
 ) -> WebResult<Json<BaseResponse<BoardHealth>>> {
     require_superuser(&user)?;
     let obs = collect(&state, &scheduler).await?;
@@ -590,6 +621,8 @@ pub async fn get_board_health(
         draining: scheduler
             .draining
             .load(std::sync::atomic::Ordering::Relaxed),
+        supervised: loops_view(scheduler.loop_health(), std::time::Instant::now()),
+        proto_sessions: limiter.in_use(),
     }))
 }
 
@@ -605,5 +638,27 @@ mod tests {
         );
         assert_eq!(upstream_host("http://10.0.0.1:5000/"), "10.0.0.1:5000");
         assert_eq!(upstream_host("cache.example.com"), "cache.example.com");
+    }
+
+    #[test]
+    fn loops_view_reports_age_of_last_ok_pass() {
+        use gradient_util::supervision::LoopHealth;
+        let now = std::time::Instant::now();
+        let rows = vec![(
+            "build-dispatch",
+            LoopHealth {
+                restarts: 1,
+                pass_errors: 2,
+                pass_timeouts: 0,
+                last_ok_at: Some(now - std::time::Duration::from_secs(5)),
+                last_error: Some("boom".into()),
+            },
+        )];
+        let view = super::loops_view(rows, now);
+        assert_eq!(view.len(), 1);
+        assert_eq!(view[0].name, "build-dispatch");
+        assert_eq!(view[0].restarts, 1);
+        assert_eq!(view[0].last_ok_seconds_ago, Some(5.0));
+        assert_eq!(view[0].last_error.as_deref(), Some("boom"));
     }
 }

--- a/backend/gradient-web/src/endpoints/caches/proto.rs
+++ b/backend/gradient-web/src/endpoints/caches/proto.rs
@@ -70,14 +70,19 @@ pub async fn cache_proto(
         .max_message_size(gradient_proto::handler::MAX_PROTO_MESSAGE_SIZE)
         .max_frame_size(gradient_proto::handler::MAX_PROTO_MESSAGE_SIZE);
 
+    let shutdown = state.shutdown.clone();
     Ok(upgrade.on_upgrade(move |sock| async move {
-        let _global_permit = global_permit;
-        let _ip_permit = ip_permit;
-        gradient_proto::handler::handle_cache_socket(
-            gradient_proto::server::accept_axum(sock),
-            state,
-            cache_id,
-        )
-        .await;
+        let _ = shutdown
+            .spawn(async move {
+                let _global_permit = global_permit;
+                let _ip_permit = ip_permit;
+                gradient_proto::handler::handle_cache_socket(
+                    gradient_proto::server::accept_axum(sock),
+                    state,
+                    cache_id,
+                )
+                .await;
+            })
+            .await;
     }))
 }

--- a/backend/gradient-web/src/endpoints/live.rs
+++ b/backend/gradient-web/src/endpoints/live.rs
@@ -158,7 +158,12 @@ pub async fn evaluation_live_ws(
     let shutdown = state.shutdown.clone();
     Ok(ws.on_upgrade(move |socket| async move {
         let _ = shutdown
-            .spawn(live_stream(socket, rx, move |ev| eval_frame(ev, eval_id), cancel))
+            .spawn(live_stream(
+                socket,
+                rx,
+                move |ev| eval_frame(ev, eval_id),
+                cancel,
+            ))
             .await;
     }))
 }
@@ -179,7 +184,12 @@ pub async fn build_live_ws(
     let shutdown = state.shutdown.clone();
     Ok(ws.on_upgrade(move |socket| async move {
         let _ = shutdown
-            .spawn(live_stream(socket, rx, move |ev| eval_frame(ev, eval_id), cancel))
+            .spawn(live_stream(
+                socket,
+                rx,
+                move |ev| eval_frame(ev, eval_id),
+                cancel,
+            ))
             .await;
     }))
 }

--- a/backend/gradient-web/src/endpoints/live.rs
+++ b/backend/gradient-web/src/endpoints/live.rs
@@ -17,6 +17,7 @@ use axum::extract::{Path, State};
 use axum::response::Response;
 use gradient_core::ServerState;
 use gradient_types::*;
+use gradient_util::shutdown::CancellationToken;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect};
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -31,8 +32,12 @@ use super::evals::EvalAccessContext;
 /// The inbound half is polled purely to notice the client leaving: a loop that
 /// only writes learns of a closed tab at the next event that fails to send, so
 /// a quiet channel would hold its task and socket open indefinitely.
-pub async fn live_stream<F>(socket: WebSocket, mut rx: BoardEventRx, mut select: F)
-where
+pub async fn live_stream<F>(
+    socket: WebSocket,
+    mut rx: BoardEventRx,
+    mut select: F,
+    cancel: CancellationToken,
+) where
     F: FnMut(&BoardEvent) -> Option<String> + Send + 'static,
 {
     use futures::{SinkExt, StreamExt};
@@ -40,6 +45,7 @@ where
     let (mut sink, mut stream) = socket.split();
     loop {
         tokio::select! {
+            _ = cancel.cancelled() => break,
             incoming = stream.next() => match incoming {
                 // Close frame, transport error, or the peer simply went away.
                 None | Some(Err(_)) | Some(Ok(Message::Close(_))) => break,
@@ -99,8 +105,17 @@ pub async fn task_live_ws(
         .unwrap_or_default();
 
     let rx = state.board_events.subscribe();
-    Ok(ws.on_upgrade(move |socket| {
-        live_stream(socket, rx, move |ev| task_frame(ev, task_id, &mut known))
+    let cancel = state.shutdown.token();
+    let shutdown = state.shutdown.clone();
+    Ok(ws.on_upgrade(move |socket| async move {
+        let _ = shutdown
+            .spawn(live_stream(
+                socket,
+                rx,
+                move |ev| task_frame(ev, task_id, &mut known),
+                cancel,
+            ))
+            .await;
     }))
 }
 
@@ -139,7 +154,13 @@ pub async fn evaluation_live_ws(
     let ctx = EvalAccessContext::load(&state, evaluation_id, &maybe_user, api_key.as_ref()).await?;
     let eval_id = ctx.evaluation.id.into_inner();
     let rx = state.board_events.subscribe();
-    Ok(ws.on_upgrade(move |socket| live_stream(socket, rx, move |ev| eval_frame(ev, eval_id))))
+    let cancel = state.shutdown.token();
+    let shutdown = state.shutdown.clone();
+    Ok(ws.on_upgrade(move |socket| async move {
+        let _ = shutdown
+            .spawn(live_stream(socket, rx, move |ev| eval_frame(ev, eval_id), cancel))
+            .await;
+    }))
 }
 
 /// `GET /builds/{build}/live` - build status changes for the build's evaluation,
@@ -154,7 +175,13 @@ pub async fn build_live_ws(
     let ctx = BuildAccessContext::load(&state, build_id, &maybe_user, api_key.as_ref()).await?;
     let eval_id = ctx.build_job.evaluation.into_inner();
     let rx = state.board_events.subscribe();
-    Ok(ws.on_upgrade(move |socket| live_stream(socket, rx, move |ev| eval_frame(ev, eval_id))))
+    let cancel = state.shutdown.token();
+    let shutdown = state.shutdown.clone();
+    Ok(ws.on_upgrade(move |socket| async move {
+        let _ = shutdown
+            .spawn(live_stream(socket, rx, move |ev| eval_frame(ev, eval_id), cancel))
+            .await;
+    }))
 }
 
 fn eval_frame(ev: &BoardEvent, eval_id: Uuid) -> Option<String> {
@@ -177,11 +204,20 @@ pub async fn cache_live_ws(
     ws: WebSocketUpgrade,
 ) -> Response {
     let rx = state.board_events.subscribe();
-    ws.on_upgrade(move |socket| {
-        live_stream(socket, rx, |ev| match ev {
-            BoardEvent::CacheChanged => frame(ev),
-            _ => None,
-        })
+    let cancel = state.shutdown.token();
+    let shutdown = state.shutdown.clone();
+    ws.on_upgrade(move |socket| async move {
+        let _ = shutdown
+            .spawn(live_stream(
+                socket,
+                rx,
+                |ev| match ev {
+                    BoardEvent::CacheChanged => frame(ev),
+                    _ => None,
+                },
+                cancel,
+            ))
+            .await;
     })
 }
 

--- a/backend/gradient-web/src/lib.rs
+++ b/backend/gradient-web/src/lib.rs
@@ -667,8 +667,12 @@ pub fn create_router(state: Arc<ServerState>) -> Result<Router, InitError> {
 
     let scheduler = Arc::new(Scheduler::new(Arc::clone(&state)));
     scheduler.start();
-    gradient_db::retention::start_retention_loop(state.db());
-    gradient_db::rollup::start_rollup_loop(state.db());
+    state
+        .shutdown
+        .supervise(gradient_db::retention::child_spec(state.db()));
+    state
+        .shutdown
+        .supervise(gradient_db::rollup::child_spec(state.db()));
     otlp::start_otlp(Arc::clone(&state), Arc::clone(&scheduler));
     gradient_proto::outbound::start_outbound_loop(Arc::clone(&scheduler));
 
@@ -887,7 +891,8 @@ pub async fn serve_web(state: Arc<ServerState>) -> std::io::Result<()> {
 
 /// Install a SIGINT/SIGTERM handler that triggers graceful shutdown.
 fn install_signal_handler(shutdown: gradient_util::shutdown::Shutdown) {
-    tokio::spawn(async move {
+    let trigger = shutdown.clone();
+    shutdown.spawn(async move {
         #[cfg(unix)]
         {
             use tokio::signal::unix::{SignalKind, signal};
@@ -908,6 +913,6 @@ fn install_signal_handler(shutdown: gradient_util::shutdown::Shutdown) {
             let _ = tokio::signal::ctrl_c().await;
             tracing::info!("received Ctrl-C, shutting down");
         }
-        shutdown.cancel();
+        trigger.cancel();
     });
 }

--- a/backend/gradient-web/src/otlp.rs
+++ b/backend/gradient-web/src/otlp.rs
@@ -16,6 +16,7 @@ use std::time::Duration;
 
 use gradient_core::ServerState;
 use gradient_scheduler::Scheduler;
+use gradient_util::supervision::ChildSpec;
 use opentelemetry::metrics::MeterProvider as _;
 use opentelemetry_otlp::WithExportConfig as _;
 use tracing::{error, info};
@@ -84,22 +85,29 @@ pub fn start_otlp(state: Arc<ServerState>, scheduler: Arc<Scheduler>) {
 
     let shutdown = state.shutdown.clone();
     let refresh = Arc::clone(&snap);
-    shutdown.spawn(async move {
-        let mut tick = tokio::time::interval(interval);
-        loop {
-            tick.tick().await;
-            if let Ok(obs) = crate::endpoints::metrics::collect(&state, &scheduler).await
-                && let Ok(mut s) = refresh.lock()
-            {
-                s.workers = obs.workers_connected;
-                s.pending = obs.jobs_pending;
-                s.active = obs.jobs_active;
-                s.cache_bytes = obs.cache_bytes;
-                s.cache_nar_bytes = obs.cache_nar_bytes;
-                s.cache_packages = obs.cache_packages;
+    shutdown.supervise(ChildSpec::periodic(
+        "otlp-snapshot",
+        interval,
+        Duration::from_secs(60),
+        move || {
+            let state = Arc::clone(&state);
+            let scheduler = Arc::clone(&scheduler);
+            let refresh = Arc::clone(&refresh);
+            async move {
+                if let Ok(obs) = crate::endpoints::metrics::collect(&state, &scheduler).await
+                    && let Ok(mut s) = refresh.lock()
+                {
+                    s.workers = obs.workers_connected;
+                    s.pending = obs.jobs_pending;
+                    s.active = obs.jobs_active;
+                    s.cache_bytes = obs.cache_bytes;
+                    s.cache_nar_bytes = obs.cache_nar_bytes;
+                    s.cache_packages = obs.cache_packages;
+                }
+                Ok(())
             }
-        }
-    });
+        },
+    ));
 
     // The provider must outlive the process so the periodic reader keeps exporting.
     Box::leak(Box::new(provider));

--- a/backend/gradient-web/tests/cache_log_upstream.rs
+++ b/backend/gradient-web/tests/cache_log_upstream.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+#![allow(clippy::disallowed_methods, reason = "test harness server")]
+
 //! A pull-through cache must serve build logs it does not hold itself (#547).
 //!
 //! Paths substituted from an upstream have no gradient build behind them, so

--- a/backend/gradient-web/tests/live_stream_disconnect.rs
+++ b/backend/gradient-web/tests/live_stream_disconnect.rs
@@ -22,6 +22,7 @@ use axum::extract::ws::WebSocketUpgrade;
 use axum::response::Response;
 use axum::routing::get;
 use gradient_types::BoardEvent;
+use gradient_util::shutdown::Shutdown;
 use tokio::net::TcpListener;
 use tokio::sync::broadcast;
 
@@ -29,13 +30,18 @@ use tokio::sync::broadcast;
 type Done = Arc<tokio::sync::Notify>;
 
 async fn live_route(
-    State((tx, done)): State<(broadcast::Sender<BoardEvent>, Done)>,
+    State((tx, done, shutdown)): State<(broadcast::Sender<BoardEvent>, Done, Shutdown)>,
     ws: WebSocketUpgrade,
 ) -> Response {
     let rx = tx.subscribe();
     ws.on_upgrade(move |socket| async move {
-        gradient_web::endpoints::live::live_stream(socket, rx, |ev| serde_json::to_string(ev).ok())
-            .await;
+        gradient_web::endpoints::live::live_stream(
+            socket,
+            rx,
+            |ev| serde_json::to_string(ev).ok(),
+            shutdown.token(),
+        )
+        .await;
         done.notify_one();
     })
 }
@@ -44,10 +50,11 @@ async fn live_route(
 async fn live_stream_ends_when_the_client_disconnects() {
     let (tx, _rx) = broadcast::channel(16);
     let done: Done = Arc::new(tokio::sync::Notify::new());
+    let shutdown = Shutdown::new();
 
     let app = Router::new()
         .route("/live", get(live_route))
-        .with_state((tx, Arc::clone(&done)));
+        .with_state((tx, Arc::clone(&done), shutdown));
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -66,4 +73,32 @@ async fn live_stream_ends_when_the_client_disconnects() {
     tokio::time::timeout(Duration::from_secs(5), done.notified())
         .await
         .expect("stream task must end when the client disconnects");
+}
+
+#[tokio::test]
+async fn live_stream_ends_when_the_server_shuts_down() {
+    let (tx, _rx) = broadcast::channel(16);
+    let done: Done = Arc::new(tokio::sync::Notify::new());
+    let shutdown = Shutdown::new();
+
+    let app = Router::new()
+        .route("/live", get(live_route))
+        .with_state((tx, Arc::clone(&done), shutdown.clone()));
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let (_client, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/live"))
+        .await
+        .expect("client connects");
+
+    // The client stays and the channel stays quiet; only shutdown ends the stream.
+    shutdown.cancel();
+
+    tokio::time::timeout(Duration::from_secs(5), done.notified())
+        .await
+        .expect("stream task must end on shutdown");
 }

--- a/backend/gradient-web/tests/live_stream_disconnect.rs
+++ b/backend/gradient-web/tests/live_stream_disconnect.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+#![allow(clippy::disallowed_methods, reason = "test harness server")]
+
 //! A `/live` channel must let go of a client that walked away.
 //!
 //! The stream only ever wrote to its socket, so a closed browser tab was
@@ -52,9 +54,10 @@ async fn live_stream_ends_when_the_client_disconnects() {
     let done: Done = Arc::new(tokio::sync::Notify::new());
     let shutdown = Shutdown::new();
 
-    let app = Router::new()
-        .route("/live", get(live_route))
-        .with_state((tx, Arc::clone(&done), shutdown));
+    let app =
+        Router::new()
+            .route("/live", get(live_route))
+            .with_state((tx, Arc::clone(&done), shutdown));
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -81,9 +84,11 @@ async fn live_stream_ends_when_the_server_shuts_down() {
     let done: Done = Arc::new(tokio::sync::Notify::new());
     let shutdown = Shutdown::new();
 
-    let app = Router::new()
-        .route("/live", get(live_route))
-        .with_state((tx, Arc::clone(&done), shutdown.clone()));
+    let app = Router::new().route("/live", get(live_route)).with_state((
+        tx,
+        Arc::clone(&done),
+        shutdown.clone(),
+    ));
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();

--- a/backend/gradient-web/tests/oidc_pkce.rs
+++ b/backend/gradient-web/tests/oidc_pkce.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+#![allow(clippy::disallowed_methods, reason = "test harness server")]
+
 //! PKCE regression tests (issue #318): the authorization redirect must carry
 //! `code_challenge` + `code_challenge_method=S256`, and the verifier stored in
 //! the signed `oidc_csrf` cookie must hash to that challenge.

--- a/backend/gradient-worker/src/main.rs
+++ b/backend/gradient-worker/src/main.rs
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+#![allow(
+    clippy::disallowed_methods,
+    reason = "the worker owns its own runtime and shutdown"
+)]
+
 mod config;
 mod connection;
 mod connection_state;

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -6839,6 +6839,24 @@ paths:
       responses:
         '200':
           description: System health
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BaseResponse'
+                  - type: object
+                    properties:
+                      message:
+                        type: object
+                        properties:
+                          supervised:
+                            type: array
+                            description: One row per loop in the process supervision tree.
+                            items:
+                              $ref: '#/components/schemas/SupervisedLoop'
+                          proto_sessions:
+                            type: integer
+                            description: Worker protocol sessions currently open.
         '403':
           description: Superuser required
 
@@ -10842,6 +10860,17 @@ components:
         pname: { type: string, nullable: true }
         score: { type: number }
         won: { type: boolean, description: Whether this candidate won the decision and was dispatched. }
+
+    SupervisedLoop:
+      type: object
+      required: [name, restarts, pass_errors, pass_timeouts]
+      properties:
+        name: { type: string }
+        restarts: { type: integer, description: Times the loop was respawned after a panic or unexpected exit. }
+        pass_errors: { type: integer, description: Passes that returned an error. }
+        pass_timeouts: { type: integer, description: Passes cancelled for exceeding their budget. }
+        last_ok_seconds_ago: { type: number, nullable: true }
+        last_error: { type: string, nullable: true }
 
     DispatchDecision:
       type: object

--- a/docs/src/development/architecture.md
+++ b/docs/src/development/architecture.md
@@ -6,28 +6,32 @@ Gradient is a multi-crate Rust workspace with two separate binaries: **`gradient
 
 ### Server
 
-The server binary starts three concurrent async tasks:
+The server binary is one process whose long-lived work runs under a
+supervision tree (`gradient_util::supervision`, on ractor). The tree is
+started on first use from the shared `Shutdown` coordinator; every subsystem
+registers its loops as children with `Shutdown::supervise`.
 
 ```text
-┌────────────────────────────────────────┐
-│           gradient binary              │
-│                                        │
-│  ┌──────────────────────────────────┐  │
-│  │             Builder              │  │
-│  │  evaluation queue │ build queue  │  │
-│  └──────────────────────────────────┘  │
-│  ┌───────────┐   ┌──────────────────┐  │
-│  │   Cache   │   │       Web        │  │
-│  │   (Axum)  │   │  (Axum /api/v1)  │  │
-│  └───────────┘   └──────────────────┘  │
-│          ┌───────────────────┐         │
-│          │  Proto Scheduler  │         │
-│          │  (WebSocket /proto│         │
-│          └───────────────────┘         │
-└────────────────────────────────────────┘
-         │                    │
-         └──── PostgreSQL ────┘
+root
+├── trigger-dispatch, eval-dispatch      periodic passes (5s)
+├── build-dispatch                       actor: 5s tick plus coalesced kicks
+├── worker-sample, instance-metrics      periodic passes
+├── worker-liveness, graph-consistency   periodic passes, absent when disabled
+├── cache-maintenance, sign-sweep,
+│   debug-index, eval-cache-sweep        cache sweeps
+├── retention, rollup, otlp-snapshot     metrics pipeline
+└── outbound-connect                     dials workers with a registered URL
 ```
+
+A child that panics or exits unexpectedly is respawned after an exponential
+backoff (1s doubling to 60s, reset after five healthy minutes); a pass that
+runs past its budget is cancelled in place and ticks again. Restarts, pass
+errors, budget timeouts and the last successful pass are reported per child on
+`/board/health`. Everything that outlives one request but is not a loop (NAR
+commits, CI action deliveries, per-connection writers, sessions) runs as a
+tracked task so shutdown drains it; bare `tokio::spawn` is a clippy error in
+the server crates. Axum serves the HTTP API and the worker WebSocket; the
+scheduler, cache and CI code are libraries the tree drives.
 
 ### Worker
 

--- a/docs/src/development/proto.md
+++ b/docs/src/development/proto.md
@@ -1416,11 +1416,12 @@ sequenceDiagram
     Note left of W: waits before reconnecting
 ```
 
-On receiving `ServerMessage::Draining`, workers:
-
- 1. Stop sending `RequestJob` - no new work.
- 2. Finish in-flight jobs and send results.
- 3. After the connection closes, wait before reconnecting (e.g. 30s) to give the server time to restart.
+On SIGTERM the server cancels its shutdown token. Every worker session sends
+`Draining` and closes; the supervision tree stops; tracked tasks (NAR commits,
+action deliveries) finish within the 30 s drain budget. Workers, on
+`Draining`, stop requesting jobs, keep in-flight results, and replay them on
+reconnect; startup recovery re-queues whatever was interrupted, so a restart
+loses no job.
 
 ---
 

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -7763,7 +7763,9 @@ leftover height.
 `backend/gradient-util/src/supervision.rs`: `a_panicking_pass_is_restarted_and_keeps_ticking`
 (a child that panics is respawned once and its ticks resume),
 `a_pass_past_its_budget_is_cancelled_and_counted` (an over-budget pass is
-cancelled in place, never restarted), `shutdown_stops_the_tree_and_never_restarts`
+cancelled in place, never restarted), `a_child_is_listed_in_health_before_its_first_pass`
+(a child has a health row from spawn, so hourly sweeps show up before they
+ever tick), `shutdown_stops_the_tree_and_never_restarts`
 (cancel stops every child and the root reports Stopped),
 `supervise_from_a_sync_context_lands_in_the_tree`, `backoff_grows_and_caps`
 (1, 2, 4, ... 60, 60 seconds), and
@@ -7780,7 +7782,7 @@ connected client ends on the shutdown token).
 `frontend/src/app/features/board/health/health.component.spec.ts`:
 `lists every supervised loop and flags restarts`.
 
-`nix/tests/gradient/cache/default.nix` Phase 9: `/board/health` lists every
+`nix/tests/gradient/cache/default.nix` Phase 11: `/board/health` lists every
 supervised loop with zero restarts and timeouts, `systemctl stop
 gradient-server` returns within the drain budget, and the worker logs the
 `Draining` message.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -7757,3 +7757,30 @@ leftover height.
 
 `frontend/src/app/features/tasks/task-detail/task-detail.component.spec.ts`:
 - `grows into the task shell and lets the panel absorb the leftover height`.
+
+## Server loops run under a supervision tree (#588)
+
+`backend/gradient-util/src/supervision.rs`: `a_panicking_pass_is_restarted_and_keeps_ticking`
+(a child that panics is respawned once and its ticks resume),
+`a_pass_past_its_budget_is_cancelled_and_counted` (an over-budget pass is
+cancelled in place, never restarted), `shutdown_stops_the_tree_and_never_restarts`
+(cancel stops every child and the root reports Stopped),
+`supervise_from_a_sync_context_lands_in_the_tree`, `backoff_grows_and_caps`
+(1, 2, 4, ... 60, 60 seconds), and
+`casts_queue_without_bound_and_a_call_waits_behind_them` (the ractor mailbox
+is unbounded and FIFO, which is why sessions call rather than cast).
+
+`backend/gradient-web/tests/live_stream_disconnect.rs`:
+`live_stream_ends_when_the_server_shuts_down` (a quiet live channel with a
+connected client ends on the shutdown token).
+
+`backend/gradient-web/src/endpoints/board_metrics.rs`:
+`loops_view_reports_age_of_last_ok_pass`.
+
+`frontend/src/app/features/board/health/health.component.spec.ts`:
+`lists every supervised loop and flags restarts`.
+
+`nix/tests/gradient/cache/default.nix` Phase 9: `/board/health` lists every
+supervised loop with zero restarts and timeouts, `systemctl stop
+gradient-server` returns within the drain budget, and the worker logs the
+`Draining` message.

--- a/frontend/src/app/core/services/board.service.ts
+++ b/frontend/src/app/core/services/board.service.ts
@@ -306,6 +306,15 @@ export interface ProcessStat {
   threads: number;
 }
 
+export interface SupervisedLoop {
+  name: string;
+  restarts: number;
+  pass_errors: number;
+  pass_timeouts: number;
+  last_ok_seconds_ago: number | null;
+  last_error: string | null;
+}
+
 export interface BoardHealth {
   version: string;
   uptime_seconds: number;
@@ -319,6 +328,8 @@ export interface BoardHealth {
   rollup_lag_seconds: number | null;
   latest_rollup_bucket: string | null;
   draining: boolean;
+  supervised: SupervisedLoop[];
+  proto_sessions: number;
 }
 
 export interface DurationsHeatmap {

--- a/frontend/src/app/features/board/health/health.component.spec.ts
+++ b/frontend/src/app/features/board/health/health.component.spec.ts
@@ -31,6 +31,11 @@ const HEALTH: BoardHealth = {
   rollup_lag_seconds: 0,
   latest_rollup_bucket: null,
   draining: false,
+  supervised: [
+    { name: 'build-dispatch', restarts: 1, pass_errors: 0, pass_timeouts: 0, last_ok_seconds_ago: 4, last_error: 'boom' },
+    { name: 'retention', restarts: 0, pass_errors: 0, pass_timeouts: 0, last_ok_seconds_ago: null, last_error: null },
+  ],
+  proto_sessions: 2,
 };
 
 const TASK: AdminTask = {
@@ -131,5 +136,15 @@ describe('BoardHealthComponent', () => {
       button.click();
       expect(setDraining).toHaveBeenCalledWith(true);
     });
+  });
+
+  it('lists every supervised loop and flags restarts', () => {
+    const fixture = setup(() => of(true));
+    const rows = fixture.nativeElement.querySelectorAll('table.supervision tbody tr');
+    expect(rows.length).toBe(2);
+    expect(rows[0].textContent).toContain('build-dispatch');
+    expect(rows[0].querySelector('td.bad')?.textContent?.trim()).toBe('1');
+    expect(rows[1].textContent).toContain('never');
+    TestBed.resetTestingModule();
   });
 });

--- a/frontend/src/app/features/board/health/health.component.ts
+++ b/frontend/src/app/features/board/health/health.component.ts
@@ -26,6 +26,7 @@ const MIB = 1024 ** 2;
         <div class="kpi"><span class="label">Uptime</span><span class="value sm">{{ uptime(h.uptime_seconds) }}</span></div>
         <div class="kpi"><span class="label">Workers</span><span class="value">{{ h.workers_connected }}</span></div>
         <div class="kpi"><span class="label">Jobs pending / active</span><span class="value sm">{{ h.jobs_pending }} / {{ h.jobs_active }}</span></div>
+        <div class="kpi"><span class="label">Sessions</span><span class="value">{{ h.proto_sessions }}</span></div>
       </div>
 
       <h2>Process</h2>
@@ -44,6 +45,25 @@ const MIB = 1024 ** 2;
         <div class="cell"><span class="label">Cache size</span><span>{{ (h.cache_bytes / (1024*1024*1024)) | number: '1.2-2' }} GiB</span></div>
         <div class="cell"><span class="label">Packages</span><span>{{ h.cache_packages }}</span></div>
       </div>
+
+      <h2>Supervision</h2>
+      <table class="http supervision">
+        <thead><tr><th>Loop</th><th>Restarts</th><th>Errors</th><th>Timeouts</th><th>Last ok</th><th>Last error</th></tr></thead>
+        <tbody>
+          @for (l of h.supervised; track l.name) {
+            <tr>
+              <td>{{ l.name }}</td>
+              <td [class.bad]="l.restarts > 0">{{ l.restarts }}</td>
+              <td [class.bad]="l.pass_errors > 0">{{ l.pass_errors }}</td>
+              <td [class.bad]="l.pass_timeouts > 0">{{ l.pass_timeouts }}</td>
+              <td>{{ l.last_ok_seconds_ago !== null ? (l.last_ok_seconds_ago | number: '1.0-0') + ' s ago' : 'never' }}</td>
+              <td [class.bad]="!!l.last_error">{{ l.last_error ?? '' }}</td>
+            </tr>
+          } @empty {
+            <tr><td colspan="6" class="muted">No supervised loops reported.</td></tr>
+          }
+        </tbody>
+      </table>
 
       <h2>Admin</h2>
       <div class="admin-actions">

--- a/nix/tests/gradient/cache/default.nix
+++ b/nix/tests/gradient/cache/default.nix
@@ -262,6 +262,7 @@ in {
       ''
       # ── Helpers ───────────────────────────────────────────────────────────
       import json
+      import time
 
       GIT     = "${lib.getExe pkgs.git}"
       CURL    = "${lib.getExe pkgs.curl}"
@@ -572,6 +573,27 @@ in {
       # The exact request from #563: a debuginfo probe against a cache root that
       # has no such cache. Used to be a 400, which crashed the client.
       assert status(f"http://server/cache/debuginfo/{build_id}.debug") == "404"
+
+      # ── Phase 11: the supervision tree is healthy and shutdown drains ─────
+      banner("Phase 11: every supervised loop is running; SIGTERM drains")
+      health = json.loads(api_get(token, "board/health"))["message"]
+      names = sorted(l["name"] for l in health["supervised"])
+      print(names)
+      for want in ["build-dispatch", "eval-dispatch", "trigger-dispatch",
+                   "cache-maintenance", "sign-sweep", "debug-index",
+                   "eval-cache-sweep", "retention", "rollup", "outbound-connect"]:
+          assert want in names, f"{want} missing from supervised loops: {names}"
+      bad = [l for l in health["supervised"] if l["restarts"] or l["pass_timeouts"]]
+      assert not bad, f"restarted or stalled loops: {bad}"
+      assert health["proto_sessions"] >= 1, health
+
+      t0 = time.time()
+      server.succeed("systemctl stop gradient-server.service")
+      stop_secs = time.time() - t0
+      print(f"gradient-server stopped in {stop_secs:.1f}s")
+      assert stop_secs < 40, f"shutdown took {stop_secs:.1f}s; the drain budget is 30s"
+      server.succeed("journalctl -u gradient-server --no-pager | grep -q 'background tasks drained cleanly'")
+      builder.succeed("journalctl -u gradient-worker --no-pager | grep -q 'server is draining'")
 
       banner("Cache test PASSED")
       '';

--- a/nix/tests/gradient/cache/default.nix
+++ b/nix/tests/gradient/cache/default.nix
@@ -110,6 +110,7 @@ in {
                 admin = {
                   email = "admin@example.com";
                   password_file = "/etc/gradient/secrets/admin_password";
+                  superuser = true;
                 };
               };
 


### PR DESCRIPTION
Closes #588. Every server loop is a child of one supervision tree, and sessions observe shutdown and receive Draining.