### PR TITLE
scheduler: refactor: scheduler actor and one session actor per connection

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2504,6 +2504,7 @@ name = "gradient-proto"
 version = "1.3.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-trait",
  "axum",
  "chrono",
@@ -2520,6 +2521,7 @@ dependencies = [
  "gradient-util",
  "hex",
  "password-auth",
+ "ractor",
  "reqwest",
  "rkyv 0.8.18",
  "sea-orm",

--- a/backend/gradient-proto/Cargo.toml
+++ b/backend/gradient-proto/Cargo.toml
@@ -26,11 +26,13 @@ gradient-scheduler = { workspace = true }
 gradient-entity = { workspace = true }
 
 anyhow            = { workspace = true }
+arc-swap          = { workspace = true }
 async-trait       = { workspace = true }
 chrono            = { workspace = true }
 futures           = { workspace = true }
 hex               = { workspace = true }
 password-auth     = { workspace = true }
+ractor            = { workspace = true }
 reqwest           = { workspace = true }
 rkyv              = { workspace = true }
 sea-orm           = { workspace = true }
@@ -47,4 +49,5 @@ axum = { workspace = true, features = ["ws", "http1", "tokio"] }
 [dev-dependencies]
 serde_json   = { workspace = true }
 tempfile     = { workspace = true }
+tokio        = { workspace = true, features = ["macros", "sync", "net", "rt-multi-thread"] }
 gradient-test-support = { workspace = true }

--- a/backend/gradient-proto/src/handler/dispatch.rs
+++ b/backend/gradient-proto/src/handler/dispatch.rs
@@ -21,6 +21,8 @@ use crate::messages::{
     ServerMessage,
 };
 use gradient_scheduler::Scheduler;
+use gradient_scheduler::actor::{WorkerCapabilities, WorkerMetrics};
+use gradient_scheduler::jobs::PendingJob;
 
 use super::auth::{
     expand_base_authorized, lookup_base_worker_challenge, lookup_registered_peers, validate_tokens,
@@ -50,6 +52,9 @@ pub(super) struct DispatchContext<'a> {
     /// Bounds the detached `NarUploaded` commits per connection - each pins a
     /// whole staged NAR in memory while writing it to `nar_storage`.
     pub nar_commit_semaphore: &'a Arc<Semaphore>,
+    /// Jobs this session currently runs, kept so a core restart can re-register
+    /// them without a DB round-trip.
+    pub active: &'a mut HashMap<String, PendingJob>,
 }
 
 impl<'a> DispatchContext<'a> {
@@ -458,12 +463,14 @@ impl<'a> DispatchContext<'a> {
         self.scheduler
             .update_worker_capabilities(
                 self.peer_id,
-                architectures,
-                system_features,
-                max_concurrent_builds,
-                cpu_count,
-                ram_total_mb,
-                cpu_core_score,
+                WorkerCapabilities {
+                    architectures,
+                    system_features,
+                    max_concurrent_builds,
+                    cpu_count,
+                    ram_total_mb,
+                    cpu_core_score,
+                },
             )
             .await;
     }
@@ -522,6 +529,8 @@ impl<'a> DispatchContext<'a> {
     async fn on_request_job(&mut self, kind: JobKind) -> bool {
         debug!(peer_id = %self.peer_id, ?kind, "RequestJob");
         if let Some(assignment) = self.scheduler.request_job(self.peer_id, kind).await {
+            self.active
+                .insert(assignment.job_id.clone(), assignment.pending.clone());
             send_credentials_for_job(
                 self.writer,
                 self.state,
@@ -566,6 +575,7 @@ impl<'a> DispatchContext<'a> {
             info!(peer_id = %self.peer_id, %job_id, "job accepted");
         } else {
             info!(peer_id = %self.peer_id, %job_id, ?reason, "job rejected by worker");
+            self.active.remove(&job_id);
             self.scheduler.job_rejected(self.peer_id, &job_id).await;
         }
     }
@@ -664,6 +674,7 @@ impl<'a> DispatchContext<'a> {
 
     async fn on_job_completed(&mut self, job_id: String) {
         info!(peer_id = %self.peer_id, %job_id, "job completed");
+        self.active.remove(&job_id);
         if let Err(e) = self
             .scheduler
             .handle_job_completed(self.peer_id, &job_id)
@@ -682,6 +693,7 @@ impl<'a> DispatchContext<'a> {
         missing_paths: Vec<String>,
     ) {
         warn!(peer_id = %self.peer_id, %job_id, %error, ?kind, "job failed");
+        self.active.remove(&job_id);
         if let Err(e) = self
             .scheduler
             .handle_job_failed(self.peer_id, &job_id, &error, kind, &missing_paths)
@@ -956,10 +968,12 @@ impl RpcContext {
         self.scheduler
             .update_worker_metrics(
                 &self.peer_id,
-                cpu_usage_pct,
-                ram_free_mb,
-                disk_speed_mbps,
-                network_speed_mbps,
+                WorkerMetrics {
+                    cpu_usage_pct,
+                    ram_free_mb,
+                    disk_speed_mbps,
+                    network_speed_mbps,
+                },
             )
             .await;
     }

--- a/backend/gradient-proto/src/handler/mod.rs
+++ b/backend/gradient-proto/src/handler/mod.rs
@@ -14,6 +14,8 @@ mod limiter;
 mod nar;
 mod nar_transfer;
 mod session;
+mod session_actor;
+mod sessions;
 mod socket;
 
 use std::sync::Arc;
@@ -31,6 +33,7 @@ pub use crate::session::frame::MAX_PROTO_MESSAGE_SIZE;
 pub use cache_session::handle_cache_socket;
 pub use limiter::{PerIpLimiter, ProtoLimiter};
 pub(crate) use session::handle_socket;
+pub use sessions::SessionsHandle;
 pub(crate) use socket::ProtoSocket;
 
 #[cfg(test)]
@@ -51,6 +54,7 @@ async fn ws_upgrade(
     State(state): State<Arc<ServerState>>,
     Extension(scheduler): Extension<Arc<Scheduler>>,
     Extension(limiter): Extension<Arc<ProtoLimiter>>,
+    Extension(sessions): Extension<Arc<SessionsHandle>>,
 ) -> Response {
     let Some(permit) = limiter.try_acquire() else {
         tracing::warn!(
@@ -77,6 +81,7 @@ async fn ws_upgrade(
                         socket::ProtoSocket::Axum(Box::new(sock)),
                         state,
                         scheduler,
+                        sessions,
                         false,
                     )
                     .await;

--- a/backend/gradient-proto/src/handler/session.rs
+++ b/backend/gradient-proto/src/handler/session.rs
@@ -4,17 +4,15 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-//! Protocol session state machine: Opening → Authenticated → Registered → run.
+//! Protocol handshake: Opening to Authenticated, then attach to a session actor.
 
 use std::collections::HashSet;
 use std::sync::Arc;
-use std::sync::atomic::AtomicI64;
-use std::time::Duration;
 
 use gradient_core::ServerState;
 use gradient_types::ids::ProjectId;
-use tokio::sync::Semaphore;
-use tracing::{debug, error, info, instrument, warn};
+use tokio::task::JoinHandle;
+use tracing::{debug, info, instrument, warn};
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -23,24 +21,15 @@ use crate::messages::{GradientCapabilities, ServerMessage};
 use crate::session::handshake as handshake_fsm;
 use crate::traits::{AuthOutcome, PeerAuthority};
 use gradient_scheduler::Scheduler;
-use gradient_scheduler::actor::SessionSignal;
 
 use super::auth::{
     BaseWorkerChallenge, aggregate_enabled_caps, expand_base_authorized,
     filter_project_peers_without_cache, has_any_registrations, lookup_base_worker_challenge,
     lookup_registered_peers, negotiate_capabilities, validate_tokens,
 };
-use super::dispatch::DispatchContext;
-use super::eval_cache::EvalCacheReceiveStore;
-use super::nar_transfer::NarReceiveStore;
-use super::socket::{
-    HANDSHAKE_TIMEOUT, JOB_OFFER_CHUNK_SIZE, ProtoSocket, ProtoWriter, recv_client_msg,
-    send_server_msg,
-};
-
-/// Detached `NarUploaded` commits running concurrently per connection; each
-/// pins one whole staged NAR in memory while writing it to `nar_storage`.
-const NAR_COMMIT_CONCURRENCY: usize = 2;
+use super::session_actor::SessionArgs;
+use super::sessions::SessionsHandle;
+use super::socket::{HANDSHAKE_TIMEOUT, ProtoSocket, ProtoWriter, send_server_msg};
 
 // ── Session state markers ─────────────────────────────────────────────────────
 
@@ -50,12 +39,6 @@ pub(super) struct Authenticated {
     pub peer_id: String,
     pub negotiated: GradientCapabilities,
     pub authorized_peers: Vec<String>,
-}
-
-pub(super) struct Registered {
-    pub peer_id: String,
-    pub signals: tokio::sync::mpsc::UnboundedReceiver<SessionSignal>,
-    pub last_seen: Arc<AtomicI64>,
 }
 
 // ── Protocol session ──────────────────────────────────────────────────────────
@@ -212,168 +195,62 @@ impl PeerAuthority for ServerAuthority {
     }
 }
 
-// ── Authenticated → Registered ────────────────────────────────────────────────
+// ── Authenticated: attach ─────────────────────────────────────────────────────
 
 impl ProtoSession<Authenticated> {
-    pub async fn register(mut self) -> Option<ProtoSession<Registered>> {
-        let Authenticated {
-            peer_id,
-            negotiated,
-            authorized_peers,
-            ..
-        } = self.session_state;
+    /// Hand the connection to the sessions supervisor. The join handle ends
+    /// when the session does, so the upgrade task holds its permit until then.
+    pub async fn attach(self, sessions: &SessionsHandle) -> Option<JoinHandle<()>> {
+        let ProtoSession {
+            mut socket,
+            state,
+            scheduler,
+            session_state:
+                Authenticated {
+                    peer_id,
+                    negotiated,
+                    authorized_peers,
+                },
+        } = self;
 
-        if self.scheduler.is_worker_connected(&peer_id).await {
+        if scheduler.is_worker_connected(&peer_id).await {
             warn!(%peer_id, "duplicate connection rejected (worker already connected)");
-            self.socket
+            socket
                 .send_reject(496, "worker already connected".into())
                 .await;
             return None;
         }
 
-        let authorized_peer_uuids: HashSet<ProjectId> = authorized_peers
+        let authorized_peers: HashSet<ProjectId> = authorized_peers
             .iter()
             .filter_map(|s| s.parse().ok())
             .collect();
-
-        let (port, signals) = tokio::sync::mpsc::unbounded_channel();
-        let registered = match self
-            .scheduler
-            .register_worker(&peer_id, negotiated, authorized_peer_uuids, Arc::new(port))
-            .await
-        {
-            Ok(r) => r,
-            Err(e) => {
-                warn!(%peer_id, error = %e, "registration failed; scheduler unavailable");
-                self.socket
-                    .send_reject(503, "scheduler unavailable".into())
-                    .await;
-                return None;
-            }
-        };
-
-        Some(ProtoSession {
-            socket: self.socket,
-            state: self.state,
-            scheduler: self.scheduler,
-            session_state: Registered {
-                peer_id,
-                signals,
-                last_seen: registered.last_seen,
-            },
-        })
-    }
-}
-
-// ── Registered: dispatch loop ─────────────────────────────────────────────────
-
-impl ProtoSession<Registered> {
-    pub async fn run(self) {
-        let ProtoSession {
-            socket,
+        let args = SessionArgs {
+            peer_id: peer_id.clone(),
             state,
             scheduler,
-            session_state:
-                Registered {
-                    peer_id,
-                    mut signals,
-                    last_seen,
-                },
-        } = self;
+            socket,
+            capabilities: negotiated,
+            authorized_peers,
+        };
 
-        let proto_cfg = &state.config.proto;
-        let send_chunk_timeout = Duration::from_secs(proto_cfg.nar_send_chunk_timeout_secs);
-        let (mut reader, writer) = socket.split(send_chunk_timeout, &state.shutdown);
-
-        let partial_root =
-            std::path::PathBuf::from(format!("{}/nar-partial", state.config.storage.base_path));
-        let partial_ttl = Duration::from_secs(proto_cfg.nar_partial_ttl_secs);
-        let max_partial_bytes = proto_cfg.max_nar_buffer_bytes as u64;
-        let mut nar = NarReceiveStore::new(partial_root, &peer_id, partial_ttl, max_partial_bytes)
-            .unwrap_or_else(|e| {
-                error!(%peer_id, error = %e, "failed to init NAR partial dir; falling back to temp");
-                NarReceiveStore::new(
-                    std::env::temp_dir().join("gradient-nar-partial"),
-                    &peer_id,
-                    partial_ttl,
-                    max_partial_bytes,
-                )
-                .expect("temp partial dir must be creatable")
-            });
-        let nar_serve_semaphore = Arc::new(Semaphore::new(proto_cfg.max_concurrent_nar_serves));
-        let nar_commit_semaphore = Arc::new(Semaphore::new(NAR_COMMIT_CONCURRENCY));
-        let mut eval_cache = EvalCacheReceiveStore::new(max_partial_bytes);
-        let cancel = state.shutdown.token();
-        let mut offers_seen = 0u64;
-        let mut active = std::collections::HashMap::new();
-
-        loop {
-            let msg = tokio::select! {
-                _ = cancel.cancelled() => {
-                    info!(%peer_id, "server shutting down; sending Draining and closing");
-                    let _ = send_server_msg(&writer, &ServerMessage::Draining).await;
-                    break;
-                }
-                msg = recv_client_msg(&mut reader) => match msg {
-                    Some(m) => m,
-                    None => break,
-                },
-                signal = signals.recv() => match signal {
-                    Some(SessionSignal::Offers(generation)) => {
-                        if generation > offers_seen
-                            && !on_offers(&writer, &scheduler, &peer_id, &mut offers_seen).await
-                        {
-                            break;
-                        }
-                        continue;
-                    }
-                    Some(SessionSignal::Reauth) => {
-                        if !on_reauth_notify(&writer, &state, &peer_id).await { break; }
-                        continue;
-                    }
-                    Some(SessionSignal::Abort { job_id, reason }) => {
-                        info!(%peer_id, %job_id, %reason, "sending AbortJob to worker");
-                        if send_server_msg(&writer, &ServerMessage::AbortJob { job_id, reason })
-                            .await
-                            .is_err()
-                        {
-                            break;
-                        }
-                        continue;
-                    }
-                    Some(SessionSignal::Drain) | None => break,
-                },
-            };
-
-            // Reaching here means a real inbound frame (the other select arms
-            // all `continue`), so the worker is alive: refresh its deadline.
-            last_seen.store(
-                gradient_types::now().and_utc().timestamp_millis(),
-                std::sync::atomic::Ordering::Relaxed,
-            );
-
-            let mut ctx = DispatchContext {
-                writer: &writer,
-                state: &state,
-                scheduler: &scheduler,
-                peer_id: &peer_id,
-                nar_serve_semaphore: &nar_serve_semaphore,
-                nar_commit_semaphore: &nar_commit_semaphore,
-                active: &mut active,
-            };
-            if !ctx.dispatch(msg, &mut nar, &mut eval_cache).await {
-                break;
+        match sessions.attach(args).await {
+            Ok((_, join)) => Some(join),
+            Err(error) => {
+                warn!(%peer_id, %error, "session could not be attached");
+                None
             }
         }
-
-        scheduler.unregister_worker(&peer_id).await;
-        info!(%peer_id, "WebSocket connection closed");
     }
 }
 
-// ── Select arm helpers ────────────────────────────────────────────────────────
+// ── Server-initiated reauth ───────────────────────────────────────────────────
 
-async fn on_reauth_notify(writer: &ProtoWriter, state: &ServerState, peer_id: &str) -> bool {
+pub(super) async fn on_reauth_notify(
+    writer: &ProtoWriter,
+    state: &ServerState,
+    peer_id: &str,
+) -> bool {
     debug!(%peer_id, "server-initiated reauth");
     let base = lookup_base_worker_challenge(state, peer_id).await;
     let registered_peers = match &base {
@@ -403,34 +280,6 @@ async fn on_reauth_notify(writer: &ProtoWriter, state: &ServerState, peer_id: &s
     .is_ok()
 }
 
-async fn on_offers(
-    writer: &ProtoWriter,
-    scheduler: &Scheduler,
-    peer_id: &str,
-    offers_seen: &mut u64,
-) -> bool {
-    let offer = scheduler.get_new_job_candidates(peer_id).await;
-    *offers_seen = offer.generation;
-    if offer.candidates.is_empty() {
-        return true;
-    }
-    debug!(%peer_id, count = offer.candidates.len(), "pushing job offer (delta)");
-    for chunk in offer.candidates.chunks(JOB_OFFER_CHUNK_SIZE) {
-        if send_server_msg(
-            writer,
-            &ServerMessage::JobOffer {
-                candidates: chunk.to_vec(),
-            },
-        )
-        .await
-        .is_err()
-        {
-            return false;
-        }
-    }
-    true
-}
-
 // ── Entry point ───────────────────────────────────────────────────────────────
 
 #[instrument(skip_all)]
@@ -438,6 +287,7 @@ pub(crate) async fn handle_socket(
     socket: ProtoSocket,
     state: Arc<ServerState>,
     scheduler: Arc<Scheduler>,
+    sessions: Arc<SessionsHandle>,
     server_initiated: bool,
 ) {
     info!(server_initiated, "WebSocket connection opened");
@@ -454,10 +304,9 @@ pub(crate) async fn handle_socket(
                 return;
             }
         };
-    let Some(session) = session.register().await else {
-        return;
-    };
-    session.run().await;
+    if let Some(join) = session.attach(&sessions).await {
+        let _ = join.await;
+    }
 }
 
 // ── Auth decision (pure) ──────────────────────────────────────────────────────

--- a/backend/gradient-proto/src/handler/session.rs
+++ b/backend/gradient-proto/src/handler/session.rs
@@ -8,6 +8,7 @@
 
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::sync::atomic::AtomicI64;
 use std::time::Duration;
 
 use gradient_core::ServerState;
@@ -22,6 +23,7 @@ use crate::messages::{GradientCapabilities, ServerMessage};
 use crate::session::handshake as handshake_fsm;
 use crate::traits::{AuthOutcome, PeerAuthority};
 use gradient_scheduler::Scheduler;
+use gradient_scheduler::actor::SessionSignal;
 
 use super::auth::{
     BaseWorkerChallenge, aggregate_enabled_caps, expand_base_authorized,
@@ -52,9 +54,8 @@ pub(super) struct Authenticated {
 
 pub(super) struct Registered {
     pub peer_id: String,
-    pub reauth_notify: Arc<tokio::sync::Notify>,
-    pub abort_rx: tokio::sync::mpsc::UnboundedReceiver<(String, String)>,
-    pub job_notify: tokio::sync::watch::Receiver<u64>,
+    pub signals: tokio::sync::mpsc::UnboundedReceiver<SessionSignal>,
+    pub last_seen: Arc<AtomicI64>,
 }
 
 // ── Protocol session ──────────────────────────────────────────────────────────
@@ -235,11 +236,21 @@ impl ProtoSession<Authenticated> {
             .filter_map(|s| s.parse().ok())
             .collect();
 
-        let (reauth_notify, abort_rx) = self
+        let (port, signals) = tokio::sync::mpsc::unbounded_channel();
+        let registered = match self
             .scheduler
-            .register_worker(&peer_id, negotiated, authorized_peer_uuids)
-            .await;
-        let job_notify = self.scheduler.job_notify();
+            .register_worker(&peer_id, negotiated, authorized_peer_uuids, Arc::new(port))
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                warn!(%peer_id, error = %e, "registration failed; scheduler unavailable");
+                self.socket
+                    .send_reject(503, "scheduler unavailable".into())
+                    .await;
+                return None;
+            }
+        };
 
         Some(ProtoSession {
             socket: self.socket,
@@ -247,9 +258,8 @@ impl ProtoSession<Authenticated> {
             scheduler: self.scheduler,
             session_state: Registered {
                 peer_id,
-                reauth_notify,
-                abort_rx,
-                job_notify,
+                signals,
+                last_seen: registered.last_seen,
             },
         })
     }
@@ -266,9 +276,8 @@ impl ProtoSession<Registered> {
             session_state:
                 Registered {
                     peer_id,
-                    reauth_notify,
-                    mut abort_rx,
-                    mut job_notify,
+                    mut signals,
+                    last_seen,
                 },
         } = self;
 
@@ -294,12 +303,9 @@ impl ProtoSession<Registered> {
         let nar_serve_semaphore = Arc::new(Semaphore::new(proto_cfg.max_concurrent_nar_serves));
         let nar_commit_semaphore = Arc::new(Semaphore::new(NAR_COMMIT_CONCURRENCY));
         let mut eval_cache = EvalCacheReceiveStore::new(max_partial_bytes);
-
-        // Lock-free handle into the worker's `last_seen`, stamped on every
-        // inbound frame so the liveness watchdog can spot a worker that died
-        // without a clean TCP close.
-        let last_seen = scheduler.worker_last_seen(&peer_id).await;
         let cancel = state.shutdown.token();
+        let mut offers_seen = 0u64;
+        let mut active = std::collections::HashMap::new();
 
         loop {
             let msg = tokio::select! {
@@ -312,41 +318,39 @@ impl ProtoSession<Registered> {
                     Some(m) => m,
                     None => break,
                 },
-                _ = reauth_notify.notified() => {
-                    if !on_reauth_notify(&writer, &state, &peer_id).await { break; }
-                    continue;
-                }
-                res = job_notify.changed() => {
-                    if res.is_err() { break; }
-                    if !on_job_notify(&writer, &scheduler, &peer_id).await { break; }
-                    continue;
-                }
-                abort_msg = abort_rx.recv() => match abort_msg {
-                    Some((job_id, reason)) => {
-                        info!(%peer_id, %job_id, %reason, "sending AbortJob to worker");
-                        if send_server_msg(
-                            &writer,
-                            &ServerMessage::AbortJob { job_id, reason },
-                        )
-                        .await
-                        .is_err()
+                signal = signals.recv() => match signal {
+                    Some(SessionSignal::Offers(generation)) => {
+                        if generation > offers_seen
+                            && !on_offers(&writer, &scheduler, &peer_id, &mut offers_seen).await
                         {
                             break;
                         }
                         continue;
                     }
-                    None => break,
+                    Some(SessionSignal::Reauth) => {
+                        if !on_reauth_notify(&writer, &state, &peer_id).await { break; }
+                        continue;
+                    }
+                    Some(SessionSignal::Abort { job_id, reason }) => {
+                        info!(%peer_id, %job_id, %reason, "sending AbortJob to worker");
+                        if send_server_msg(&writer, &ServerMessage::AbortJob { job_id, reason })
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                        continue;
+                    }
+                    Some(SessionSignal::Drain) | None => break,
                 },
             };
 
             // Reaching here means a real inbound frame (the other select arms
             // all `continue`), so the worker is alive: refresh its deadline.
-            if let Some(ls) = &last_seen {
-                ls.store(
-                    gradient_types::now().and_utc().timestamp_millis(),
-                    std::sync::atomic::Ordering::Relaxed,
-                );
-            }
+            last_seen.store(
+                gradient_types::now().and_utc().timestamp_millis(),
+                std::sync::atomic::Ordering::Relaxed,
+            );
 
             let mut ctx = DispatchContext {
                 writer: &writer,
@@ -355,6 +359,7 @@ impl ProtoSession<Registered> {
                 peer_id: &peer_id,
                 nar_serve_semaphore: &nar_serve_semaphore,
                 nar_commit_semaphore: &nar_commit_semaphore,
+                active: &mut active,
             };
             if !ctx.dispatch(msg, &mut nar, &mut eval_cache).await {
                 break;
@@ -398,13 +403,19 @@ async fn on_reauth_notify(writer: &ProtoWriter, state: &ServerState, peer_id: &s
     .is_ok()
 }
 
-async fn on_job_notify(writer: &ProtoWriter, scheduler: &Scheduler, peer_id: &str) -> bool {
-    let candidates = scheduler.get_new_job_candidates(peer_id).await;
-    if candidates.is_empty() {
+async fn on_offers(
+    writer: &ProtoWriter,
+    scheduler: &Scheduler,
+    peer_id: &str,
+    offers_seen: &mut u64,
+) -> bool {
+    let offer = scheduler.get_new_job_candidates(peer_id).await;
+    *offers_seen = offer.generation;
+    if offer.candidates.is_empty() {
         return true;
     }
-    debug!(%peer_id, count = candidates.len(), "pushing job offer (delta)");
-    for chunk in candidates.chunks(JOB_OFFER_CHUNK_SIZE) {
+    debug!(%peer_id, count = offer.candidates.len(), "pushing job offer (delta)");
+    for chunk in offer.candidates.chunks(JOB_OFFER_CHUNK_SIZE) {
         if send_server_msg(
             writer,
             &ServerMessage::JobOffer {

--- a/backend/gradient-proto/src/handler/session_actor.rs
+++ b/backend/gradient-proto/src/handler/session_actor.rs
@@ -1,0 +1,393 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! One actor per worker connection. The reader task delivers each inbound
+//! frame with a call and reads the next only after the reply, so the mailbox
+//! never holds more than one frame plus signals and TCP backpressure holds.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::time::Duration;
+
+use gradient_core::ServerState;
+use gradient_scheduler::Scheduler;
+use gradient_scheduler::actor::{SessionPort, SessionSignal};
+use gradient_scheduler::jobs::PendingJob;
+use gradient_types::ids::ProjectId;
+use ractor::rpc::CallResult;
+use ractor::{Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
+use tokio::sync::Semaphore;
+use tokio::task::JoinHandle;
+use tracing::{debug, error, info, warn};
+
+use super::dispatch::DispatchContext;
+use super::eval_cache::EvalCacheReceiveStore;
+use super::nar_transfer::NarReceiveStore;
+use super::session::on_reauth_notify;
+use super::socket::{
+    JOB_OFFER_CHUNK_SIZE, ProtoSocket, ProtoWriter, recv_client_msg, send_server_msg,
+};
+use crate::messages::{ClientMessage, GradientCapabilities, ServerMessage};
+use crate::session::frame::ProtoReader;
+
+/// How long a draining session waits for its in-flight jobs before closing.
+pub const SESSION_DRAIN_BUDGET: Duration = Duration::from_secs(20);
+const NAR_COMMIT_CONCURRENCY: usize = 2;
+
+pub enum SessionMsg {
+    Frame(ClientMessage, RpcReplyPort<bool>),
+    Signal(SessionSignal),
+    Reattach,
+    ReaderClosed,
+    DrainDeadline,
+}
+
+#[derive(Clone)]
+pub struct SessionRef(pub ActorRef<SessionMsg>);
+
+impl SessionPort for SessionRef {
+    fn signal(&self, signal: SessionSignal) {
+        let _ = self.0.send_message(SessionMsg::Signal(signal));
+    }
+}
+
+pub struct SessionArgs {
+    pub peer_id: String,
+    pub state: Arc<ServerState>,
+    pub scheduler: Arc<Scheduler>,
+    pub socket: ProtoSocket,
+    pub capabilities: GradientCapabilities,
+    pub authorized_peers: HashSet<ProjectId>,
+}
+
+pub struct SessionState {
+    peer_id: String,
+    state: Arc<ServerState>,
+    scheduler: Arc<Scheduler>,
+    writer: ProtoWriter,
+    capabilities: GradientCapabilities,
+    authorized_peers: HashSet<ProjectId>,
+    nar: NarReceiveStore,
+    eval_cache: EvalCacheReceiveStore,
+    nar_serve_semaphore: Arc<Semaphore>,
+    nar_commit_semaphore: Arc<Semaphore>,
+    last_seen: Arc<AtomicI64>,
+    offers_seen: u64,
+    active: HashMap<String, PendingJob>,
+    draining: bool,
+    reader: JoinHandle<()>,
+}
+
+pub struct SessionActor;
+
+impl Actor for SessionActor {
+    type Msg = SessionMsg;
+    type State = SessionState;
+    type Arguments = SessionArgs;
+
+    async fn pre_start(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        args: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        let SessionArgs {
+            peer_id,
+            state,
+            scheduler,
+            mut socket,
+            capabilities,
+            authorized_peers,
+        } = args;
+        let port: Arc<dyn SessionPort> = Arc::new(SessionRef(myself.clone()));
+        let registered = match scheduler
+            .register_worker(
+                &peer_id,
+                capabilities.clone(),
+                authorized_peers.clone(),
+                port,
+            )
+            .await
+        {
+            Ok(registered) => registered,
+            Err(e) => {
+                warn!(%peer_id, error = %e, "registration failed; scheduler unavailable");
+                socket
+                    .send_reject(503, "scheduler unavailable".into())
+                    .await;
+                return Err(ActorProcessingErr::from(e.to_string()));
+            }
+        };
+
+        let proto_cfg = &state.config.proto;
+        let send_chunk_timeout = Duration::from_secs(proto_cfg.nar_send_chunk_timeout_secs);
+        let partial_ttl = Duration::from_secs(proto_cfg.nar_partial_ttl_secs);
+        let max_partial_bytes = proto_cfg.max_nar_buffer_bytes as u64;
+        let max_serves = proto_cfg.max_concurrent_nar_serves;
+        let partial_root =
+            std::path::PathBuf::from(format!("{}/nar-partial", state.config.storage.base_path));
+        let nar = NarReceiveStore::new(partial_root, &peer_id, partial_ttl, max_partial_bytes)
+            .unwrap_or_else(|e| {
+                error!(%peer_id, error = %e, "failed to init NAR partial dir; falling back to temp");
+                NarReceiveStore::new(
+                    std::env::temp_dir().join("gradient-nar-partial"),
+                    &peer_id,
+                    partial_ttl,
+                    max_partial_bytes,
+                )
+                .expect("temp partial dir must be creatable")
+            });
+        let (reader, writer) = socket.split(send_chunk_timeout, &state.shutdown);
+        let reader = state.shutdown.spawn(read_loop(reader, myself));
+
+        Ok(SessionState {
+            peer_id,
+            state,
+            scheduler,
+            writer,
+            capabilities,
+            authorized_peers,
+            nar,
+            eval_cache: EvalCacheReceiveStore::new(max_partial_bytes),
+            nar_serve_semaphore: Arc::new(Semaphore::new(max_serves)),
+            nar_commit_semaphore: Arc::new(Semaphore::new(NAR_COMMIT_CONCURRENCY)),
+            last_seen: registered.last_seen,
+            offers_seen: 0,
+            active: HashMap::new(),
+            draining: false,
+            reader,
+        })
+    }
+
+    async fn handle(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        msg: Self::Msg,
+        st: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        match msg {
+            SessionMsg::Frame(frame, reply) => {
+                st.last_seen.store(
+                    gradient_types::now().and_utc().timestamp_millis(),
+                    Ordering::Relaxed,
+                );
+                let keep = {
+                    let mut ctx = DispatchContext {
+                        writer: &st.writer,
+                        state: &st.state,
+                        scheduler: &st.scheduler,
+                        peer_id: &st.peer_id,
+                        nar_serve_semaphore: &st.nar_serve_semaphore,
+                        nar_commit_semaphore: &st.nar_commit_semaphore,
+                        active: &mut st.active,
+                    };
+
+                    ctx.dispatch(frame, &mut st.nar, &mut st.eval_cache).await
+                };
+                let _ = reply.send(keep);
+
+                if !keep {
+                    myself.stop(Some("peer closed".into()));
+                } else if st.draining && st.active.is_empty() {
+                    myself.stop(Some("drained".into()));
+                }
+            }
+            SessionMsg::Signal(SessionSignal::Offers(generation)) => {
+                if generation > st.offers_seen && !st.draining && !offer_jobs(st).await {
+                    myself.stop(Some("write failed".into()));
+                }
+            }
+            SessionMsg::Signal(SessionSignal::Reauth) => {
+                if !on_reauth_notify(&st.writer, &st.state, &st.peer_id).await {
+                    myself.stop(Some("deactivated".into()));
+                }
+            }
+            SessionMsg::Signal(SessionSignal::Abort { job_id, reason }) => {
+                info!(peer_id = %st.peer_id, %job_id, %reason, "sending AbortJob to worker");
+                if send_server_msg(&st.writer, &ServerMessage::AbortJob { job_id, reason })
+                    .await
+                    .is_err()
+                {
+                    myself.stop(Some("write failed".into()));
+                }
+            }
+            SessionMsg::Signal(SessionSignal::Drain) => {
+                if st.draining {
+                    return Ok(());
+                }
+
+                st.draining = true;
+                info!(peer_id = %st.peer_id, active = st.active.len(), "draining session");
+                let _ = send_server_msg(&st.writer, &ServerMessage::Draining).await;
+                st.scheduler.mark_worker_draining(&st.peer_id).await;
+
+                if st.active.is_empty() {
+                    myself.stop(Some("drained".into()));
+                } else {
+                    myself.send_after(SESSION_DRAIN_BUDGET, || SessionMsg::DrainDeadline);
+                }
+            }
+            SessionMsg::DrainDeadline => {
+                warn!(peer_id = %st.peer_id, active = st.active.len(), "drain budget expired; closing with jobs in flight");
+                myself.stop(Some("drain deadline".into()));
+            }
+            SessionMsg::Reattach => {
+                let port: Arc<dyn SessionPort> = Arc::new(SessionRef(myself.clone()));
+                let active = st
+                    .active
+                    .iter()
+                    .map(|(id, job)| (id.clone(), job.clone()))
+                    .collect();
+                if let Err(e) = st
+                    .scheduler
+                    .reattach_worker(
+                        &st.peer_id,
+                        st.capabilities.clone(),
+                        st.authorized_peers.clone(),
+                        port,
+                        active,
+                    )
+                    .await
+                {
+                    warn!(peer_id = %st.peer_id, error = %e, "re-registration after scheduler restart failed; closing");
+                    myself.stop(Some("reattach failed".into()));
+                }
+            }
+            SessionMsg::ReaderClosed => myself.stop(Some("peer closed".into())),
+        }
+
+        Ok(())
+    }
+
+    async fn post_stop(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        st: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        st.reader.abort();
+        st.scheduler.unregister_worker(&st.peer_id).await;
+        info!(peer_id = %st.peer_id, "WebSocket connection closed");
+        Ok(())
+    }
+}
+
+async fn offer_jobs(st: &mut SessionState) -> bool {
+    let offer = st.scheduler.get_new_job_candidates(&st.peer_id).await;
+    st.offers_seen = offer.generation;
+    if offer.candidates.is_empty() {
+        return true;
+    }
+
+    debug!(peer_id = %st.peer_id, count = offer.candidates.len(), "pushing job offer (delta)");
+    for chunk in offer.candidates.chunks(JOB_OFFER_CHUNK_SIZE) {
+        if send_server_msg(
+            &st.writer,
+            &ServerMessage::JobOffer {
+                candidates: chunk.to_vec(),
+            },
+        )
+        .await
+        .is_err()
+        {
+            return false;
+        }
+    }
+
+    true
+}
+
+async fn read_loop(mut reader: ProtoReader, session: ActorRef<SessionMsg>) {
+    while let Some(msg) = recv_client_msg(&mut reader).await {
+        match session
+            .call(|reply| SessionMsg::Frame(msg, reply), None)
+            .await
+        {
+            Ok(CallResult::Success(true)) => {}
+            _ => return,
+        }
+    }
+
+    let _ = session.send_message(SessionMsg::ReaderClosed);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::messages::decode_server_message;
+    use futures::StreamExt;
+    use gradient_test_support::prelude::*;
+    use sea_orm::{DatabaseBackend, MockDatabase};
+    use tokio::net::{TcpListener, TcpStream};
+    use tokio_tungstenite::tungstenite::Message;
+    use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
+
+    async fn connected_pair() -> (ProtoSocket, WebSocketStream<MaybeTlsStream<TcpStream>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let dial = tokio_tungstenite::connect_async(format!("ws://{addr}/proto"));
+        let accept = async {
+            let (tcp, _) = listener.accept().await.unwrap();
+            tokio_tungstenite::accept_async(MaybeTlsStream::Plain(tcp))
+                .await
+                .unwrap()
+        };
+        let (client, server) = tokio::join!(dial, accept);
+
+        (
+            ProtoSocket::Tungstenite(Box::new(server)),
+            client.unwrap().0,
+        )
+    }
+
+    #[tokio::test]
+    async fn drain_sends_draining_and_closes_an_idle_session() {
+        let (socket, mut client) = connected_pair().await;
+        let state = test_state(MockDatabase::new(DatabaseBackend::Postgres).into_connection());
+        let scheduler = Arc::new(Scheduler::new(Arc::clone(&state)));
+        scheduler.spawn_core(None).await.unwrap();
+        let (actor, join) = Actor::spawn(
+            None,
+            SessionActor,
+            SessionArgs {
+                peer_id: "w1".into(),
+                state: Arc::clone(&state),
+                scheduler: Arc::clone(&scheduler),
+                socket,
+                capabilities: GradientCapabilities::default(),
+                authorized_peers: HashSet::new(),
+            },
+        )
+        .await
+        .unwrap();
+        assert!(scheduler.is_worker_connected("w1").await);
+
+        actor
+            .send_message(SessionMsg::Signal(SessionSignal::Drain))
+            .unwrap();
+
+        let frame = client
+            .next()
+            .await
+            .expect("a frame")
+            .expect("no transport error");
+        let Message::Binary(bytes) = frame else {
+            panic!("expected a binary frame, got {frame:?}");
+        };
+        assert!(matches!(
+            decode_server_message(&bytes).unwrap(),
+            ServerMessage::Draining
+        ));
+        assert!(
+            matches!(
+                client.next().await,
+                None | Some(Ok(Message::Close(_))) | Some(Err(_))
+            ),
+            "the server closes after Draining"
+        );
+        join.await.unwrap();
+        assert!(!scheduler.is_worker_connected("w1").await);
+    }
+}

--- a/backend/gradient-proto/src/handler/sessions.rs
+++ b/backend/gradient-proto/src/handler/sessions.rs
@@ -1,0 +1,209 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! The sessions supervisor: one linked `SessionActor` per connection, drained
+//! before the tree stops them, and re-registered when the scheduler core is
+//! respawned.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use arc_swap::ArcSwapOption;
+use gradient_scheduler::Scheduler;
+use gradient_scheduler::actor::{CALL_TIMEOUT, SessionSignal};
+use gradient_util::shutdown::Shutdown;
+use gradient_util::supervision::{ChildCtx, ChildSpec};
+use ractor::rpc::CallResult;
+use ractor::{
+    Actor, ActorId, ActorProcessingErr, ActorRef, ActorStatus, RpcReplyPort, SupervisionEvent,
+};
+use tokio::task::JoinHandle;
+use tracing::{info, warn};
+
+use super::session_actor::{SESSION_DRAIN_BUDGET, SessionActor, SessionArgs, SessionMsg};
+
+pub type AttachedSession = (ActorRef<SessionMsg>, JoinHandle<()>);
+
+pub enum SessionsMsg {
+    Attach(SessionArgs, RpcReplyPort<Result<AttachedSession, String>>),
+    Reattach,
+}
+
+/// The process-wide handle the upgrade paths use to attach a connection; the
+/// factory republishes the supervisor's ref on every (re)spawn.
+pub struct SessionsHandle {
+    actor: ArcSwapOption<ActorRef<SessionsMsg>>,
+}
+
+impl SessionsHandle {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            actor: ArcSwapOption::empty(),
+        })
+    }
+
+    pub fn child_spec(self: &Arc<Self>, scheduler: Arc<Scheduler>) -> ChildSpec {
+        let handle = Arc::clone(self);
+        ChildSpec::Custom {
+            name: "sessions",
+            spawn: Arc::new(move |ctx: ChildCtx| {
+                let handle = Arc::clone(&handle);
+                let scheduler = Arc::clone(&scheduler);
+                Box::pin(async move {
+                    let args = SessionsArgs {
+                        shutdown: scheduler.state.shutdown.clone(),
+                        scheduler,
+                    };
+                    let (actor, _) = Actor::spawn_linked(None, Sessions, args, ctx.parent).await?;
+                    handle.actor.store(Some(Arc::new(actor.clone())));
+                    Ok(actor.get_cell())
+                })
+            }),
+        }
+    }
+
+    pub async fn attach(&self, args: SessionArgs) -> Result<AttachedSession, String> {
+        let Some(actor) = self.actor.load_full() else {
+            return Err("sessions supervisor not running".into());
+        };
+
+        match actor
+            .call(|reply| SessionsMsg::Attach(args, reply), Some(CALL_TIMEOUT))
+            .await
+        {
+            Ok(CallResult::Success(result)) => result,
+            Ok(CallResult::Timeout) => Err("sessions supervisor timed out".into()),
+            Ok(CallResult::SenderError) => Err("sessions supervisor dropped the reply".into()),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+}
+
+pub struct Sessions;
+
+pub struct SessionsArgs {
+    pub scheduler: Arc<Scheduler>,
+    pub shutdown: Shutdown,
+}
+
+pub struct SessionsState {
+    scheduler: Arc<Scheduler>,
+    live: HashMap<ActorId, (String, ActorRef<SessionMsg>)>,
+    core_watch: JoinHandle<()>,
+}
+
+impl Actor for Sessions {
+    type Msg = SessionsMsg;
+    type State = SessionsState;
+    type Arguments = SessionsArgs;
+
+    async fn pre_start(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        args: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        let mut cores = args.scheduler.core_changes();
+        let core_watch = args.shutdown.spawn(async move {
+            while cores.changed().await.is_ok() {
+                if cores.borrow_and_update().is_some()
+                    && myself.send_message(SessionsMsg::Reattach).is_err()
+                {
+                    return;
+                }
+            }
+        });
+
+        Ok(SessionsState {
+            scheduler: args.scheduler,
+            live: HashMap::new(),
+            core_watch,
+        })
+    }
+
+    async fn handle(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        msg: Self::Msg,
+        st: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        match msg {
+            SessionsMsg::Attach(args, reply) => {
+                let peer_id = args.peer_id.clone();
+                let result =
+                    match Actor::spawn_linked(None, SessionActor, args, myself.get_cell()).await {
+                        Ok((actor, join)) => {
+                            st.live.insert(actor.get_id(), (peer_id, actor.clone()));
+                            Ok((actor, join))
+                        }
+                        Err(e) => Err(e.to_string()),
+                    };
+                let _ = reply.send(result);
+            }
+            SessionsMsg::Reattach => {
+                info!(
+                    sessions = st.live.len(),
+                    "scheduler core republished; re-registering sessions"
+                );
+                for (_, actor) in st.live.values() {
+                    let _ = actor.send_message(SessionMsg::Reattach);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn handle_supervisor_evt(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        evt: SupervisionEvent,
+        st: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        let (cell, failed) = match evt {
+            SupervisionEvent::ActorFailed(cell, err) => {
+                warn!(error = %err, "session actor panicked");
+                (cell, true)
+            }
+            SupervisionEvent::ActorTerminated(cell, _, _) => (cell, false),
+            _ => return Ok(()),
+        };
+        if let Some((peer_id, _)) = st.live.remove(&cell.get_id())
+            && failed
+        {
+            st.scheduler.unregister_worker(&peer_id).await;
+        }
+
+        Ok(())
+    }
+
+    /// Sessions get `Draining` and their budget before the tree stops them.
+    async fn post_stop(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        st: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        st.core_watch.abort();
+        info!(sessions = st.live.len(), "draining sessions");
+        for (_, actor) in st.live.values() {
+            let _ = actor.send_message(SessionMsg::Signal(SessionSignal::Drain));
+        }
+        let deadline = Instant::now() + SESSION_DRAIN_BUDGET + Duration::from_secs(1);
+        while Instant::now() < deadline
+            && st
+                .live
+                .values()
+                .any(|(_, a)| a.get_cell().get_status() != ActorStatus::Stopped)
+        {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        for (_, actor) in st.live.values() {
+            actor.stop(Some("shutdown".into()));
+        }
+
+        Ok(())
+    }
+}

--- a/backend/gradient-proto/src/handler/socket.rs
+++ b/backend/gradient-proto/src/handler/socket.rs
@@ -32,12 +32,12 @@ pub(super) async fn push_pending_candidates(
     scheduler: &Scheduler,
     peer_id: &str,
 ) {
-    let candidates = scheduler.get_new_job_candidates(peer_id).await;
-    if candidates.is_empty() {
+    let offer = scheduler.get_new_job_candidates(peer_id).await;
+    if offer.candidates.is_empty() {
         return;
     }
-    debug!(%peer_id, count = candidates.len(), "pushing job offer (delta) after message processing");
-    for chunk in candidates.chunks(JOB_OFFER_CHUNK_SIZE) {
+    debug!(%peer_id, count = offer.candidates.len(), "pushing job offer (delta) after message processing");
+    for chunk in offer.candidates.chunks(JOB_OFFER_CHUNK_SIZE) {
         let _ = send_server_msg(
             writer,
             &ServerMessage::JobOffer {

--- a/backend/gradient-proto/src/lib.rs
+++ b/backend/gradient-proto/src/lib.rs
@@ -43,7 +43,7 @@ pub mod traits;
 #[cfg(test)]
 mod tests;
 
-pub use handler::{ProtoLimiter, proto_router};
+pub use handler::{ProtoLimiter, SessionsHandle, proto_router};
 pub use messages::{ClientMessage, PROTO_VERSION, ServerMessage};
 
 pub use gradient_scheduler::Scheduler;

--- a/backend/gradient-proto/src/outbound.rs
+++ b/backend/gradient-proto/src/outbound.rs
@@ -25,12 +25,12 @@ use tracing::{debug, error, info, warn};
 
 use gradient_entity::worker_registration::{Column, Entity as EWorkerRegistration};
 
-use crate::handler::{MAX_PROTO_MESSAGE_SIZE, ProtoSocket, handle_socket};
+use crate::handler::{MAX_PROTO_MESSAGE_SIZE, ProtoSocket, SessionsHandle, handle_socket};
 use gradient_scheduler::Scheduler;
 
 /// The outbound connection pass as a supervised child; each connection it
 /// opens is a tracked task of its own.
-pub fn start_outbound_loop(scheduler: Arc<Scheduler>) {
+pub fn start_outbound_loop(scheduler: Arc<Scheduler>, sessions: Arc<SessionsHandle>) {
     let connecting: Arc<Mutex<HashSet<String>>> = Arc::default();
     let pass_scheduler = Arc::clone(&scheduler);
     scheduler.state.shutdown.supervise(ChildSpec::periodic(
@@ -39,9 +39,10 @@ pub fn start_outbound_loop(scheduler: Arc<Scheduler>) {
         Duration::from_secs(60),
         move || {
             let scheduler = Arc::clone(&pass_scheduler);
+            let sessions = Arc::clone(&sessions);
             let connecting = Arc::clone(&connecting);
             async move {
-                connect_to_registered_workers(&scheduler, &connecting).await;
+                connect_to_registered_workers(&scheduler, &sessions, &connecting).await;
                 Ok(())
             }
         },
@@ -50,6 +51,7 @@ pub fn start_outbound_loop(scheduler: Arc<Scheduler>) {
 
 async fn connect_to_registered_workers(
     scheduler: &Arc<Scheduler>,
+    sessions: &Arc<SessionsHandle>,
     connecting: &Arc<Mutex<HashSet<String>>>,
 ) {
     let state = &scheduler.state;
@@ -94,6 +96,7 @@ async fn connect_to_registered_workers(
         let url = url.to_owned();
         let worker_id = reg.worker_id.clone();
         let scheduler = Arc::clone(scheduler);
+        let sessions = Arc::clone(sessions);
         let connecting = Arc::clone(connecting);
         let shutdown = scheduler.state.shutdown.clone();
 
@@ -117,6 +120,7 @@ async fn connect_to_registered_workers(
                         socket,
                         Arc::clone(&scheduler.state),
                         Arc::clone(&scheduler),
+                        Arc::clone(&sessions),
                         true,
                     )
                     .await;

--- a/backend/gradient-scheduler/src/actor.rs
+++ b/backend/gradient-scheduler/src/actor.rs
@@ -1,0 +1,447 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! The scheduler's state as one actor: `WorkerPool` and `JobTracker` are its
+//! private state, every mutation is a message, and sessions are reached only
+//! through a [`SessionPort`].
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::sync::atomic::AtomicI64;
+use std::time::Duration;
+
+use gradient_score::{InstanceContext, ScoringPolicy};
+use gradient_types::ids::{DispatchedJobId, EvaluationId, ProjectId};
+use gradient_types::proto::{CandidateScore, GradientCapabilities, JobCandidate, JobKind};
+use ractor::{Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
+use tracing::{debug, info};
+
+use crate::jobs::{
+    Assignment, BoardActiveJob, CandidateDetail, DispatchDecision, JobTracker, PendingJob,
+    PendingJobInfo, WorkerCaps,
+};
+use crate::worker_pool::{WorkerInfo, WorkerPool};
+
+pub const CALL_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// What the scheduler pushes to a session. Every variant is idempotent;
+/// `Offers` carries the generation that lets a session coalesce a burst.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionSignal {
+    Offers(u64),
+    Reauth,
+    Abort { job_id: String, reason: String },
+    Drain,
+}
+
+pub trait SessionPort: Send + Sync + 'static {
+    fn signal(&self, signal: SessionSignal);
+}
+
+impl SessionPort for tokio::sync::mpsc::UnboundedSender<SessionSignal> {
+    fn signal(&self, signal: SessionSignal) {
+        let _ = self.send(signal);
+    }
+}
+
+pub struct Registration {
+    pub worker: String,
+    pub capabilities: GradientCapabilities,
+    pub authorized_peers: HashSet<ProjectId>,
+    pub session: Arc<dyn SessionPort>,
+    pub active: Vec<(String, PendingJob)>,
+}
+
+pub struct Registered {
+    pub last_seen: Arc<AtomicI64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkerCapabilities {
+    pub architectures: Vec<String>,
+    pub system_features: Vec<String>,
+    pub max_concurrent_builds: u32,
+    pub cpu_count: u32,
+    pub ram_total_mb: u64,
+    pub cpu_core_score: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct WorkerMetrics {
+    pub cpu_usage_pct: f32,
+    pub ram_free_mb: u64,
+    pub disk_speed_mbps: Option<f32>,
+    pub network_speed_mbps: Option<f32>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Offer {
+    pub candidates: Vec<JobCandidate>,
+    pub generation: u64,
+}
+
+#[allow(
+    clippy::large_enum_variant,
+    reason = "one assignment per RequestJob reply; boxing only relocates the allocation"
+)]
+pub enum AssignOutcome {
+    AtCapacity,
+    Nothing,
+    Assigned(Assignment),
+}
+
+pub struct Released {
+    pub job: Option<PendingJob>,
+    pub worker_idle: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Counts {
+    pub workers: usize,
+    pub idle_workers: usize,
+    pub pending: usize,
+    pub active: usize,
+    pub pending_builds: u32,
+    pub active_builds: u32,
+}
+
+#[allow(
+    clippy::large_enum_variant,
+    reason = "one message per mailbox send; boxing only relocates the allocation"
+)]
+pub enum SchedulerMsg {
+    Register(Registration, RpcReplyPort<Registered>),
+    SetWorkerProject { worker: String, project: ProjectId },
+    Unregister { worker: String, reply: RpcReplyPort<Vec<PendingJob>> },
+    IsConnected { worker: String, reply: RpcReplyPort<bool> },
+    AuthorizedFor { worker: String, project: ProjectId, reply: RpcReplyPort<bool> },
+    UpdatePeers { worker: String, peers: HashSet<ProjectId>, reply: RpcReplyPort<()> },
+    RevokePeers { worker: String, revoked: HashSet<ProjectId>, reply: RpcReplyPort<usize> },
+    Reauth { worker: String },
+    UpdateCapabilities { worker: String, caps: WorkerCapabilities, reply: RpcReplyPort<()> },
+    UpdateMetrics { worker: String, metrics: WorkerMetrics, reply: RpcReplyPort<()> },
+    MarkDraining { worker: String, reply: RpcReplyPort<()> },
+    Enqueue { job_id: String, job: PendingJob, reply: RpcReplyPort<()> },
+    Candidates { worker: String, only_new: bool, reply: RpcReplyPort<Offer> },
+    Assign {
+        worker: String,
+        kind: JobKind,
+        instance: Arc<InstanceContext>,
+        reply: RpcReplyPort<AssignOutcome>,
+    },
+    RecordScores { worker: String, scores: Vec<CandidateScore>, reply: RpcReplyPort<()> },
+    Rejected { worker: String, job_id: String, reply: RpcReplyPort<()> },
+    Release { worker: String, job_id: String, reply: RpcReplyPort<Released> },
+    AbortJob { worker: String, job_id: String, reason: String, reply: RpcReplyPort<bool> },
+    AbortEvaluation { evaluation_id: EvaluationId, reply: RpcReplyPort<Vec<(String, String)>> },
+    RemoveJobs { job_ids: Vec<String>, reply: RpcReplyPort<()> },
+    ActiveJob { job_id: String, reply: RpcReplyPort<Option<PendingJob>> },
+    PendingJob { job_id: String, reply: RpcReplyPort<Option<PendingJob>> },
+    Untracked { job_ids: Vec<String>, reply: RpcReplyPort<Vec<String>> },
+    HasIdleEvalOnlyWorker { reply: RpcReplyPort<bool> },
+    Workers { reply: RpcReplyPort<Vec<WorkerInfo>> },
+    WorkerCaps { worker: String, reply: RpcReplyPort<Option<GradientCapabilities>> },
+    StaleWorkers { now_ms: i64, timeout_ms: i64, reply: RpcReplyPort<Vec<String>> },
+    Counts { reply: RpcReplyPort<Counts> },
+    PendingSnapshot { reply: RpcReplyPort<Vec<PendingJobInfo>> },
+    BoardActiveJobs { reply: RpcReplyPort<Vec<BoardActiveJob>> },
+    RecentDecisions { reply: RpcReplyPort<Vec<DispatchDecision>> },
+    CandidateDetail { id: DispatchedJobId, reply: RpcReplyPort<Option<CandidateDetail>> },
+    BumpRescore { reply: RpcReplyPort<()> },
+    ReOffer,
+}
+
+pub struct CoreArgs {
+    pub policy: Arc<dyn ScoringPolicy>,
+}
+
+pub struct SchedulerCore {
+    pool: WorkerPool,
+    tracker: JobTracker,
+    offers: u64,
+    policy: Arc<dyn ScoringPolicy>,
+}
+
+impl SchedulerCore {
+    fn bump_offers(&mut self) {
+        self.offers = self.offers.wrapping_add(1);
+        self.pool.signal_active(SessionSignal::Offers(self.offers));
+    }
+
+    fn auth_and_caps(&self, worker: &str) -> (Option<HashSet<ProjectId>>, Option<WorkerCaps>) {
+        let authorized = self
+            .pool
+            .peer_auth_for(worker)
+            .and_then(|a| a.as_filter())
+            .cloned();
+        (authorized, self.pool.worker_caps(worker))
+    }
+
+    fn candidates(&mut self, worker: &str, only_new: bool) -> Offer {
+        let (authorized, caps) = self.auth_and_caps(worker);
+        let mut candidates = self
+            .tracker
+            .candidates_for_worker(authorized.as_ref(), caps.as_ref());
+        if only_new && let Some(sent) = self.pool.sent_candidates_for(worker) {
+            candidates.retain(|c| !sent.contains(&c.job_id));
+        }
+        let ids: Vec<String> = candidates.iter().map(|c| c.job_id.clone()).collect();
+        self.pool.mark_candidates_sent(worker, &ids);
+        Offer {
+            candidates,
+            generation: self.offers,
+        }
+    }
+
+    fn assign(&mut self, worker: &str, kind: &JobKind, instance: &InstanceContext) -> AssignOutcome {
+        if !self.pool.has_capacity(worker, kind) {
+            debug!(%worker, ?kind, "RequestJob ignored - worker at capacity");
+            return AssignOutcome::AtCapacity;
+        }
+        let (authorized, caps) = self.auth_and_caps(worker);
+        let policy = Arc::clone(&self.policy);
+        match self.tracker.take_best_of_kind(
+            worker,
+            authorized.as_ref(),
+            caps.as_ref(),
+            kind,
+            &*policy,
+            instance,
+        ) {
+            Some(assignment) => {
+                self.pool.assign_job(worker, &assignment.job_id);
+                AssignOutcome::Assigned(assignment)
+            }
+            None => AssignOutcome::Nothing,
+        }
+    }
+}
+
+pub struct CoreActor;
+
+impl Actor for CoreActor {
+    type Msg = SchedulerMsg;
+    type State = SchedulerCore;
+    type Arguments = CoreArgs;
+
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        args: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        Ok(SchedulerCore {
+            pool: WorkerPool::new(),
+            tracker: JobTracker::new(),
+            offers: 0,
+            policy: args.policy,
+        })
+    }
+
+    async fn handle(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        msg: Self::Msg,
+        core: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        match msg {
+            SchedulerMsg::Register(reg, reply) => {
+                let last_seen = core.pool.register(
+                    reg.worker.clone(),
+                    reg.capabilities,
+                    reg.authorized_peers,
+                    reg.session,
+                );
+                for (job_id, job) in reg.active {
+                    core.tracker.restore_active(&reg.worker, job_id.clone(), job);
+                    core.pool.assign_job(&reg.worker, &job_id);
+                }
+                info!(worker = %reg.worker, "worker registered");
+                let _ = reply.send(Registered { last_seen });
+            }
+            SchedulerMsg::SetWorkerProject { worker, project } => {
+                core.pool.set_worker_project(&worker, project);
+            }
+            SchedulerMsg::Unregister { worker, reply } => {
+                let orphaned = core.pool.unregister(&worker);
+                let requeued = core.tracker.worker_disconnected(&worker);
+                let total = orphaned.len() + requeued.len();
+                if total > 0 {
+                    info!(%worker, orphaned_jobs = total, "worker disconnected; jobs re-queued");
+                }
+                let _ = reply.send(requeued);
+            }
+            SchedulerMsg::IsConnected { worker, reply } => {
+                let _ = reply.send(core.pool.is_connected(&worker));
+            }
+            SchedulerMsg::AuthorizedFor { worker, project, reply } => {
+                let ok = core
+                    .pool
+                    .peer_auth_for(&worker)
+                    .map(|a| a.contains(&project))
+                    .unwrap_or(false);
+                let _ = reply.send(ok);
+            }
+            SchedulerMsg::UpdatePeers { worker, peers, reply } => {
+                core.pool.update_authorized_peers(&worker, peers);
+                let _ = reply.send(());
+            }
+            SchedulerMsg::RevokePeers { worker, revoked, reply } => {
+                let job_ids = core.tracker.drain_peer_jobs_on_worker(&worker, &revoked);
+                for job_id in &job_ids {
+                    core.pool.send_abort(
+                        &worker,
+                        job_id.clone(),
+                        "project deactivated worker".to_owned(),
+                    );
+                }
+                if !job_ids.is_empty() {
+                    core.bump_offers();
+                }
+                let _ = reply.send(job_ids.len());
+            }
+            SchedulerMsg::Reauth { worker } => core.pool.request_reauth(&worker),
+            SchedulerMsg::UpdateCapabilities { worker, caps, reply } => {
+                core.pool.update_capabilities(
+                    &worker,
+                    caps.architectures,
+                    caps.system_features,
+                    caps.max_concurrent_builds,
+                    caps.cpu_count,
+                    caps.ram_total_mb,
+                    caps.cpu_core_score,
+                );
+                let _ = reply.send(());
+            }
+            SchedulerMsg::UpdateMetrics { worker, metrics, reply } => {
+                core.pool.update_metrics(
+                    &worker,
+                    metrics.cpu_usage_pct,
+                    metrics.ram_free_mb,
+                    metrics.disk_speed_mbps,
+                    metrics.network_speed_mbps,
+                );
+                let _ = reply.send(());
+            }
+            SchedulerMsg::MarkDraining { worker, reply } => {
+                core.pool.mark_draining(&worker);
+                let _ = reply.send(());
+            }
+            SchedulerMsg::Enqueue { job_id, job, reply } => {
+                let is_build = matches!(job, PendingJob::Build(_));
+                core.tracker.add_pending(job_id.clone(), job);
+                if is_build {
+                    core.pool.remove_sent_candidate(&job_id);
+                }
+                core.bump_offers();
+                let _ = reply.send(());
+            }
+            SchedulerMsg::Candidates { worker, only_new, reply } => {
+                let _ = reply.send(core.candidates(&worker, only_new));
+            }
+            SchedulerMsg::Assign { worker, kind, instance, reply } => {
+                let _ = reply.send(core.assign(&worker, &kind, &instance));
+            }
+            SchedulerMsg::RecordScores { worker, scores, reply } => {
+                core.tracker.record_scores(&worker, scores);
+                let _ = reply.send(());
+            }
+            SchedulerMsg::Rejected { worker, job_id, reply } => {
+                core.pool.release_job(&worker, &job_id);
+                core.tracker.release_to_pending(&job_id);
+                core.pool.remove_sent_candidate(&job_id);
+                info!(%worker, %job_id, "job rejected; re-queued");
+                let _ = reply.send(());
+            }
+            SchedulerMsg::Release { worker, job_id, reply } => {
+                let worker_idle = core.pool.release_job(&worker, &job_id);
+                let job = core.tracker.remove_active(&job_id);
+                let _ = reply.send(Released { job, worker_idle });
+            }
+            SchedulerMsg::AbortJob { worker, job_id, reason, reply } => {
+                let _ = reply.send(core.pool.send_abort(&worker, job_id, reason));
+            }
+            SchedulerMsg::AbortEvaluation { evaluation_id, reply } => {
+                let to_abort: Vec<(String, String)> = core
+                    .tracker
+                    .active_jobs()
+                    .filter(|(_, _, job)| job.evaluation_id() == evaluation_id)
+                    .map(|(job_id, worker, _)| (worker.to_owned(), job_id.to_owned()))
+                    .collect();
+                for (worker, job_id) in &to_abort {
+                    core.pool
+                        .send_abort(worker, job_id.clone(), "evaluation aborted".to_owned());
+                }
+                core.tracker.remove_pending_for_evaluation(evaluation_id);
+                let _ = reply.send(to_abort);
+            }
+            SchedulerMsg::RemoveJobs { job_ids, reply } => {
+                for id in &job_ids {
+                    core.tracker.remove_job(id);
+                }
+                let _ = reply.send(());
+            }
+            SchedulerMsg::ActiveJob { job_id, reply } => {
+                let _ = reply.send(core.tracker.active_job(&job_id).cloned());
+            }
+            SchedulerMsg::PendingJob { job_id, reply } => {
+                let _ = reply.send(core.tracker.pending_job(&job_id).cloned());
+            }
+            SchedulerMsg::Untracked { job_ids, reply } => {
+                let unknown = job_ids
+                    .into_iter()
+                    .filter(|id| !core.tracker.contains_job(id))
+                    .collect();
+                let _ = reply.send(unknown);
+            }
+            SchedulerMsg::HasIdleEvalOnlyWorker { reply } => {
+                let _ = reply.send(core.pool.has_idle_eval_only_worker());
+            }
+            SchedulerMsg::Workers { reply } => {
+                let _ = reply.send(core.pool.all_workers());
+            }
+            SchedulerMsg::WorkerCaps { worker, reply } => {
+                let _ = reply.send(core.pool.gradient_caps_for(&worker));
+            }
+            SchedulerMsg::StaleWorkers { now_ms, timeout_ms, reply } => {
+                let _ = reply.send(core.pool.stale_worker_ids(now_ms, timeout_ms));
+            }
+            SchedulerMsg::Counts { reply } => {
+                let (workers, idle_workers) = core.pool.worker_counts();
+                let (active_builds, pending_builds) = core.tracker.instance_counts();
+                let _ = reply.send(Counts {
+                    workers: workers as usize,
+                    idle_workers: idle_workers as usize,
+                    pending: core.tracker.pending_count(),
+                    active: core.tracker.active_count(),
+                    pending_builds,
+                    active_builds,
+                });
+            }
+            SchedulerMsg::PendingSnapshot { reply } => {
+                let _ = reply.send(core.tracker.pending_snapshot());
+            }
+            SchedulerMsg::BoardActiveJobs { reply } => {
+                let _ = reply.send(core.tracker.board_active_jobs());
+            }
+            SchedulerMsg::RecentDecisions { reply } => {
+                let _ = reply.send(core.tracker.recent_decisions());
+            }
+            SchedulerMsg::CandidateDetail { id, reply } => {
+                let _ = reply.send(core.tracker.candidate_detail(id));
+            }
+            SchedulerMsg::BumpRescore { reply } => {
+                core.tracker.bump_rescore_counts();
+                let _ = reply.send(());
+            }
+            SchedulerMsg::ReOffer => {
+                if core.tracker.has_pending() {
+                    core.bump_offers();
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/backend/gradient-scheduler/src/actor.rs
+++ b/backend/gradient-scheduler/src/actor.rs
@@ -114,43 +114,141 @@ pub struct Counts {
 )]
 pub enum SchedulerMsg {
     Register(Registration, RpcReplyPort<Registered>),
-    SetWorkerProject { worker: String, project: ProjectId },
-    Unregister { worker: String, reply: RpcReplyPort<Vec<PendingJob>> },
-    IsConnected { worker: String, reply: RpcReplyPort<bool> },
-    AuthorizedFor { worker: String, project: ProjectId, reply: RpcReplyPort<bool> },
-    UpdatePeers { worker: String, peers: HashSet<ProjectId>, reply: RpcReplyPort<()> },
-    RevokePeers { worker: String, revoked: HashSet<ProjectId>, reply: RpcReplyPort<usize> },
-    Reauth { worker: String },
-    UpdateCapabilities { worker: String, caps: WorkerCapabilities, reply: RpcReplyPort<()> },
-    UpdateMetrics { worker: String, metrics: WorkerMetrics, reply: RpcReplyPort<()> },
-    MarkDraining { worker: String, reply: RpcReplyPort<()> },
-    Enqueue { job_id: String, job: PendingJob, reply: RpcReplyPort<()> },
-    Candidates { worker: String, only_new: bool, reply: RpcReplyPort<Offer> },
+    SetWorkerProject {
+        worker: String,
+        project: ProjectId,
+    },
+    Unregister {
+        worker: String,
+        reply: RpcReplyPort<Vec<PendingJob>>,
+    },
+    IsConnected {
+        worker: String,
+        reply: RpcReplyPort<bool>,
+    },
+    AuthorizedFor {
+        worker: String,
+        project: ProjectId,
+        reply: RpcReplyPort<bool>,
+    },
+    UpdatePeers {
+        worker: String,
+        peers: HashSet<ProjectId>,
+        reply: RpcReplyPort<()>,
+    },
+    RevokePeers {
+        worker: String,
+        revoked: HashSet<ProjectId>,
+        reply: RpcReplyPort<usize>,
+    },
+    Reauth {
+        worker: String,
+    },
+    UpdateCapabilities {
+        worker: String,
+        caps: WorkerCapabilities,
+        reply: RpcReplyPort<()>,
+    },
+    UpdateMetrics {
+        worker: String,
+        metrics: WorkerMetrics,
+        reply: RpcReplyPort<()>,
+    },
+    MarkDraining {
+        worker: String,
+        reply: RpcReplyPort<()>,
+    },
+    Enqueue {
+        job_id: String,
+        job: PendingJob,
+        reply: RpcReplyPort<()>,
+    },
+    Candidates {
+        worker: String,
+        only_new: bool,
+        reply: RpcReplyPort<Offer>,
+    },
     Assign {
         worker: String,
         kind: JobKind,
         instance: Arc<InstanceContext>,
         reply: RpcReplyPort<AssignOutcome>,
     },
-    RecordScores { worker: String, scores: Vec<CandidateScore>, reply: RpcReplyPort<()> },
-    Rejected { worker: String, job_id: String, reply: RpcReplyPort<()> },
-    Release { worker: String, job_id: String, reply: RpcReplyPort<Released> },
-    AbortJob { worker: String, job_id: String, reason: String, reply: RpcReplyPort<bool> },
-    AbortEvaluation { evaluation_id: EvaluationId, reply: RpcReplyPort<Vec<(String, String)>> },
-    RemoveJobs { job_ids: Vec<String>, reply: RpcReplyPort<()> },
-    ActiveJob { job_id: String, reply: RpcReplyPort<Option<PendingJob>> },
-    PendingJob { job_id: String, reply: RpcReplyPort<Option<PendingJob>> },
-    Untracked { job_ids: Vec<String>, reply: RpcReplyPort<Vec<String>> },
-    HasIdleEvalOnlyWorker { reply: RpcReplyPort<bool> },
-    Workers { reply: RpcReplyPort<Vec<WorkerInfo>> },
-    WorkerCaps { worker: String, reply: RpcReplyPort<Option<GradientCapabilities>> },
-    StaleWorkers { now_ms: i64, timeout_ms: i64, reply: RpcReplyPort<Vec<String>> },
-    Counts { reply: RpcReplyPort<Counts> },
-    PendingSnapshot { reply: RpcReplyPort<Vec<PendingJobInfo>> },
-    BoardActiveJobs { reply: RpcReplyPort<Vec<BoardActiveJob>> },
-    RecentDecisions { reply: RpcReplyPort<Vec<DispatchDecision>> },
-    CandidateDetail { id: DispatchedJobId, reply: RpcReplyPort<Option<CandidateDetail>> },
-    BumpRescore { reply: RpcReplyPort<()> },
+    RecordScores {
+        worker: String,
+        scores: Vec<CandidateScore>,
+        reply: RpcReplyPort<()>,
+    },
+    Rejected {
+        worker: String,
+        job_id: String,
+        reply: RpcReplyPort<()>,
+    },
+    Release {
+        worker: String,
+        job_id: String,
+        reply: RpcReplyPort<Released>,
+    },
+    AbortJob {
+        worker: String,
+        job_id: String,
+        reason: String,
+        reply: RpcReplyPort<bool>,
+    },
+    AbortEvaluation {
+        evaluation_id: EvaluationId,
+        reply: RpcReplyPort<Vec<(String, String)>>,
+    },
+    RemoveJobs {
+        job_ids: Vec<String>,
+        reply: RpcReplyPort<()>,
+    },
+    ActiveJob {
+        job_id: String,
+        reply: RpcReplyPort<Option<PendingJob>>,
+    },
+    PendingJob {
+        job_id: String,
+        reply: RpcReplyPort<Option<PendingJob>>,
+    },
+    Untracked {
+        job_ids: Vec<String>,
+        reply: RpcReplyPort<Vec<String>>,
+    },
+    HasIdleEvalOnlyWorker {
+        reply: RpcReplyPort<bool>,
+    },
+    Workers {
+        reply: RpcReplyPort<Vec<WorkerInfo>>,
+    },
+    WorkerCaps {
+        worker: String,
+        reply: RpcReplyPort<Option<GradientCapabilities>>,
+    },
+    StaleWorkers {
+        now_ms: i64,
+        timeout_ms: i64,
+        reply: RpcReplyPort<Vec<String>>,
+    },
+    Counts {
+        reply: RpcReplyPort<Counts>,
+    },
+    PendingSnapshot {
+        reply: RpcReplyPort<Vec<PendingJobInfo>>,
+    },
+    BoardActiveJobs {
+        reply: RpcReplyPort<Vec<BoardActiveJob>>,
+    },
+    RecentDecisions {
+        reply: RpcReplyPort<Vec<DispatchDecision>>,
+    },
+    CandidateDetail {
+        id: DispatchedJobId,
+        reply: RpcReplyPort<Option<CandidateDetail>>,
+    },
+    BumpRescore {
+        reply: RpcReplyPort<()>,
+    },
     ReOffer,
 }
 
@@ -196,7 +294,12 @@ impl SchedulerCore {
         }
     }
 
-    fn assign(&mut self, worker: &str, kind: &JobKind, instance: &InstanceContext) -> AssignOutcome {
+    fn assign(
+        &mut self,
+        worker: &str,
+        kind: &JobKind,
+        instance: &InstanceContext,
+    ) -> AssignOutcome {
         if !self.pool.has_capacity(worker, kind) {
             debug!(%worker, ?kind, "RequestJob ignored - worker at capacity");
             return AssignOutcome::AtCapacity;
@@ -255,7 +358,8 @@ impl Actor for CoreActor {
                     reg.session,
                 );
                 for (job_id, job) in reg.active {
-                    core.tracker.restore_active(&reg.worker, job_id.clone(), job);
+                    core.tracker
+                        .restore_active(&reg.worker, job_id.clone(), job);
                     core.pool.assign_job(&reg.worker, &job_id);
                 }
                 info!(worker = %reg.worker, "worker registered");
@@ -276,7 +380,11 @@ impl Actor for CoreActor {
             SchedulerMsg::IsConnected { worker, reply } => {
                 let _ = reply.send(core.pool.is_connected(&worker));
             }
-            SchedulerMsg::AuthorizedFor { worker, project, reply } => {
+            SchedulerMsg::AuthorizedFor {
+                worker,
+                project,
+                reply,
+            } => {
                 let ok = core
                     .pool
                     .peer_auth_for(&worker)
@@ -284,11 +392,19 @@ impl Actor for CoreActor {
                     .unwrap_or(false);
                 let _ = reply.send(ok);
             }
-            SchedulerMsg::UpdatePeers { worker, peers, reply } => {
+            SchedulerMsg::UpdatePeers {
+                worker,
+                peers,
+                reply,
+            } => {
                 core.pool.update_authorized_peers(&worker, peers);
                 let _ = reply.send(());
             }
-            SchedulerMsg::RevokePeers { worker, revoked, reply } => {
+            SchedulerMsg::RevokePeers {
+                worker,
+                revoked,
+                reply,
+            } => {
                 let job_ids = core.tracker.drain_peer_jobs_on_worker(&worker, &revoked);
                 for job_id in &job_ids {
                     core.pool.send_abort(
@@ -303,7 +419,11 @@ impl Actor for CoreActor {
                 let _ = reply.send(job_ids.len());
             }
             SchedulerMsg::Reauth { worker } => core.pool.request_reauth(&worker),
-            SchedulerMsg::UpdateCapabilities { worker, caps, reply } => {
+            SchedulerMsg::UpdateCapabilities {
+                worker,
+                caps,
+                reply,
+            } => {
                 core.pool.update_capabilities(
                     &worker,
                     caps.architectures,
@@ -315,7 +435,11 @@ impl Actor for CoreActor {
                 );
                 let _ = reply.send(());
             }
-            SchedulerMsg::UpdateMetrics { worker, metrics, reply } => {
+            SchedulerMsg::UpdateMetrics {
+                worker,
+                metrics,
+                reply,
+            } => {
                 core.pool.update_metrics(
                     &worker,
                     metrics.cpu_usage_pct,
@@ -338,32 +462,61 @@ impl Actor for CoreActor {
                 core.bump_offers();
                 let _ = reply.send(());
             }
-            SchedulerMsg::Candidates { worker, only_new, reply } => {
+            SchedulerMsg::Candidates {
+                worker,
+                only_new,
+                reply,
+            } => {
                 let _ = reply.send(core.candidates(&worker, only_new));
             }
-            SchedulerMsg::Assign { worker, kind, instance, reply } => {
+            SchedulerMsg::Assign {
+                worker,
+                kind,
+                instance,
+                reply,
+            } => {
                 let _ = reply.send(core.assign(&worker, &kind, &instance));
             }
-            SchedulerMsg::RecordScores { worker, scores, reply } => {
+            SchedulerMsg::RecordScores {
+                worker,
+                scores,
+                reply,
+            } => {
                 core.tracker.record_scores(&worker, scores);
                 let _ = reply.send(());
             }
-            SchedulerMsg::Rejected { worker, job_id, reply } => {
+            SchedulerMsg::Rejected {
+                worker,
+                job_id,
+                reply,
+            } => {
                 core.pool.release_job(&worker, &job_id);
                 core.tracker.release_to_pending(&job_id);
                 core.pool.remove_sent_candidate(&job_id);
                 info!(%worker, %job_id, "job rejected; re-queued");
                 let _ = reply.send(());
             }
-            SchedulerMsg::Release { worker, job_id, reply } => {
+            SchedulerMsg::Release {
+                worker,
+                job_id,
+                reply,
+            } => {
                 let worker_idle = core.pool.release_job(&worker, &job_id);
                 let job = core.tracker.remove_active(&job_id);
                 let _ = reply.send(Released { job, worker_idle });
             }
-            SchedulerMsg::AbortJob { worker, job_id, reason, reply } => {
+            SchedulerMsg::AbortJob {
+                worker,
+                job_id,
+                reason,
+                reply,
+            } => {
                 let _ = reply.send(core.pool.send_abort(&worker, job_id, reason));
             }
-            SchedulerMsg::AbortEvaluation { evaluation_id, reply } => {
+            SchedulerMsg::AbortEvaluation {
+                evaluation_id,
+                reply,
+            } => {
                 let to_abort: Vec<(String, String)> = core
                     .tracker
                     .active_jobs()
@@ -405,7 +558,11 @@ impl Actor for CoreActor {
             SchedulerMsg::WorkerCaps { worker, reply } => {
                 let _ = reply.send(core.pool.gradient_caps_for(&worker));
             }
-            SchedulerMsg::StaleWorkers { now_ms, timeout_ms, reply } => {
+            SchedulerMsg::StaleWorkers {
+                now_ms,
+                timeout_ms,
+                reply,
+            } => {
                 let _ = reply.send(core.pool.stale_worker_ids(now_ms, timeout_ms));
             }
             SchedulerMsg::Counts { reply } => {

--- a/backend/gradient-scheduler/src/dispatch/background.rs
+++ b/backend/gradient-scheduler/src/dispatch/background.rs
@@ -70,13 +70,12 @@ pub(super) async fn worker_liveness_pass(scheduler: Arc<Scheduler>) -> anyhow::R
 /// Recompute the windowed [`gradient_score::InstanceContext`] snapshot consumed
 /// by resource-aware scoring and publish it lock-free.
 pub(super) async fn instance_metrics_pass(scheduler: Arc<Scheduler>) -> anyhow::Result<()> {
-    let (active_builds, pending_builds) = scheduler.job_tracker.read().await.instance_counts();
-    let (total_workers, idle_workers) = scheduler.worker_pool.read().await.worker_counts();
+    let c = scheduler.counts().await;
     let counts = crate::instance::InstanceCounts {
-        active_builds,
-        pending_builds,
-        total_workers,
-        idle_workers,
+        active_builds: c.active_builds,
+        pending_builds: c.pending_builds,
+        total_workers: c.workers as u32,
+        idle_workers: c.idle_workers as u32,
     };
     let ctx = crate::instance::compute_instance_context(
         &scheduler.state.worker_db,
@@ -96,7 +95,7 @@ pub(super) async fn instance_metrics_pass(scheduler: Arc<Scheduler>) -> anyhow::
 /// Snapshot every connected worker's live metrics into `worker_sample` for the
 /// Job Board's worker statistics.
 pub(super) async fn worker_sample_pass(scheduler: Arc<Scheduler>) -> anyhow::Result<()> {
-    let workers = scheduler.worker_pool.read().await.all_workers();
+    let workers = scheduler.board_workers().await;
     for info in &workers {
         crate::worker_lifecycle::record_worker_sample(&scheduler.state.worker_db, info).await;
     }

--- a/backend/gradient-scheduler/src/dispatch/build.rs
+++ b/backend/gradient-scheduler/src/dispatch/build.rs
@@ -18,9 +18,10 @@ use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 
 use gradient_util::supervision::{ChildCtx, ChildSpec, run_pass};
 use ractor::{Actor, ActorProcessingErr, ActorRef};
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
 use crate::Scheduler;
+use crate::actor::SchedulerMsg;
 use crate::jobs::PendingBuildJob;
 use gradient_types::proto::{BuildJob, BuildSpec, CacheInfo, DerivationOutput, RequiredPath};
 
@@ -40,7 +41,9 @@ pub(crate) async fn build_dispatch_pass(scheduler: &Scheduler, timer_tick: bool,
     // intervals, so only the timer advances it - reactive kicks (which can
     // fire many times per interval) just run an extra dispatch pass.
     if timer_tick {
-        scheduler.job_tracker.write().await.bump_rescore_counts();
+        let _ = scheduler
+            .call(|reply| SchedulerMsg::BumpRescore { reply })
+            .await;
 
         // Every timer tick runs promotion (Tick); the anchor-side flag
         // fixpoints, unbacked-output demote, and failure sweep (Global) run
@@ -83,9 +86,7 @@ pub(crate) async fn build_dispatch_pass(scheduler: &Scheduler, timer_tick: bool,
     // so this re-offers it (workers score it a second time) - including to a
     // worker that just freed capacity via the kick. Sessions ignore an empty
     // delta, so this is cheap when nothing changed.
-    if scheduler.job_tracker.read().await.has_pending() {
-        scheduler.job_notify.send_modify(|g| *g = g.wrapping_add(1));
-    }
+    let _ = scheduler.cast(SchedulerMsg::ReOffer).await;
 }
 
 pub(crate) enum BuildMsg {
@@ -800,15 +801,13 @@ pub(crate) async fn dispatch_ready_builds(scheduler: &Scheduler) -> anyhow::Resu
         return Ok(());
     }
 
-    // Filter out anchors already in the in-memory tracker - one lock acquisition
-    // for the whole pass instead of per-anchor.
-    let new_anchors: Vec<MDerivationBuild> = {
-        let tracker = scheduler.job_tracker.read().await;
-        anchors
-            .into_iter()
-            .filter(|a| !tracker.contains_job(&format!("build:{}", a.id)))
-            .collect()
-    };
+    // Filter out anchors already in the in-memory tracker.
+    let ids: Vec<String> = anchors.iter().map(|a| format!("build:{}", a.id)).collect();
+    let untracked: HashSet<String> = scheduler.untracked(ids).await.into_iter().collect();
+    let new_anchors: Vec<MDerivationBuild> = anchors
+        .into_iter()
+        .filter(|a| untracked.contains(&format!("build:{}", a.id)))
+        .collect();
     if new_anchors.is_empty() {
         return Ok(());
     }
@@ -833,10 +832,8 @@ pub(crate) async fn dispatch_ready_builds(scheduler: &Scheduler) -> anyhow::Resu
     }
 
     let connected_architectures: HashSet<String> = scheduler
-        .worker_pool
-        .read()
+        .board_workers()
         .await
-        .all_workers()
         .into_iter()
         .flat_map(|w| w.architectures)
         .collect();
@@ -853,7 +850,10 @@ pub(crate) async fn dispatch_ready_builds(scheduler: &Scheduler) -> anyhow::Resu
     for anchor in new_anchors {
         match maps.classify_dispatch(&anchor) {
             DispatchOutcome::Dispatch(job_id, pending) => {
-                scheduler.enqueue_build_job(job_id, *pending).await;
+                if let Err(e) = scheduler.enqueue_build_job(job_id, *pending).await {
+                    warn!(error = %e, "enqueue_build_job failed");
+                    continue;
+                }
                 enqueued += 1;
             }
             DispatchOutcome::Defer(reason) => {

--- a/backend/gradient-scheduler/src/dispatch/eval.rs
+++ b/backend/gradient-scheduler/src/dispatch/eval.rs
@@ -33,25 +33,19 @@ pub(crate) async fn dispatch_queued_evals(scheduler: &Scheduler) -> anyhow::Resu
         .all(&state.worker_db)
         .await?;
 
-    // One tracker snapshot instead of a read lock per eval; `add_pending` is
-    // idempotent under the write lock, so the snapshot race is harmless.
-    let evals: Vec<MEvaluation> = {
-        let tracker = scheduler.job_tracker.read().await;
-        evals
-            .into_iter()
-            .filter(|e| !tracker.contains_job(&format!("eval:{}", e.id)))
-            .collect()
-    };
+    // One untracked check instead of a lock per eval.
+    let ids: Vec<String> = evals.iter().map(|e| format!("eval:{}", e.id)).collect();
+    let untracked: HashSet<String> = scheduler.untracked(ids).await.into_iter().collect();
+    let evals: Vec<MEvaluation> = evals
+        .into_iter()
+        .filter(|e| untracked.contains(&format!("eval:{}", e.id)))
+        .collect();
     if evals.is_empty() {
         return Ok(());
     }
 
     let maps = EvalDispatchMaps::load(state, &evals).await?;
-    let split_fetch = scheduler
-        .worker_pool
-        .read()
-        .await
-        .has_idle_eval_only_worker();
+    let split_fetch = scheduler.has_idle_eval_only_worker().await;
     let eval_history = scheduler.eval_history.load();
 
     for eval in evals {
@@ -125,7 +119,10 @@ pub(crate) async fn dispatch_queued_evals(scheduler: &Scheduler) -> anyhow::Resu
             history,
         };
 
-        scheduler.enqueue_eval_job(job_id.clone(), pending).await;
+        if let Err(e) = scheduler.enqueue_eval_job(job_id.clone(), pending).await {
+            error!(error = %e, %job_id, "enqueue_eval_job failed");
+            continue;
+        }
         debug!(evaluation_id = %eval.id, %job_id, split_fetch, "eval job enqueued");
     }
 

--- a/backend/gradient-scheduler/src/dispatch/mod.rs
+++ b/backend/gradient-scheduler/src/dispatch/mod.rs
@@ -46,7 +46,8 @@ pub(super) const DISPATCH_BUDGET: Duration = Duration::from_secs(120);
 const METRICS_BUDGET: Duration = Duration::from_secs(60);
 const CONSISTENCY_BUDGET: Duration = Duration::from_secs(600);
 
-/// Registers every dispatch loop on the process supervision tree.
+/// Registers the scheduler node (core actor plus the three dispatch passes) and
+/// the maintenance passes on the process supervision tree.
 pub fn start_dispatch_loops(scheduler: Arc<Scheduler>) {
     for spec in child_specs(&scheduler) {
         scheduler.state.shutdown.supervise(spec);
@@ -67,22 +68,27 @@ fn core_child_spec(scheduler: &Arc<Scheduler>) -> ChildSpec {
 fn child_specs(scheduler: &Arc<Scheduler>) -> Vec<ChildSpec> {
     let metrics = &scheduler.state.config.metrics_args;
     let mut children = vec![
-        core_child_spec(scheduler),
-        periodic(
-            scheduler,
-            "trigger-dispatch",
-            DISPATCH_TICK,
-            DISPATCH_BUDGET,
-            |s| async move { crate::trigger_dispatch::dispatch_once(&s).await },
+        ChildSpec::supervisor(
+            "scheduler",
+            vec![
+                core_child_spec(scheduler),
+                periodic(
+                    scheduler,
+                    "trigger-dispatch",
+                    DISPATCH_TICK,
+                    DISPATCH_BUDGET,
+                    |s| async move { crate::trigger_dispatch::dispatch_once(&s).await },
+                ),
+                periodic(
+                    scheduler,
+                    "eval-dispatch",
+                    DISPATCH_TICK,
+                    DISPATCH_BUDGET,
+                    |s| async move { eval::dispatch_queued_evals(&s).await },
+                ),
+                build::child_spec(scheduler),
+            ],
         ),
-        periodic(
-            scheduler,
-            "eval-dispatch",
-            DISPATCH_TICK,
-            DISPATCH_BUDGET,
-            |s| async move { eval::dispatch_queued_evals(&s).await },
-        ),
-        build::child_spec(scheduler),
         periodic(
             scheduler,
             "worker-sample",

--- a/backend/gradient-scheduler/src/dispatch/mod.rs
+++ b/backend/gradient-scheduler/src/dispatch/mod.rs
@@ -24,7 +24,7 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
-use gradient_util::supervision::ChildSpec;
+use gradient_util::supervision::{ChildCtx, ChildSpec};
 use tracing::info;
 
 use super::Scheduler;
@@ -53,9 +53,21 @@ pub fn start_dispatch_loops(scheduler: Arc<Scheduler>) {
     }
 }
 
+fn core_child_spec(scheduler: &Arc<Scheduler>) -> ChildSpec {
+    let scheduler = Arc::clone(scheduler);
+    ChildSpec::Custom {
+        name: "scheduler-core",
+        spawn: Arc::new(move |ctx: ChildCtx| {
+            let scheduler = Arc::clone(&scheduler);
+            Box::pin(async move { Ok(scheduler.spawn_core(Some(ctx.parent)).await?.get_cell()) })
+        }),
+    }
+}
+
 fn child_specs(scheduler: &Arc<Scheduler>) -> Vec<ChildSpec> {
     let metrics = &scheduler.state.config.metrics_args;
     let mut children = vec![
+        core_child_spec(scheduler),
         periodic(
             scheduler,
             "trigger-dispatch",

--- a/backend/gradient-scheduler/src/dispatch_tests.rs
+++ b/backend/gradient-scheduler/src/dispatch_tests.rs
@@ -82,9 +82,11 @@ fn make_task(id: TaskId, project_id: ProjectId) -> gradient_entity::task::Model 
     }
 }
 
-fn make_scheduler(db: sea_orm::DatabaseConnection) -> Arc<Scheduler> {
+async fn make_scheduler(db: sea_orm::DatabaseConnection) -> Arc<Scheduler> {
     let state = gradient_test_support::prelude::test_state(db);
-    Arc::new(Scheduler::new(state))
+    let scheduler = Arc::new(Scheduler::new(state));
+    scheduler.spawn_core(None).await.expect("core actor");
+    scheduler
 }
 
 // ── Group F: dispatch_queued_evals ───────────────────────────────────────────
@@ -110,7 +112,7 @@ async fn dispatch_queued_eval_enqueues_job() {
         .append_query_results([vec![make_task(task_id, project_id)]])
         .into_connection();
 
-    let scheduler = make_scheduler(db);
+    let scheduler = make_scheduler(db).await;
     dispatch::dispatch_queued_evals(&scheduler)
         .await
         .expect("dispatch failed");
@@ -149,7 +151,7 @@ async fn dispatch_queued_eval_skips_already_enqueued() {
         // No bulk loads - the tracker snapshot filters out every eval
         .into_connection();
 
-    let scheduler = make_scheduler(db);
+    let scheduler = make_scheduler(db).await;
     dispatch::dispatch_queued_evals(&scheduler)
         .await
         .expect("first dispatch failed");
@@ -184,7 +186,7 @@ async fn dispatch_queued_eval_skips_missing_commit() {
         .append_query_results([Vec::<gradient_entity::task::Model>::new()])
         .into_connection();
 
-    let scheduler = make_scheduler(db);
+    let scheduler = make_scheduler(db).await;
     dispatch::dispatch_queued_evals(&scheduler)
         .await
         .expect("dispatch failed");
@@ -215,7 +217,7 @@ async fn dispatch_queued_eval_without_task_is_skipped() {
         // No task query - no eval carries a task id
         .into_connection();
 
-    let scheduler = make_scheduler(db);
+    let scheduler = make_scheduler(db).await;
     dispatch::dispatch_queued_evals(&scheduler)
         .await
         .expect("dispatch failed");
@@ -255,7 +257,7 @@ async fn dispatch_once_no_triggers_is_noop() {
         .append_query_results([Vec::<gradient_entity::task_trigger::Model>::new()])
         .into_connection();
 
-    let scheduler = make_scheduler(db);
+    let scheduler = make_scheduler(db).await;
     let result = trigger_dispatch::dispatch_once(&scheduler).await;
     assert!(
         result.is_ok(),
@@ -291,7 +293,7 @@ async fn dispatch_once_skips_trigger_within_interval() {
         // No further queries expected (trigger not due)
         .into_connection();
 
-    let scheduler = make_scheduler(db);
+    let scheduler = make_scheduler(db).await;
     trigger_dispatch::dispatch_once(&scheduler)
         .await
         .expect("dispatch_once should not fail");

--- a/backend/gradient-scheduler/src/eval_metrics.rs
+++ b/backend/gradient-scheduler/src/eval_metrics.rs
@@ -20,15 +20,9 @@ impl Scheduler {
         job_id: &str,
         report: EvalStatsReport,
     ) -> anyhow::Result<()> {
-        let evaluation_id = {
-            let tracker = self.job_tracker.read().await;
-            match tracker.active_job(job_id) {
-                Some(j) => j.evaluation_id(),
-                None => {
-                    debug!(%job_id, "EvalStats dropped: no active job");
-                    return Ok(());
-                }
-            }
+        let Some(evaluation_id) = self.active_job(job_id).await.map(|j| j.evaluation_id()) else {
+            debug!(%job_id, "EvalStats dropped: no active job");
+            return Ok(());
         };
 
         for cost in report.per_entry_point {

--- a/backend/gradient-scheduler/src/job_handlers/abort.rs
+++ b/backend/gradient-scheduler/src/job_handlers/abort.rs
@@ -11,45 +11,41 @@ use tracing::info;
 use gradient_types::*;
 
 use crate::Scheduler;
+use crate::actor::SchedulerMsg;
 
 impl Scheduler {
     // ── Abort ─────────────────────────────────────────────────────────────────
 
-    /// Abort an evaluation: update DB status and send `AbortJob` to any
-    /// worker currently executing a job belonging to this evaluation.
+    /// Abort an evaluation: DB status first, then every worker running one of
+    /// its jobs gets `AbortJob` and its pending jobs are dropped.
     pub async fn abort_evaluation(&self, evaluation: MEvaluation) {
         let evaluation_id = evaluation.id;
-
-        // Update DB (builds → Aborted, eval → Aborted).
         gradient_db::abort_evaluation(&self.state.db(), evaluation).await;
-
-        // Find active jobs for this evaluation and abort them.
-        let tracker = self.job_tracker.read().await;
-        let pool = self.worker_pool.read().await;
-
-        let to_abort: Vec<(String, String)> = tracker
-            .active_jobs()
-            .filter_map(|(job_id, worker_id, job)| {
-                if job.evaluation_id() == evaluation_id {
-                    Some((worker_id.to_owned(), job_id.to_owned()))
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        for (worker_id, job_id) in to_abort {
-            if pool.send_abort(&worker_id, job_id.clone(), "evaluation aborted".to_owned()) {
-                info!(%worker_id, %job_id, %evaluation_id, "sent AbortJob to worker");
-            }
+        for (worker_id, job_id) in self.abort_evaluation_jobs(evaluation_id).await {
+            info!(%worker_id, %job_id, %evaluation_id, "sent AbortJob to worker");
         }
+    }
 
-        // Also remove any pending (unassigned) jobs for this evaluation.
-        drop(pool);
-        drop(tracker);
-        self.job_tracker
-            .write()
-            .await
-            .remove_pending_for_evaluation(evaluation_id);
+    /// The in-memory half of an abort: `(worker, job)` pairs that were told to stop.
+    pub async fn abort_evaluation_jobs(&self, evaluation_id: EvaluationId) -> Vec<(String, String)> {
+        self.call(|reply| SchedulerMsg::AbortEvaluation {
+            evaluation_id,
+            reply,
+        })
+        .await
+        .unwrap_or_default()
+    }
+
+    /// Tell one worker to stop one job; `false` when it is not connected.
+    pub async fn abort_job(&self, worker_id: &str, job_id: String, reason: String) -> bool {
+        let worker = worker_id.to_owned();
+        self.call(|reply| SchedulerMsg::AbortJob {
+            worker,
+            job_id,
+            reason,
+            reply,
+        })
+        .await
+        .unwrap_or(false)
     }
 }

--- a/backend/gradient-scheduler/src/job_handlers/abort.rs
+++ b/backend/gradient-scheduler/src/job_handlers/abort.rs
@@ -27,7 +27,10 @@ impl Scheduler {
     }
 
     /// The in-memory half of an abort: `(worker, job)` pairs that were told to stop.
-    pub async fn abort_evaluation_jobs(&self, evaluation_id: EvaluationId) -> Vec<(String, String)> {
+    pub async fn abort_evaluation_jobs(
+        &self,
+        evaluation_id: EvaluationId,
+    ) -> Vec<(String, String)> {
         self.call(|reply| SchedulerMsg::AbortEvaluation {
             evaluation_id,
             reply,

--- a/backend/gradient-scheduler/src/job_handlers/assignment.rs
+++ b/backend/gradient-scheduler/src/job_handlers/assignment.rs
@@ -6,160 +6,127 @@
 
 //! Scoring and job assignment (`RequestJob`).
 
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use sea_orm::EntityTrait;
 use sea_orm::{ColumnTrait, IntoActiveModel, QueryFilter};
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 use gradient_core::ServerState;
 use gradient_types::proto::{CandidateScore, JobKind};
 use gradient_types::*;
 
 use crate::Scheduler;
+use crate::actor::{AssignOutcome, SchedulerMsg};
 use crate::dispatch;
-use crate::jobs::{Assignment, DispatchRecord, WorkerCaps};
+use crate::jobs::{Assignment, DispatchRecord};
 
 impl Scheduler {
     // ── Scoring / assignment ──────────────────────────────────────────────────
 
-    /// Try to directly assign a job of `kind` to `worker_id` without scoring.
-    ///
-    /// Called when the worker sends `RequestJob { kind }` to signal it has a
-    /// free slot.  Returns `Some(Assignment)` if a matching pending job was
-    /// found and claimed; `None` if no such job exists yet.
+    /// Claim the best pending job of `kind` for the worker. When the tracker
+    /// has nothing for a build request, refresh from the DB once and retry.
     pub async fn request_job(&self, worker_id: &str, kind: JobKind) -> Option<Assignment> {
-        // ── Server-side capacity guard ──────────────────────────────────────
-        {
-            let pool = self.worker_pool.read().await;
-            if !pool.has_capacity(worker_id, &kind) {
-                debug!(%worker_id, ?kind, "RequestJob ignored - worker at capacity");
-                return None;
+        let instance = self.instance.load_full();
+        match self.try_assign(worker_id, &kind, &instance).await {
+            AssignOutcome::Assigned(a) => {
+                info!(%worker_id, job_id = %a.job_id, ?kind, "job assigned via RequestJob");
+                return Some(a);
             }
+            AssignOutcome::AtCapacity => return None,
+            AssignOutcome::Nothing => {}
         }
 
-        let (authorized, caps) = self.worker_auth_and_caps(worker_id).await;
-
-        // ── First try: pick from what's already in the tracker ──────────────
-        if let Some(a) = self
-            .try_assign(worker_id, authorized.as_ref(), caps.as_ref(), &kind)
-            .await
-        {
-            info!(%worker_id, job_id = %a.job_id, ?kind, "job assigned via RequestJob");
-            return Some(a);
-        }
-
-        // ── Tracker empty: on-demand DB refresh ─────────────────────────────
-        // On-demand dispatch: query the DB immediately when a worker asks for
-        // work and the tracker has nothing, instead of waiting for the next
-        // build_dispatch_loop tick. Complements - does not replace - that
-        // periodic 5s loop, which also runs dispatch_ready_builds.
         if matches!(kind, JobKind::Build) {
             if let Err(e) = dispatch::dispatch_ready_builds(self).await {
                 warn!(error = %e, "on-demand dispatch_ready_builds failed");
             }
-            // Kick the dispatch loop to reconcile Waiting/Building state off the
-            // read loop, rather than blocking this worker's next message on it.
             self.kick_dispatch();
         }
 
-        // ── Second try after refresh ────────────────────────────────────────
-        if let Some(a) = self
-            .try_assign(worker_id, authorized.as_ref(), caps.as_ref(), &kind)
-            .await
-        {
-            info!(%worker_id, job_id = %a.job_id, ?kind, "job assigned via RequestJob (after DB refresh)");
-            return Some(a);
+        match self.try_assign(worker_id, &kind, &instance).await {
+            AssignOutcome::Assigned(a) => {
+                info!(%worker_id, job_id = %a.job_id, ?kind, "job assigned via RequestJob (after DB refresh)");
+                Some(a)
+            }
+            _ => None,
         }
-
-        None
     }
 
-    /// Record candidate scores from a worker. Does NOT assign - the worker
-    /// explicitly signals capacity via `RequestJob`. Scores are used later
-    /// by `request_job` to pick the best candidate.
     pub async fn record_scores(&self, worker_id: &str, scores: Vec<CandidateScore>) {
-        self.job_tracker
-            .write()
-            .await
-            .record_scores(worker_id, scores);
+        let worker = worker_id.to_owned();
+        let _ = self
+            .call(|reply| SchedulerMsg::RecordScores {
+                worker,
+                scores,
+                reply,
+            })
+            .await;
     }
 
     pub async fn job_rejected(&self, worker_id: &str, job_id: &str) {
-        self.worker_pool
-            .write()
-            .await
-            .release_job(worker_id, job_id);
-        self.job_tracker.write().await.release_to_pending(job_id);
-        // Clear the sent-candidate flag so the job shows up in the next delta push.
-        self.worker_pool.write().await.remove_sent_candidate(job_id);
-        info!(%worker_id, %job_id, "job rejected; re-queued");
+        let worker = worker_id.to_owned();
+        let job_id = job_id.to_owned();
+        let _ = self
+            .call(|reply| SchedulerMsg::Rejected {
+                worker,
+                job_id,
+                reply,
+            })
+            .await;
     }
 
-    /// Return the project UUID that owns the active job, if found.
     pub async fn project_for_job(&self, job_id: &str) -> Option<ProjectId> {
-        self.job_tracker
-            .read()
-            .await
-            .active_job(job_id)
-            .map(|j| j.project_id())
+        self.active_job(job_id).await.map(|j| j.project_id())
     }
 
-    /// Fetch the peer auth filter and capabilities for a worker from the pool.
-    pub(super) async fn worker_auth_and_caps(
-        &self,
-        worker_id: &str,
-    ) -> (Option<HashSet<ProjectId>>, Option<WorkerCaps>) {
-        let pool = self.worker_pool.read().await;
-        let authorized = pool
-            .peer_auth_for(worker_id)
-            .and_then(|a| a.as_filter())
-            .cloned();
-        (authorized, pool.worker_caps(worker_id))
-    }
-
-    /// Atomically take the best matching job from the tracker and record the
-    /// assignment on the worker pool. Returns `None` if no suitable job exists.
+    /// One atomic claim in the actor; the board event and the `dispatched_job`
+    /// row follow outside it so DB latency never blocks the mailbox.
     async fn try_assign(
         &self,
         worker_id: &str,
-        authorized: Option<&HashSet<ProjectId>>,
-        caps: Option<&WorkerCaps>,
         kind: &JobKind,
-    ) -> Option<Assignment> {
-        let policy = Arc::clone(&self.policy);
-        let instance = self.instance.load_full();
-        let mut assignment = self
-            .job_tracker
-            .write()
+        instance: &Arc<gradient_score::InstanceContext>,
+    ) -> AssignOutcome {
+        let worker = worker_id.to_owned();
+        let kind = kind.clone();
+        let instance = Arc::clone(instance);
+        let outcome = match self
+            .call(|reply| SchedulerMsg::Assign {
+                worker,
+                kind,
+                instance,
+                reply,
+            })
             .await
-            .take_best_of_kind(worker_id, authorized, caps, kind, &*policy, &instance);
-        if let Some(a) = assignment.as_mut() {
-            self.worker_pool
-                .write()
-                .await
-                .assign_job(worker_id, &a.job_id);
-            if let Some(record) = a.dispatch_record.take() {
-                let _ = self
-                    .state
-                    .board_events
-                    .send(crate::BoardEvent::JobDispatched {
-                        project: record.project.into(),
-                        worker_id: worker_id.to_owned(),
-                        kind: i16::from(record.kind),
-                        score: record.score,
-                        build_id: record.derivation_build.map(Into::into),
-                        evaluation_id: record.evaluation_id.into(),
-                    });
-                let state = Arc::clone(&self.state);
-                let worker = worker_id.to_owned();
-                self.state.shutdown.spawn(async move {
-                    persist_dispatched_job(&state, &worker, record).await;
-                });
+        {
+            Ok(outcome) => outcome,
+            Err(e) => {
+                warn!(error = %e, %worker_id, "RequestJob did not reach the scheduler");
+                return AssignOutcome::Nothing;
             }
+        };
+        if let AssignOutcome::Assigned(a) = &outcome
+            && let Some(record) = a.dispatch_record.clone()
+        {
+            let _ = self
+                .state
+                .board_events
+                .send(crate::BoardEvent::JobDispatched {
+                    project: record.project.into(),
+                    worker_id: worker_id.to_owned(),
+                    kind: i16::from(record.kind),
+                    score: record.score,
+                    build_id: record.derivation_build.map(Into::into),
+                    evaluation_id: record.evaluation_id.into(),
+                });
+            let state = Arc::clone(&self.state);
+            let worker = worker_id.to_owned();
+            self.state.shutdown.spawn(async move {
+                persist_dispatched_job(&state, &worker, record).await;
+            });
         }
-        assignment
+        outcome
     }
 }
 

--- a/backend/gradient-scheduler/src/job_handlers/build_status.rs
+++ b/backend/gradient-scheduler/src/job_handlers/build_status.rs
@@ -15,6 +15,7 @@ use gradient_types::proto::{BuildFailureKind, BuildMetrics, BuildOutput};
 use gradient_types::*;
 
 use crate::Scheduler;
+use crate::actor::SchedulerMsg;
 use crate::jobs::PendingJob;
 use crate::{build, eval};
 
@@ -39,11 +40,8 @@ impl Scheduler {
                 // to stop instead of letting it build to completion.
                 if anchor.status == BuildStatus::Aborted {
                     let job_id = format!("build:{derivation_build}");
-                    self.worker_pool.read().await.send_abort(
-                        worker_id,
-                        job_id,
-                        "evaluation aborted".to_owned(),
-                    );
+                    self.abort_job(worker_id, job_id, "evaluation aborted".to_owned())
+                        .await;
                     info!(%derivation_build, %worker_id, "aborting build that started after its evaluation was aborted");
                     return;
                 }
@@ -74,15 +72,12 @@ impl Scheduler {
             .parse()
             .map_err(|_| anyhow::anyhow!("invalid derivation_build: {}", build_id_str))?;
 
-        let job = {
-            let tracker = self.job_tracker.read().await;
-            match tracker.active_job(job_id) {
-                Some(PendingJob::Build(j)) => j.clone(),
-                Some(_) => anyhow::bail!("job {} is not a build job", job_id),
-                None => {
-                    warn!(%job_id, "build output for unknown job - ignoring");
-                    return Ok(());
-                }
+        let job = match self.active_job(job_id).await {
+            Some(PendingJob::Build(j)) => j,
+            Some(_) => anyhow::bail!("job {} is not a build job", job_id),
+            None => {
+                warn!(%job_id, "build output for unknown job - ignoring");
+                return Ok(());
             }
         };
         build::handle_build_output(
@@ -99,13 +94,16 @@ impl Scheduler {
     // ── Job completion ────────────────────────────────────────────────────────
 
     pub async fn handle_job_completed(&self, worker_id: &str, job_id: &str) -> Result<()> {
-        let worker_idle = self
-            .worker_pool
-            .write()
-            .await
-            .release_job(worker_id, job_id);
-        let job = self.job_tracker.write().await.remove_active(job_id);
-        match job {
+        let worker = worker_id.to_owned();
+        let released = self
+            .call(|reply| SchedulerMsg::Release {
+                worker,
+                job_id: job_id.to_owned(),
+                reply,
+            })
+            .await?;
+        let worker_idle = released.worker_idle;
+        match released.job {
             Some(PendingJob::Eval(j)) => {
                 // Split mode: a fetch-only job just archived the source. Enqueue
                 // the cached eval follow-up instead of finalizing - eval has not run.
@@ -119,8 +117,12 @@ impl Scheduler {
                     return match store_path {
                         Some(path) => {
                             let follow_id = format!("eval:{}", j.evaluation_id);
-                            self.enqueue_eval_job(follow_id, j.cached_followup(path))
-                                .await;
+                            if let Err(e) = self
+                                .enqueue_eval_job(follow_id, j.cached_followup(path))
+                                .await
+                            {
+                                warn!(error = %e, evaluation_id = %j.evaluation_id, "enqueue_eval_job failed for cached follow-up");
+                            }
                             info!(evaluation_id = %j.evaluation_id, "fetch complete; enqueued cached eval follow-up");
                             Ok(())
                         }
@@ -183,12 +185,15 @@ impl Scheduler {
         kind: BuildFailureKind,
         missing_paths: &[String],
     ) -> Result<()> {
-        self.worker_pool
-            .write()
-            .await
-            .release_job(worker_id, job_id);
-        let job = self.job_tracker.write().await.remove_active(job_id);
-        match job {
+        let worker = worker_id.to_owned();
+        let released = self
+            .call(|reply| SchedulerMsg::Release {
+                worker,
+                job_id: job_id.to_owned(),
+                reply,
+            })
+            .await?;
+        match released.job {
             Some(PendingJob::Eval(j)) => {
                 self.eval_edges.write().await.remove(&j.evaluation_id);
                 let r = eval::handle_eval_job_failed(

--- a/backend/gradient-scheduler/src/job_handlers/eval_status.rs
+++ b/backend/gradient-scheduler/src/job_handlers/eval_status.rs
@@ -26,13 +26,10 @@ impl Scheduler {
         job_id: &str,
         new_status: gradient_entity::evaluation::EvaluationStatus,
     ) {
-        let evaluation_id = {
-            let tracker = self.job_tracker.read().await;
-            let Some(j) = tracker.active_eval_job(job_id) else {
-                return;
-            };
-            j.evaluation_id
+        let Some(PendingJob::Eval(j)) = self.active_job(job_id).await else {
+            return;
         };
+        let evaluation_id = j.evaluation_id;
         match EEvaluation::find_by_id(evaluation_id)
             .one(&self.state.worker_db)
             .await
@@ -54,13 +51,10 @@ impl Scheduler {
         use sea_orm::Set;
 
         let Some(path) = flake_source else { return };
-        let evaluation_id = {
-            let tracker = self.job_tracker.read().await;
-            let Some(j) = tracker.active_eval_job(job_id) else {
-                return;
-            };
-            j.evaluation_id
+        let Some(PendingJob::Eval(j)) = self.active_job(job_id).await else {
+            return;
         };
+        let evaluation_id = j.evaluation_id;
         let am = gradient_entity::evaluation::ActiveModel {
             id: Set(evaluation_id),
             flake_source: Set(Some(path)),
@@ -84,13 +78,10 @@ impl Scheduler {
             ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, Set,
         };
 
-        let evaluation_id = {
-            let tracker = self.job_tracker.read().await;
-            let Some(j) = tracker.active_eval_job(job_id) else {
-                return;
-            };
-            j.evaluation_id
+        let Some(PendingJob::Eval(j)) = self.active_job(job_id).await else {
+            return;
         };
+        let evaluation_id = j.evaluation_id;
 
         let bumped_json = serde_json::json!(
             bumped
@@ -133,13 +124,10 @@ impl Scheduler {
     pub async fn persist_input_update_expansion(&self, job_id: &str, matched: Vec<String>) {
         use sea_orm::{ColumnTrait, QueryFilter};
 
-        let evaluation_id = {
-            let tracker = self.job_tracker.read().await;
-            let Some(j) = tracker.active_eval_job(job_id) else {
-                return;
-            };
-            j.evaluation_id
+        let Some(PendingJob::Eval(j)) = self.active_job(job_id).await else {
+            return;
         };
+        let evaluation_id = j.evaluation_id;
         let db = &self.state.worker_db;
 
         let eval = match EEvaluation::find_by_id(evaluation_id).one(db).await {
@@ -194,15 +182,12 @@ impl Scheduler {
         warnings: Vec<String>,
         errors: Vec<String>,
     ) -> Result<()> {
-        let job = {
-            let tracker = self.job_tracker.read().await;
-            match tracker.active_job(job_id) {
-                Some(PendingJob::Eval(j)) => j.clone(),
-                Some(_) => anyhow::bail!("job {} is not an eval job", job_id),
-                None => {
-                    warn!(%job_id, "eval result for unknown job - ignoring");
-                    return Ok(());
-                }
+        let job = match self.active_job(job_id).await {
+            Some(PendingJob::Eval(j)) => j,
+            Some(_) => anyhow::bail!("job {} is not an eval job", job_id),
+            None => {
+                warn!(%job_id, "eval result for unknown job - ignoring");
+                return Ok(());
             }
         };
 
@@ -260,15 +245,9 @@ impl Scheduler {
         source: String,
         message: String,
     ) -> Result<()> {
-        let evaluation_id = {
-            let tracker = self.job_tracker.read().await;
-            match tracker.active_job(job_id) {
-                Some(j) => j.evaluation_id(),
-                None => {
-                    debug!(%job_id, "EvalMessage dropped: no active job");
-                    return Ok(());
-                }
-            }
+        let Some(evaluation_id) = self.active_job(job_id).await.map(|j| j.evaluation_id()) else {
+            debug!(%job_id, "EvalMessage dropped: no active job");
+            return Ok(());
         };
 
         let entity_level = match level {

--- a/backend/gradient-scheduler/src/job_handlers/logs.rs
+++ b/backend/gradient-scheduler/src/job_handlers/logs.rs
@@ -22,26 +22,19 @@ impl Scheduler {
         let text = String::from_utf8_lossy(&data);
         let text = text.as_ref();
 
-        let build_id_str = {
-            let tracker = self.job_tracker.read().await;
-            match tracker.active_job(job_id) {
-                Some(PendingJob::Build(j)) => j
-                    .job
-                    .builds
-                    .get(task_index as usize)
-                    .map(|t| t.build_id.clone()),
-                Some(PendingJob::Eval(_)) => {
-                    debug!(%job_id, task_index, bytes = bytes_len, "log chunk dropped: job is an eval, not a build");
-                    return Ok(());
-                }
-                None => {
-                    // Common shortly after a build finishes: a few in-flight
-                    // log lines from the worker arrive after the job has
-                    // already been removed from the active tracker. Not an
-                    // error - just lost output, log at debug.
-                    debug!(%job_id, task_index, bytes = bytes_len, "log chunk dropped: no active job (likely race with completion)");
-                    return Ok(());
-                }
+        let build_id_str = match self.active_job(job_id).await {
+            Some(PendingJob::Build(j)) => j
+                .job
+                .builds
+                .get(task_index as usize)
+                .map(|t| t.build_id.clone()),
+            Some(PendingJob::Eval(_)) => {
+                debug!(%job_id, task_index, bytes = bytes_len, "log chunk dropped: job is an eval, not a build");
+                return Ok(());
+            }
+            None => {
+                debug!(%job_id, task_index, bytes = bytes_len, "log chunk dropped: no active job (likely race with completion)");
+                return Ok(());
             }
         };
 

--- a/backend/gradient-scheduler/src/job_handlers/queue.rs
+++ b/backend/gradient-scheduler/src/job_handlers/queue.rs
@@ -6,53 +6,36 @@
 
 //! Job queue: enqueue, candidate listing, and diagnostics.
 
-use gradient_types::proto::JobCandidate;
-
 use crate::Scheduler;
+use crate::actor::{Offer, SchedulerMsg};
 use crate::jobs::{PendingBuildJob, PendingEvalJob, PendingJob};
 use crate::worker_pool::WorkerInfo;
+use gradient_types::proto::{GradientCapabilities, JobCandidate};
 
 impl Scheduler {
-    // ── Job queue ─────────────────────────────────────────────────────────────
-
-    pub async fn enqueue_eval_job(&self, job_id: String, job: PendingEvalJob) -> JobCandidate {
-        let candidate = self
-            .job_tracker
-            .write()
-            .await
-            .add_pending(job_id, PendingJob::Eval(job));
-        self.job_notify.send_modify(|g| *g = g.wrapping_add(1));
-        candidate
+    pub async fn enqueue_eval_job(&self, job_id: String, job: PendingEvalJob) -> anyhow::Result<()> {
+        self.call(|reply| SchedulerMsg::Enqueue {
+            job_id,
+            job: PendingJob::Eval(job),
+            reply,
+        })
+        .await
     }
 
-    pub async fn enqueue_build_job(&self, job_id: String, job: PendingBuildJob) -> JobCandidate {
-        let candidate = self
-            .job_tracker
-            .write()
-            .await
-            .add_pending(job_id.clone(), PendingJob::Build(job));
-        // A re-queued build (after a failed/rejected/orphaned dispatch) must be
-        // offered again so workers score it a second time; clear stale
-        // sent-candidate flags. No-op on a first enqueue.
-        self.worker_pool
-            .write()
-            .await
-            .remove_sent_candidate(&job_id);
-        self.job_notify.send_modify(|g| *g = g.wrapping_add(1));
-        candidate
+    pub async fn enqueue_build_job(
+        &self,
+        job_id: String,
+        job: PendingBuildJob,
+    ) -> anyhow::Result<()> {
+        self.call(|reply| SchedulerMsg::Enqueue {
+            job_id,
+            job: PendingJob::Build(job),
+            reply,
+        })
+        .await
     }
 
-    /// Returns a `watch` receiver handler dispatch loops `await` (via
-    /// `changed()`) to learn that new jobs were enqueued. Level-triggered: a
-    /// bump fired while the session is busy is seen on its next `changed()`.
-    pub fn job_notify(&self) -> tokio::sync::watch::Receiver<u64> {
-        self.job_notify.subscribe()
-    }
-
-    /// Wake the build dispatcher now instead of waiting for its 5s tick. Called
-    /// when a job completes and leaves its worker idle, so the dependents it just
-    /// unblocked are enqueued and offered immediately - collapsing per-level
-    /// latency on serial chains without kicking while the worker is still busy.
+    /// Wake the build dispatcher now instead of waiting for its 5s tick.
     pub(crate) fn kick_dispatch(&self) {
         self.kick_gen
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -61,75 +44,56 @@ impl Scheduler {
         }
     }
 
-    /// Returns ALL pending job candidates visible to the given worker.
-    /// Used for `RequestJobList` / `RequestAllCandidates` (full snapshot).
-    /// Also marks all returned IDs as sent so delta pushes skip them.
+    /// Every pending candidate visible to the worker (`RequestJobList`,
+    /// `RequestAllCandidates`); all of them are marked sent.
     pub async fn get_job_candidates(&self, worker_id: &str) -> Vec<JobCandidate> {
-        let (authorized, caps) = self.worker_auth_and_caps(worker_id).await;
-        let candidates = self
-            .job_tracker
-            .read()
-            .await
-            .candidates_for_worker(authorized.as_ref(), caps.as_ref());
-        // Mark all as sent so the next delta push skips them.
-        let ids: Vec<String> = candidates.iter().map(|c| c.job_id.clone()).collect();
-        self.worker_pool
-            .write()
-            .await
-            .mark_candidates_sent(worker_id, &ids);
-        candidates
+        let worker = worker_id.to_owned();
+        self.call(|reply| SchedulerMsg::Candidates {
+            worker,
+            only_new: false,
+            reply,
+        })
+        .await
+        .map(|o| o.candidates)
+        .unwrap_or_default()
     }
 
-    /// Returns only NEW pending job candidates (not yet sent to this worker).
-    /// Used for incremental `JobOffer` pushes after `job_notify`.
-    /// Marks the returned IDs as sent.
-    pub async fn get_new_job_candidates(&self, worker_id: &str) -> Vec<JobCandidate> {
-        let (authorized, caps) = self.worker_auth_and_caps(worker_id).await;
-        let sent = {
-            let pool = self.worker_pool.read().await;
-            pool.sent_candidates_for(worker_id)
-                .cloned()
-                .unwrap_or_default()
-        };
-        let all = self
-            .job_tracker
-            .read()
+    /// Only the candidates not yet sent to the worker, with the offer
+    /// generation they answer so the session can skip stale `Offers` signals.
+    pub async fn get_new_job_candidates(&self, worker_id: &str) -> Offer {
+        let worker = worker_id.to_owned();
+        self.call(|reply| SchedulerMsg::Candidates {
+            worker,
+            only_new: true,
+            reply,
+        })
+        .await
+        .unwrap_or_default()
+    }
+
+    pub async fn worker_gradient_caps(&self, worker_id: &str) -> Option<GradientCapabilities> {
+        let worker = worker_id.to_owned();
+        self.call(|reply| SchedulerMsg::WorkerCaps { worker, reply })
             .await
-            .candidates_for_worker(authorized.as_ref(), caps.as_ref());
-        let new_candidates: Vec<JobCandidate> = all
-            .into_iter()
-            .filter(|c| !sent.contains(&c.job_id))
-            .collect();
-        if !new_candidates.is_empty() {
-            let ids: Vec<String> = new_candidates.iter().map(|c| c.job_id.clone()).collect();
-            self.worker_pool
-                .write()
-                .await
-                .mark_candidates_sent(worker_id, &ids);
-        }
-        new_candidates
+            .ok()
+            .flatten()
     }
 
-    /// Returns the connected worker's negotiated `GradientCapabilities`,
-    /// or `None` if the worker is not connected.
-    pub async fn worker_gradient_caps(
-        &self,
-        worker_id: &str,
-    ) -> Option<gradient_types::proto::GradientCapabilities> {
-        self.worker_pool.read().await.gradient_caps_for(worker_id)
+    pub async fn has_idle_eval_only_worker(&self) -> bool {
+        self.call(|reply| SchedulerMsg::HasIdleEvalOnlyWorker { reply })
+            .await
+            .unwrap_or(false)
     }
-
-    // ── Diagnostics ───────────────────────────────────────────────────────────
 
     pub async fn worker_count(&self) -> usize {
-        self.worker_pool.read().await.worker_count()
+        self.counts().await.workers
     }
 
     pub async fn workers_info(&self) -> Vec<WorkerInfo> {
-        self.worker_pool.read().await.all_workers()
+        self.board_workers().await
     }
 
     pub async fn pending_job_count(&self) -> usize {
-        self.job_tracker.read().await.pending_count()
+        self.counts().await.pending
     }
 }

--- a/backend/gradient-scheduler/src/job_handlers/queue.rs
+++ b/backend/gradient-scheduler/src/job_handlers/queue.rs
@@ -13,7 +13,11 @@ use crate::worker_pool::WorkerInfo;
 use gradient_types::proto::{GradientCapabilities, JobCandidate};
 
 impl Scheduler {
-    pub async fn enqueue_eval_job(&self, job_id: String, job: PendingEvalJob) -> anyhow::Result<()> {
+    pub async fn enqueue_eval_job(
+        &self,
+        job_id: String,
+        job: PendingEvalJob,
+    ) -> anyhow::Result<()> {
         self.call(|reply| SchedulerMsg::Enqueue {
             job_id,
             job: PendingJob::Eval(job),

--- a/backend/gradient-scheduler/src/jobs.rs
+++ b/backend/gradient-scheduler/src/jobs.rs
@@ -260,9 +260,13 @@ pub struct Assignment {
     /// Scoring/context snapshot for the winning job, persisted best-effort by
     /// the caller into `dispatched_job`. `None` outside the scored path.
     pub dispatch_record: Option<DispatchRecord>,
+    /// The tracker's own record of the job, kept by the session so it can
+    /// re-register the job after a scheduler restart.
+    pub pending: PendingJob,
 }
 
 /// Owned snapshot of a dispatch decision for the `dispatched_job` table.
+#[derive(Clone)]
 pub struct DispatchRecord {
     pub kind: DispatchedJobKind,
     pub derivation_build: Option<DerivationBuildId>,
@@ -843,10 +847,20 @@ impl JobTracker {
             job: job.clone().into_job(),
             project_id: job.project_id(),
             dispatch_record: None,
+            pending: job.clone(),
         };
         self.active
             .insert(job_id.to_owned(), (worker_id.to_owned(), job));
         Some(assignment)
+    }
+
+    /// Re-attach a job a session still runs after the tracker was rebuilt.
+    pub fn restore_active(&mut self, worker_id: &str, job_id: String, job: PendingJob) {
+        if self.active.contains_key(&job_id) {
+            return;
+        }
+        self.pending.remove(&job_id);
+        self.active.insert(job_id, (worker_id.to_owned(), job));
     }
 
     pub fn release_to_pending(&mut self, job_id: &str) {

--- a/backend/gradient-scheduler/src/lib.rs
+++ b/backend/gradient-scheduler/src/lib.rs
@@ -189,7 +189,10 @@ impl Scheduler {
     ) {
         let mut job_ids = vec![format!("eval:{eval_id}")];
         job_ids.extend(anchor_ids.iter().map(|id| format!("build:{id}")));
-        if let Err(e) = self.call(|reply| SchedulerMsg::RemoveJobs { job_ids, reply }).await {
+        if let Err(e) = self
+            .call(|reply| SchedulerMsg::RemoveJobs { job_ids, reply })
+            .await
+        {
             tracing::warn!(error = %e, %eval_id, "cancel_evaluation_jobs did not reach the scheduler");
         }
         self.eval_edges.write().await.remove(&eval_id);

--- a/backend/gradient-scheduler/src/lib.rs
+++ b/backend/gradient-scheduler/src/lib.rs
@@ -16,6 +16,7 @@
 //! - [`waiting_state`] - reconciles evaluation status against the worker pool
 //! - [`buildability`] - whether the connected pool can build a pending anchor
 
+pub mod actor;
 pub mod build;
 pub mod buildability;
 pub mod dispatch;
@@ -42,10 +43,10 @@ use std::sync::atomic::{AtomicBool, AtomicU64};
 
 use gradient_core::ServerState;
 use gradient_types::*;
+use ractor::{Actor, ActorCell, ActorRef, RpcReplyPort, SpawnErr};
 use tokio::sync::RwLock;
 
-use jobs::JobTracker;
-use worker_pool::WorkerPool;
+use actor::{CALL_TIMEOUT, CoreActor, CoreArgs, Counts, SchedulerMsg};
 
 /// Per-evaluation accumulator of discovered `(drv_path, dependencies)` pairs.
 /// Fully-resolvable pairs flush to `derivation_dependency` edges after each
@@ -68,13 +69,9 @@ mod scheduler_tests;
 pub struct Scheduler {
     /// Shared application state (DB, CLI config, etc.).
     pub state: Arc<ServerState>,
-    pub(crate) worker_pool: Arc<RwLock<WorkerPool>>,
-    pub(crate) job_tracker: Arc<RwLock<JobTracker>>,
-    /// Bumped when new jobs are enqueued so handler dispatch loops can push
-    /// `JobOffer` messages to connected workers. A `watch` generation counter
-    /// (not `Notify`) so a bump fired while a session is busy is still observed
-    /// on its next loop iteration instead of being a lost edge-triggered wakeup.
-    pub(crate) job_notify: Arc<tokio::sync::watch::Sender<u64>>,
+    /// The live state actor, republished on every (re)spawn; callers wait on
+    /// the watch so a restart looks like latency, not an error.
+    core: Arc<tokio::sync::watch::Sender<Option<ActorRef<SchedulerMsg>>>>,
     /// The live build-dispatch actor, re-published by its factory on every
     /// (re)spawn, so `kick_dispatch` always reaches the current instance.
     pub(crate) build_dispatch: Arc<arc_swap::ArcSwapOption<ractor::ActorRef<dispatch::BuildMsg>>>,
@@ -118,9 +115,7 @@ impl Scheduler {
         let policy = gradient_score::policy_by_name(&state.config.eval.scheduler_scoring_policy);
         Self {
             state,
-            worker_pool: Arc::new(RwLock::new(WorkerPool::new())),
-            job_tracker: Arc::new(RwLock::new(JobTracker::new())),
-            job_notify: Arc::new(tokio::sync::watch::channel(0u64).0),
+            core: Arc::new(tokio::sync::watch::channel(None).0),
             build_dispatch: Arc::new(arc_swap::ArcSwapOption::empty()),
             kick_gen: Arc::new(AtomicU64::new(0)),
             eval_edges: Arc::new(RwLock::new(HashMap::new())),
@@ -135,21 +130,68 @@ impl Scheduler {
         }
     }
 
-    /// Drop the eval job and any associated build jobs from the in-memory
-    /// tracker. Workers that have already been assigned will finish or time out
-    /// normally; the DB-side abort (via `gradient_ci::abort_evaluation`) is the
-    /// caller's responsibility.
+    /// Spawn the state actor, linked to `parent` when supervised, and publish it.
+    pub async fn spawn_core(
+        &self,
+        parent: Option<ActorCell>,
+    ) -> Result<ActorRef<SchedulerMsg>, SpawnErr> {
+        let args = CoreArgs {
+            policy: Arc::clone(&self.policy),
+        };
+        let (actor, _) = match parent {
+            Some(parent) => Actor::spawn_linked(None, CoreActor, args, parent).await?,
+            None => Actor::spawn(None, CoreActor, args).await?,
+        };
+        self.core.send_replace(Some(actor.clone()));
+        Ok(actor)
+    }
+
+    /// Observe core (re)publications; the sessions supervisor re-registers on each.
+    pub fn core_changes(&self) -> tokio::sync::watch::Receiver<Option<ActorRef<SchedulerMsg>>> {
+        self.core.subscribe()
+    }
+
+    async fn core(&self) -> anyhow::Result<ActorRef<SchedulerMsg>> {
+        let mut rx = self.core.subscribe();
+        let live = tokio::time::timeout(CALL_TIMEOUT, rx.wait_for(|c| c.is_some()))
+            .await
+            .map_err(|_| anyhow::anyhow!("scheduler core unavailable"))?
+            .map_err(|_| anyhow::anyhow!("scheduler core closed"))?;
+        Ok(live.clone().expect("wait_for guarantees Some"))
+    }
+
+    pub(crate) async fn call<T: Send + 'static>(
+        &self,
+        msg: impl FnOnce(RpcReplyPort<T>) -> SchedulerMsg,
+    ) -> anyhow::Result<T> {
+        use ractor::rpc::CallResult;
+        match self.core().await?.call(msg, Some(CALL_TIMEOUT)).await {
+            Ok(CallResult::Success(v)) => Ok(v),
+            Ok(CallResult::Timeout) => Err(anyhow::anyhow!("scheduler call timed out")),
+            Ok(CallResult::SenderError) => Err(anyhow::anyhow!("scheduler core dropped the reply")),
+            Err(e) => Err(anyhow::anyhow!("scheduler core unreachable: {e}")),
+        }
+    }
+
+    pub(crate) async fn cast(&self, msg: SchedulerMsg) -> anyhow::Result<()> {
+        self.core()
+            .await?
+            .send_message(msg)
+            .map_err(|e| anyhow::anyhow!("scheduler core unreachable: {e}"))
+    }
+
+    /// Drop the eval job and its build jobs from the tracker. Workers already
+    /// assigned finish or time out; the DB-side abort is the caller's job.
     pub async fn cancel_evaluation_jobs(
         &self,
         eval_id: EvaluationId,
         anchor_ids: &[DerivationBuildId],
     ) {
-        let mut tracker = self.job_tracker.write().await;
-        tracker.remove_job(&format!("eval:{eval_id}"));
-        for id in anchor_ids {
-            tracker.remove_job(&format!("build:{id}"));
+        let mut job_ids = vec![format!("eval:{eval_id}")];
+        job_ids.extend(anchor_ids.iter().map(|id| format!("build:{id}")));
+        if let Err(e) = self.call(|reply| SchedulerMsg::RemoveJobs { job_ids, reply }).await {
+            tracing::warn!(error = %e, %eval_id, "cancel_evaluation_jobs did not reach the scheduler");
         }
-
         self.eval_edges.write().await.remove(&eval_id);
     }
 
@@ -169,31 +211,69 @@ impl Scheduler {
             .unwrap_or_default()
     }
 
-    /// Snapshot of in-memory scheduler counts used by the metrics endpoint.
-    /// Returns `(workers_connected, jobs_pending, jobs_active)`.
+    pub async fn counts(&self) -> Counts {
+        self.call(|reply| SchedulerMsg::Counts { reply })
+            .await
+            .unwrap_or_default()
+    }
+
+    /// `(workers_connected, jobs_pending, jobs_active)` for the metrics endpoint.
     pub async fn metrics_snapshot(&self) -> (usize, usize, usize) {
-        let workers = self.worker_pool.read().await.worker_count();
-        let tracker = self.job_tracker.read().await;
-        (workers, tracker.pending_count(), tracker.active_count())
+        let c = self.counts().await;
+        (c.workers, c.pending, c.active)
     }
 
     pub async fn pending_jobs_snapshot(&self) -> Vec<jobs::PendingJobInfo> {
-        self.job_tracker.read().await.pending_snapshot()
+        self.call(|reply| SchedulerMsg::PendingSnapshot { reply })
+            .await
+            .unwrap_or_default()
     }
 
     /// Per-dimension classification of in-flight jobs for the worker-load radar.
     pub async fn board_active_jobs(&self) -> Vec<jobs::BoardActiveJob> {
-        self.job_tracker.read().await.board_active_jobs()
+        self.call(|reply| SchedulerMsg::BoardActiveJobs { reply })
+            .await
+            .unwrap_or_default()
     }
 
     pub async fn recent_decisions(&self) -> Vec<jobs::DispatchDecision> {
-        self.job_tracker.read().await.recent_decisions()
+        self.call(|reply| SchedulerMsg::RecentDecisions { reply })
+            .await
+            .unwrap_or_default()
     }
 
     pub async fn candidate_detail(
         &self,
         id: gradient_types::ids::DispatchedJobId,
     ) -> Option<jobs::CandidateDetail> {
-        self.job_tracker.read().await.candidate_detail(id)
+        self.call(|reply| SchedulerMsg::CandidateDetail { id, reply })
+            .await
+            .ok()
+            .flatten()
+    }
+
+    pub async fn active_job(&self, job_id: &str) -> Option<jobs::PendingJob> {
+        let job_id = job_id.to_owned();
+        self.call(|reply| SchedulerMsg::ActiveJob { job_id, reply })
+            .await
+            .ok()
+            .flatten()
+    }
+
+    pub async fn pending_job(&self, job_id: &str) -> Option<jobs::PendingJob> {
+        let job_id = job_id.to_owned();
+        self.call(|reply| SchedulerMsg::PendingJob { job_id, reply })
+            .await
+            .ok()
+            .flatten()
+    }
+
+    /// The subset of `job_ids` the tracker knows nothing about (neither pending
+    /// nor active). On a core outage every id counts as tracked, so a dispatch
+    /// pass enqueues nothing rather than duplicating work.
+    pub async fn untracked(&self, job_ids: Vec<String>) -> Vec<String> {
+        self.call(|reply| SchedulerMsg::Untracked { job_ids, reply })
+            .await
+            .unwrap_or_default()
     }
 }

--- a/backend/gradient-scheduler/src/scheduler_tests.rs
+++ b/backend/gradient-scheduler/src/scheduler_tests.rs
@@ -15,16 +15,40 @@ use gradient_types::ids::*;
 use gradient_types::proto::{CandidateScore, FlakeJob, FlakeStep, GradientCapabilities, JobKind};
 
 use super::Scheduler;
+use super::actor::{SessionPort, SessionSignal, WorkerCapabilities};
 use super::jobs::{PendingBuildJob, PendingEvalJob};
+use tokio::sync::mpsc;
 
-/// Create a scheduler backed by a mock DB that returns empty results.
-fn test_scheduler() -> Arc<Scheduler> {
+/// A scheduler with its state actor running, backed by a mock DB that returns
+/// empty results.
+async fn test_scheduler() -> Arc<Scheduler> {
     use gradient_test_support::prelude::*;
     use sea_orm::{DatabaseBackend, MockDatabase};
 
     let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
     let state = test_state(db);
-    Arc::new(Scheduler::new(state))
+    let scheduler = Arc::new(Scheduler::new(state));
+    scheduler.spawn_core(None).await.expect("core actor");
+    scheduler
+}
+
+fn port() -> (Arc<dyn SessionPort>, mpsc::UnboundedReceiver<SessionSignal>) {
+    let (tx, rx) = mpsc::unbounded_channel();
+    (Arc::new(tx), rx)
+}
+
+async fn register(
+    scheduler: &Scheduler,
+    worker: &str,
+    caps: GradientCapabilities,
+    peers: HashSet<ProjectId>,
+) -> mpsc::UnboundedReceiver<SessionSignal> {
+    let (session, signals) = port();
+    scheduler
+        .register_worker(worker, caps, peers, session)
+        .await
+        .expect("register");
+    signals
 }
 
 fn eval_job(peer: ProjectId) -> PendingEvalJob {
@@ -66,61 +90,56 @@ fn eval_worker_caps() -> GradientCapabilities {
 
 #[tokio::test]
 async fn test_enqueue_and_get_candidates() {
-    let scheduler = test_scheduler();
+    let scheduler = test_scheduler().await;
     let peer = ProjectId::now_v7();
 
-    scheduler
-        .register_worker("w1", eval_worker_caps(), HashSet::new())
-        .await;
+    register(&scheduler, "w1", eval_worker_caps(), HashSet::new()).await;
 
     scheduler
         .enqueue_eval_job("j1".into(), eval_job(peer))
-        .await;
+        .await
+        .unwrap();
     scheduler
         .enqueue_eval_job("j2".into(), eval_job(peer))
-        .await;
+        .await
+        .unwrap();
 
     // Open mode (empty authorized peers) → see all jobs.
     let candidates = scheduler.get_job_candidates("w1").await;
     assert_eq!(candidates.len(), 2);
 }
 
-/// Regression (#359): an enqueue that happens while a session is NOT parked on
-/// the notification must still be observed on its next check. The `watch`
-/// generation is level-triggered, unlike the old `Notify::notify_waiters()`
-/// which dropped any wakeup fired while no task was awaiting - starving deep
-/// build chains of `JobOffer`s under load.
+/// Regression (#359): an enqueue must signal every active session, and the
+/// generation it carries lets a session that missed the signal (busy on
+/// something else) still fetch the delta on its next check instead of losing
+/// the wakeup.
 #[tokio::test]
-async fn job_notify_bump_is_not_lost_when_not_awaiting() {
-    let scheduler = test_scheduler();
+async fn enqueue_signals_offers_with_a_rising_generation() {
+    let scheduler = test_scheduler().await;
     let peer = ProjectId::now_v7();
-
-    let mut rx = scheduler.job_notify();
-    assert!(
-        !rx.has_changed().unwrap(),
-        "fresh receiver starts un-bumped"
-    );
+    let mut signals = register(&scheduler, "w1", eval_worker_caps(), HashSet::new()).await;
 
     scheduler
         .enqueue_eval_job("j1".into(), eval_job(peer))
-        .await;
-    assert!(
-        rx.has_changed().unwrap(),
-        "missed-while-busy enqueue must still be observed"
-    );
-
-    rx.changed().await.unwrap();
-    assert!(
-        !rx.has_changed().unwrap(),
-        "consuming the change resets the flag"
-    );
-
+        .await
+        .unwrap();
     scheduler
         .enqueue_eval_job("j2".into(), eval_job(peer))
-        .await;
+        .await
+        .unwrap();
+
+    assert_eq!(signals.recv().await, Some(SessionSignal::Offers(1)));
+    assert_eq!(signals.recv().await, Some(SessionSignal::Offers(2)));
+    let offer = scheduler.get_new_job_candidates("w1").await;
+    assert_eq!(offer.candidates.len(), 2);
+    assert_eq!(offer.generation, 2, "the offer carries the generation it answers");
     assert!(
-        rx.has_changed().unwrap(),
-        "a later enqueue re-arms the receiver"
+        scheduler
+            .get_new_job_candidates("w1")
+            .await
+            .candidates
+            .is_empty(),
+        "a second fetch is a delta and finds nothing new"
     );
 }
 
@@ -130,7 +149,7 @@ async fn job_notify_bump_is_not_lost_when_not_awaiting() {
 #[tokio::test]
 async fn dispatch_kick_is_retained_when_not_awaiting() {
     use std::sync::atomic::Ordering;
-    let scheduler = test_scheduler();
+    let scheduler = test_scheduler().await;
     let before = scheduler.kick_gen.load(Ordering::Relaxed);
     scheduler.kick_dispatch();
     assert_eq!(
@@ -147,9 +166,19 @@ async fn dispatch_kick_is_retained_when_not_awaiting() {
 /// that loop.
 #[tokio::test]
 async fn capability_update_kicks_dispatch_instead_of_reconciling_inline() {
-    let scheduler = test_scheduler();
+    let scheduler = test_scheduler().await;
     scheduler
-        .update_worker_capabilities("peer-x", vec![], vec![], 4, 8, 16_000, 100)
+        .update_worker_capabilities(
+            "peer-x",
+            WorkerCapabilities {
+                architectures: vec![],
+                system_features: vec![],
+                max_concurrent_builds: 4,
+                cpu_count: 8,
+                ram_total_mb: 16_000,
+                cpu_core_score: 100,
+            },
+        )
         .await;
     assert_eq!(
         scheduler
@@ -162,20 +191,20 @@ async fn capability_update_kicks_dispatch_instead_of_reconciling_inline() {
 
 #[tokio::test]
 async fn test_candidates_filtered_by_authorized_peers() {
-    let scheduler = test_scheduler();
+    let scheduler = test_scheduler().await;
     let peer_a = ProjectId::now_v7();
     let peer_b = ProjectId::now_v7();
 
-    scheduler
-        .register_worker("w1", eval_worker_caps(), HashSet::from([peer_a]))
-        .await;
+    register(&scheduler, "w1", eval_worker_caps(), HashSet::from([peer_a])).await;
 
     scheduler
         .enqueue_eval_job("ja".into(), eval_job(peer_a))
-        .await;
+        .await
+        .unwrap();
     scheduler
         .enqueue_eval_job("jb".into(), eval_job(peer_b))
-        .await;
+        .await
+        .unwrap();
 
     let candidates = scheduler.get_job_candidates("w1").await;
     assert_eq!(candidates.len(), 1);
@@ -184,16 +213,15 @@ async fn test_candidates_filtered_by_authorized_peers() {
 
 #[tokio::test]
 async fn test_score_assignment_flow() {
-    let scheduler = test_scheduler();
+    let scheduler = test_scheduler().await;
     let peer = ProjectId::now_v7();
 
-    scheduler
-        .register_worker("w1", eval_worker_caps(), HashSet::new())
-        .await;
+    register(&scheduler, "w1", eval_worker_caps(), HashSet::new()).await;
 
     scheduler
         .enqueue_eval_job("j1".into(), eval_job(peer))
-        .await;
+        .await
+        .unwrap();
 
     // Worker scores the job, then explicitly requests one.
     scheduler
@@ -215,16 +243,15 @@ async fn test_score_assignment_flow() {
 
 #[tokio::test]
 async fn test_job_rejected_requeues() {
-    let scheduler = test_scheduler();
+    let scheduler = test_scheduler().await;
     let peer = ProjectId::now_v7();
 
-    scheduler
-        .register_worker("w1", eval_worker_caps(), HashSet::new())
-        .await;
+    register(&scheduler, "w1", eval_worker_caps(), HashSet::new()).await;
 
     scheduler
         .enqueue_eval_job("j1".into(), eval_job(peer))
-        .await;
+        .await
+        .unwrap();
 
     // Assign via RequestJob.
     scheduler.request_job("w1", JobKind::Flake).await;
@@ -237,19 +264,19 @@ async fn test_job_rejected_requeues() {
 
 #[tokio::test]
 async fn test_worker_disconnect_requeues_jobs() {
-    let scheduler = test_scheduler();
+    let scheduler = test_scheduler().await;
     let peer = ProjectId::now_v7();
 
-    scheduler
-        .register_worker("w1", eval_worker_caps(), HashSet::new())
-        .await;
+    register(&scheduler, "w1", eval_worker_caps(), HashSet::new()).await;
 
     scheduler
         .enqueue_eval_job("j1".into(), eval_job(peer))
-        .await;
+        .await
+        .unwrap();
     scheduler
         .enqueue_eval_job("j2".into(), eval_job(peer))
-        .await;
+        .await
+        .unwrap();
 
     // Assign both via RequestJob.
     scheduler.request_job("w1", JobKind::Flake).await;
@@ -263,30 +290,28 @@ async fn test_worker_disconnect_requeues_jobs() {
     assert_eq!(scheduler.worker_count().await, 0);
 
     // Another worker can pick them up.
-    scheduler
-        .register_worker("w2", eval_worker_caps(), HashSet::new())
-        .await;
+    register(&scheduler, "w2", eval_worker_caps(), HashSet::new()).await;
     let candidates = scheduler.get_job_candidates("w2").await;
     assert_eq!(candidates.len(), 2);
 }
 
 #[tokio::test]
 async fn test_update_authorized_peers_expands_access() {
-    let scheduler = test_scheduler();
+    let scheduler = test_scheduler().await;
     let peer_a = ProjectId::now_v7();
     let peer_b = ProjectId::now_v7();
 
     // Worker starts authorized for peer_a only.
-    scheduler
-        .register_worker("w1", eval_worker_caps(), HashSet::from([peer_a]))
-        .await;
+    register(&scheduler, "w1", eval_worker_caps(), HashSet::from([peer_a])).await;
 
     scheduler
         .enqueue_eval_job("ja".into(), eval_job(peer_a))
-        .await;
+        .await
+        .unwrap();
     scheduler
         .enqueue_eval_job("jb".into(), eval_job(peer_b))
-        .await;
+        .await
+        .unwrap();
 
     assert_eq!(scheduler.get_job_candidates("w1").await.len(), 1);
 
@@ -300,16 +325,15 @@ async fn test_update_authorized_peers_expands_access() {
 
 #[tokio::test]
 async fn test_draining_worker_still_has_assigned_jobs() {
-    let scheduler = test_scheduler();
+    let scheduler = test_scheduler().await;
     let peer = ProjectId::now_v7();
 
-    scheduler
-        .register_worker("w1", eval_worker_caps(), HashSet::new())
-        .await;
+    register(&scheduler, "w1", eval_worker_caps(), HashSet::new()).await;
 
     scheduler
         .enqueue_eval_job("j1".into(), eval_job(peer))
-        .await;
+        .await
+        .unwrap();
 
     scheduler.request_job("w1", JobKind::Flake).await;
     scheduler.mark_worker_draining("w1").await;
@@ -323,33 +347,57 @@ async fn test_draining_worker_still_has_assigned_jobs() {
 
 #[tokio::test]
 async fn test_request_reauth_signals_connected_worker() {
-    let scheduler = test_scheduler();
-
-    let (notify, _abort_rx) = scheduler
-        .register_worker("w1", eval_worker_caps(), HashSet::new())
-        .await;
+    let scheduler = test_scheduler().await;
+    let mut signals = register(&scheduler, "w1", eval_worker_caps(), HashSet::new()).await;
 
     scheduler.request_reauth("w1").await;
 
-    // The notify should fire immediately - the dispatch loop would use this
-    // to send an AuthChallenge to the worker.
-    tokio::time::timeout(std::time::Duration::from_millis(50), notify.notified())
-        .await
-        .expect("reauth notify should fire immediately");
+    assert_eq!(signals.recv().await, Some(SessionSignal::Reauth));
 }
 
 #[tokio::test]
 async fn test_request_reauth_noop_for_disconnected_worker() {
-    let scheduler = test_scheduler();
-    // Should not panic when the worker is not connected.
+    let scheduler = test_scheduler().await;
     scheduler.request_reauth("nonexistent").await;
+}
+
+#[tokio::test]
+async fn abort_evaluation_signals_the_worker_running_its_job() {
+    let scheduler = test_scheduler().await;
+    let peer = ProjectId::now_v7();
+    let mut signals = register(&scheduler, "w1", eval_worker_caps(), HashSet::new()).await;
+    let job = eval_job(peer);
+    let eval_id = job.evaluation_id;
+    scheduler
+        .enqueue_eval_job("j1".into(), job)
+        .await
+        .unwrap();
+    assert_eq!(signals.recv().await, Some(SessionSignal::Offers(1)));
+    let assigned = scheduler
+        .request_job("w1", JobKind::Flake)
+        .await
+        .expect("assigned");
+    assert_eq!(assigned.job_id, "j1");
+    assert_eq!(assigned.pending.evaluation_id(), eval_id);
+
+    let aborted = scheduler.abort_evaluation_jobs(eval_id).await;
+
+    assert_eq!(aborted, vec![("w1".to_string(), "j1".to_string())]);
+    assert_eq!(
+        signals.recv().await,
+        Some(SessionSignal::Abort {
+            job_id: "j1".into(),
+            reason: "evaluation aborted".into()
+        })
+    );
+    assert_eq!(scheduler.counts().await.active, 1, "the worker still runs it until it reports");
 }
 
 #[tokio::test]
 async fn record_eval_message_drops_when_job_unknown() {
     // No active job → silently accepted, no DB insert attempted (MockDatabase
     // would panic on an unexpected exec; absence of panic proves no insert).
-    let scheduler = test_scheduler();
+    let scheduler = test_scheduler().await;
     let r = scheduler
         .record_eval_message(
             "ghost-job",
@@ -380,6 +428,7 @@ async fn record_eval_message_inserts_for_active_build_job() {
         .into_connection();
     let state = test_state(db);
     let scheduler = Arc::new(Scheduler::new(state));
+    scheduler.spawn_core(None).await.expect("core actor");
 
     scheduler
         .enqueue_build_job(
@@ -414,12 +463,11 @@ async fn record_eval_message_inserts_for_active_build_job() {
                 substitute: false,
             },
         )
-        .await;
+        .await
+        .unwrap();
     // Move to assigned so active_job() finds it. A zero-missing score clears the
     // negative-total dispatch gate.
-    scheduler
-        .register_worker("w1", eval_worker_caps(), HashSet::new())
-        .await;
+    register(&scheduler, "w1", eval_worker_caps(), HashSet::new()).await;
     scheduler
         .record_scores(
             "w1",
@@ -472,24 +520,28 @@ async fn fetch_only_completion_enqueues_cached_eval_followup() {
         .append_query_results([vec![archived_eval]])
         .into_connection();
     let scheduler = Arc::new(Scheduler::new(test_state(db)));
+    scheduler.spawn_core(None).await.expect("core actor");
 
     let mut fetch_job = eval_job(peer);
     fetch_job.evaluation_id = eval_id;
     fetch_job.job.steps = vec![FlakeStep::FetchFlake];
     let job_id = format!("eval:{eval_id}");
 
-    scheduler.enqueue_eval_job(job_id.clone(), fetch_job).await;
     scheduler
-        .register_worker(
-            "w1",
-            GradientCapabilities {
-                eval: true,
-                fetch: true,
-                ..GradientCapabilities::default()
-            },
-            HashSet::new(),
-        )
-        .await;
+        .enqueue_eval_job(job_id.clone(), fetch_job)
+        .await
+        .unwrap();
+    register(
+        &scheduler,
+        "w1",
+        GradientCapabilities {
+            eval: true,
+            fetch: true,
+            ..GradientCapabilities::default()
+        },
+        HashSet::new(),
+    )
+    .await;
     scheduler.request_job("w1", JobKind::Flake).await;
 
     scheduler
@@ -503,9 +555,9 @@ async fn fetch_only_completion_enqueues_cached_eval_followup() {
     // inspect the pending tracker rather than dispatching, since under the new
     // negative-total gate a fetch-capable worker is reserved off cached-eval
     // work by ReserveFetchWorkersRule when spare capacity is unknown.)
-    let tracker = scheduler.job_tracker.read().await;
-    let follow = match tracker
+    let follow = match scheduler
         .pending_job(&job_id)
+        .await
         .expect("follow-up must be pending")
     {
         crate::jobs::PendingJob::Eval(e) => e,
@@ -523,7 +575,7 @@ async fn fetch_only_completion_enqueues_cached_eval_followup() {
 async fn cancel_evaluation_jobs_drops_eval_and_build_jobs() {
     use gradient_types::proto::{BuildJob, BuildSpec};
 
-    let scheduler = test_scheduler();
+    let scheduler = test_scheduler().await;
     let peer = ProjectId::now_v7();
     let eval_id = EvaluationId::now_v7();
     let build_id_a = DerivationBuildId::now_v7();
@@ -556,7 +608,8 @@ async fn cancel_evaluation_jobs_drops_eval_and_build_jobs() {
                 history: Default::default(),
             },
         )
-        .await;
+        .await
+        .unwrap();
 
     for (build_id, job_id) in [
         (build_id_a, format!("build:{build_id_a}")),
@@ -595,7 +648,8 @@ async fn cancel_evaluation_jobs_drops_eval_and_build_jobs() {
                     substitute: false,
                 },
             )
-            .await;
+            .await
+            .unwrap();
     }
 
     assert_eq!(scheduler.pending_job_count().await, 3);
@@ -604,9 +658,12 @@ async fn cancel_evaluation_jobs_drops_eval_and_build_jobs() {
         .cancel_evaluation_jobs(eval_id, &[build_id_a, build_id_b])
         .await;
 
-    let tracker = scheduler.job_tracker.read().await;
-    assert!(!tracker.contains_job(&format!("eval:{eval_id}")));
-    assert!(!tracker.contains_job(&format!("build:{build_id_a}")));
-    assert!(!tracker.contains_job(&format!("build:{build_id_b}")));
-    assert_eq!(tracker.pending_count() + tracker.active_count(), 0);
+    let ids = vec![
+        format!("eval:{eval_id}"),
+        format!("build:{build_id_a}"),
+        format!("build:{build_id_b}"),
+    ];
+    assert_eq!(scheduler.untracked(ids.clone()).await, ids);
+    let counts = scheduler.counts().await;
+    assert_eq!(counts.pending + counts.active, 0);
 }

--- a/backend/gradient-scheduler/src/scheduler_tests.rs
+++ b/backend/gradient-scheduler/src/scheduler_tests.rs
@@ -667,3 +667,50 @@ async fn cancel_evaluation_jobs_drops_eval_and_build_jobs() {
     let counts = scheduler.counts().await;
     assert_eq!(counts.pending + counts.active, 0);
 }
+
+#[tokio::test]
+async fn a_respawned_core_is_rebuilt_from_reattached_sessions() {
+    let scheduler = test_scheduler().await;
+    let peer = ProjectId::now_v7();
+    let (session, mut signals) = port();
+    scheduler
+        .register_worker("w1", eval_worker_caps(), HashSet::new(), Arc::clone(&session))
+        .await
+        .unwrap();
+    scheduler
+        .enqueue_eval_job("j1".into(), eval_job(peer))
+        .await
+        .unwrap();
+    assert_eq!(signals.recv().await, Some(SessionSignal::Offers(1)));
+    let assigned = scheduler
+        .request_job("w1", JobKind::Flake)
+        .await
+        .expect("assigned");
+
+    let old = scheduler
+        .core_changes()
+        .borrow()
+        .clone()
+        .expect("core published");
+    old.stop_and_wait(None, None)
+        .await
+        .expect("stop the old core");
+    scheduler.spawn_core(None).await.expect("respawn");
+    assert_eq!(scheduler.counts().await.active, 0, "a fresh core knows nothing");
+
+    scheduler
+        .reattach_worker(
+            "w1",
+            eval_worker_caps(),
+            HashSet::new(),
+            session,
+            vec![(assigned.job_id.clone(), assigned.pending.clone())],
+        )
+        .await
+        .unwrap();
+
+    let counts = scheduler.counts().await;
+    assert_eq!((counts.workers, counts.active, counts.pending), (1, 1, 0));
+    assert!(scheduler.active_job(&assigned.job_id).await.is_some());
+    assert!(scheduler.is_worker_connected("w1").await);
+}

--- a/backend/gradient-scheduler/src/scheduler_tests.rs
+++ b/backend/gradient-scheduler/src/scheduler_tests.rs
@@ -132,7 +132,10 @@ async fn enqueue_signals_offers_with_a_rising_generation() {
     assert_eq!(signals.recv().await, Some(SessionSignal::Offers(2)));
     let offer = scheduler.get_new_job_candidates("w1").await;
     assert_eq!(offer.candidates.len(), 2);
-    assert_eq!(offer.generation, 2, "the offer carries the generation it answers");
+    assert_eq!(
+        offer.generation, 2,
+        "the offer carries the generation it answers"
+    );
     assert!(
         scheduler
             .get_new_job_candidates("w1")
@@ -195,7 +198,13 @@ async fn test_candidates_filtered_by_authorized_peers() {
     let peer_a = ProjectId::now_v7();
     let peer_b = ProjectId::now_v7();
 
-    register(&scheduler, "w1", eval_worker_caps(), HashSet::from([peer_a])).await;
+    register(
+        &scheduler,
+        "w1",
+        eval_worker_caps(),
+        HashSet::from([peer_a]),
+    )
+    .await;
 
     scheduler
         .enqueue_eval_job("ja".into(), eval_job(peer_a))
@@ -302,7 +311,13 @@ async fn test_update_authorized_peers_expands_access() {
     let peer_b = ProjectId::now_v7();
 
     // Worker starts authorized for peer_a only.
-    register(&scheduler, "w1", eval_worker_caps(), HashSet::from([peer_a])).await;
+    register(
+        &scheduler,
+        "w1",
+        eval_worker_caps(),
+        HashSet::from([peer_a]),
+    )
+    .await;
 
     scheduler
         .enqueue_eval_job("ja".into(), eval_job(peer_a))
@@ -368,10 +383,7 @@ async fn abort_evaluation_signals_the_worker_running_its_job() {
     let mut signals = register(&scheduler, "w1", eval_worker_caps(), HashSet::new()).await;
     let job = eval_job(peer);
     let eval_id = job.evaluation_id;
-    scheduler
-        .enqueue_eval_job("j1".into(), job)
-        .await
-        .unwrap();
+    scheduler.enqueue_eval_job("j1".into(), job).await.unwrap();
     assert_eq!(signals.recv().await, Some(SessionSignal::Offers(1)));
     let assigned = scheduler
         .request_job("w1", JobKind::Flake)
@@ -390,7 +402,11 @@ async fn abort_evaluation_signals_the_worker_running_its_job() {
             reason: "evaluation aborted".into()
         })
     );
-    assert_eq!(scheduler.counts().await.active, 1, "the worker still runs it until it reports");
+    assert_eq!(
+        scheduler.counts().await.active,
+        1,
+        "the worker still runs it until it reports"
+    );
 }
 
 #[tokio::test]
@@ -674,7 +690,12 @@ async fn a_respawned_core_is_rebuilt_from_reattached_sessions() {
     let peer = ProjectId::now_v7();
     let (session, mut signals) = port();
     scheduler
-        .register_worker("w1", eval_worker_caps(), HashSet::new(), Arc::clone(&session))
+        .register_worker(
+            "w1",
+            eval_worker_caps(),
+            HashSet::new(),
+            Arc::clone(&session),
+        )
         .await
         .unwrap();
     scheduler
@@ -696,7 +717,11 @@ async fn a_respawned_core_is_rebuilt_from_reattached_sessions() {
         .await
         .expect("stop the old core");
     scheduler.spawn_core(None).await.expect("respawn");
-    assert_eq!(scheduler.counts().await.active, 0, "a fresh core knows nothing");
+    assert_eq!(
+        scheduler.counts().await.active,
+        0,
+        "a fresh core knows nothing"
+    );
 
     scheduler
         .reattach_worker(

--- a/backend/gradient-scheduler/src/scheduler_tests.rs
+++ b/backend/gradient-scheduler/src/scheduler_tests.rs
@@ -530,9 +530,6 @@ async fn fetch_only_completion_enqueues_cached_eval_followup() {
     };
 
     let db = MockDatabase::new(DatabaseBackend::Postgres)
-        // register_worker resolves the worker's owning project from worker_registration;
-        // an empty result means "no registration row" and skips the connection record.
-        .append_query_results([Vec::<gradient_entity::worker_registration::Model>::new()])
         .append_query_results([vec![archived_eval]])
         .into_connection();
     let scheduler = Arc::new(Scheduler::new(test_state(db)));
@@ -543,22 +540,23 @@ async fn fetch_only_completion_enqueues_cached_eval_followup() {
     fetch_job.job.steps = vec![FlakeStep::FetchFlake];
     let job_id = format!("eval:{eval_id}");
 
+    // Attach with the job already active: a dispatched assignment would spawn
+    // the dispatched_job insert, which races the ordered mock for the eval row.
+    let (session, _signals) = port();
     scheduler
-        .enqueue_eval_job(job_id.clone(), fetch_job)
+        .reattach_worker(
+            "w1",
+            GradientCapabilities {
+                eval: true,
+                fetch: true,
+                ..GradientCapabilities::default()
+            },
+            HashSet::new(),
+            session,
+            vec![(job_id.clone(), crate::jobs::PendingJob::Eval(fetch_job))],
+        )
         .await
-        .unwrap();
-    register(
-        &scheduler,
-        "w1",
-        GradientCapabilities {
-            eval: true,
-            fetch: true,
-            ..GradientCapabilities::default()
-        },
-        HashSet::new(),
-    )
-    .await;
-    scheduler.request_job("w1", JobKind::Flake).await;
+        .expect("reattach");
 
     scheduler
         .handle_job_completed("w1", &job_id)

--- a/backend/gradient-scheduler/src/worker_lifecycle.rs
+++ b/backend/gradient-scheduler/src/worker_lifecycle.rs
@@ -100,7 +100,13 @@ impl Scheduler {
     ) -> Result<Registered> {
         let caps_json = serde_json::to_value(&capabilities).unwrap_or(serde_json::Value::Null);
         let registered = self
-            .reattach_worker(worker_id, capabilities, authorized_peers, session, Vec::new())
+            .reattach_worker(
+                worker_id,
+                capabilities,
+                authorized_peers,
+                session,
+                Vec::new(),
+            )
             .await?;
         self.record_worker_connection(worker_id, caps_json).await;
         Ok(registered)

--- a/backend/gradient-scheduler/src/worker_lifecycle.rs
+++ b/backend/gradient-scheduler/src/worker_lifecycle.rs
@@ -20,7 +20,11 @@ use gradient_types::ids::ProjectId;
 use gradient_types::proto::GradientCapabilities;
 
 use crate::Scheduler;
+use crate::actor::{
+    Registered, Registration, SchedulerMsg, SessionPort, WorkerCapabilities, WorkerMetrics,
+};
 use crate::build;
+use crate::jobs::PendingJob;
 
 /// Insert a `worker_sample` time-series row for a connected worker. Best-effort;
 /// skipped when the worker's owning project is unknown. Called from the heartbeat loop.
@@ -58,57 +62,73 @@ pub(crate) async fn record_worker_sample(
 
 impl Scheduler {
     pub async fn is_worker_connected(&self, worker_id: &str) -> bool {
-        self.worker_pool.read().await.is_connected(worker_id)
-    }
-
-    /// Clone a connected worker's `last_seen` handle so the session loop can
-    /// stamp it lock-free on every inbound frame.
-    pub async fn worker_last_seen(
-        &self,
-        worker_id: &str,
-    ) -> Option<std::sync::Arc<std::sync::atomic::AtomicI64>> {
-        self.worker_pool.read().await.last_seen_handle(worker_id)
+        let worker = worker_id.to_owned();
+        self.call(|reply| SchedulerMsg::IsConnected { worker, reply })
+            .await
+            .unwrap_or(false)
     }
 
     /// Connected peers silent longer than `timeout_ms` as of `now_ms`.
     pub async fn stale_workers(&self, now_ms: i64, timeout_ms: i64) -> Vec<String> {
-        self.worker_pool
-            .read()
-            .await
-            .stale_worker_ids(now_ms, timeout_ms)
+        self.call(|reply| SchedulerMsg::StaleWorkers {
+            now_ms,
+            timeout_ms,
+            reply,
+        })
+        .await
+        .unwrap_or_default()
     }
 
     pub async fn worker_authorized_for_project(&self, worker_id: &str, project: ProjectId) -> bool {
-        self.worker_pool
-            .read()
-            .await
-            .peer_auth_for(worker_id)
-            .map(|a| a.contains(&project))
-            .unwrap_or(false)
+        let worker = worker_id.to_owned();
+        self.call(|reply| SchedulerMsg::AuthorizedFor {
+            worker,
+            project,
+            reply,
+        })
+        .await
+        .unwrap_or(false)
     }
 
+    /// Register a new connection and open its `worker_connection` row.
     pub async fn register_worker(
         &self,
         worker_id: &str,
         capabilities: GradientCapabilities,
         authorized_peers: HashSet<ProjectId>,
-    ) -> (
-        Arc<tokio::sync::Notify>,
-        tokio::sync::mpsc::UnboundedReceiver<(String, String)>,
-    ) {
+        session: Arc<dyn SessionPort>,
+    ) -> Result<Registered> {
         let caps_json = serde_json::to_value(&capabilities).unwrap_or(serde_json::Value::Null);
-        let (notify, abort_rx) = self.worker_pool.write().await.register(
-            worker_id.to_owned(),
-            capabilities,
-            authorized_peers,
-        );
-        info!(%worker_id, "worker registered");
+        let registered = self
+            .reattach_worker(worker_id, capabilities, authorized_peers, session, Vec::new())
+            .await?;
         self.record_worker_connection(worker_id, caps_json).await;
-        (notify, abort_rx)
+        Ok(registered)
     }
 
-    /// Resolve the worker's owning project from `worker_registration`, cache it on
-    /// the pool for sample attribution, and open a `worker_connection` row.
+    /// Register without touching the DB: the session is already connected and
+    /// the scheduler's state was rebuilt, so only the in-memory view is missing.
+    pub async fn reattach_worker(
+        &self,
+        worker_id: &str,
+        capabilities: GradientCapabilities,
+        authorized_peers: HashSet<ProjectId>,
+        session: Arc<dyn SessionPort>,
+        active: Vec<(String, PendingJob)>,
+    ) -> Result<Registered> {
+        let registration = Registration {
+            worker: worker_id.to_owned(),
+            capabilities,
+            authorized_peers,
+            session,
+            active,
+        };
+        self.call(|reply| SchedulerMsg::Register(registration, reply))
+            .await
+    }
+
+    /// Resolve the worker's owning project from `worker_registration`, record it
+    /// for sample attribution, and open a `worker_connection` row.
     async fn record_worker_connection(&self, worker_id: &str, capabilities: serde_json::Value) {
         let reg = gradient_entity::worker_registration::Entity::find()
             .filter(gradient_entity::worker_registration::Column::WorkerId.eq(worker_id))
@@ -118,10 +138,12 @@ impl Scheduler {
         let Ok(Some(reg)) = reg else {
             return;
         };
-        self.worker_pool
-            .write()
-            .await
-            .set_worker_project(worker_id, reg.peer_id);
+        let _ = self
+            .cast(SchedulerMsg::SetWorkerProject {
+                worker: worker_id.to_owned(),
+                project: reg.peer_id,
+            })
+            .await;
         let conn = gradient_entity::worker_connection::Model {
             id: gradient_entity::ids::WorkerConnectionId::now_v7(),
             worker_id: worker_id.to_string(),
@@ -170,15 +192,19 @@ impl Scheduler {
         worker_id: &str,
         authorized_peers: HashSet<ProjectId>,
     ) {
-        self.worker_pool
-            .write()
-            .await
-            .update_authorized_peers(worker_id, authorized_peers);
+        let worker = worker_id.to_owned();
+        let _ = self
+            .call(|reply| SchedulerMsg::UpdatePeers {
+                worker,
+                peers: authorized_peers,
+                reply,
+            })
+            .await;
         debug!(%worker_id, "authorized peers updated");
     }
 
-    /// Abort all active jobs on `worker_id` that belong to any of `revoked_peers`.
-    /// Jobs are moved back to pending so they can be re-assigned to another worker.
+    /// Abort the worker's active jobs that belong to `revoked_peers`; they go
+    /// back to pending and every other session is offered them.
     pub async fn abort_project_jobs_on_worker(
         &self,
         worker_id: &str,
@@ -187,123 +213,73 @@ impl Scheduler {
         if revoked_peers.is_empty() {
             return;
         }
-        let job_ids = self
-            .job_tracker
-            .write()
+        let worker = worker_id.to_owned();
+        let revoked = revoked_peers.clone();
+        let aborted = self
+            .call(|reply| SchedulerMsg::RevokePeers {
+                worker,
+                revoked,
+                reply,
+            })
             .await
-            .drain_peer_jobs_on_worker(worker_id, revoked_peers);
-        if job_ids.is_empty() {
-            return;
+            .unwrap_or(0);
+        if aborted > 0 {
+            info!(%worker_id, aborted, "aborted jobs for revoked project(s) on worker");
         }
-        let pool = self.worker_pool.read().await;
-        for job_id in &job_ids {
-            pool.send_abort(
-                worker_id,
-                job_id.clone(),
-                "project deactivated worker".to_owned(),
-            );
-        }
-        info!(
-            %worker_id,
-            aborted = job_ids.len(),
-            "aborted jobs for revoked project(s) on worker"
-        );
-        // Notify other workers that these jobs are available again.
-        self.job_notify.send_modify(|g| *g = g.wrapping_add(1));
     }
 
-    /// Signal a connected worker that its registrations have changed,
-    /// triggering a server-initiated re-authentication.
     pub async fn request_reauth(&self, worker_id: &str) {
-        self.worker_pool.read().await.request_reauth(worker_id);
+        let _ = self
+            .cast(SchedulerMsg::Reauth {
+                worker: worker_id.to_owned(),
+            })
+            .await;
     }
 
-    #[allow(
-        clippy::too_many_arguments,
-        reason = "mirrors the WorkerCapabilities wire fields; refactor tracked in #503"
-    )]
-    pub async fn update_worker_capabilities(
-        &self,
-        worker_id: &str,
-        architectures: Vec<String>,
-        system_features: Vec<String>,
-        max_concurrent_builds: u32,
-        cpu_count: u32,
-        ram_total_mb: u64,
-        cpu_core_score: u32,
-    ) {
-        self.worker_pool.write().await.update_capabilities(
-            worker_id,
-            architectures,
-            system_features,
-            max_concurrent_builds,
-            cpu_count,
-            ram_total_mb,
-            cpu_core_score,
-        );
+    pub async fn update_worker_capabilities(&self, worker_id: &str, caps: WorkerCapabilities) {
+        let worker = worker_id.to_owned();
+        let _ = self
+            .call(|reply| SchedulerMsg::UpdateCapabilities {
+                worker,
+                caps,
+                reply,
+            })
+            .await;
         debug!(%worker_id, "worker capabilities updated");
-        // Capabilities just changed - a build that was previously "no worker can
-        // do this" might now be servable, or vice-versa. Kick the dispatch loop
-        // to re-evaluate every in-flight eval's Waiting/Building gate off this
-        // connection's read loop. Reconciling inline here (a DB-heavy pass) blocked
-        // the loop from reading the same worker's next `CacheQuery`, which then
-        // timed out after 75s.
         self.kick_dispatch();
     }
 
-    pub async fn update_worker_metrics(
-        &self,
-        worker_id: &str,
-        cpu_usage_pct: f32,
-        ram_free_mb: u64,
-        disk_speed_mbps: Option<f32>,
-        network_speed_mbps: Option<f32>,
-    ) {
-        self.worker_pool.write().await.update_metrics(
-            worker_id,
-            cpu_usage_pct,
-            ram_free_mb,
-            disk_speed_mbps,
-            network_speed_mbps,
-        );
-        debug!(%worker_id, cpu_usage_pct, ram_free_mb, "worker metrics updated");
+    pub async fn update_worker_metrics(&self, worker_id: &str, metrics: WorkerMetrics) {
+        let worker = worker_id.to_owned();
+        let _ = self
+            .call(|reply| SchedulerMsg::UpdateMetrics {
+                worker,
+                metrics,
+                reply,
+            })
+            .await;
     }
 
     pub async fn unregister_worker(&self, worker_id: &str) {
         self.close_worker_connection(worker_id).await;
-        let orphaned = self.worker_pool.write().await.unregister(worker_id);
+        let worker = worker_id.to_owned();
         let requeued = self
-            .job_tracker
-            .write()
+            .call(|reply| SchedulerMsg::Unregister { worker, reply })
             .await
-            .worker_disconnected(worker_id);
-        let total = orphaned.len() + requeued.len();
-        if total > 0 {
-            info!(%worker_id, orphaned_jobs = total, "worker disconnected; jobs re-queued");
-        }
-
-        // The in-memory requeue above leaves the DB rows in a non-terminal
-        // status (`Building` / mid-eval) that the dispatcher never re-selects;
-        // reset them so the orphaned work actually retries.
+            .unwrap_or_default();
         build::requeue_orphaned_jobs(&self.state, &requeued).await;
-
         let _ = self
             .state
             .board_events
             .send(crate::BoardEvent::WorkerDisconnected {
                 worker_id: worker_id.to_owned(),
             });
-        // A worker leaving may strand evaluations whose remaining builds only it
-        // could service; kick the dispatch loop to re-evaluate off the read loop.
         self.kick_dispatch();
     }
 
-    /// Snapshot every connected worker's `(architectures, system_features)`
-    /// plus the counts of those advertising the `eval` and `fetch`
-    /// capabilities, then reconcile each in-flight evaluation's status. See
-    /// [`build::reconcile_waiting_state`].
+    /// Reconcile each in-flight evaluation's status against the connected pool.
     pub async fn reconcile_waiting_state(&self) -> Result<()> {
-        let workers = self.worker_pool.read().await.all_workers();
+        let workers = self.board_workers().await;
         let eval_capable = workers.iter().filter(|w| w.capabilities.eval).count();
         let fetch_capable = workers.iter().filter(|w| w.capabilities.fetch).count();
         let caps: Vec<(Vec<String>, Vec<String>)> = workers
@@ -315,14 +291,18 @@ impl Scheduler {
             .await
     }
 
-    /// Snapshot of every connected worker for the Job Board (includes the
-    /// internal sampling fields; the API layer masks them per caller scope).
+    /// Every connected worker, including the sampling fields the API masks.
     pub async fn board_workers(&self) -> Vec<crate::WorkerInfo> {
-        self.worker_pool.read().await.all_workers()
+        self.call(|reply| SchedulerMsg::Workers { reply })
+            .await
+            .unwrap_or_default()
     }
 
     pub async fn mark_worker_draining(&self, worker_id: &str) {
-        self.worker_pool.write().await.mark_draining(worker_id);
+        let worker = worker_id.to_owned();
+        let _ = self
+            .call(|reply| SchedulerMsg::MarkDraining { worker, reply })
+            .await;
         info!(%worker_id, "worker marked draining");
     }
 }

--- a/backend/gradient-scheduler/src/worker_pool.rs
+++ b/backend/gradient-scheduler/src/worker_pool.rs
@@ -679,7 +679,12 @@ mod tests {
         let peer_a = ProjectId::now_v7();
         let peer_b = ProjectId::now_v7();
 
-        pool.register("w1".into(), caps(), HashSet::from([peer_a, peer_b]), port().0);
+        pool.register(
+            "w1".into(),
+            caps(),
+            HashSet::from([peer_a, peer_b]),
+            port().0,
+        );
         let auth = pool.peer_auth_for("w1").unwrap();
         assert!(auth.contains(&peer_a));
         assert!(auth.contains(&peer_b));

--- a/backend/gradient-scheduler/src/worker_pool.rs
+++ b/backend/gradient-scheduler/src/worker_pool.rs
@@ -15,11 +15,10 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicI64, Ordering};
 
-use tokio::sync::{Notify, mpsc};
-
 use gradient_types::ids::ProjectId;
 use gradient_types::proto::{GradientCapabilities, JobKind};
 
+use crate::actor::{SessionPort, SessionSignal};
 use crate::peer_auth::PeerAuth;
 use crate::worker_state::{Active, Draining, TypedWorker};
 
@@ -88,18 +87,16 @@ impl WorkerPool {
         self.workers.contains_key(id)
     }
 
+    /// Register a connection, carrying the prior connection's reported sizing
+    /// forward so a reconnect without a fresh `WorkerCapabilities` still builds.
+    /// Returns the `last_seen` handle the session stamps on every inbound frame.
     pub fn register(
         &mut self,
         id: String,
         capabilities: GradientCapabilities,
         authorized_peers: HashSet<ProjectId>,
-    ) -> (Arc<Notify>, mpsc::UnboundedReceiver<(String, String)>) {
-        // Carry the prior connection's reported capabilities into the new slot.
-        // Architectures/features/sizing arrive once per session via a separate
-        // `WorkerCapabilities` message, but a reconnect or server-initiated
-        // re-auth re-registers the worker without it re-sending them - so without
-        // this the slot resets to empty architectures and `can_build` rejects
-        // every real-arch job, stranding the worker idle while builds queue.
+        session: Arc<dyn SessionPort>,
+    ) -> Arc<AtomicI64> {
         let prior = self.workers.get(&id).map(|slot| {
             let s = slot.shared();
             (
@@ -111,14 +108,8 @@ impl WorkerPool {
                 s.cpu_core_score,
             )
         });
-        let notify = Arc::new(Notify::new());
-        let (abort_tx, abort_rx) = mpsc::unbounded_channel();
-        let worker = TypedWorker::<Active>::new(
-            capabilities,
-            authorized_peers,
-            Arc::clone(&notify),
-            abort_tx,
-        );
+        let worker = TypedWorker::<Active>::new(capabilities, authorized_peers, session);
+        let last_seen = Arc::clone(&worker.last_seen);
         self.workers.insert(id.clone(), WorkerSlot::Active(worker));
         if let Some((
             architectures,
@@ -138,7 +129,7 @@ impl WorkerPool {
             s.ram_total_mb = ram_total_mb;
             s.cpu_core_score = cpu_core_score;
         }
-        (notify, abort_rx)
+        last_seen
     }
 
     /// Record the owning project for a connected worker.
@@ -146,21 +137,31 @@ impl WorkerPool {
         self.worker_projects.insert(id.to_owned(), project);
     }
 
-    /// Signal a connected worker that its registrations have changed and it
-    /// should re-authenticate.  No-op if the worker is not connected.
     pub fn request_reauth(&self, worker_id: &str) {
         if let Some(slot) = self.workers.get(worker_id) {
-            slot.shared().reauth_notify.notify_one();
+            slot.shared().session.signal(SessionSignal::Reauth);
         }
     }
 
-    /// Send an abort message to a connected worker's handler.
-    /// Returns `true` if the message was sent (worker connected), `false` otherwise.
+    /// Push an abort to the worker's session; `false` when it is not connected.
     pub fn send_abort(&self, worker_id: &str, job_id: String, reason: String) -> bool {
-        if let Some(slot) = self.workers.get(worker_id) {
-            slot.shared().abort_tx.send((job_id, reason)).is_ok()
-        } else {
-            false
+        match self.workers.get(worker_id) {
+            Some(slot) => {
+                slot.shared()
+                    .session
+                    .signal(SessionSignal::Abort { job_id, reason });
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Push `signal` to every active (not draining) worker's session.
+    pub fn signal_active(&self, signal: SessionSignal) {
+        for slot in self.workers.values() {
+            if let WorkerSlot::Active(w) = slot {
+                w.session.signal(signal.clone());
+            }
         }
     }
 
@@ -396,14 +397,6 @@ impl WorkerPool {
             .collect()
     }
 
-    /// Clone the `last_seen` handle for a connected worker so the session loop
-    /// can stamp it lock-free on each inbound frame. `None` if not connected.
-    pub fn last_seen_handle(&self, id: &str) -> Option<Arc<AtomicI64>> {
-        self.workers
-            .get(id)
-            .map(|slot| Arc::clone(&slot.shared().last_seen))
-    }
-
     /// Peers whose last inbound frame is older than `timeout_ms` relative to
     /// `now_ms` - i.e. silent past the heartbeat deadline, so presumed dead.
     pub fn stale_worker_ids(&self, now_ms: i64, timeout_ms: i64) -> Vec<String> {
@@ -455,10 +448,17 @@ pub struct WorkerInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::actor::{SessionPort, SessionSignal};
     use crate::peer_auth::PeerAuth;
+    use tokio::sync::mpsc;
 
     fn caps() -> GradientCapabilities {
         GradientCapabilities::default()
+    }
+
+    fn port() -> (Arc<dyn SessionPort>, mpsc::UnboundedReceiver<SessionSignal>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (Arc::new(tx), rx)
     }
 
     fn caps_ef(eval: bool, fetch: bool) -> GradientCapabilities {
@@ -472,13 +472,13 @@ mod tests {
     #[test]
     fn idle_eval_only_worker_detected() {
         let mut pool = WorkerPool::new();
-        pool.register("f1".into(), caps_ef(true, true), HashSet::new());
+        pool.register("f1".into(), caps_ef(true, true), HashSet::new(), port().0);
         assert!(
             !pool.has_idle_eval_only_worker(),
             "only a fetch worker present"
         );
 
-        pool.register("e1".into(), caps_ef(true, false), HashSet::new());
+        pool.register("e1".into(), caps_ef(true, false), HashSet::new(), port().0);
         assert!(
             pool.has_idle_eval_only_worker(),
             "idle eval-only worker present"
@@ -494,7 +494,7 @@ mod tests {
     #[test]
     fn draining_eval_only_worker_does_not_count() {
         let mut pool = WorkerPool::new();
-        pool.register("e1".into(), caps_ef(true, false), HashSet::new());
+        pool.register("e1".into(), caps_ef(true, false), HashSet::new(), port().0);
         pool.mark_draining("e1");
         assert!(
             !pool.has_idle_eval_only_worker(),
@@ -506,7 +506,7 @@ mod tests {
     fn test_register_and_is_connected() {
         let mut pool = WorkerPool::new();
         assert!(!pool.is_connected("w1"));
-        pool.register("w1".into(), caps(), HashSet::new());
+        pool.register("w1".into(), caps(), HashSet::new(), port().0);
         assert!(pool.is_connected("w1"));
         assert_eq!(pool.worker_count(), 1);
     }
@@ -514,7 +514,7 @@ mod tests {
     #[test]
     fn test_unregister_returns_assigned_jobs() {
         let mut pool = WorkerPool::new();
-        pool.register("w1".into(), caps(), HashSet::new());
+        pool.register("w1".into(), caps(), HashSet::new(), port().0);
         pool.assign_job("w1", "j1");
         pool.assign_job("w1", "j2");
 
@@ -534,7 +534,7 @@ mod tests {
     #[test]
     fn test_update_capabilities() {
         let mut pool = WorkerPool::new();
-        pool.register("w1".into(), caps(), HashSet::new());
+        pool.register("w1".into(), caps(), HashSet::new(), port().0);
         pool.update_capabilities(
             "w1",
             vec!["x86_64-linux".into()],
@@ -560,7 +560,7 @@ mod tests {
     #[test]
     fn reregister_preserves_reported_capabilities() {
         let mut pool = WorkerPool::new();
-        pool.register("w1".into(), caps(), HashSet::new());
+        pool.register("w1".into(), caps(), HashSet::new(), port().0);
         pool.update_capabilities(
             "w1",
             vec!["x86_64-linux".into()],
@@ -573,7 +573,7 @@ mod tests {
 
         // A reconnect/re-auth re-registers without the worker re-sending caps;
         // architectures and sizing must survive so the worker stays matchable.
-        pool.register("w1".into(), caps(), HashSet::new());
+        pool.register("w1".into(), caps(), HashSet::new(), port().0);
 
         let workers = pool.all_workers();
         assert_eq!(workers[0].architectures, vec!["x86_64-linux"]);
@@ -587,7 +587,7 @@ mod tests {
     #[test]
     fn test_update_metrics_updates_view() {
         let mut pool = WorkerPool::new();
-        pool.register("w1".into(), caps(), HashSet::new());
+        pool.register("w1".into(), caps(), HashSet::new(), port().0);
         pool.update_capabilities("w1", vec![], vec![], 1, 4, 8192, 1000);
 
         // Before any heartbeat the dynamic fields are absent, not zero.
@@ -621,6 +621,7 @@ mod tests {
                 ..Default::default()
             },
             HashSet::new(),
+            port().0,
         );
         pool.update_capabilities(
             "w1",
@@ -646,7 +647,7 @@ mod tests {
     #[test]
     fn test_mark_draining() {
         let mut pool = WorkerPool::new();
-        pool.register("w1".into(), caps(), HashSet::new());
+        pool.register("w1".into(), caps(), HashSet::new(), port().0);
 
         let info = &pool.all_workers()[0];
         assert!(!info.draining);
@@ -659,7 +660,7 @@ mod tests {
     #[test]
     fn test_draining_worker_has_no_capacity() {
         let mut pool = WorkerPool::new();
-        pool.register("w1".into(), caps(), HashSet::new());
+        pool.register("w1".into(), caps(), HashSet::new(), port().0);
         pool.update_capabilities("w1", vec![], vec![], 10, 0, 0, 0);
 
         // Active worker has capacity.
@@ -678,7 +679,7 @@ mod tests {
         let peer_a = ProjectId::now_v7();
         let peer_b = ProjectId::now_v7();
 
-        pool.register("w1".into(), caps(), HashSet::from([peer_a, peer_b]));
+        pool.register("w1".into(), caps(), HashSet::from([peer_a, peer_b]), port().0);
         let auth = pool.peer_auth_for("w1").unwrap();
         assert!(auth.contains(&peer_a));
         assert!(auth.contains(&peer_b));
@@ -693,7 +694,7 @@ mod tests {
         let peer_a = ProjectId::now_v7();
         let peer_b = ProjectId::now_v7();
 
-        pool.register("w1".into(), caps(), HashSet::from([peer_a]));
+        pool.register("w1".into(), caps(), HashSet::from([peer_a]), port().0);
         assert!(matches!(
             pool.peer_auth_for("w1").unwrap(),
             PeerAuth::Restricted(_)
@@ -710,7 +711,7 @@ mod tests {
     #[test]
     fn test_open_mode_on_empty_peers() {
         let mut pool = WorkerPool::new();
-        pool.register("w1".into(), caps(), HashSet::new());
+        pool.register("w1".into(), caps(), HashSet::new(), port().0);
         assert!(matches!(pool.peer_auth_for("w1").unwrap(), PeerAuth::Open));
     }
 
@@ -719,7 +720,7 @@ mod tests {
         // A build re-queued after a failed/rejected dispatch must lose its
         // sent flag so the next delta push re-offers it (workers re-score it).
         let mut pool = WorkerPool::new();
-        pool.register("w1".into(), caps(), HashSet::new());
+        pool.register("w1".into(), caps(), HashSet::new(), port().0);
         pool.mark_candidates_sent("w1", &["build:a".to_string(), "build:b".to_string()]);
         assert!(pool.sent_candidates_for("w1").unwrap().contains("build:a"));
 
@@ -734,7 +735,7 @@ mod tests {
         // Worker at exactly max_concurrent_builds must reject new builds.
         // Guards against `<` → `<=` off-by-one in `has_build_capacity`.
         let mut pool = WorkerPool::new();
-        pool.register("w1".into(), caps(), HashSet::new());
+        pool.register("w1".into(), caps(), HashSet::new(), port().0);
         pool.update_capabilities("w1", vec!["x86_64-linux".into()], vec![], 2, 0, 0, 0);
 
         assert!(pool.has_capacity("w1", &JobKind::Build), "0/2 has capacity");
@@ -752,7 +753,7 @@ mod tests {
     #[test]
     fn test_assign_and_release_job() {
         let mut pool = WorkerPool::new();
-        pool.register("w1".into(), caps(), HashSet::new());
+        pool.register("w1".into(), caps(), HashSet::new(), port().0);
 
         pool.assign_job("w1", "j1");
         assert_eq!(pool.all_workers()[0].assigned_job_count, 1);
@@ -772,8 +773,8 @@ mod tests {
     #[test]
     fn test_all_workers_info() {
         let mut pool = WorkerPool::new();
-        pool.register("w1".into(), caps(), HashSet::new());
-        pool.register("w2".into(), caps(), HashSet::new());
+        pool.register("w1".into(), caps(), HashSet::new(), port().0);
+        pool.register("w2".into(), caps(), HashSet::new(), port().0);
         pool.update_capabilities("w1", vec!["x86_64-linux".into()], vec![], 2, 0, 0, 0);
         pool.assign_job("w1", "j1");
         pool.mark_draining("w2");
@@ -797,9 +798,9 @@ mod tests {
         let project_b = ProjectId::now_v7();
 
         // Restricted: worker authorized for project_a only.
-        pool.register("w1".into(), caps(), HashSet::from([project_a]));
+        pool.register("w1".into(), caps(), HashSet::from([project_a]), port().0);
         // Open: no registrations.
-        pool.register("w2".into(), caps(), HashSet::new());
+        pool.register("w2".into(), caps(), HashSet::new(), port().0);
 
         let mut workers = pool.all_workers();
         workers.sort_by(|a, b| a.id.cmp(&b.id));
@@ -820,19 +821,29 @@ mod tests {
     #[test]
     fn test_request_reauth_notifies_connected_worker() {
         let mut pool = WorkerPool::new();
-        let (notify, _abort_rx) = pool.register("w1".into(), caps(), HashSet::new());
+        let (session, mut signals) = port();
+        pool.register("w1".into(), caps(), HashSet::new(), session);
 
         pool.request_reauth("w1");
 
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_time()
-            .build()
-            .unwrap();
-        rt.block_on(async {
-            tokio::time::timeout(std::time::Duration::from_millis(50), notify.notified())
-                .await
-                .expect("reauth notify should fire immediately");
-        });
+        assert_eq!(signals.try_recv(), Ok(SessionSignal::Reauth));
+    }
+
+    #[test]
+    fn send_abort_reaches_the_session_and_reports_unknown_workers() {
+        let mut pool = WorkerPool::new();
+        let (session, mut signals) = port();
+        pool.register("w1".into(), caps(), HashSet::new(), session);
+
+        assert!(pool.send_abort("w1", "j1".into(), "why".into()));
+        assert!(!pool.send_abort("nope", "j1".into(), "why".into()));
+        assert_eq!(
+            signals.try_recv(),
+            Ok(SessionSignal::Abort {
+                job_id: "j1".into(),
+                reason: "why".into()
+            })
+        );
     }
 
     #[test]
@@ -842,18 +853,9 @@ mod tests {
     }
 
     #[test]
-    fn last_seen_handle_none_for_unknown_worker() {
-        let pool = WorkerPool::new();
-        assert!(pool.last_seen_handle("nope").is_none());
-    }
-
-    #[test]
     fn stale_worker_ids_flags_only_silent_workers() {
         let mut pool = WorkerPool::new();
-        pool.register("w1".into(), caps(), HashSet::new());
-        let handle = pool
-            .last_seen_handle("w1")
-            .expect("registered worker exposes a last_seen handle");
+        let handle = pool.register("w1".into(), caps(), HashSet::new(), port().0);
 
         let now_ms = 1_000_000_000_000i64;
         let timeout_ms = 30_000i64;
@@ -875,7 +877,7 @@ mod tests {
 
         // A freshly registered worker is stamped with `now`, so it is never
         // immediately stale against the real clock.
-        pool.register("w2".into(), caps(), HashSet::new());
+        pool.register("w2".into(), caps(), HashSet::new(), port().0);
         let real_now = gradient_types::now().and_utc().timestamp_millis();
         assert!(
             !pool

--- a/backend/gradient-scheduler/src/worker_state.rs
+++ b/backend/gradient-scheduler/src/worker_state.rs
@@ -23,10 +23,10 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicI64;
 
 use gradient_types::ids::ProjectId;
-use tokio::sync::{Notify, mpsc};
 
 use gradient_types::proto::GradientCapabilities;
 
+use crate::actor::SessionPort;
 use crate::peer_auth::PeerAuth;
 
 // ── Sealing trait ─────────────────────────────────────────────────────────────
@@ -60,7 +60,6 @@ impl WorkerMarker for Draining {}
 /// All fields that are relevant regardless of the worker's lifecycle state.
 ///
 /// Accessed via [`TypedWorker<S>`]'s `Deref` / `DerefMut` impls.
-#[derive(Debug)]
 pub struct WorkerShared {
     pub capabilities: GradientCapabilities,
     pub architectures: Vec<String>,
@@ -81,16 +80,25 @@ pub struct WorkerShared {
     pub peer_auth: PeerAuth,
     /// Job IDs already sent to this worker as candidates (for delta `JobOffer`).
     pub sent_candidates: HashSet<String>,
-    /// Signalled by the API when registrations change and the worker should
-    /// re-authenticate without disconnecting.
-    pub reauth_notify: Arc<Notify>,
-    /// Channel for sending abort messages to the handler for this worker.
-    pub abort_tx: mpsc::UnboundedSender<(String, String)>,
+    /// The session this worker is connected through; the scheduler's only way
+    /// to push to it.
+    pub session: Arc<dyn SessionPort>,
     /// Wall-clock epoch-millis of the last message received from this worker.
     /// Bumped lock-free by the session loop on every inbound frame and read by
     /// the liveness watchdog to detect a worker that died without a clean TCP
     /// close. Shared so the session loop holds a handle without the pool lock.
     pub last_seen: Arc<AtomicI64>,
+}
+
+impl std::fmt::Debug for WorkerShared {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WorkerShared")
+            .field("capabilities", &self.capabilities)
+            .field("architectures", &self.architectures)
+            .field("assigned_jobs", &self.assigned_jobs)
+            .field("peer_auth", &self.peer_auth)
+            .finish_non_exhaustive()
+    }
 }
 
 // ── TypedWorker<S> ────────────────────────────────────────────────────────────
@@ -123,8 +131,7 @@ impl TypedWorker<Active> {
     pub fn new(
         capabilities: GradientCapabilities,
         authorized_peers: HashSet<ProjectId>,
-        reauth_notify: Arc<Notify>,
-        abort_tx: mpsc::UnboundedSender<(String, String)>,
+        session: Arc<dyn SessionPort>,
     ) -> Self {
         Self {
             shared: WorkerShared {
@@ -142,8 +149,7 @@ impl TypedWorker<Active> {
                 assigned_jobs: HashSet::new(),
                 peer_auth: PeerAuth::from_peers(authorized_peers),
                 sent_candidates: HashSet::new(),
-                reauth_notify,
-                abort_tx,
+                session,
                 last_seen: Arc::new(AtomicI64::new(
                     gradient_types::now().and_utc().timestamp_millis(),
                 )),

--- a/backend/gradient-util/src/supervision.rs
+++ b/backend/gradient-util/src/supervision.rs
@@ -34,7 +34,7 @@ pub type SpawnFn = Arc<dyn Fn(ChildCtx) -> SpawnFuture + Send + Sync>;
 const BACKOFF_BASE: Duration = Duration::from_secs(1);
 const BACKOFF_MAX: Duration = Duration::from_secs(60);
 const HEALTHY_RESET: Duration = Duration::from_secs(300);
-const STOP_TIMEOUT: Duration = Duration::from_secs(10);
+const STOP_TIMEOUT: Duration = Duration::from_secs(25);
 
 /// A pass that runs every `period`, cancelled in place past `budget`.
 #[derive(Clone)]
@@ -45,11 +45,19 @@ pub struct PeriodicSpec {
     pub run: PassFn,
 }
 
-/// What the root supervises: a periodic pass, or any actor spawned by a factory.
+/// What the root supervises: a periodic pass, any actor spawned by a factory,
+/// or a nested supervisor with children of its own.
 #[derive(Clone)]
 pub enum ChildSpec {
     Periodic(PeriodicSpec),
-    Custom { name: &'static str, spawn: SpawnFn },
+    Custom {
+        name: &'static str,
+        spawn: SpawnFn,
+    },
+    Supervisor {
+        name: &'static str,
+        children: Vec<ChildSpec>,
+    },
 }
 
 impl ChildSpec {
@@ -66,10 +74,17 @@ impl ChildSpec {
         })
     }
 
+    /// A nested node holding its own children. Its name is not a health row;
+    /// only its leaves are.
+    pub fn supervisor(name: &'static str, children: Vec<ChildSpec>) -> Self {
+        Self::Supervisor { name, children }
+    }
+
     pub fn name(&self) -> &'static str {
         match self {
             Self::Periodic(p) => p.name,
             Self::Custom { name, .. } => name,
+            Self::Supervisor { name, .. } => name,
         }
     }
 }
@@ -267,9 +282,21 @@ async fn spawn_child(
             child.get_cell()
         }
         ChildSpec::Custom { spawn, .. } => spawn(ctx).await?,
+        ChildSpec::Supervisor { children, .. } => {
+            let args = RootArgs {
+                children: children.clone(),
+                health: Arc::clone(&ctx.health),
+                cancel: ctx.cancel.clone(),
+            };
+            let (child, _) = Actor::spawn_linked(None, Root, args, ctx.parent).await?;
+            child.get_cell()
+        }
     };
     state.live.insert(cell.get_id(), spec.name());
-    state.args.health.register(spec.name());
+    if !matches!(spec, ChildSpec::Supervisor { .. }) {
+        state.args.health.register(spec.name());
+    }
+
     info!(loop_name = spec.name(), "supervised loop started");
     Ok(())
 }
@@ -393,7 +420,10 @@ impl Supervisor {
         tracker.spawn(async move {
             token.cancelled().await;
             if let Err(e) = stop
-                .stop_and_wait(Some("shutdown".into()), Some(STOP_TIMEOUT))
+                .stop_and_wait(
+                    Some("shutdown".into()),
+                    Some(STOP_TIMEOUT + Duration::from_secs(5)),
+                )
                 .await
             {
                 warn!(error = %e, "supervision tree did not stop cleanly");
@@ -478,6 +508,37 @@ mod tests {
         let h = health.get("hourly");
         assert!(h.last_ok_at.is_none() && h.restarts == 0, "{h:?}");
         shutdown.cancel_and_drain(Duration::from_secs(2)).await;
+    }
+
+    #[tokio::test]
+    async fn a_nested_supervisor_restarts_its_own_child_and_stops_with_the_tree() {
+        let shutdown = Shutdown::new();
+        let calls = Arc::new(AtomicU32::new(0));
+        shutdown
+            .supervise_now(ChildSpec::supervisor(
+                "node",
+                vec![counting_pass(Arc::clone(&calls), Some(2))],
+            ))
+            .await
+            .expect("supervise");
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+        let health = shutdown.supervision_health().expect("tree");
+        assert_eq!(
+            health.get("t").restarts,
+            1,
+            "the nested root respawned its child"
+        );
+        let names: Vec<_> = health.snapshot().into_iter().map(|(n, _)| n).collect();
+        assert_eq!(names, vec!["t"], "the node name is not a health row");
+        assert!(calls.load(Ordering::SeqCst) > 3, "ticking resumed");
+        assert!(shutdown.cancel_and_drain(Duration::from_secs(5)).await);
+        let after = calls.load(Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            after,
+            "no ticks after shutdown"
+        );
     }
 
     #[tokio::test]

--- a/backend/gradient-web/src/lib.rs
+++ b/backend/gradient-web/src/lib.rs
@@ -674,7 +674,11 @@ pub fn create_router(state: Arc<ServerState>) -> Result<Router, InitError> {
         .shutdown
         .supervise(gradient_db::rollup::child_spec(state.db()));
     otlp::start_otlp(Arc::clone(&state), Arc::clone(&scheduler));
-    gradient_proto::outbound::start_outbound_loop(Arc::clone(&scheduler));
+    let sessions = gradient_proto::SessionsHandle::new();
+    state
+        .shutdown
+        .supervise(sessions.child_spec(Arc::clone(&scheduler)));
+    gradient_proto::outbound::start_outbound_loop(Arc::clone(&scheduler), Arc::clone(&sessions));
 
     let proto_limiter = Arc::new(ProtoLimiter::new(state.config.proto.max_proto_connections));
 
@@ -688,7 +692,8 @@ pub fn create_router(state: Arc<ServerState>) -> Result<Router, InitError> {
         .nest("/api/v1", api)
         .merge(proto_router().route_layer(GovernorLayer::new(rl_per_ms(200, 150)?)))
         .layer(axum::Extension(Arc::clone(&scheduler)))
-        .layer(axum::Extension(Arc::clone(&proto_limiter)));
+        .layer(axum::Extension(Arc::clone(&proto_limiter)))
+        .layer(axum::Extension(Arc::clone(&sessions)));
 
     // Metrics endpoint - root-mounted, only when an operator-configured
     // bearer token is present. Uses the same rate-limit tier as
@@ -751,7 +756,8 @@ pub fn create_router(state: Arc<ServerState>) -> Result<Router, InitError> {
         ))
         .route_layer(GovernorLayer::new(nar_cache_limit()?))
         .layer(axum::Extension(cache_per_ip))
-        .layer(axum::Extension(Arc::clone(&proto_limiter)));
+        .layer(axum::Extension(Arc::clone(&proto_limiter)))
+        .layer(axum::Extension(Arc::clone(&sessions)));
 
     app = app
         .merge(cache_routes)

--- a/backend/gradient-web/tests/proto_connection_limit.rs
+++ b/backend/gradient-web/tests/proto_connection_limit.rs
@@ -39,7 +39,8 @@ fn make_server(limiter: Arc<ProtoLimiter>) -> TestServer {
     let app = proto_router()
         .with_state(Arc::clone(&state))
         .layer(Extension(scheduler))
-        .layer(Extension(limiter));
+        .layer(Extension(limiter))
+        .layer(Extension(gradient_proto::SessionsHandle::new()));
     // Real HTTP transport: in-memory transport rejects WS-shaped requests with
     // 426 inside the `WebSocketUpgrade` extractor before the handler body
     // runs, which would mask the limiter behaviour we're testing.

--- a/docs/src/development/architecture.md
+++ b/docs/src/development/architecture.md
@@ -13,8 +13,11 @@ registers its loops as children with `Shutdown::supervise`.
 
 ```text
 root
-├── trigger-dispatch, eval-dispatch      periodic passes (5s)
-├── build-dispatch                       actor: 5s tick plus coalesced kicks
+├── scheduler                            supervisor node
+│   ├── scheduler-core                   actor: WorkerPool + JobTracker behind messages
+│   ├── trigger-dispatch, eval-dispatch  periodic passes (5s)
+│   └── build-dispatch                   actor: 5s tick plus coalesced kicks
+├── sessions                             supervisor: one actor per worker connection
 ├── worker-sample, instance-metrics      periodic passes
 ├── worker-liveness, graph-consistency   periodic passes, absent when disabled
 ├── cache-maintenance, sign-sweep,
@@ -23,15 +26,25 @@ root
 └── outbound-connect                     dials workers with a registered URL
 ```
 
-A child that panics or exits unexpectedly is respawned after an exponential
-backoff (1s doubling to 60s, reset after five healthy minutes); a pass that
-runs past its budget is cancelled in place and ticks again. Restarts, pass
-errors, budget timeouts and the last successful pass are reported per child on
-`/board/health`. Everything that outlives one request but is not a loop (NAR
-commits, CI action deliveries, per-connection writers, sessions) runs as a
-tracked task so shutdown drains it; bare `tokio::spawn` is a clippy error in
-the server crates. Axum serves the HTTP API and the worker WebSocket; the
-scheduler, cache and CI code are libraries the tree drives.
+The scheduler's state (`WorkerPool`, `JobTracker`) is private to one actor;
+`Scheduler` is a facade whose every method is one message with a typed reply,
+so a claim, a release or a peer revocation is atomic and nothing holds a lock
+across a database call. The scheduler pushes to a session only through a
+`SessionPort` signal (`Offers`, `Reauth`, `Abort`, `Drain`); a burst of
+enqueues collapses into one offer per generation. Each worker connection is a
+`SessionActor`: its reader task delivers one inbound frame at a time with a
+call and reads the next only after the reply, so TCP backpressure holds.
+Order-independent RPCs (`CacheQuery`, `QueryKnownDerivations`, `WorkerMetrics`)
+still run as tracked tasks off the session. When the core actor is respawned,
+the sessions supervisor re-registers every live session together with the
+jobs it still runs. A child that panics or exits unexpectedly is respawned
+after an exponential backoff (1s doubling to 60s, reset after five healthy
+minutes); a pass that runs past its budget is cancelled in place and ticks
+again. Restarts, pass errors, budget timeouts and the last successful pass are
+reported per child on `/board/health`. Everything that outlives one request but
+is not a loop runs as a tracked task so shutdown drains it; bare `tokio::spawn`
+is a clippy error in the server crates. Axum serves the HTTP API and the worker
+WebSocket; the scheduler, cache and CI code are libraries the tree drives.
 
 ### Worker
 

--- a/docs/src/development/proto.md
+++ b/docs/src/development/proto.md
@@ -1416,12 +1416,14 @@ sequenceDiagram
     Note left of W: waits before reconnecting
 ```
 
-On SIGTERM the server cancels its shutdown token. Every worker session sends
-`Draining` and closes; the supervision tree stops; tracked tasks (NAR commits,
-action deliveries) finish within the 30 s drain budget. Workers, on
-`Draining`, stop requesting jobs, keep in-flight results, and replay them on
-reconnect; startup recovery re-queues whatever was interrupted, so a restart
-loses no job.
+On SIGTERM the server cancels its shutdown token. The sessions supervisor sends
+`Draining` to every worker session and marks the worker draining, so it is
+offered and assigned nothing more; a session closes as soon as the worker has
+no job in flight, or 20 s after `Draining` at the latest. The rest of the tree
+stops, and tracked tasks (NAR commits, action deliveries) finish within the
+30 s drain budget. Workers, on `Draining`, stop requesting jobs, keep in-flight
+results, and replay them on reconnect; startup recovery re-queues whatever was
+interrupted, so a restart loses no job.
 
 ---
 

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -7786,3 +7786,26 @@ connected client ends on the shutdown token).
 supervised loop with zero restarts and timeouts, `systemctl stop
 gradient-server` returns within the drain budget, and the worker logs the
 `Draining` message.
+
+## Scheduler actor and session actors (#595)
+
+`backend/gradient-scheduler/src/scheduler_tests.rs`:
+`enqueue_signals_offers_with_a_rising_generation` (each enqueue signals
+`Offers(n)` and a delta fetch answers with that generation),
+`abort_evaluation_signals_the_worker_running_its_job`,
+`a_respawned_core_is_rebuilt_from_reattached_sessions` (stop the core, spawn a
+new one, re-register the session with its active job: counts and the active
+job are back), plus the existing scheduler tests moved onto the message API.
+
+`backend/gradient-scheduler/src/worker_pool.rs`:
+`test_request_reauth_notifies_connected_worker` and
+`send_abort_reaches_the_session_and_reports_unknown_workers` assert the
+`SessionSignal` a pool pushes through a `SessionPort`.
+
+`backend/gradient-util/src/supervision.rs`:
+`a_nested_supervisor_restarts_its_own_child_and_stops_with_the_tree`.
+
+`backend/gradient-proto/src/handler/session_actor.rs`:
+`drain_sends_draining_and_closes_an_idle_session` (a real WebSocket pair; the
+`Drain` signal produces one `Draining` frame, then the socket closes and the
+worker is unregistered).


### PR DESCRIPTION
Closes #595. Stacked on #599: the scheduler state is one actor behind typed messages, and every worker connection is a session actor under a supervisor that drains on shutdown and re-registers after a core restart.