### PR TITLE
repo: feat: enforce the no-unwrap policy with clippy

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -20,6 +20,7 @@ unreachable_code = "warn"
 dbg_macro                       = "warn"
 todo                            = "warn"
 allow_attributes_without_reason = "warn"
+unwrap_used                     = "deny"
 
 [workspace.dependencies]
 # Internal crates

--- a/backend/clippy.toml
+++ b/backend/clippy.toml
@@ -1,3 +1,5 @@
+allow-unwrap-in-tests = true
+
 disallowed-methods = [
     { path = "tokio::task::spawn", reason = "use Shutdown::spawn for a tracked task or Shutdown::supervise for a loop" },
 ]

--- a/backend/gradient-cache/src/cacher/sign_sweep.rs
+++ b/backend/gradient-cache/src/cacher/sign_sweep.rs
@@ -19,6 +19,7 @@ use gradient_core::ServerState;
 use gradient_sources::CacheSigner;
 use gradient_types::*;
 use gradient_util::nix_hash::normalize_nar_hash;
+use gradient_util::sync::Mutex;
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, QuerySelect, Set,
 };
@@ -202,8 +203,8 @@ pub async fn sign_missing_signatures(state: Arc<ServerState>) -> anyhow::Result<
 const FULL_BACKFILL_SECS: u64 = 3600;
 
 fn full_backfill_due() -> bool {
-    static LAST: std::sync::Mutex<Option<std::time::Instant>> = std::sync::Mutex::new(None);
-    let mut last = LAST.lock().unwrap();
+    static LAST: Mutex<Option<std::time::Instant>> = Mutex::new(None);
+    let mut last = LAST.lock();
     match *last {
         // Arm on first call instead of running: a restart must not pay the
         // full scan immediately (frontier passes cover the steady state).

--- a/backend/gradient-core/tests/nar_extract.rs
+++ b/backend/gradient-core/tests/nar_extract.rs
@@ -8,6 +8,11 @@
 //!
 //! Async assertions use sync `#[test]` + `tokio::runtime::Builder::block_on`.
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use bytes::Bytes;
 use futures::StreamExt as _;
 use gradient_storage::nar_extract::{

--- a/backend/gradient-core/tests/nar_pack.rs
+++ b/backend/gradient-core/tests/nar_pack.rs
@@ -17,6 +17,11 @@
 //! and compare it to `write_nar`, the reference encoder, so a large file's bytes
 //! must survive the route the dumper picks for it.
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use bytes::Bytes;
 use futures::StreamExt as _;
 use harmonia_file_nar::NarByteStream;

--- a/backend/gradient-notify/src/lib.rs
+++ b/backend/gradient-notify/src/lib.rs
@@ -193,13 +193,16 @@ impl EmailSender for EmailService {
         subject: &str,
         body: &str,
     ) -> Result<MailDeliveryResult> {
-        if !self.enabled || self.transport.is_none() {
+        if !self.enabled {
             bail!("SMTP is not configured on this server");
         }
         if to.is_empty() {
             bail!("send_action_mail: no recipients");
         }
-        let transport = self.transport.as_ref().unwrap();
+        let transport = self
+            .transport
+            .as_ref()
+            .context("SMTP is not configured on this server")?;
         let from = format!("{} <{}>", self.from_name, self.from_address);
         let mut builder = Message::builder()
             .from(from.parse().context("invalid from address")?)

--- a/backend/gradient-scheduler/src/history.rs
+++ b/backend/gradient-scheduler/src/history.rs
@@ -119,7 +119,7 @@ fn percentile_or_max(values: &mut [i64], p: f64) -> i64 {
     }
     values.sort_unstable();
     if values.len() < 20 {
-        return *values.last().unwrap();
+        return values[values.len() - 1];
     }
     let idx = ((values.len() as f64 - 1.0) * p).round() as usize;
     values[idx]

--- a/backend/gradient-storage/src/nar_extract.rs
+++ b/backend/gradient-storage/src/nar_extract.rs
@@ -111,8 +111,7 @@ where
             NarEvent::EndDirectory => {
                 let leaving = collector.as_ref().is_some_and(|c| stack.len() == c.depth);
                 stack.pop();
-                if leaving {
-                    let c = collector.take().unwrap();
+                if leaving && let Some(c) = collector.take() {
                     return Ok(Extracted::Directory {
                         tar_zst: c.finish()?,
                     });
@@ -147,9 +146,10 @@ where
                     let cap = std::cmp::min(size, NAR_EXTRACT_MAX_PREALLOC as u64) as usize;
                     let mut buf = Vec::with_capacity(cap);
                     reader.read_to_end(&mut buf).await?;
-                    let c = collector.as_mut().unwrap();
-                    let path = c.entry_path(&stack, Some(name.as_ref()));
-                    c.append_file(&path, &buf, executable)?;
+                    if let Some(c) = collector.as_mut() {
+                        let path = c.entry_path(&stack, Some(name.as_ref()));
+                        c.append_file(&path, &buf, executable)?;
+                    }
                 } else {
                     tokio::io::copy(&mut reader, &mut tokio::io::sink()).await?;
                 }

--- a/backend/gradient-test-support/src/lib.rs
+++ b/backend/gradient-test-support/src/lib.rs
@@ -19,6 +19,11 @@
 //! }
 //! ```
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 pub mod cache_fixture;
 pub mod cli;
 pub mod db;

--- a/backend/gradient-types/src/triggers.rs
+++ b/backend/gradient-types/src/triggers.rs
@@ -112,7 +112,8 @@ impl TriggerConfig {
 
     /// Serialise to the JSON shape stored in the DB (without the `"type"` tag).
     pub fn to_db_json(&self) -> serde_json::Value {
-        let mut v = serde_json::to_value(self).unwrap();
+        let mut v = serde_json::to_value(self)
+            .expect("a TriggerConfig is a derived enum of strings and numbers");
         if let serde_json::Value::Object(ref mut m) = v {
             m.remove("type");
         }

--- a/backend/gradient-util/src/lib.rs
+++ b/backend/gradient-util/src/lib.rs
@@ -10,5 +10,5 @@ pub mod http_validation;
 pub mod hydra;
 pub mod nix_hash;
 pub mod shutdown;
-pub mod sync;
 pub mod supervision;
+pub mod sync;

--- a/backend/gradient-util/src/lib.rs
+++ b/backend/gradient-util/src/lib.rs
@@ -10,4 +10,5 @@ pub mod http_validation;
 pub mod hydra;
 pub mod nix_hash;
 pub mod shutdown;
+pub mod sync;
 pub mod supervision;

--- a/backend/gradient-util/src/sync.rs
+++ b/backend/gradient-util/src/sync.rs
@@ -1,0 +1,99 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Shared-memory primitives whose failure modes we have designed away.
+
+use std::fmt;
+use std::sync::MutexGuard;
+
+/// A mutex that ignores poisoning. Everything guarded this way is a plain
+/// collection, queue or counter whose invariants survive a panic mid-critical
+/// section, so a poisoned lock hands the value back instead of turning one
+/// panic into a cascade of them at every later `lock()`.
+pub struct Mutex<T: ?Sized>(std::sync::Mutex<T>);
+
+impl<T> Mutex<T> {
+    pub const fn new(value: T) -> Self {
+        Self(std::sync::Mutex::new(value))
+    }
+
+    pub fn into_inner(self) -> T {
+        self.0.into_inner().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+impl<T: ?Sized> Mutex<T> {
+    pub fn lock(&self) -> MutexGuard<'_, T> {
+        self.0.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    pub fn get_mut(&mut self) -> &mut T {
+        self.0.get_mut().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+impl<T: Default> Default for Mutex<T> {
+    fn default() -> Self {
+        Self::new(T::default())
+    }
+}
+
+impl<T> From<T> for Mutex<T> {
+    fn from(value: T) -> Self {
+        Self::new(value)
+    }
+}
+
+impl<T: ?Sized + fmt::Debug> fmt::Debug for Mutex<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Mutex").field(&&*self.lock()).finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Mutex;
+    use std::sync::Arc;
+
+    /// A panic while the lock is held must not turn every later `lock()` into
+    /// a second panic: the guarded value is still there to be read.
+    #[test]
+    fn a_poisoned_lock_still_hands_out_the_value() {
+        let m = Arc::new(Mutex::new(vec![1, 2, 3]));
+        let poisoner = Arc::clone(&m);
+        let panicked = std::thread::spawn(move || {
+            let _guard = poisoner.lock();
+            panic!("holding the lock");
+        })
+        .join();
+
+        assert!(panicked.is_err(), "the helper thread must have panicked");
+        assert_eq!(*m.lock(), vec![1, 2, 3]);
+    }
+
+    /// `into_inner` is the other half of the same promise: draining an
+    /// accumulator after a worker panicked must still yield what it collected.
+    #[test]
+    fn into_inner_survives_a_poisoned_lock() {
+        let m = Arc::new(Mutex::new(vec![1, 2, 3]));
+        let poisoner = Arc::clone(&m);
+        let _ = std::thread::spawn(move || {
+            let _guard = poisoner.lock();
+            panic!("holding the lock");
+        })
+        .join();
+
+        let inner = Arc::into_inner(m).expect("the poisoner thread is joined");
+        assert_eq!(inner.into_inner(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn the_guard_writes_through() {
+        let m = Mutex::new(0);
+        *m.lock() += 5;
+        assert_eq!(*m.lock(), 5);
+    }
+}

--- a/backend/gradient-web/src/authorization/jwt.rs
+++ b/backend/gradient-web/src/authorization/jwt.rs
@@ -254,13 +254,7 @@ pub fn generate_api_key() -> String {
 pub fn hash_api_key(raw: &str) -> String {
     let mut h = Sha256::new();
     h.update(raw.as_bytes());
-    let bytes = h.finalize();
-    let mut out = String::with_capacity(64);
-    for b in bytes {
-        use std::fmt::Write as _;
-        write!(&mut out, "{:02x}", b).unwrap();
-    }
-    out
+    hex::encode(h.finalize())
 }
 
 #[cfg(test)]

--- a/backend/gradient-web/src/authorization/middleware.rs
+++ b/backend/gradient-web/src/authorization/middleware.rs
@@ -89,7 +89,7 @@ pub async fn authorize(
         };
         let mut parts = val.split_whitespace();
         let (bearer, token) = (parts.next(), parts.next());
-        if bearer != Some("Bearer") || token.is_none() {
+        let Some(token) = token.filter(|_| bearer == Some("Bearer")) else {
             audit_deny(
                 &state,
                 None,
@@ -100,8 +100,8 @@ pub async fn authorize(
             )
             .await;
             return Err(WebError::forbidden("Invalid Authorization header"));
-        }
-        token.unwrap().to_string()
+        };
+        token.to_string()
     } else if let Some(t) = token_from_cookie(&req) {
         t
     } else {

--- a/backend/gradient-web/src/endpoints/auth.rs
+++ b/backend/gradient-web/src/endpoints/auth.rs
@@ -737,13 +737,7 @@ fn generate_user_code() -> String {
 fn hash_device_code(raw: &str) -> String {
     let mut h = Sha256::new();
     h.update(raw.as_bytes());
-    let bytes = h.finalize();
-    let mut out = String::with_capacity(64);
-    for b in bytes {
-        use std::fmt::Write as _;
-        write!(&mut out, "{:02x}", b).unwrap();
-    }
-    out
+    hex::encode(h.finalize())
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/backend/gradient-web/src/endpoints/tasks/flake_inputs.rs
+++ b/backend/gradient-web/src/endpoints/tasks/flake_inputs.rs
@@ -89,13 +89,14 @@ fn validate_input_name(name: &str) -> WebResult<()> {
         ));
     }
     // A literal (non-glob) name must still be a valid flake input identifier.
-    if !gradient_util::glob::is_pattern(name) {
-        let first = name.chars().next().unwrap();
-        if !first.is_ascii_alphabetic() && first != '_' {
-            return Err(WebError::bad_request(
-                "input_name must match ^[A-Za-z_][A-Za-z0-9_-]*$",
-            ));
-        }
+    if !gradient_util::glob::is_pattern(name)
+        && let Some(first) = name.chars().next()
+        && !first.is_ascii_alphabetic()
+        && first != '_'
+    {
+        return Err(WebError::bad_request(
+            "input_name must match ^[A-Za-z_][A-Za-z0-9_-]*$",
+        ));
     }
     Ok(())
 }

--- a/backend/gradient-web/src/scim/groups.rs
+++ b/backend/gradient-web/src/scim/groups.rs
@@ -21,12 +21,17 @@ use super::error::{SCIM_CONTENT_TYPE, ScimError, ScimResult};
 use super::filter::parse_eq_filter;
 
 fn scim_json(status: StatusCode, body: impl serde::Serialize) -> Response {
-    (
-        status,
-        [(header::CONTENT_TYPE, SCIM_CONTENT_TYPE)],
-        Json(serde_json::to_value(body).unwrap()),
-    )
-        .into_response()
+    match serde_json::to_value(body) {
+        Ok(value) => (
+            status,
+            [(header::CONTENT_TYPE, SCIM_CONTENT_TYPE)],
+            Json(value),
+        )
+            .into_response(),
+        Err(e) => {
+            ScimError::internal(format!("failed to serialise SCIM response: {e}")).into_response()
+        }
+    }
 }
 
 fn grants<'a>(state: &'a Arc<ServerState>, group: &str) -> Option<&'a Vec<(ProjectId, RoleId)>> {

--- a/backend/gradient-web/src/scim/users.rs
+++ b/backend/gradient-web/src/scim/users.rs
@@ -45,12 +45,17 @@ fn user_resource(u: &UserModel) -> UserResource {
 }
 
 fn scim_json(status: StatusCode, body: impl serde::Serialize) -> Response {
-    (
-        status,
-        [(axum::http::header::CONTENT_TYPE, SCIM_CONTENT_TYPE)],
-        Json(serde_json::to_value(body).unwrap()),
-    )
-        .into_response()
+    match serde_json::to_value(body) {
+        Ok(value) => (
+            status,
+            [(axum::http::header::CONTENT_TYPE, SCIM_CONTENT_TYPE)],
+            Json(value),
+        )
+            .into_response(),
+        Err(e) => {
+            ScimError::internal(format!("failed to serialise SCIM response: {e}")).into_response()
+        }
+    }
 }
 
 #[derive(Deserialize)]

--- a/backend/gradient-web/tests/actions.rs
+++ b/backend/gradient-web/tests/actions.rs
@@ -10,6 +10,11 @@
 //! + `MockDatabase`. The SMTP-disabled test builds its own `ServerState` so it
 //!   can swap in an `InMemoryEmailSender::disabled()`.
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use axum_test::TestServer;
 use gradient_core::ServerState;
 use gradient_db::{WebDb, WorkerDb};

--- a/backend/gradient-web/tests/admin_state.rs
+++ b/backend/gradient-web/tests/admin_state.rs
@@ -11,6 +11,11 @@
 //! for both formats. A full round-trip against real data lives in the nix api
 //! integration test (`nix/tests/gradient/api`).
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use gradient_test_support::fixtures::user;
 use gradient_test_support::web::{live_session, make_test_server, make_token};
 use gradient_types::SessionId;

--- a/backend/gradient-web/tests/auth_hardening.rs
+++ b/backend/gradient-web/tests/auth_hardening.rs
@@ -10,6 +10,11 @@
 //! `axum_test::TestServer` against a `MockDatabase` so they exercise the
 //! same handlers the real server runs without needing Postgres.
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use axum_test::TestServer;
 use chrono::{Duration, Utc};
 use gradient_core::ServerState;

--- a/backend/gradient-web/tests/board_decisions.rs
+++ b/backend/gradient-web/tests/board_decisions.rs
@@ -12,6 +12,11 @@
 //! on every request - the Live Jobs "incl. rejected" table then swallowed the
 //! error and stayed empty (#419).
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use gradient_test_support::fixtures::user;
 use gradient_test_support::web::{live_session, make_test_server, make_token};
 use gradient_types::SessionId;

--- a/backend/gradient-web/tests/build_requests_blobs.rs
+++ b/backend/gradient-web/tests/build_requests_blobs.rs
@@ -9,6 +9,11 @@
 //! mismatch, foreign hash, already-dispatched, expired) and the happy
 //! path where one blob lands in storage and shrinks `session.missing`.
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use axum::http::StatusCode;
 use axum_test::multipart::{MultipartForm, Part};
 use chrono::{Duration, Utc};

--- a/backend/gradient-web/tests/build_requests_dispatch.rs
+++ b/backend/gradient-web/tests/build_requests_dispatch.rs
@@ -10,6 +10,11 @@
 //! against a mock DB. The source NAR's cache-index row is the graph actor's
 //! write, so it is not in this transaction.
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use axum::http::StatusCode;
 use chrono::{Duration, Utc};
 use gradient_db::permissions::PermissionMask;

--- a/backend/gradient-web/tests/build_requests_manifest.rs
+++ b/backend/gradient-web/tests/build_requests_manifest.rs
@@ -10,6 +10,11 @@
 //! hashes, duplicates) and the happy-path response shape - `session` is a
 //! UUID and `missing` is the subset of hex hashes the project doesn't have yet.
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use axum::http::StatusCode;
 use gradient_db::permissions::PermissionMask;
 use gradient_entity::ids::*;

--- a/backend/gradient-web/tests/build_requests_source.rs
+++ b/backend/gradient-web/tests/build_requests_source.rs
@@ -8,6 +8,11 @@
 //! `nix`-feature CLI uploads a pre-packed source NAR; the server computes the
 //! store path and queues a build-request evaluation.
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use axum::http::StatusCode;
 use axum_test::multipart::{MultipartForm, Part};
 use chrono::Utc;

--- a/backend/gradient-web/tests/build_requests_url.rs
+++ b/backend/gradient-web/tests/build_requests_url.rs
@@ -14,6 +14,11 @@
 //! Query sequence: session, session update, user (authorize), project by name,
 //! membership, role (TriggerEvaluation), then the queueing transaction.
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use gradient_db::permissions::PermissionMask;
 use gradient_entity::{ids::*, project, project_user, role, task};
 use gradient_test_support::fixtures::{project_id, task_id, test_date, user, user_id};

--- a/backend/gradient-web/tests/cache_api_key_pinning.rs
+++ b/backend/gradient-web/tests/cache_api_key_pinning.rs
@@ -12,6 +12,11 @@
 //!   3. SELECT api  (re-select after save)
 //!   4. SELECT user
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use gradient_db::permissions::{cache_admin_mask, cache_view_mask};
 use gradient_entity::{api, cache, cache_role, cache_user, ids::*};
 use gradient_test_support::fixtures::{test_date, user, user_id};

--- a/backend/gradient-web/tests/cache_local_priority.rs
+++ b/backend/gradient-web/tests/cache_local_priority.rs
@@ -7,6 +7,11 @@
 //! Integration tests for the local-priority override in
 //! `GET /cache/{cache}/nix-cache-info`.
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use axum::extract::connect_info::MockConnectInfo;
 use axum_test::TestServer;
 use gradient_core::ServerState;

--- a/backend/gradient-web/tests/cache_log_upstream.rs
+++ b/backend/gradient-web/tests/cache_log_upstream.rs
@@ -4,6 +4,10 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
 #![allow(clippy::disallowed_methods, reason = "test harness server")]
 
 //! A pull-through cache must serve build logs it does not hold itself (#547).

--- a/backend/gradient-web/tests/cache_members.rs
+++ b/backend/gradient-web/tests/cache_members.rs
@@ -7,6 +7,11 @@
 //! Integration tests for the cache member management API
 //! (`/api/v1/caches/{cache}/members`).
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use gradient_db::permissions::{cache_admin_mask, cache_view_mask};
 use gradient_entity::{cache, cache_role, cache_user, ids::*, user};
 use gradient_test_support::fixtures::{test_date, user, user_id};

--- a/backend/gradient-web/tests/cache_roles.rs
+++ b/backend/gradient-web/tests/cache_roles.rs
@@ -7,6 +7,11 @@
 //! Integration tests for the cache-scoped role management API
 //! (`/api/v1/caches/{cache}/roles`).
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use gradient_db::permissions::{cache_admin_mask, cache_view_mask};
 use gradient_entity::{cache, cache_role, cache_user, ids::*};
 use gradient_test_support::fixtures::{test_date, user, user_id};

--- a/backend/gradient-web/tests/cache_subscription_gate.rs
+++ b/backend/gradient-web/tests/cache_subscription_gate.rs
@@ -25,6 +25,11 @@
 //!   8. SELECT cache_user (membership)
 //!   9. SELECT cache_role (bitmask)  - only when member exists
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use gradient_db::permissions::{admin_mask, cache_admin_mask, cache_view_mask, mask_from};
 use gradient_entity::{cache, cache_role, cache_user, ids::*, project_cache, project_user, role};
 use gradient_test_support::fixtures::{project, project_id, test_date, user, user_id};

--- a/backend/gradient-web/tests/cache_upstreams_public.rs
+++ b/backend/gradient-web/tests/cache_upstreams_public.rs
@@ -9,6 +9,11 @@
 //! trusted-public-key needed to consume pull-through paths, while a private
 //! cache stays hidden. Regression for #527.
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use gradient_entity::cache_upstream::CacheUpstreamKind;
 use gradient_entity::project_cache::CacheSubscriptionMode;
 use gradient_entity::{cache, cache_upstream, ids::*};

--- a/backend/gradient-web/tests/caches_upload.rs
+++ b/backend/gradient-web/tests/caches_upload.rs
@@ -5,6 +5,11 @@
 
 //! Integration tests for `POST /api/v1/caches/{cache}/nars`.
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use axum::http::StatusCode;
 use axum_test::TestServer;
 use axum_test::multipart::{MultipartForm, Part};

--- a/backend/gradient-web/tests/cli_device_authorization.rs
+++ b/backend/gradient-web/tests/cli_device_authorization.rs
@@ -11,6 +11,11 @@
 //! pin down the state machine (pending → authorized/denied/expired) and the
 //! "device_code is single-use" guarantee.
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use axum_test::TestServer;
 use chrono::{Duration, Utc};
 use gradient_core::ServerState;

--- a/backend/gradient-web/tests/commits_authorization.rs
+++ b/backend/gradient-web/tests/commits_authorization.rs
@@ -25,6 +25,11 @@
 //!   Then membership probe (only when no project is public AND caller is authenticated):
 //!     8. SELECT project_user
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use axum_test::TestServer;
 use chrono::{Duration, Utc};
 use gradient_core::ServerState;

--- a/backend/gradient-web/tests/config_endpoint.rs
+++ b/backend/gradient-web/tests/config_endpoint.rs
@@ -7,6 +7,11 @@
 //! `GET /api/v1/config` exposes the `create_project` / `create_cache` permission
 //! knobs so the frontend can hide the create buttons (issue #470).
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use gradient_test_support::web::{make_test_server, make_test_server_configured};
 use gradient_types::CreatePermission;
 use sea_orm::{DatabaseBackend, MockDatabase};

--- a/backend/gradient-web/tests/create_permissions.rs
+++ b/backend/gradient-web/tests/create_permissions.rs
@@ -11,6 +11,11 @@
 //! only the auth query chain. The allow path is proven by reaching the
 //! name-taken pre-check (409) with the gate satisfied.
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use axum::http::StatusCode;
 use gradient_entity::ids::*;
 use gradient_entity::{cache, project};

--- a/backend/gradient-web/tests/evaluations_search.rs
+++ b/backend/gradient-web/tests/evaluations_search.rs
@@ -16,6 +16,11 @@
 //! mocked reads before the handler's own: session by jti, session update, user,
 //! project by name, task by project and name.
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use gradient_entity::evaluation::EvaluationStatus;
 use gradient_entity::{commit, evaluation, ids::*, project, task};
 use gradient_test_support::fixtures::{commit_id, project_id, task_id, test_date, user, user_id};

--- a/backend/gradient-web/tests/flake_input_overrides.rs
+++ b/backend/gradient-web/tests/flake_input_overrides.rs
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use gradient_entity::ids::*;
 use gradient_entity::task_flake_input_override;
 use gradient_test_support::fixtures::{project, project_id, task_id, test_date, user, user_id};

--- a/backend/gradient-web/tests/forge_hooks.rs
+++ b/backend/gradient-web/tests/forge_hooks.rs
@@ -15,6 +15,11 @@
 //! Uses manual Tokio runtimes because `#[tokio::test]` expands to
 //! `::gradient_core::…` which clashes with the local `core` crate name.
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use axum_test::TestServer;
 use gradient_ci::actions::encrypt_secret_with_file as encrypt_webhook_secret;
 use gradient_core::ServerState;

--- a/backend/gradient-web/tests/nar_serve.rs
+++ b/backend/gradient-web/tests/nar_serve.rs
@@ -10,6 +10,11 @@
 //! carry an accurate `Content-Length` (the streamed body has no implicit
 //! length, so the handler sets it from the storage object size).
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use axum::extract::connect_info::MockConnectInfo;
 use axum_test::TestServer;
 use gradient_core::ServerState;

--- a/backend/gradient-web/tests/narinfo.rs
+++ b/backend/gradient-web/tests/narinfo.rs
@@ -6,6 +6,11 @@
 
 //! Integration test: `.narinfo` handler serves metadata from DB rows only.
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use axum_test::TestServer;
 use gradient_core::ServerState;
 use gradient_db::{WebDb, WorkerDb};

--- a/backend/gradient-web/tests/oidc_pkce.rs
+++ b/backend/gradient-web/tests/oidc_pkce.rs
@@ -4,6 +4,10 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
 #![allow(clippy::disallowed_methods, reason = "test harness server")]
 
 //! PKCE regression tests (issue #318): the authorization redirect must carry

--- a/backend/gradient-web/tests/projects_integrations.rs
+++ b/backend/gradient-web/tests/projects_integrations.rs
@@ -15,6 +15,11 @@
 //!   `has_secret`/`has_access_token` booleans so non-admin members cannot
 //!   probe credential state.
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use gradient_entity::integration::IntegrationKind;
 use gradient_entity::{github_installation, ids::*, integration, project_user, role};
 use gradient_test_support::fixtures::{project, project_id, test_date, user, user_id};

--- a/backend/gradient-web/tests/reports_require_auth.rs
+++ b/backend/gradient-web/tests/reports_require_auth.rs
@@ -14,6 +14,11 @@
 //! passed `include_instance=false`. The OpenAPI contract has always listed this
 //! path under the global `bearerAuth`; these tests hold the code to it.
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use gradient_entity::ids::EvaluationId;
 use gradient_test_support::web::make_test_server;
 use sea_orm::{DatabaseBackend, MockDatabase};

--- a/backend/gradient-web/tests/roles_crud.rs
+++ b/backend/gradient-web/tests/roles_crud.rs
@@ -16,6 +16,11 @@
 //! `append_exec_results` with `rows_affected: 1`, otherwise SeaORM treats the
 //! insert as a no-op and short-circuits.
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use gradient_db::permissions::{Permission, admin_mask, view_mask, write_mask};
 use gradient_entity::{ids::*, project_user, role};
 use gradient_test_support::fixtures::{project, project_id, user, user_id};

--- a/backend/gradient-web/tests/task_evaluate_response.rs
+++ b/backend/gradient-web/tests/task_evaluate_response.rs
@@ -14,6 +14,11 @@
 //! `restart_failed` is the path exercised here because the normal path resolves
 //! the branch head over git first; both return the same thing.
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use gradient_entity::evaluation::EvaluationStatus;
 use gradient_entity::{entry_point, evaluation, ids::*, project, project_user, role, task};
 use gradient_test_support::fixtures::{commit_id, project_id, task_id, test_date, user, user_id};

--- a/backend/gradient-web/tests/tasks_sign_cache.rs
+++ b/backend/gradient-web/tests/tasks_sign_cache.rs
@@ -10,6 +10,11 @@
 //! `axum_test::TestServer`, and `MockDatabase` because `#[tokio::test]`
 //! macro expansion clashes with the local `core` crate name.
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use axum_test::TestServer;
 use chrono::{Duration, Utc};
 use gradient_core::ServerState;

--- a/backend/gradient-web/tests/triggers.rs
+++ b/backend/gradient-web/tests/triggers.rs
@@ -20,6 +20,11 @@
 //!   5. SELECT task (by project + name)
 //!   6. SELECT project_user membership (permission check)
 
+#![expect(
+    clippy::unwrap_used,
+    reason = "test scaffolding: a fixture helper that cannot build its value should fail the test loudly"
+)]
+
 use gradient_entity::{ids::*, integration, project_user, task, task_trigger};
 use gradient_test_support::fixtures::{project, project_id, task_id, test_date, user, user_id};
 use gradient_test_support::web::{live_session, make_test_server, make_token};

--- a/backend/gradient-worker/src/proto/credentials.rs
+++ b/backend/gradient-worker/src/proto/credentials.rs
@@ -17,7 +17,8 @@
 
 use gradient_proto::messages::CredentialKind;
 use gradient_types::SecretBytes;
-use std::sync::{Arc, Mutex};
+use gradient_util::sync::Mutex;
+use std::sync::Arc;
 
 #[derive(Default)]
 struct Inner {
@@ -37,7 +38,7 @@ impl CredentialStore {
 
     /// Store a credential delivered by the server.
     pub fn store(&self, kind: CredentialKind, data: Vec<u8>) {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock();
         match kind {
             CredentialKind::SshKey => {
                 inner.ssh_key = Some(SecretBytes::new(data));
@@ -49,7 +50,6 @@ impl CredentialStore {
     pub fn ssh_key(&self) -> Option<SecretBytes> {
         self.inner
             .lock()
-            .unwrap()
             .ssh_key
             .as_ref()
             .map(|b| SecretBytes::new(b.expose().to_vec()))
@@ -57,7 +57,7 @@ impl CredentialStore {
 
     /// Clear all stored credentials (called after a job completes).
     pub fn clear(&self) {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock();
         inner.ssh_key = None;
     }
 }

--- a/backend/gradient-worker/src/proto/eval_cache_recv.rs
+++ b/backend/gradient-worker/src/proto/eval_cache_recv.rs
@@ -20,8 +20,9 @@
 //! Mirrors [`super::nar_recv`] but simpler: the executor runs one eval at a
 //! time so a single in-flight pull *or* push per `job_id` is enough.
 
+use gradient_util::sync::Mutex;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use anyhow::Result;
 use gradient_proto::messages::{EvalCachePullOutcome, EvalCachePushMode, TRANSFER_TIMEOUT};
@@ -96,7 +97,7 @@ impl PendingPull {
     /// mode and await the assembled blob delivered on `is_final`.
     pub async fn await_inline(self, total_bytes: u64) -> Result<Vec<u8>> {
         let (bytes_tx, bytes_rx) = oneshot::channel();
-        self.recv.inner.lock().unwrap().pending.insert(
+        self.recv.inner.lock().pending.insert(
             self.job_id.clone(),
             Pending::PullStream {
                 buf: Vec::with_capacity(total_bytes as usize),
@@ -164,7 +165,6 @@ impl EvalCacheReceiver {
         let (result_tx, result_rx) = oneshot::channel();
         self.inner
             .lock()
-            .unwrap()
             .pending
             .insert(job_id.to_owned(), Pending::Pull { result_tx });
         PendingPull {
@@ -179,7 +179,6 @@ impl EvalCacheReceiver {
         let (grant_tx, grant_rx) = oneshot::channel();
         self.inner
             .lock()
-            .unwrap()
             .pending
             .insert(job_id.to_owned(), Pending::Push { grant_tx });
         PendingPush {
@@ -191,7 +190,7 @@ impl EvalCacheReceiver {
 
     /// Route an `EvalCachePullResult` to its waiter.
     pub fn deliver_pull_result(&self, job_id: &str, outcome: EvalCachePullOutcome) {
-        let pending = self.inner.lock().unwrap().pending.remove(job_id);
+        let pending = self.inner.lock().pending.remove(job_id);
         match pending {
             Some(Pending::Pull { result_tx }) => {
                 if result_tx.send(outcome).is_err() {
@@ -205,7 +204,7 @@ impl EvalCacheReceiver {
     /// Append an inline `EvalCacheChunk`; on `is_final` deliver the assembled
     /// blob. A non-contiguous offset fails the waiter, mirroring `nar_recv`.
     pub fn deliver_pull_chunk(&self, job_id: &str, data: Vec<u8>, offset: u64, is_final: bool) {
-        let mut g = self.inner.lock().unwrap();
+        let mut g = self.inner.lock();
         let Some(Pending::PullStream { buf, .. }) = g.pending.get_mut(job_id) else {
             warn!(%job_id, "EvalCacheChunk with no inline pull stream - discarding");
             return;
@@ -238,7 +237,7 @@ impl EvalCacheReceiver {
 
     /// Route an `EvalCachePushGrant` to its waiter.
     pub fn deliver_push_grant(&self, job_id: &str, mode: EvalCachePushMode) {
-        let pending = self.inner.lock().unwrap().pending.remove(job_id);
+        let pending = self.inner.lock().pending.remove(job_id);
         match pending {
             Some(Pending::Push { grant_tx }) => {
                 if grant_tx.send(mode).is_err() {
@@ -252,7 +251,7 @@ impl EvalCacheReceiver {
     /// Drop any pending transfer state for `job_id`. Called from job cleanup
     /// next to `nar_recv.forget_job`.
     pub fn forget_job(&self, job_id: &str) {
-        self.inner.lock().unwrap().pending.remove(job_id);
+        self.inner.lock().pending.remove(job_id);
     }
 }
 

--- a/backend/gradient-worker/src/proto/job.rs
+++ b/backend/gradient-worker/src/proto/job.rs
@@ -9,8 +9,9 @@
 //! [`JobUpdater`] wraps the WebSocket sender and provides typed methods for
 //! reporting progress back to the server during job execution.
 
+use gradient_util::sync::Mutex;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -57,7 +58,6 @@ pub(crate) fn register_cache_waiter(
     let (reply, rx) = oneshot::channel();
     waiters
         .lock()
-        .unwrap()
         .insert(query_id, CacheWaiter { job_id, reply });
     rx
 }
@@ -70,7 +70,7 @@ pub(crate) fn deliver_cache_reply(
     query_id: &str,
     result: Result<Vec<CachedPath>, String>,
 ) -> bool {
-    match waiters.lock().unwrap().remove(query_id) {
+    match waiters.lock().remove(query_id) {
         Some(w) => {
             let _ = w.reply.send(result);
             true
@@ -82,13 +82,13 @@ pub(crate) fn deliver_cache_reply(
 /// Drop the waiter for a single timed-out query so a late reply is discarded
 /// rather than delivered to a closed channel.
 pub(crate) fn forget_cache_waiter(waiters: &CacheWaiters, query_id: &str) {
-    waiters.lock().unwrap().remove(query_id);
+    waiters.lock().remove(query_id);
 }
 
 /// Drop every waiter belonging to `job_id` so a query a finished or aborted job
 /// left in flight can't leak its slot.
 pub(crate) fn forget_cache_waiters_for_job(waiters: &CacheWaiters, job_id: &str) {
-    waiters.lock().unwrap().retain(|_, w| w.job_id != job_id);
+    waiters.lock().retain(|_, w| w.job_id != job_id);
 }
 
 /// Shared map from job-id to a oneshot sender that delivers `KnownDerivations`
@@ -444,7 +444,7 @@ async fn known_derivations_chunk(
 ) -> Result<Vec<String>> {
     let path_count = drv_paths.len();
     let (tx, rx) = oneshot::channel();
-    waiters.lock().unwrap().insert(job_id.to_owned(), tx);
+    waiters.lock().insert(job_id.to_owned(), tx);
     writer
         .send(ClientMessage::QueryKnownDerivations {
             job_id: job_id.to_owned(),
@@ -457,7 +457,7 @@ async fn known_derivations_chunk(
             "known-derivation waiter dropped - connection closed or superseded?"
         )),
         Err(_) => {
-            waiters.lock().unwrap().remove(job_id);
+            waiters.lock().remove(job_id);
             Err(anyhow::anyhow!(
                 "QueryKnownDerivations for {} paths timed out after {}s (job_id={})",
                 path_count,
@@ -901,7 +901,7 @@ mod tests {
                         deliver_cache_reply(&cache_waiters, &query_id, Ok(cached));
                     }
                     gradient_proto::messages::ServerMessage::KnownDerivations { job_id, known } => {
-                        let waiter = known_waiters.lock().unwrap().remove(&job_id);
+                        let waiter = known_waiters.lock().remove(&job_id);
                         if let Some(tx) = waiter {
                             let _ = tx.send(known);
                         }

--- a/backend/gradient-worker/src/proto/nar_recv.rs
+++ b/backend/gradient-worker/src/proto/nar_recv.rs
@@ -27,8 +27,9 @@
 //! [`gradient_proto::messages::ServerMessage::NarPushResume`], handing the
 //! pusher the byte offset to seek to.
 
+use gradient_util::sync::Mutex;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
@@ -152,7 +153,7 @@ impl NarReceiver {
     pub fn register(&self, job_id: &str, store_path: &str) -> PendingNar {
         let key = (job_id.to_owned(), store_path.to_owned());
         let (tx, rx) = oneshot::channel();
-        self.inner.lock().unwrap().waiters.insert(key, tx);
+        self.inner.lock().waiters.insert(key, tx);
         PendingNar {
             job_id: job_id.to_owned(),
             store_path: store_path.to_owned(),
@@ -182,7 +183,7 @@ impl NarReceiver {
                 store_path
             )),
             Err(_) => {
-                let mut g = self.inner.lock().unwrap();
+                let mut g = self.inner.lock();
                 g.buffers.remove(&key);
                 g.headers.remove(&key);
                 g.waiters.remove(&key);
@@ -208,7 +209,7 @@ impl NarReceiver {
     /// Record the `NarStreamHeader` that precedes a pull's chunks.
     pub fn note_header(&self, job_id: &str, store_path: &str, total_bytes: u64, token: &str) {
         let key = (job_id.to_owned(), store_path.to_owned());
-        self.inner.lock().unwrap().headers.insert(
+        self.inner.lock().headers.insert(
             key,
             HeaderInfo {
                 total_bytes,
@@ -232,7 +233,7 @@ impl NarReceiver {
         // Snapshot the active token and stamp the start time without holding
         // the lock across disk I/O.
         let token = {
-            let mut g = self.inner.lock().unwrap();
+            let mut g = self.inner.lock();
             if !data.is_empty() {
                 g.started
                     .entry(key.clone())
@@ -257,7 +258,6 @@ impl NarReceiver {
                 _ => {
                     self.inner
                         .lock()
-                        .unwrap()
                         .buffers
                         .entry(key.clone())
                         .or_default()
@@ -273,7 +273,7 @@ impl NarReceiver {
         // Take the in-memory state under the lock; read/discard the on-disk
         // partial off the runtime.
         let (expected, started, disk_key, mem_buf) = {
-            let mut g = self.inner.lock().unwrap();
+            let mut g = self.inner.lock();
             let expected = g.headers.remove(&key).map(|h| h.total_bytes);
             let started = g.started.remove(&key);
             let disk_key = match (self.partial.as_ref(), partial_key(job_id, store_path)) {
@@ -322,7 +322,7 @@ impl NarReceiver {
 
     /// Resolve the waiter for `key`, warning if none is registered.
     fn deliver(&self, key: &Key, result: Result<Vec<u8>, String>) {
-        let mut g = self.inner.lock().unwrap();
+        let mut g = self.inner.lock();
         match g.waiters.remove(key) {
             Some(tx) => {
                 if tx.send(result).is_err() {
@@ -340,7 +340,7 @@ impl NarReceiver {
     /// later request can resume from where it stopped.
     pub fn fail(&self, job_id: &str, store_path: &str, reason: String) {
         let key = (job_id.to_owned(), store_path.to_owned());
-        let mut g = self.inner.lock().unwrap();
+        let mut g = self.inner.lock();
         g.buffers.remove(&key);
         g.headers.remove(&key);
         g.started.remove(&key);
@@ -360,14 +360,14 @@ impl NarReceiver {
     pub fn register_push(&self, job_id: &str, store_path: &str) -> PushResumeGate {
         let key = (job_id.to_owned(), store_path.to_owned());
         let (tx, rx) = oneshot::channel();
-        self.inner.lock().unwrap().push_waiters.insert(key, tx);
+        self.inner.lock().push_waiters.insert(key, tx);
         PushResumeGate { rx }
     }
 
     /// Resolve a push-resume gate with the server's `received_bytes`.
     pub fn resolve_push(&self, job_id: &str, store_path: &str, received_bytes: u64) {
         let key = (job_id.to_owned(), store_path.to_owned());
-        if let Some(tx) = self.inner.lock().unwrap().push_waiters.remove(&key) {
+        if let Some(tx) = self.inner.lock().push_waiters.remove(&key) {
             let _ = tx.send(received_bytes);
         } else {
             debug!(%job_id, %store_path, "NarPushResume with no push gate - discarding");
@@ -377,7 +377,7 @@ impl NarReceiver {
     /// Drop in-memory state for a job. On-disk partials (keyed by hash) are
     /// left for the GC sweep so a later attempt can still resume.
     pub fn forget_job(&self, job_id: &str) {
-        let mut g = self.inner.lock().unwrap();
+        let mut g = self.inner.lock();
         g.buffers.retain(|(j, _), _| j != job_id);
         g.headers.retain(|(j, _), _| j != job_id);
         g.waiters.retain(|(j, _), _| j != job_id);

--- a/backend/gradient-worker/src/worker/dispatch.rs
+++ b/backend/gradient-worker/src/worker/dispatch.rs
@@ -10,8 +10,9 @@
 //! [`run_dispatch_loop`] is the main entry point. It owns one [`DispatchState`]
 //! per connection; every inbound [`ServerMessage`] is routed to a method on it.
 
+use gradient_util::sync::Mutex;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use anyhow::{Context as _, Result};
 use gradient_proto::messages::{
@@ -330,10 +331,7 @@ impl DispatchState {
     async fn on_job_done(&mut self, job_id: String, result: Result<()>) -> Result<()> {
         self.jobs.abort_senders.remove(&job_id);
         crate::proto::job::forget_cache_waiters_for_job(&self.cache_waiters, &job_id);
-        self.known_derivation_waiters
-            .lock()
-            .unwrap()
-            .remove(&job_id);
+        self.known_derivation_waiters.lock().remove(&job_id);
         self.nar_recv.forget_job(&job_id);
         self.eval_cache_recv.forget_job(&job_id);
         self.credentials.clear();
@@ -427,7 +425,7 @@ impl DispatchState {
             return;
         }
         {
-            let mut g = self.candidates.lock().unwrap();
+            let mut g = self.candidates.lock();
             for c in &cands {
                 g.insert(c.job_id.clone(), c.clone());
             }
@@ -450,7 +448,7 @@ impl DispatchState {
             return;
         }
         let new_candidates: Vec<JobCandidate> = {
-            let mut g = self.candidates.lock().unwrap();
+            let mut g = self.candidates.lock();
             cands
                 .into_iter()
                 .filter(|c| {
@@ -486,8 +484,8 @@ impl DispatchState {
 
     fn on_revoke_job(&mut self, job_ids: Vec<String>) {
         debug!(?job_ids, "jobs revoked");
-        let mut cands = self.candidates.lock().unwrap();
-        let mut scores = self.last_scores.lock().unwrap();
+        let mut cands = self.candidates.lock();
+        let mut scores = self.last_scores.lock();
         for id in &job_ids {
             cands.remove(id);
             scores.remove(id);
@@ -495,7 +493,7 @@ impl DispatchState {
     }
 
     async fn on_request_all_scores(&mut self) {
-        let all: Vec<JobCandidate> = self.candidates.lock().unwrap().values().cloned().collect();
+        let all: Vec<JobCandidate> = self.candidates.lock().values().cloned().collect();
         debug!(
             count = all.len(),
             "RequestAllScores - re-scoring all cached candidates"
@@ -524,8 +522,8 @@ impl DispatchState {
     /// re-offer is treated as new and re-scored (the delta filter skips
     /// unchanged cached entries).
     fn forget_candidate(&self, job_id: &str) {
-        self.candidates.lock().unwrap().remove(job_id);
-        self.last_scores.lock().unwrap().remove(job_id);
+        self.candidates.lock().remove(job_id);
+        self.last_scores.lock().remove(job_id);
     }
 
     async fn on_assign_job(&mut self, job_id: String, job: Job) -> Result<()> {
@@ -657,12 +655,7 @@ impl DispatchState {
     }
 
     fn on_known_derivations(&mut self, job_id: String, known: Vec<String>) {
-        if let Some(tx) = self
-            .known_derivation_waiters
-            .lock()
-            .unwrap()
-            .remove(&job_id)
-        {
+        if let Some(tx) = self.known_derivation_waiters.lock().remove(&job_id) {
             let _ = tx.send(known);
         } else {
             debug!(%job_id, count = known.len(), "KnownDerivations arrived after waiter cleared");

--- a/backend/gradient-worker/src/worker/mod.rs
+++ b/backend/gradient-worker/src/worker/mod.rs
@@ -24,9 +24,10 @@ mod dispatch;
 mod id;
 mod scoring;
 
+use gradient_util::sync::Mutex;
 use std::collections::HashMap;
 use std::marker::PhantomData;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use gradient_proto::messages::{ClientMessage, JobCandidate, JobKind};

--- a/backend/gradient-worker/src/worker/scoring.rs
+++ b/backend/gradient-worker/src/worker/scoring.rs
@@ -7,8 +7,9 @@
 //! Background scoring tasks: compute `missing_count` per candidate and send
 //! `RequestJobChunk` messages back to the server.
 
+use gradient_util::sync::Mutex;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use gradient_proto::messages::{CandidateScore, JobCandidate, JobKind};
 use tracing::warn;
@@ -57,7 +58,7 @@ pub(super) fn spawn_scoring_task(
         };
 
         let to_send: Vec<CandidateScore> = {
-            let mut g = last_scores.lock().unwrap();
+            let mut g = last_scores.lock();
             let mut out = Vec::with_capacity(scores.len());
             for s in scores {
                 if !delta_filter || g.get(&s.job_id) != Some(&s) {

--- a/backend/gradient-worker/src/worker_pool/driver.rs
+++ b/backend/gradient-worker/src/worker_pool/driver.rs
@@ -12,9 +12,10 @@
 //! through [`EvalWorker`] means the test covers both sides of the wire.
 
 use anyhow::{Context, Result};
+use gradient_util::sync::Mutex;
 use serde_json::json;
 use std::collections::HashSet;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use super::transport::EvalWorker;
 use gradient_eval::ipc::EvalRequest;

--- a/backend/gradient-worker/src/worker_pool/pool.rs
+++ b/backend/gradient-worker/src/worker_pool/pool.rs
@@ -11,10 +11,11 @@
 
 use anyhow::{Context, Result};
 use futures::stream::{FuturesUnordered, StreamExt};
+use gradient_util::sync::Mutex;
 use std::collections::HashSet;
 use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tracing::{debug, trace};
@@ -87,7 +88,7 @@ impl EvalWorkerPool {
 
     /// Snapshot of every live eval-subprocess pid.
     pub(super) fn live_pids(&self) -> Vec<u32> {
-        self.live.lock().unwrap().iter().copied().collect()
+        self.live.lock().iter().copied().collect()
     }
 
     /// Reaper feedback: latches the pressure flag `acquire` throttles on.
@@ -119,7 +120,7 @@ impl EvalWorkerPool {
         // Skip such corpses so we never hand out a worker whose first stdin
         // write fails with a broken pipe; spawn fresh once the idle vec drains.
         let worker = loop {
-            let candidate = self.idle.lock().unwrap().pop();
+            let candidate = self.idle.lock().pop();
             match candidate {
                 Some(mut w) => {
                     let pid = w.pid();
@@ -165,7 +166,7 @@ impl EvalWorkerPool {
         self.semaphore.close();
 
         let drained: Vec<EvalWorker> = {
-            let mut idle = self.idle.lock().unwrap();
+            let mut idle = self.idle.lock();
             std::mem::take(&mut *idle)
         };
         if drained.is_empty() {
@@ -187,7 +188,7 @@ impl EvalWorkerPool {
     /// still usable - and `kill_on_drop` reaps the discarded children.
     pub(super) fn recycle_idle(&self) {
         let drained: Vec<EvalWorker> = {
-            let mut idle = self.idle.lock().unwrap();
+            let mut idle = self.idle.lock();
             std::mem::take(&mut *idle)
         };
         if !drained.is_empty() {
@@ -198,7 +199,7 @@ impl EvalWorkerPool {
 
     #[cfg(test)]
     pub(super) fn idle_count(&self) -> usize {
-        self.idle.lock().unwrap().len()
+        self.idle.lock().len()
     }
 
     #[cfg(test)]
@@ -210,7 +211,7 @@ impl EvalWorkerPool {
     /// `acquire()` calls reuse it instead of spawning a fresh one.
     #[cfg(test)]
     pub(super) fn push_for_test(&self, worker: EvalWorker) {
-        self.idle.lock().unwrap().push(worker);
+        self.idle.lock().push(worker);
     }
 }
 
@@ -259,13 +260,17 @@ impl PooledEvalWorker {
 impl Deref for PooledEvalWorker {
     type Target = EvalWorker;
     fn deref(&self) -> &Self::Target {
-        self.worker.as_ref().unwrap()
+        self.worker
+            .as_ref()
+            .expect("the worker is taken only by Drop")
     }
 }
 
 impl DerefMut for PooledEvalWorker {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.worker.as_mut().unwrap()
+        self.worker
+            .as_mut()
+            .expect("the worker is taken only by Drop")
     }
 }
 
@@ -291,12 +296,7 @@ impl Drop for PooledEvalWorker {
                 }
             }
             Disposition::ReturnToIdle => {
-                if let Ok(mut idle) = self.idle.lock() {
-                    idle.push(worker);
-                } else {
-                    debug!("discarding eval worker (idle mutex poisoned)");
-                    drop(worker);
-                }
+                self.idle.lock().push(worker);
             }
             Disposition::Kill => {
                 debug!("discarding eval worker (unhealthy)");
@@ -466,16 +466,16 @@ mod tests {
         use super::super::transport::PidGuard;
 
         let live = Arc::new(Mutex::new(HashSet::new()));
-        live.lock().unwrap().insert(4242u32);
+        live.lock().insert(4242u32);
         {
             let _guard = PidGuard {
                 live: Some(Arc::clone(&live)),
                 pid: Some(4242),
             };
-            assert!(live.lock().unwrap().contains(&4242));
+            assert!(live.lock().contains(&4242));
         }
         assert!(
-            !live.lock().unwrap().contains(&4242),
+            !live.lock().contains(&4242),
             "PidGuard must remove its pid from the live registry on drop"
         );
     }

--- a/backend/gradient-worker/src/worker_pool/resolver.rs
+++ b/backend/gradient-worker/src/worker_pool/resolver.rs
@@ -12,9 +12,10 @@ use gradient_db::{Derivation, parse_drv};
 use gradient_eval::ipc::ResolvedItem;
 use gradient_exec::path_utils::nix_store_path;
 use gradient_nix::{DerivationResolver, FlakeDiscovery, ResolvedDerivation};
+use gradient_util::sync::Mutex;
 use std::collections::VecDeque;
 use std::future::Future;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use tracing::debug;
 
 use super::eval_stats::{EvalStatsAccumulator, EvalStatsTotals, StatsDelta};
@@ -125,7 +126,7 @@ where
             loop {
                 // Scope the pop so the guard drops before the await; holding
                 // it across `.await` would deadlock the executor.
-                let item = queue.lock().unwrap().pop_front();
+                let item = queue.lock().pop_front();
                 let Some(item) = item else { break };
                 run(item).await?;
             }
@@ -267,7 +268,7 @@ impl WorkerPoolResolver {
 
     /// Bucket one worker delta under `entry_point`, folding peak RSS in too.
     fn observe_stats(&self, entry_point: &str, delta: StatsDelta, rss: u64) {
-        self.stats.lock().unwrap().observe(entry_point, delta, rss);
+        self.stats.lock().observe(entry_point, delta, rss);
     }
 
     /// Post-call bookkeeping shared by every successful worker call: record
@@ -289,14 +290,14 @@ impl WorkerPoolResolver {
     /// bleed is minor.
     fn bucket_of(&self, first_attr: Option<&String>) -> String {
         first_attr
-            .map(|a| entry_point_of(a, &self.patterns.lock().unwrap()))
+            .map(|a| entry_point_of(a, &self.patterns.lock()))
             .unwrap_or_default()
     }
 
     /// Drain the accumulated per-eval stats, resetting the accumulator so the
     /// next eval starts clean. Called once by the executor at eval completion.
     pub fn take_eval_stats(&self) -> EvalStatsTotals {
-        let acc = std::mem::take(&mut *self.stats.lock().unwrap());
+        let acc = std::mem::take(&mut *self.stats.lock());
         acc.finish()
     }
 
@@ -444,7 +445,7 @@ impl WorkerPoolResolver {
 
     fn record_warnings(&self, warnings: Vec<String>) {
         if !warnings.is_empty() {
-            self.resolve_warnings.lock().unwrap().extend(warnings);
+            self.resolve_warnings.lock().extend(warnings);
         }
     }
 }
@@ -458,7 +459,7 @@ impl DerivationResolver for WorkerPoolResolver {
         overrides: &[(String, String)],
     ) -> Result<FlakeDiscovery> {
         // Record the user entry-points so the resolve pass can bucket by them.
-        *self.patterns.lock().unwrap() = wildcards
+        *self.patterns.lock() = wildcards
             .iter()
             .filter(|w| !w.starts_with('!'))
             .cloned()
@@ -523,21 +524,21 @@ impl DerivationResolver for WorkerPoolResolver {
                 pattern.extend_from_slice(excludes);
 
                 let (a, w, e) = self.list_shard(repo, pattern, overrides).await?;
-                attrs.lock().unwrap().extend(a);
-                warnings.lock().unwrap().extend(w);
-                errors.lock().unwrap().extend(e);
+                attrs.lock().extend(a);
+                warnings.lock().extend(w);
+                errors.lock().extend(e);
                 Ok(())
             })
             .await?;
         }
 
-        let mut attrs = attrs.into_inner().unwrap();
+        let mut attrs = attrs.into_inner();
         attrs.sort_unstable();
         attrs.dedup();
-        let mut warnings = warnings.into_inner().unwrap();
+        let mut warnings = warnings.into_inner();
         warnings.sort_unstable();
         warnings.dedup();
-        let mut errors = errors.into_inner().unwrap();
+        let mut errors = errors.into_inner();
         errors.sort_unstable();
         errors.dedup();
 
@@ -589,15 +590,15 @@ impl DerivationResolver for WorkerPoolResolver {
                 // A crash became per-attr errors in the pure core; only a
                 // protocol violation or pool failure is a hard error.
                 let resolved = resolve_chunk(resolve_batch, batch, 0).await?;
-                indexed.lock().unwrap().extend(resolved);
+                indexed.lock().extend(resolved);
                 Ok(())
             })
             .await?;
         }
 
-        let mut indexed = indexed.into_inner().unwrap();
+        let mut indexed = indexed.into_inner();
         indexed.sort_by_key(|(idx, _)| *idx);
-        let mut all_warnings = std::mem::take(&mut *self.resolve_warnings.lock().unwrap());
+        let mut all_warnings = std::mem::take(&mut *self.resolve_warnings.lock());
         all_warnings.sort_unstable();
         all_warnings.dedup();
 
@@ -625,8 +626,8 @@ impl DerivationResolver for WorkerPoolResolver {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gradient_util::sync::Mutex;
     use std::collections::{HashMap, HashSet};
-    use std::sync::Mutex;
 
     #[test]
     fn entry_point_longest_prefix_match() {
@@ -680,7 +681,7 @@ mod tests {
         }
 
         fn calls(&self) -> usize {
-            *self.calls.lock().unwrap()
+            *self.calls.lock()
         }
     }
 
@@ -705,7 +706,7 @@ mod tests {
             let resolve_once = move |attrs: Vec<String>| -> BoxFuture<'_, Result<BatchCall>> {
                 Box::pin(async move {
                     let prior = {
-                        let mut n = stub.calls.lock().unwrap();
+                        let mut n = stub.calls.lock();
                         let prior = *n;
                         *n += 1;
                         prior
@@ -805,12 +806,12 @@ mod tests {
         let seen = Mutex::new(Vec::new());
         let seen_ref = &seen;
         pooled_fan_out(3, (0..10).collect(), |n| async move {
-            seen_ref.lock().unwrap().push(n);
+            seen_ref.lock().push(n);
             Ok(())
         })
         .await
         .expect("no errors");
-        let mut got = seen.into_inner().unwrap();
+        let mut got = seen.into_inner();
         got.sort_unstable();
         assert_eq!(got, (0..10).collect::<Vec<_>>());
 

--- a/backend/gradient-worker/src/worker_pool/transport.rs
+++ b/backend/gradient-worker/src/worker_pool/transport.rs
@@ -9,9 +9,10 @@
 //! lifecycle lives in [`super::pool`], memory accounting in [`super::memory`].
 
 use anyhow::{Context, Result};
+use gradient_util::sync::Mutex;
 use std::collections::HashSet;
 use std::process::Stdio;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
@@ -80,7 +81,7 @@ pub(super) struct PidGuard {
 impl Drop for PidGuard {
     fn drop(&mut self) {
         if let (Some(live), Some(pid)) = (&self.live, self.pid) {
-            live.lock().unwrap().remove(&pid);
+            live.lock().remove(&pid);
         }
     }
 }
@@ -130,7 +131,7 @@ impl EvalWorker {
         // Register the pid so the memory reaper can find this subprocess even
         // while it is checked out of the pool. Deregistered by `PidGuard`.
         if let Some(pid) = worker.pid_guard.pid {
-            live.lock().unwrap().insert(pid);
+            live.lock().insert(pid);
         }
         worker.pid_guard.live = Some(live);
 

--- a/docs/src/development/contributing.md
+++ b/docs/src/development/contributing.md
@@ -70,7 +70,11 @@ nix build .#checks.x86_64-linux.gradient-remote    -L
 ### Rust
 
 - Format with `cargo fmt` before committing.
-- No `unwrap()` in production paths - use `?` or explicit error handling.
+- No `unwrap()` in production paths - enforced by `clippy::unwrap_used = "deny"`. Use `?`, an
+  explicit error branch, or `.expect("<the invariant>")` where the call is infallible by
+  construction and the message says why.
+- Shared state uses `gradient_util::sync::Mutex`, not `std::sync::Mutex`: it ignores poisoning,
+  so a panic in one critical section does not become a panic at every later `lock()`.
 - New API endpoints go in `web/src/endpoints/` following the pattern: extract path/query params → check authorization → query DB → return response.
 - New database tables require a migration in `migration/src/` and an entity module in `entity/src/`.
 - Log with `tracing::{info, debug, warn, error}`, not `println!`. Add `#[instrument]` to significant async functions.
@@ -98,6 +102,10 @@ nix build .#checks.x86_64-linux.clippy -L   # cargo clippy --workspace --all-tar
   (CI grep-gate) - fix the underlying warning instead of silencing it.
 - Every other `#[allow(...)]` must carry a `reason = "..."` (`clippy::allow_attributes_without_reason`).
   `clippy::too_many_arguments` allows are temporary and tracked in #503.
+- `clippy.toml` sets `allow-unwrap-in-tests`, which only reaches code lexically inside a `#[test]`
+  function. Integration tests and `gradient-test-support` keep their fixture helpers outside one, so
+  those files carry a crate-level `#![expect(clippy::unwrap_used, reason = "...")]` - `expect` rather
+  than `allow` so the attribute itself warns once the last `unwrap()` in the file is gone.
 
 CI (`.github/workflows/rust.yml`) runs fmt, the grep-gate and cargo-deny; clippy runs as the
 `checks.clippy` flake check.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -7859,3 +7859,15 @@ complete, record the same build set, no derivation hash has two rows, no anchor
 of either evaluation lacks its edges, and the server log has no pool timeout
 and no dropped graph call. Phase 11 now expects `graph` among the supervised
 loops.
+
+## The no-unwrap policy is enforced by clippy (#585)
+
+`backend/gradient-util/src/sync.rs`:
+`a_poisoned_lock_still_hands_out_the_value` and
+`into_inner_survives_a_poisoned_lock` (a helper thread panics holding the lock;
+the guarded value is still readable afterwards, so one panic cannot cascade
+into a panic at every later `lock()`), plus `the_guard_writes_through`.
+
+The policy itself has no test: `clippy::unwrap_used = "deny"` in
+`backend/Cargo.toml` is the assertion, and `nix build
+.#checks.x86_64-linux.clippy` is where it runs.


### PR DESCRIPTION
Closes #585. Stacked on #602: turns on `clippy::unwrap_used` and clears the 246 sites it flags, mostly by deleting the failure mode rather than annotating it: a poison-free `gradient_util::sync::Mutex` absorbs 68 lock unwraps, the genuinely-real ones get a real branch or an `.expect("<invariant>")`, and only test fixture helpers keep a crate-level `#![expect]`.