### PR TITLE
db: refactor: cheap graph walks and one closure representation

### DIFF
--- a/backend/gradient-db/src/cache_storage.rs
+++ b/backend/gradient-db/src/cache_storage.rs
@@ -499,18 +499,19 @@ fn cached_path_eval_scope_fragments(
     match scope {
         None => (String::new(), String::new()),
         Some(_) => (
-            "WITH RECURSIVE eval_paths(hash) AS ( \
-                 SELECT DISTINCT o.hash FROM derivation_output o \
-                 JOIN build_job bj ON bj.derivation = o.derivation \
-                 WHERE bj.evaluation = $1 \
-               UNION \
-                 SELECT DISTINCT d.hash FROM derivation d \
-                 JOIN build_job bj ON bj.derivation = d.id \
-                 WHERE bj.evaluation = $1 \
-               UNION \
-                 SELECT r.reference_hash FROM cached_path_reference r \
-                 JOIN eval_paths ep ON r.referrer = ep.hash) "
-                .to_string(),
+            format!(
+                "{} ",
+                crate::graph_sql::reference_closure_cte(
+                    "eval_paths",
+                    "SELECT DISTINCT o.hash FROM derivation_output o \
+                     JOIN build_job bj ON bj.derivation = o.derivation \
+                     WHERE bj.evaluation = $1 \
+                   UNION \
+                     SELECT DISTINCT d.hash FROM derivation d \
+                     JOIN build_job bj ON bj.derivation = d.id \
+                     WHERE bj.evaluation = $1",
+                )
+            ),
             " AND cp.hash IN (SELECT hash FROM eval_paths)".to_string(),
         ),
     }
@@ -1008,7 +1009,9 @@ mod tests {
                 "seeded from the eval's build_job outputs: {stmt}"
             );
             assert!(
-                stmt.contains("SELECT r.reference_hash FROM cached_path_reference r"),
+                stmt.contains(
+                    "SELECT r.reference_hash AS next FROM cached_path_reference r WHERE r.referrer = c.hash"
+                ),
                 "walks the NAR reference closure so leaves converge first: {stmt}"
             );
             assert!(
@@ -1047,7 +1050,7 @@ mod tests {
             // rejected at runtime, which no type or compile check would catch.
             let drv_seed = sql.find("FROM derivation d").expect("drv seed present");
             let walk = sql
-                .find("FROM cached_path_reference r JOIN eval_paths")
+                .find("FROM eval_paths c")
                 .expect("recursive walk present");
             assert!(
                 drv_seed < walk,

--- a/backend/gradient-db/src/closure.rs
+++ b/backend/gradient-db/src/closure.rs
@@ -13,37 +13,60 @@
 //! over that set is the closure size used by the build-closure endpoint and by
 //! the scheduler's scoring context.
 
-use sea_orm::{ColumnTrait, ConnectionTrait, DbErr, EntityTrait, QueryFilter};
+use crate::graph_sql::{ClosureDirection, dependency_closure_cte};
+use sea_orm::{
+    ColumnTrait, ConnectionTrait, DatabaseBackend, DbErr, EntityTrait, FromQueryResult,
+    QueryFilter, Statement,
+};
 use std::collections::{HashMap, HashSet};
 
 use gradient_types::*;
 
-/// BFS over forward `derivation_dependency` edges from `roots`; returns every
-/// reachable derivation id (roots included).
+#[derive(FromQueryResult)]
+struct DerivationRow {
+    derivation: uuid::Uuid,
+}
+
+#[derive(FromQueryResult)]
+struct EdgeRow {
+    derivation: uuid::Uuid,
+    dependency: uuid::Uuid,
+}
+
+/// The `WITH RECURSIVE closure(derivation)` prelude seeded from a bound
+/// `uuid[]` of roots. One statement replaces a level-at-a-time BFS that cost a
+/// round trip per level (18 to 21 on production graphs).
+fn roots_closure_cte() -> String {
+    dependency_closure_cte(
+        "closure",
+        "SELECT unnest($1::uuid[])",
+        ClosureDirection::Dependencies,
+    )
+}
+
+/// Forward `derivation_dependency` closure of `roots`; returns every reachable
+/// derivation id (roots included).
 pub async fn transitive_closure_reachable<C: ConnectionTrait>(
     db: &C,
     roots: &[DerivationId],
 ) -> Result<HashSet<DerivationId>, DbErr> {
-    let mut visited: HashSet<DerivationId> = roots.iter().copied().collect();
-    let mut frontier: Vec<DerivationId> = roots.to_vec();
-
-    while !frontier.is_empty() {
-        let edges = crate::fetch_in_chunks(&frontier, |chunk| async move {
-            EDerivationDependency::find()
-                .filter(CDerivationDependency::Derivation.is_in(chunk))
-                .all(db)
-                .await
-        })
-        .await?;
-        frontier.clear();
-        for edge in edges {
-            if visited.insert(edge.dependency) {
-                frontier.push(edge.dependency);
-            }
-        }
+    if roots.is_empty() {
+        return Ok(HashSet::new());
     }
 
-    Ok(visited)
+    let ids: Vec<uuid::Uuid> = roots.iter().map(|d| d.into_inner()).collect();
+    Ok(
+        DerivationRow::find_by_statement(Statement::from_sql_and_values(
+            DatabaseBackend::Postgres,
+            format!("{} SELECT derivation FROM closure", roots_closure_cte()),
+            [ids.into()],
+        ))
+        .all(db)
+        .await?
+        .into_iter()
+        .map(|r| DerivationId::new(r.derivation))
+        .collect(),
+    )
 }
 
 /// Map each derivation id to its coalesced output NAR size
@@ -107,12 +130,12 @@ pub async fn transitive_closure_size<C: ConnectionTrait>(
     Ok(by_drv.values().sum())
 }
 
-/// Closure size for many roots at once. Loads the dependency graph and output
-/// sizes for the combined reachable set in a handful of batched queries, then
-/// sums each root's closure in memory (diamonds deduped via a per-root visited
-/// set). This is `O(depth)` DB round-trips for the whole batch instead of one
-/// full DB walk per root, which matters when a dispatch round backfills many
-/// derivations that share most of their closure.
+/// Closure size for many roots at once. One recursive statement returns every
+/// edge inside the combined closure and a second returns the output sizes, then
+/// each root's closure is summed in memory (diamonds deduped via a per-root
+/// visited set). Two round trips for the whole batch instead of one full DB walk
+/// per root, which matters when a dispatch round backfills many derivations that
+/// share most of their closure.
 pub async fn transitive_closure_sizes<C: ConnectionTrait>(
     db: &C,
     roots: &[DerivationId],
@@ -121,27 +144,29 @@ pub async fn transitive_closure_sizes<C: ConnectionTrait>(
         return Ok(HashMap::new());
     }
 
+    let ids: Vec<uuid::Uuid> = roots.iter().map(|d| d.into_inner()).collect();
+    let edges = EdgeRow::find_by_statement(Statement::from_sql_and_values(
+        DatabaseBackend::Postgres,
+        format!(
+            "{} SELECT e.derivation, e.dependency FROM derivation_dependency e \
+             JOIN closure c ON e.derivation = c.derivation",
+            roots_closure_cte()
+        ),
+        [ids.into()],
+    ))
+    .all(db)
+    .await?;
+
     let mut adjacency: HashMap<DerivationId, Vec<DerivationId>> = HashMap::new();
     let mut reachable: HashSet<DerivationId> = roots.iter().copied().collect();
-    let mut frontier: Vec<DerivationId> = roots.to_vec();
-    while !frontier.is_empty() {
-        let edges = crate::fetch_in_chunks(&frontier, |chunk| async move {
-            EDerivationDependency::find()
-                .filter(CDerivationDependency::Derivation.is_in(chunk))
-                .all(db)
-                .await
-        })
-        .await?;
-        frontier.clear();
-        for edge in edges {
-            adjacency
-                .entry(edge.derivation)
-                .or_default()
-                .push(edge.dependency);
-            if reachable.insert(edge.dependency) {
-                frontier.push(edge.dependency);
-            }
-        }
+    for edge in edges {
+        let (from, to) = (
+            DerivationId::new(edge.derivation),
+            DerivationId::new(edge.dependency),
+        );
+        adjacency.entry(from).or_default().push(to);
+        reachable.insert(from);
+        reachable.insert(to);
     }
 
     let sizes = output_sizes_by_drv(db, &reachable.iter().copied().collect::<Vec<_>>()).await?;
@@ -200,15 +225,19 @@ mod tests {
         }
     }
 
+    // The closure walk projects one `derivation` column; the mock only has to
+    // carry that, so the edge model stands in with both ends set to the node.
+    fn node(derivation: DerivationId) -> derivation_dependency::Model {
+        dep(derivation, derivation)
+    }
+
     #[tokio::test]
     async fn sums_closure_output_sizes() {
         let root = DerivationId::now_v7();
         let child = DerivationId::now_v7();
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            // reachable: wave 1 (root) -> edge root->child
-            .append_query_results([vec![dep(root, child)]])
-            // wave 2 (child) -> no further edges
-            .append_query_results([Vec::<derivation_dependency::Model>::new()])
+            // the whole closure walk is now one statement
+            .append_query_results([vec![node(root), node(child)]])
             // output_sizes_by_drv: outputs for [root, child]
             .append_query_results([vec![out(root, "r", Some(100)), out(child, "c", Some(40))]])
             .into_connection();
@@ -232,9 +261,8 @@ mod tests {
         let b = DerivationId::now_v7();
         let c = DerivationId::now_v7();
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_query_results([vec![dep(root, a), dep(root, b)]])
-            .append_query_results([vec![dep(a, c), dep(b, c)]])
-            .append_query_results([Vec::<derivation_dependency::Model>::new()])
+            // one statement returns every edge inside the closure
+            .append_query_results([vec![dep(root, a), dep(root, b), dep(a, c), dep(b, c)]])
             .append_query_results([vec![
                 out(root, "r", Some(10)),
                 out(a, "a", Some(20)),

--- a/backend/gradient-db/src/closure.rs
+++ b/backend/gradient-db/src/closure.rs
@@ -195,7 +195,6 @@ mod tests {
 
     fn dep(derivation: DerivationId, dependency: DerivationId) -> derivation_dependency::Model {
         derivation_dependency::Model {
-            id: DerivationDependencyId::now_v7(),
             derivation,
             dependency,
         }

--- a/backend/gradient-db/src/dep_closure.rs
+++ b/backend/gradient-db/src/dep_closure.rs
@@ -118,12 +118,10 @@ pub async fn materialize_entry_point_closures<C: ConnectionTrait>(
         if count > 0 {
             healed += 1;
         }
-        db.execute_raw(Statement::from_string(
+        db.execute_raw(Statement::from_sql_and_values(
             DbBackend::Postgres,
-            format!(
-                "UPDATE derivation SET dep_closure_count = {count} WHERE id = '{}'",
-                root.id.into_inner()
-            ),
+            "UPDATE derivation SET dep_closure_count = $1 WHERE id = $2",
+            [count.into(), root.id.into_inner().into()],
         ))
         .await?;
     }
@@ -141,25 +139,23 @@ pub async fn init_entry_point_dep_counts<C: ConnectionTrait>(
     evaluation: EvaluationId,
 ) -> Result<(), DbErr> {
     let eval = evaluation.into_inner();
-    db.execute_raw(Statement::from_string(
+    db.execute_raw(Statement::from_sql_and_values(
         DbBackend::Postgres,
-        format!(
-            "DELETE FROM entry_point_dep_count \
-             WHERE entry_point IN (SELECT id FROM entry_point WHERE evaluation = '{eval}')"
-        ),
+        "DELETE FROM entry_point_dep_count \
+         WHERE entry_point IN (SELECT id FROM entry_point WHERE evaluation = $1)",
+        [eval.into()],
     ))
     .await?;
-    db.execute_raw(Statement::from_string(
+    db.execute_raw(Statement::from_sql_and_values(
         DbBackend::Postgres,
-        format!(
-            "INSERT INTO entry_point_dep_count (id, entry_point, status, count) \
-             SELECT uuidv7(), ep.id, b.status, COUNT(*) \
-             FROM entry_point ep \
-             JOIN derivation_closure dc ON dc.root_derivation = ep.derivation \
-             JOIN derivation_build b ON b.derivation = dc.dep_derivation \
-             WHERE ep.evaluation = '{eval}' \
-             GROUP BY ep.id, b.status"
-        ),
+        "INSERT INTO entry_point_dep_count (id, entry_point, status, count) \
+         SELECT uuidv7(), ep.id, b.status, COUNT(*) \
+         FROM entry_point ep \
+         JOIN derivation_closure dc ON dc.root_derivation = ep.derivation \
+         JOIN derivation_build b ON b.derivation = dc.dep_derivation \
+         WHERE ep.evaluation = $1 \
+         GROUP BY ep.id, b.status",
+        [eval.into()],
     ))
     .await?;
     Ok(())

--- a/backend/gradient-db/src/dep_closure.rs
+++ b/backend/gradient-db/src/dep_closure.rs
@@ -17,7 +17,7 @@
 use crate::closure::transitive_closure_reachable;
 use crate::fetch_in_chunks;
 use gradient_entity::build::BuildStatus;
-use gradient_entity::ids::{DerivationClosureId, DerivationId, EntryPointId, EvaluationId};
+use gradient_entity::ids::{DerivationId, EntryPointId, EvaluationId};
 use gradient_types::*;
 use sea_orm::sea_query::OnConflict;
 use sea_orm::{
@@ -88,7 +88,6 @@ pub async fn materialize_entry_point_closures<C: ConnectionTrait>(
             .filter(|&&dep| dep != root.id)
             .map(|&dep| {
                 MDerivationClosure {
-                    id: DerivationClosureId::now_v7(),
                     root_derivation: root.id,
                     dep_derivation: dep,
                 }

--- a/backend/gradient-db/src/dependency_graph.rs
+++ b/backend/gradient-db/src/dependency_graph.rs
@@ -15,43 +15,49 @@
 //! shapes (cache invalidation closure revocation, build-failure cascade); this
 //! module hosts the single canonical version.
 
+use crate::graph_sql::{ClosureDirection, dependency_closure_cte};
 use anyhow::{Context, Result};
-use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
+use sea_orm::{ConnectionTrait, DatabaseBackend, FromQueryResult, Statement};
 use std::collections::HashSet;
 
 use gradient_types::*;
 
+#[derive(FromQueryResult)]
+struct DerivationRow {
+    derivation: uuid::Uuid,
+}
+
 /// Returns the set of all transitive dependents of `start`, **including** `start`
-/// itself. Walks reverse `derivation_dependency` edges in BFS layers, batching
-/// each layer into a single `IS IN` query.
+/// itself, as one recursive statement over the reverse `derivation_dependency`
+/// edges.
 ///
-/// Empty input (caller passes `start` only) ⇒ result contains exactly `{start}`.
+/// A start node nothing depends on ⇒ result contains exactly `{start}`.
 pub async fn collect_transitive_dependents<C: ConnectionTrait>(
     db: &C,
     start: DerivationId,
 ) -> Result<HashSet<DerivationId>> {
-    let mut visited: HashSet<DerivationId> = HashSet::new();
-    visited.insert(start);
-    let mut frontier: Vec<DerivationId> = vec![start];
+    let sql = format!(
+        "{} SELECT derivation FROM dependents",
+        dependency_closure_cte(
+            "dependents",
+            "SELECT $1::uuid",
+            ClosureDirection::Dependents,
+        )
+    );
+    let rows = DerivationRow::find_by_statement(Statement::from_sql_and_values(
+        DatabaseBackend::Postgres,
+        sql,
+        [start.into_inner().into()],
+    ))
+    .all(db)
+    .await
+    .context("walk derivation_dependency reverse edges")?;
 
-    while !frontier.is_empty() {
-        let edges = crate::fetch_in_chunks(&frontier, |chunk| async move {
-            EDerivationDependency::find()
-                .filter(CDerivationDependency::Dependency.is_in(chunk))
-                .all(db)
-                .await
-        })
-        .await
-        .context("walk derivation_dependency reverse edges")?;
-        frontier.clear();
-        for edge in edges {
-            if visited.insert(edge.derivation) {
-                frontier.push(edge.derivation);
-            }
-        }
-    }
-
-    Ok(visited)
+    Ok(rows
+        .into_iter()
+        .map(|r| DerivationId::new(r.derivation))
+        .chain(std::iter::once(start))
+        .collect())
 }
 
 #[cfg(test)]
@@ -59,13 +65,16 @@ mod tests {
     use super::*;
     use sea_orm::{DatabaseBackend, MockDatabase};
 
-    fn dep_edge(derivation: DerivationId, dependency: DerivationId) -> MDerivationDependency {
+    fn node(derivation: DerivationId) -> MDerivationDependency {
         gradient_entity::derivation_dependency::Model {
             derivation,
-            dependency,
+            dependency: derivation,
         }
     }
 
+    /// A derivation nothing depends on still reports itself, so callers can
+    /// treat the result as "everything this change touches" without special
+    /// casing the start node.
     #[tokio::test]
     async fn no_dependents_returns_only_start() {
         let start = DerivationId::now_v7();
@@ -74,45 +83,24 @@ mod tests {
             .into_connection();
 
         let visited = collect_transitive_dependents(&db, start).await.unwrap();
+
         assert_eq!(visited.len(), 1);
         assert!(visited.contains(&start));
     }
 
+    /// The walk seeds itself, so `start` comes back from the database as well as
+    /// from the chain; the set must hold one copy.
     #[tokio::test]
-    async fn walks_multiple_layers_breadth_first() {
-        let a = DerivationId::now_v7(); // start
-        let b = DerivationId::now_v7(); // depends on a
-        let c = DerivationId::now_v7(); // depends on b
-        let d = DerivationId::now_v7(); // depends on a (sibling of b)
-
-        // Layer 1: dependents of {a}        → b, d
-        // Layer 2: dependents of {b, d}     → c
-        // Layer 3: dependents of {c}        → ∅
-        let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_query_results([vec![dep_edge(b, a), dep_edge(d, a)]])
-            .append_query_results([vec![dep_edge(c, b)]])
-            .append_query_results([Vec::<MDerivationDependency>::new()])
-            .into_connection();
-
-        let visited = collect_transitive_dependents(&db, a).await.unwrap();
-        assert_eq!(visited.len(), 4);
-        for id in [a, b, c, d] {
-            assert!(visited.contains(&id), "missing {}", id);
-        }
-    }
-
-    #[tokio::test]
-    async fn cycles_terminate() {
+    async fn start_is_not_double_counted() {
         let a = DerivationId::now_v7();
         let b = DerivationId::now_v7();
-        // Pathological cycle: b depends on a AND a depends on b. The visited
-        // set must dedupe so the BFS terminates.
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_query_results([vec![dep_edge(b, a)]])
-            .append_query_results([vec![dep_edge(a, b)]])
+            .append_query_results([vec![node(a), node(b)]])
             .into_connection();
 
         let visited = collect_transitive_dependents(&db, a).await.unwrap();
+
         assert_eq!(visited.len(), 2);
+        assert!(visited.contains(&a) && visited.contains(&b));
     }
 }

--- a/backend/gradient-db/src/dependency_graph.rs
+++ b/backend/gradient-db/src/dependency_graph.rs
@@ -61,7 +61,6 @@ mod tests {
 
     fn dep_edge(derivation: DerivationId, dependency: DerivationId) -> MDerivationDependency {
         gradient_entity::derivation_dependency::Model {
-            id: DerivationDependencyId::now_v7(),
             derivation,
             dependency,
         }

--- a/backend/gradient-db/src/graph_sql.rs
+++ b/backend/gradient-db/src/graph_sql.rs
@@ -4,10 +4,28 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-//! The single definition of the recursive build-graph walk. Every traversal of
+//! The single definition of the recursive graph walks. Every traversal of
 //! `derivation_dependency` (failure cascades, eval-closure sweeps, GC
-//! reachability) is generated here so the walkers can never disagree on what
-//! "reachable" means.
+//! reachability) and of `cached_path_reference` (NAR reference closures) is
+//! generated here so the walkers can never disagree on what "reachable" means,
+//! and so the join shape below has exactly one place to live.
+//!
+//! Postgres estimates a recursive CTE's working table at ten times the seed,
+//! which for these walks overshoots by two orders of magnitude (348,870
+//! estimated against 2,439 actual on a 44k-node eval closure). At that
+//! cardinality a merge join against the whole edge index costs out cheaper than
+//! a nested loop, so the planner rescans all four million edges once per
+//! iteration. Every recursive term here is therefore written as a `LATERAL`
+//! subquery with an `OFFSET 0` optimisation fence: the fence stops the planner
+//! pulling the subquery back up, which leaves a nested loop with a per-row index
+//! lookup as the only legal plan. Measured on production: eval closure 5,278 ms
+//! to 955 ms, GC keep-set 40,069 ms to 9,746 ms, the `cached_path_reference`
+//! walk from over 180,000 ms to 18,425 ms.
+//!
+//! The set operator stays `UNION`. It is what deduplicates the frontier on each
+//! iteration, and these graphs are diamond-heavy enough that the dependents walk
+//! already emits 940k rows for 68k distinct nodes; `UNION ALL` would drop the
+//! deduplication and make the walk exponential in depth.
 
 pub enum ClosureDirection {
     /// Walk from the roots toward the inputs they need (the build-time closure).
@@ -38,15 +56,51 @@ pub fn dependency_closure_cte_body(
     seed_select: &str,
     direction: ClosureDirection,
 ) -> String {
-    let step = match direction {
-        ClosureDirection::Dependencies => format!(
-            "SELECT e.dependency FROM derivation_dependency e JOIN {name} c ON e.derivation = c.derivation"
-        ),
-        ClosureDirection::Dependents => format!(
-            "SELECT e.derivation FROM derivation_dependency e JOIN {name} c ON e.dependency = c.derivation"
-        ),
+    let (probe, project) = match direction {
+        ClosureDirection::Dependencies => ("e.derivation", "e.dependency"),
+        ClosureDirection::Dependents => ("e.dependency", "e.derivation"),
     };
-    format!("{name}(derivation) AS ({seed_select} UNION {step})")
+    format!(
+        "{name}(derivation) AS ({seed_select} UNION {})",
+        lateral_step(
+            name,
+            &format!(
+                "SELECT {project} AS next FROM derivation_dependency e WHERE {probe} = c.derivation"
+            ),
+        )
+    )
+}
+
+/// One fenced recursive term: join the working table `{name}` (aliased `c`) to
+/// `probe_select` through a `LATERAL` subquery that `OFFSET 0` keeps the planner
+/// from pulling up. See the module docs for why the fence is load-bearing rather
+/// than decorative. `probe_select` projects a single column aliased `next` and
+/// correlates to the working-table row through `c`.
+fn lateral_step(name: &str, probe_select: &str) -> String {
+    format!("SELECT s.next FROM {name} c, LATERAL ({probe_select} OFFSET 0) s")
+}
+
+/// A `WITH RECURSIVE {name}(hash) AS (...)` prelude closing `seed_select` over
+/// `cached_path_reference`, walking from a referrer to the store hashes it
+/// references. This is the NAR-level closure (what a client must fetch), as
+/// opposed to the build-time closure over `derivation_dependency`.
+pub fn reference_closure_cte(name: &str, seed_select: &str) -> String {
+    format!(
+        "WITH RECURSIVE {}",
+        reference_closure_cte_body(name, seed_select)
+    )
+}
+
+/// The bare `{name}(hash) AS (...)` reference-closure body, for statements that
+/// bind it as a prelude to an UPDATE or alongside another CTE.
+pub fn reference_closure_cte_body(name: &str, seed_select: &str) -> String {
+    format!(
+        "{name}(hash) AS ({seed_select} UNION {})",
+        lateral_step(
+            name,
+            "SELECT r.reference_hash AS next FROM cached_path_reference r WHERE r.referrer = c.hash",
+        )
+    )
 }
 
 /// Dependency-readiness of anchor `{alias}`: every build dependency is
@@ -163,7 +217,9 @@ mod tests {
             "{cte}"
         );
         assert!(
-            cte.contains("SELECT e.derivation FROM derivation_dependency e JOIN dependents c ON e.dependency = c.derivation"),
+            cte.contains(
+                "SELECT e.derivation AS next FROM derivation_dependency e WHERE e.dependency = c.derivation"
+            ),
             "must walk dependents upward via the dependency edge: {cte}"
         );
     }
@@ -182,7 +238,9 @@ mod tests {
             "{cte}"
         );
         assert!(
-            cte.contains("SELECT e.dependency FROM derivation_dependency e JOIN closure c ON e.derivation = c.derivation"),
+            cte.contains(
+                "SELECT e.dependency AS next FROM derivation_dependency e WHERE e.derivation = c.derivation"
+            ),
             "must recurse toward dependencies: {cte}"
         );
     }
@@ -239,8 +297,61 @@ mod tests {
             "build_job derivations are roots: {cte}"
         );
         assert!(
-            cte.contains("SELECT e.dependency"),
+            cte.contains("SELECT e.dependency AS next"),
             "recursion walks toward dependencies (the inputs a root needs): {cte}"
+        );
+    }
+
+    /// The fence is the whole performance fix: without `LATERAL (... OFFSET 0)`
+    /// the planner takes the recursive CTE's 10x working-table estimate at face
+    /// value and merge-joins the entire edge table once per iteration. Assert it
+    /// on every generated walk so a later tidy-up cannot quietly drop it.
+    #[test]
+    fn every_recursive_term_is_fenced_into_a_nested_loop() {
+        for cte in [
+            norm(&eval_closure_cte()),
+            norm(&reachable_derivations_cte()),
+            norm(&dependency_closure_cte(
+                "dependents",
+                "SELECT $1::uuid",
+                ClosureDirection::Dependents,
+            )),
+            norm(&reference_closure_cte("refs", "SELECT $1::text")),
+        ] {
+            assert!(
+                cte.contains("LATERAL ("),
+                "recursive term must be lateral: {cte}"
+            );
+            assert!(
+                cte.contains("OFFSET 0) s"),
+                "lateral probe must be fenced: {cte}"
+            );
+            assert!(
+                !cte.contains("UNION ALL"),
+                "UNION dedupes the frontier; UNION ALL is exponential on a diamond graph: {cte}"
+            );
+        }
+    }
+
+    /// The reference closure walks NAR references (what a client must fetch),
+    /// not build inputs, so it keys on `cached_path_reference` and carries a
+    /// `hash` column rather than a `derivation` one.
+    #[test]
+    fn reference_closure_walks_cached_path_reference_by_referrer() {
+        let cte = norm(&reference_closure_cte(
+            "eval_paths",
+            "SELECT $1::text AS hash",
+        ));
+
+        assert!(
+            cte.starts_with("WITH RECURSIVE eval_paths(hash) AS"),
+            "{cte}"
+        );
+        assert!(
+            cte.contains(
+                "SELECT r.reference_hash AS next FROM cached_path_reference r WHERE r.referrer = c.hash"
+            ),
+            "must walk referrer to referenced hash: {cte}"
         );
     }
 }

--- a/backend/gradient-db/src/graph_sql.rs
+++ b/backend/gradient-db/src/graph_sql.rs
@@ -56,16 +56,36 @@ pub fn dependency_closure_cte_body(
     seed_select: &str,
     direction: ClosureDirection,
 ) -> String {
+    bounded_dependency_closure_cte_body(name, seed_select, direction, "")
+}
+
+/// A closure walk confined to a set another CTE in the same statement already
+/// binds (an eval closure, a requeue candidate set). `bound` is an extra
+/// predicate over the edge alias `e`, applied inside the lateral probe so it
+/// prunes at the index lookup rather than after the join; an empty `bound` is
+/// the unrestricted walk.
+pub fn bounded_dependency_closure_cte_body(
+    name: &str,
+    seed_select: &str,
+    direction: ClosureDirection,
+    bound: &str,
+) -> String {
     let (probe, project) = match direction {
         ClosureDirection::Dependencies => ("e.derivation", "e.dependency"),
         ClosureDirection::Dependents => ("e.dependency", "e.derivation"),
+    };
+    let restrict = if bound.is_empty() {
+        String::new()
+    } else {
+        format!(" AND {bound}")
     };
     format!(
         "{name}(derivation) AS ({seed_select} UNION {})",
         lateral_step(
             name,
             &format!(
-                "SELECT {project} AS next FROM derivation_dependency e WHERE {probe} = c.derivation"
+                "SELECT {project} AS next FROM derivation_dependency e \
+                 WHERE {probe} = c.derivation{restrict}"
             ),
         )
     )

--- a/backend/gradient-db/src/graph_sql.rs
+++ b/backend/gradient-db/src/graph_sql.rs
@@ -365,10 +365,11 @@ mod tests {
             "e.derivation IN (SELECT derivation FROM closure)",
         ));
 
+        let probe = "WHERE e.dependency = c.derivation \
+                     AND e.derivation IN (SELECT derivation FROM closure) OFFSET 0) s";
+
         assert!(
-            cte.contains(
-                "WHERE e.dependency = c.derivation                  AND e.derivation IN (SELECT derivation FROM closure) OFFSET 0) s"
-            ),
+            cte.contains(probe),
             "the bound belongs inside the fenced probe: {cte}"
         );
     }

--- a/backend/gradient-db/src/graph_sql.rs
+++ b/backend/gradient-db/src/graph_sql.rs
@@ -353,6 +353,26 @@ mod tests {
         }
     }
 
+    /// A bounded walk must apply its restriction inside the lateral probe and
+    /// ahead of the fence, so the frontier is pruned at the index lookup rather
+    /// than after the join, and the `OFFSET 0` still terminates the subquery.
+    #[test]
+    fn a_bounded_walk_restricts_inside_the_probe() {
+        let cte = norm(&bounded_dependency_closure_cte_body(
+            "dependents",
+            "SELECT $1::uuid",
+            ClosureDirection::Dependents,
+            "e.derivation IN (SELECT derivation FROM closure)",
+        ));
+
+        assert!(
+            cte.contains(
+                "WHERE e.dependency = c.derivation                  AND e.derivation IN (SELECT derivation FROM closure) OFFSET 0) s"
+            ),
+            "the bound belongs inside the fenced probe: {cte}"
+        );
+    }
+
     /// The reference closure walks NAR references (what a client must fetch),
     /// not build inputs, so it keys on `cached_path_reference` and carries a
     /// `hash` column rather than a `derivation` one.

--- a/backend/gradient-db/src/promotion.rs
+++ b/backend/gradient-db/src/promotion.rs
@@ -43,7 +43,8 @@
 //! separate `edges_unresolved` flag instead of a clear.
 
 use crate::graph_sql::{
-    ClosureDirection, dependency_closure_cte, eval_closure_cte, eval_closure_cte_body,
+    ClosureDirection, bounded_dependency_closure_cte_body, dependency_closure_cte,
+    dependency_closure_cte_body, eval_closure_cte, eval_closure_cte_body,
 };
 use crate::status::TransitionChange;
 use crate::status_sql;
@@ -529,14 +530,18 @@ fn dependency_failed_reconcile_sql(scope: Option<gradient_types::EvaluationId>) 
         ),
         Some(_) => (
             format!(
-                r#"WITH RECURSIVE {closure},
-    dependents(derivation) AS (
-        SELECT derivation FROM derivation_build
-        WHERE status IN ({terminal_failure}) AND derivation IN (SELECT derivation FROM closure)
-        UNION
-        SELECT e.derivation FROM derivation_dependency e JOIN dependents c ON e.dependency = c.derivation
-        WHERE e.derivation IN (SELECT derivation FROM closure))"#,
+                "WITH RECURSIVE {closure},\n    {dependents}",
                 closure = eval_closure_cte_body(),
+                dependents = bounded_dependency_closure_cte_body(
+                    "dependents",
+                    &format!(
+                        "SELECT derivation FROM derivation_build \
+                         WHERE status IN ({terminal_failure}) \
+                           AND derivation IN (SELECT derivation FROM closure)"
+                    ),
+                    ClosureDirection::Dependents,
+                    "e.derivation IN (SELECT derivation FROM closure)",
+                ),
             ),
             " AND db.derivation IN (SELECT derivation FROM closure)".to_string(),
         ),
@@ -745,17 +750,18 @@ pub async fn requeue_failed_anchors<C: ConnectionTrait>(
 fn requeue_ctes(closure_seed: &str) -> String {
     let deterministic = deterministic_build_failure("dbf");
     format!(
-        r#"WITH RECURSIVE closure(derivation) AS (
-        {closure_seed}
-        UNION
-        SELECT e.dependency FROM derivation_dependency e JOIN closure c ON e.derivation = c.derivation),
-    deterministic_blocked(derivation) AS (
-        SELECT dbf.derivation FROM derivation_build dbf
-        WHERE dbf.derivation IN (SELECT derivation FROM closure) AND {deterministic}
-        UNION
-        SELECT e.derivation FROM derivation_dependency e
-        JOIN deterministic_blocked c ON e.dependency = c.derivation
-        WHERE e.derivation IN (SELECT derivation FROM closure))"#
+        "WITH RECURSIVE {closure},\n    {blocked}",
+        closure =
+            dependency_closure_cte_body("closure", closure_seed, ClosureDirection::Dependencies,),
+        blocked = bounded_dependency_closure_cte_body(
+            "deterministic_blocked",
+            &format!(
+                "SELECT dbf.derivation FROM derivation_build dbf \
+                 WHERE dbf.derivation IN (SELECT derivation FROM closure) AND {deterministic}"
+            ),
+            ClosureDirection::Dependents,
+            "e.derivation IN (SELECT derivation FROM closure)",
+        ),
     )
 }
 
@@ -932,7 +938,9 @@ mod tests {
                 "blocked set must seed from a reproducible builder-nonzero exit: {sql}"
             );
             assert!(
-                sql.contains("JOIN deterministic_blocked c ON e.dependency = c.derivation"),
+                sql.contains(
+                "SELECT e.derivation AS next FROM derivation_dependency e WHERE e.dependency = c.derivation"
+            ),
                 "must close upward over dependents so DependencyFailed victims are caught: {sql}"
             );
             assert!(
@@ -990,7 +998,9 @@ mod tests {
             "must capture the pre-update status for the effects emitter: {sql}"
         );
         assert!(
-            sql.contains("JOIN dependents c ON e.dependency = c.derivation"),
+            sql.contains(
+                "SELECT e.derivation AS next FROM derivation_dependency e WHERE e.dependency = c.derivation"
+            ),
             "must walk dependents upward via the dependency edge: {sql}"
         );
         assert!(

--- a/backend/gradient-db/src/runtime_closure.rs
+++ b/backend/gradient-db/src/runtime_closure.rs
@@ -16,7 +16,7 @@ use sea_orm::{
     ColumnTrait, ConnectionTrait, DatabaseBackend, DbErr, EntityTrait, FromQueryResult,
     QueryFilter, Statement,
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use gradient_types::*;
 
@@ -104,39 +104,32 @@ pub async fn references_for_hash<C: ConnectionTrait>(
     )
 }
 
-/// BFS over `cached_path_reference` from `seed_hashes`; returns every reached
-/// `cached_path` row keyed by hash. Seeds and references without a `cached_path`
-/// row (NAR not yet uploaded) are simply absent from the result.
+/// Reference closure of `seed_hashes` as one recursive statement; returns every
+/// reached `cached_path` row keyed by hash. Seeds and references without a
+/// `cached_path` row (NAR not yet uploaded) are simply absent from the result.
 pub async fn runtime_closure_reachable<C: ConnectionTrait>(
     db: &C,
     seed_hashes: &[String],
 ) -> Result<HashMap<String, gradient_entity::cached_path::Model>, DbErr> {
-    let mut reached: HashMap<String, gradient_entity::cached_path::Model> = HashMap::new();
-    let mut visited: HashSet<String> = seed_hashes.iter().cloned().collect();
-    let mut frontier: Vec<String> = seed_hashes.to_vec();
-
-    while !frontier.is_empty() {
-        let rows = crate::fetch_in_chunks(&frontier, |chunk| async move {
-            ECachedPath::find()
-                .filter(CCachedPath::Hash.is_in(chunk))
-                .all(db)
-                .await
-        })
-        .await?;
-        let edges = reference_edges(db, &frontier).await?;
-        frontier.clear();
-
-        for row in rows {
-            reached.insert(row.hash.clone(), row);
-        }
-        for (_, reference_hash) in edges {
-            if visited.insert(reference_hash.clone()) {
-                frontier.push(reference_hash);
-            }
-        }
+    if seed_hashes.is_empty() {
+        return Ok(HashMap::new());
     }
 
-    Ok(reached)
+    let sql = format!(
+        "{} SELECT cp.* FROM cached_path cp JOIN refs r ON cp.hash = r.hash",
+        crate::graph_sql::reference_closure_cte("refs", "SELECT unnest($1::text[])")
+    );
+    Ok(ECachedPath::find()
+        .from_raw_sql(Statement::from_sql_and_values(
+            DatabaseBackend::Postgres,
+            sql,
+            [seed_hashes.to_vec().into()],
+        ))
+        .all(db)
+        .await?
+        .into_iter()
+        .map(|row| (row.hash.clone(), row))
+        .collect())
 }
 
 /// Total NAR size of the runtime closure seeded at `seed_hashes`.
@@ -163,9 +156,9 @@ mod tests {
         assert_eq!(parse_reference_hash(""), None);
     }
 
-    // Empty seeds never query and sum to zero. The non-trivial walk over
-    // `cached_path_reference` is covered end-to-end by the cache integration test
-    // (MockDatabase cannot represent the per-level model + edge queries).
+    // Empty seeds never query and sum to zero. The walk itself is one recursive
+    // statement now, so its behaviour is Postgres's; the cache integration test
+    // covers it end to end.
     #[tokio::test]
     async fn empty_seeds_is_zero() {
         let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();

--- a/backend/gradient-db/src/task_board.rs
+++ b/backend/gradient-db/src/task_board.rs
@@ -29,20 +29,17 @@ pub async fn build_status_counts_by_evaluation<C: ConnectionTrait>(
     eval_ids: &[EvaluationId],
 ) -> Result<HashMap<EvaluationId, HashMap<BuildStatus, i64>>, DbErr> {
     let rows = fetch_in_chunks(eval_ids, |chunk| async move {
-        let ids = chunk
-            .iter()
-            .map(|id| format!("'{id}'"))
-            .collect::<Vec<_>>()
-            .join(",");
-        let sql = format!(
+        let ids: Vec<Uuid> = chunk.iter().map(|id| id.into_inner()).collect();
+        EvalStatusCountRow::find_by_statement(Statement::from_sql_and_values(
+            DbBackend::Postgres,
             "SELECT bj.evaluation AS evaluation, db.status AS status, COUNT(*) AS cnt \
              FROM build_job bj JOIN derivation_build db ON db.id = bj.derivation_build \
-             WHERE bj.evaluation IN ({ids}) \
-             GROUP BY bj.evaluation, db.status"
-        );
-        EvalStatusCountRow::find_by_statement(Statement::from_string(DbBackend::Postgres, sql))
-            .all(db)
-            .await
+             WHERE bj.evaluation = ANY($1) \
+             GROUP BY bj.evaluation, db.status",
+            [ids.into()],
+        ))
+        .all(db)
+        .await
     })
     .await?;
 
@@ -72,19 +69,16 @@ pub async fn evaluation_message_counts<C: ConnectionTrait>(
     eval_ids: &[EvaluationId],
 ) -> Result<HashMap<EvaluationId, HashMap<MessageLevel, i64>>, DbErr> {
     let rows = fetch_in_chunks(eval_ids, |chunk| async move {
-        let ids = chunk
-            .iter()
-            .map(|id| format!("'{id}'"))
-            .collect::<Vec<_>>()
-            .join(",");
-        let sql = format!(
+        let ids: Vec<Uuid> = chunk.iter().map(|id| id.into_inner()).collect();
+        EvalLevelCountRow::find_by_statement(Statement::from_sql_and_values(
+            DbBackend::Postgres,
             "SELECT evaluation, level, COUNT(*) AS cnt \
-             FROM evaluation_message WHERE evaluation IN ({ids}) \
-             GROUP BY evaluation, level"
-        );
-        EvalLevelCountRow::find_by_statement(Statement::from_string(DbBackend::Postgres, sql))
-            .all(db)
-            .await
+             FROM evaluation_message WHERE evaluation = ANY($1) \
+             GROUP BY evaluation, level",
+            [ids.into()],
+        ))
+        .all(db)
+        .await
     })
     .await?;
 
@@ -175,34 +169,32 @@ pub async fn entry_point_dep_counts<C: ConnectionTrait>(
         return Ok(HashMap::new());
     }
 
-    let values = seeds
+    let (eps, drvs): (Vec<Uuid>, Vec<Uuid>) = seeds
         .iter()
-        .map(|(ep, drv)| format!("('{ep}'::uuid,'{drv}'::uuid)"))
-        .collect::<Vec<_>>()
-        .join(",");
-    let eval = evaluation.into_inner();
-    let sql = format!(
-        "WITH RECURSIVE seeds(ep, root_drv) AS (VALUES {values}), \
+        .map(|(ep, drv)| (ep.into_inner(), *drv))
+        .unzip();
+    let rows = DepCountRow::find_by_statement(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        "WITH RECURSIVE seeds(ep, root_drv) AS (SELECT * FROM unnest($1::uuid[], $2::uuid[])), \
          closure(ep, drv) AS ( \
             SELECT ep, root_drv FROM seeds \
             UNION \
-            SELECT c.ep, dd.dependency \
-            FROM closure c \
-            JOIN derivation_dependency dd ON dd.derivation = c.drv \
-            JOIN build_job bj ON bj.derivation = dd.dependency AND bj.evaluation = '{eval}' \
+            SELECT c.ep, s.next FROM closure c, LATERAL ( \
+              SELECT dd.dependency AS next FROM derivation_dependency dd \
+              JOIN build_job bj ON bj.derivation = dd.dependency AND bj.evaluation = $3 \
+              WHERE dd.derivation = c.drv OFFSET 0) s \
          ) \
          SELECT c.ep AS entry_point, b.status AS status, COUNT(*) AS cnt \
          FROM closure c \
          JOIN seeds s ON s.ep = c.ep \
-         JOIN build_job bj ON bj.derivation = c.drv AND bj.evaluation = '{eval}' \
+         JOIN build_job bj ON bj.derivation = c.drv AND bj.evaluation = $3 \
          JOIN derivation_build b ON b.id = bj.derivation_build \
          WHERE c.drv <> s.root_drv \
-         GROUP BY c.ep, b.status"
-    );
-
-    let rows = DepCountRow::find_by_statement(Statement::from_string(DbBackend::Postgres, sql))
-        .all(db)
-        .await?;
+         GROUP BY c.ep, b.status",
+        [eps.into(), drvs.into(), evaluation.into_inner().into()],
+    ))
+    .all(db)
+    .await?;
 
     let mut out: HashMap<EntryPointId, HashMap<BuildStatus, i64>> = HashMap::new();
     for r in rows {

--- a/backend/gradient-entity/src/derivation_closure.rs
+++ b/backend/gradient-entity/src/derivation_closure.rs
@@ -12,14 +12,14 @@
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::ids::{DerivationClosureId, DerivationId};
+use crate::ids::DerivationId;
 
 #[derive(Clone, Debug, Default, PartialEq, DeriveEntityModel, Deserialize, Serialize)]
 #[sea_orm(table_name = "derivation_closure")]
 pub struct Model {
-    #[sea_orm(primary_key)]
-    pub id: DerivationClosureId,
+    #[sea_orm(primary_key, auto_increment = false)]
     pub root_derivation: DerivationId,
+    #[sea_orm(primary_key, auto_increment = false)]
     pub dep_derivation: DerivationId,
 }
 

--- a/backend/gradient-entity/src/derivation_dependency.rs
+++ b/backend/gradient-entity/src/derivation_dependency.rs
@@ -7,14 +7,14 @@
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::ids::{DerivationDependencyId, DerivationId};
+use crate::ids::DerivationId;
 
 #[derive(Clone, Debug, Default, PartialEq, DeriveEntityModel, Deserialize, Serialize)]
 #[sea_orm(table_name = "derivation_dependency")]
 pub struct Model {
-    #[sea_orm(primary_key)]
-    pub id: DerivationDependencyId,
+    #[sea_orm(primary_key, auto_increment = false)]
     pub derivation: DerivationId,
+    #[sea_orm(primary_key, auto_increment = false)]
     pub dependency: DerivationId,
 }
 

--- a/backend/gradient-entity/src/ids.rs
+++ b/backend/gradient-entity/src/ids.rs
@@ -99,8 +99,6 @@ id_newtype!(CachedPathSignatureId);
 id_newtype!(CommitId);
 id_newtype!(DebugInfoId);
 id_newtype!(DerivationId);
-id_newtype!(DerivationClosureId);
-id_newtype!(DerivationDependencyId);
 id_newtype!(DerivationInputSourceId);
 id_newtype!(DerivationMetricId);
 id_newtype!(DerivationFeatureId);

--- a/backend/gradient-graph/src/ingest.rs
+++ b/backend/gradient-graph/src/ingest.rs
@@ -828,7 +828,6 @@ async fn flush_ready_edges(
             let src_id = known[src];
             deps.iter().map(move |dep| {
                 MDerivationDependency {
-                    id: DerivationDependencyId::now_v7(),
                     derivation: src_id,
                     dependency: known[dep],
                 }
@@ -947,7 +946,6 @@ pub(crate) async fn flush_deferred_deps(
         .iter()
         .map(|(src, dep)| {
             MDerivationDependency {
-                id: DerivationDependencyId::now_v7(),
                 derivation: *src,
                 dependency: *dep,
             }

--- a/backend/gradient-graph/src/nar.rs
+++ b/backend/gradient-graph/src/nar.rs
@@ -155,8 +155,8 @@ async fn sync_reference_index(
     db.execute_raw(sea_orm::Statement::from_sql_and_values(
         sea_orm::DatabaseBackend::Postgres,
         r#"
-        INSERT INTO cached_path_reference (id, referrer, reference, reference_hash, position)
-        SELECT uuidv7(), $1, t.tok, split_part(t.tok, '-', 1), t.ord
+        INSERT INTO cached_path_reference (referrer, reference, reference_hash, position)
+        SELECT $1, t.tok, split_part(t.tok, '-', 1), t.ord
         FROM unnest($2::text[]) WITH ORDINALITY AS t(tok, ord)
         WHERE t.tok <> ''
         ON CONFLICT (referrer, reference) DO NOTHING

--- a/backend/gradient-migration/src/lib.rs
+++ b/backend/gradient-migration/src/lib.rs
@@ -39,6 +39,7 @@ mod m20260822_000001_rename_organization_to_project;
 mod m20260827_000000_metric_rollup_scope_project;
 mod m20260827_000001_commit_hash_index;
 mod m20260904_000000_dispatched_job_phase;
+mod m20260904_000001_graph_edge_indexes;
 
 pub struct Migrator;
 
@@ -79,6 +80,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260827_000000_metric_rollup_scope_project::Migration),
             Box::new(m20260827_000001_commit_hash_index::Migration),
             Box::new(m20260904_000000_dispatched_job_phase::Migration),
+            Box::new(m20260904_000001_graph_edge_indexes::Migration),
         ]
     }
 }

--- a/backend/gradient-migration/src/m20260904_000001_graph_edge_indexes.rs
+++ b/backend/gradient-migration/src/m20260904_000001_graph_edge_indexes.rs
@@ -1,0 +1,95 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::ConnectionTrait;
+
+/// Covering indexes for the two reverse graph walks, and retirement of the
+/// surrogate primary keys on the three junction tables.
+///
+/// The walks project the far end of an edge, so an index on the probed column
+/// alone forces a heap fetch per row: the dependents walk spent 871k buffers on
+/// 68k nodes, and the `cached_path_reference` walk (57% of all database time)
+/// bitmap-scanned 82,925 heap blocks per pass. Adding the projected column makes
+/// both index-only.
+///
+/// The surrogate `id` keys go because none of the three has ever been read:
+/// `idx_scan = 0` over an eleven-day production window on `derivation_closure`
+/// (909 MB), `cached_path_reference` (372 MB) and `derivation_dependency`
+/// (161 MB). Each one is a third of the index maintenance on the hottest insert
+/// paths in the system. The natural pair already carries a unique index, so
+/// `ADD PRIMARY KEY USING INDEX` adopts it without a rebuild; note that this
+/// renames each `idx-*-pair` index to the table's `_pkey` name.
+const STATEMENTS: &[&str] = &[
+    "CREATE INDEX IF NOT EXISTS \"idx-derivation_dependency-reverse-pair\" \
+     ON derivation_dependency (dependency, derivation)",
+    "DROP INDEX IF EXISTS \"idx-derivation_dependency-dependency\"",
+    "CREATE INDEX IF NOT EXISTS \"idx-cached_path_reference-referrer-hash\" \
+     ON cached_path_reference (referrer, reference_hash)",
+    "ALTER TABLE derivation_dependency DROP CONSTRAINT IF EXISTS derivation_dependency_pkey",
+    "ALTER TABLE derivation_dependency \
+     ADD PRIMARY KEY USING INDEX \"idx-derivation_dependency-pair\"",
+    "ALTER TABLE derivation_dependency DROP COLUMN IF EXISTS id",
+    "ALTER TABLE derivation_closure DROP CONSTRAINT IF EXISTS derivation_closure_pkey",
+    "ALTER TABLE derivation_closure ADD PRIMARY KEY USING INDEX \"idx-derivation_closure-pair\"",
+    "ALTER TABLE derivation_closure DROP COLUMN IF EXISTS id",
+    "ALTER TABLE cached_path_reference DROP CONSTRAINT IF EXISTS cached_path_reference_pkey",
+    "ALTER TABLE cached_path_reference \
+     ADD PRIMARY KEY USING INDEX \"idx-cached_path_reference-pair\"",
+    "ALTER TABLE cached_path_reference DROP COLUMN IF EXISTS id",
+];
+
+/// Restores the surrogate keys. The backfills rewrite every row, so this is far
+/// more expensive than the forward migration.
+const REVERT: &[&str] = &[
+    "ALTER TABLE cached_path_reference DROP CONSTRAINT IF EXISTS cached_path_reference_pkey",
+    "ALTER TABLE cached_path_reference ADD COLUMN IF NOT EXISTS id uuid",
+    "UPDATE cached_path_reference SET id = uuidv7() WHERE id IS NULL",
+    "ALTER TABLE cached_path_reference ALTER COLUMN id SET NOT NULL",
+    "ALTER TABLE cached_path_reference ADD PRIMARY KEY (id)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS \"idx-cached_path_reference-pair\" \
+     ON cached_path_reference (referrer, reference)",
+    "DROP INDEX IF EXISTS \"idx-cached_path_reference-referrer-hash\"",
+    "ALTER TABLE derivation_closure DROP CONSTRAINT IF EXISTS derivation_closure_pkey",
+    "ALTER TABLE derivation_closure ADD COLUMN IF NOT EXISTS id uuid",
+    "UPDATE derivation_closure SET id = uuidv7() WHERE id IS NULL",
+    "ALTER TABLE derivation_closure ALTER COLUMN id SET NOT NULL",
+    "ALTER TABLE derivation_closure ADD PRIMARY KEY (id)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS \"idx-derivation_closure-pair\" \
+     ON derivation_closure (root_derivation, dep_derivation)",
+    "ALTER TABLE derivation_dependency DROP CONSTRAINT IF EXISTS derivation_dependency_pkey",
+    "ALTER TABLE derivation_dependency ADD COLUMN IF NOT EXISTS id uuid",
+    "UPDATE derivation_dependency SET id = uuidv7() WHERE id IS NULL",
+    "ALTER TABLE derivation_dependency ALTER COLUMN id SET NOT NULL",
+    "ALTER TABLE derivation_dependency ADD PRIMARY KEY (id)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS \"idx-derivation_dependency-pair\" \
+     ON derivation_dependency (derivation, dependency)",
+    "CREATE INDEX IF NOT EXISTS \"idx-derivation_dependency-dependency\" \
+     ON derivation_dependency (dependency)",
+    "DROP INDEX IF EXISTS \"idx-derivation_dependency-reverse-pair\"",
+];
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        for stmt in STATEMENTS {
+            manager.get_connection().execute_unprepared(stmt).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        for stmt in REVERT {
+            manager.get_connection().execute_unprepared(stmt).await?;
+        }
+
+        Ok(())
+    }
+}

--- a/backend/gradient-report/src/schema.rs
+++ b/backend/gradient-report/src/schema.rs
@@ -13,7 +13,7 @@ use rusqlite::Connection;
 
 /// Bumped whenever an exported table's shape changes, so an inspector can
 /// refuse a file it does not understand rather than print wrong answers.
-pub const SCHEMA_VERSION: i64 = 3;
+pub const SCHEMA_VERSION: i64 = 4;
 
 #[derive(Clone, Copy, Debug)]
 pub struct ReportOptions {

--- a/backend/gradient-report/src/tables.rs
+++ b/backend/gradient-report/src/tables.rs
@@ -345,10 +345,10 @@ pub fn eval_scope_tables() -> &'static [TableSpec] {
         ),
         spec!(
             "derivation_dependency",
-            "CREATE TABLE derivation_dependency (id TEXT, derivation TEXT, dependency TEXT)",
-            "SELECT dd.id::text, dd.derivation::text, dd.dependency::text FROM derivation_dependency dd WHERE dd.derivation IN (SELECT derivation FROM build_job WHERE evaluation = $1)",
+            "CREATE TABLE derivation_dependency (derivation TEXT, dependency TEXT)",
+            "SELECT dd.derivation::text, dd.dependency::text FROM derivation_dependency dd WHERE dd.derivation IN (SELECT derivation FROM build_job WHERE evaluation = $1)",
             "the evaluation's derivations, shared with every other evaluation that built them",
-            ["id", "derivation", "dependency"]
+            ["derivation", "dependency"]
         ),
         spec!(
             "cached_path",
@@ -371,10 +371,10 @@ pub fn eval_scope_tables() -> &'static [TableSpec] {
         ),
         spec!(
             "cached_path_reference",
-            "CREATE TABLE cached_path_reference (id TEXT, referrer TEXT, reference TEXT, reference_hash TEXT, position INTEGER)",
-            "SELECT r.id::text, r.referrer::text, r.reference::text, r.reference_hash::text, r.position::text FROM cached_path_reference r WHERE r.referrer IN (SELECT o.hash FROM derivation_output o WHERE o.derivation IN (SELECT derivation FROM build_job WHERE evaluation = $1))",
+            "CREATE TABLE cached_path_reference (referrer TEXT, reference TEXT, reference_hash TEXT, position INTEGER)",
+            "SELECT r.referrer::text, r.reference::text, r.reference_hash::text, r.position::text FROM cached_path_reference r WHERE r.referrer IN (SELECT o.hash FROM derivation_output o WHERE o.derivation IN (SELECT derivation FROM build_job WHERE evaluation = $1))",
             "the evaluation's output hashes, shared with every other evaluation that produced them",
-            ["id", "referrer", "reference", "reference_hash", "position"]
+            ["referrer", "reference", "reference_hash", "position"]
         ),
     ];
 

--- a/backend/gradient-web/src/endpoints/builds/closure.rs
+++ b/backend/gradient-web/src/endpoints/builds/closure.rs
@@ -294,7 +294,6 @@ mod tests {
 
     fn dep(derivation: DerivationId, dependency: DerivationId) -> derivation_dependency::Model {
         derivation_dependency::Model {
-            id: DerivationDependencyId::now_v7(),
             derivation,
             dependency,
         }

--- a/backend/gradient-web/src/endpoints/builds/closure.rs
+++ b/backend/gradient-web/src/endpoints/builds/closure.rs
@@ -299,16 +299,20 @@ mod tests {
         }
     }
 
+    // The closure walk projects one `derivation` column; the mock only has to
+    // carry that, so the edge model stands in with both ends set to the node.
+    fn node(derivation: DerivationId) -> derivation_dependency::Model {
+        dep(derivation, derivation)
+    }
+
     // root depends on child; sizes 100 + 40 => total 140, two nodes, one edge.
     #[tokio::test]
     async fn build_closure_graph_sums_and_links() {
         let root = DerivationId::now_v7();
         let child = DerivationId::now_v7();
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            // derivation_closure_reachable: wave 1 (root) -> edge root->child
-            .append_query_results([vec![dep(root, child)]])
-            // wave 2 (child) -> no further edges
-            .append_query_results([Vec::<derivation_dependency::Model>::new()])
+            // derivation_closure_reachable is now one statement
+            .append_query_results([vec![node(root), node(child)]])
             // output_sizes_by_drv: outputs for [root, child] (drives both total and per-node)
             .append_query_results([vec![out(root, "r", Some(100)), out(child, "c", Some(40))]])
             // EDerivation::find for nodes
@@ -334,7 +338,6 @@ mod tests {
         );
     }
 
-    // The runtime closure graph walks `cached_path_reference` (per-level model +
-    // edge queries); it is covered end-to-end by the cache integration test rather
-    // than a MockDatabase fixture that cannot represent that query sequence.
+    // The runtime closure graph walks `cached_path_reference` in one recursive
+    // statement; it is covered end to end by the cache integration test.
 }

--- a/docs/src/development/internals.md
+++ b/docs/src/development/internals.md
@@ -160,6 +160,41 @@ Batching the BFS (one DB round-trip per level) keeps the query count proportiona
 
 ---
 
+## Recursive Graph Walks
+
+Every unbounded traversal is generated in `gradient-db/src/graph_sql.rs`: the build closure and the failure cascade over `derivation_dependency`, and the NAR reference closure over `cached_path_reference`. Callers pass a seed and a direction and get back a `WITH RECURSIVE` prelude, so no two walkers can disagree about what "reachable" means.
+
+The recursive term is always a `LATERAL` probe behind an `OFFSET 0` fence:
+
+```sql
+WITH RECURSIVE closure(derivation) AS (
+    SELECT unnest($1::uuid[])
+  UNION
+    SELECT s.next FROM closure c, LATERAL (
+      SELECT e.dependency AS next FROM derivation_dependency e
+      WHERE e.derivation = c.derivation OFFSET 0) s)
+```
+
+The fence is load-bearing, not decoration. Postgres estimates a recursive CTE's working table at ten times the seed; on a 44 000-node evaluation closure that is 348 870 rows estimated against 2 439 actual. At the estimated cardinality a merge join against the whole edge index costs out cheaper than a nested loop, so the planner rescans all four million edges once per iteration. `OFFSET 0` stops the subquery being pulled up, and a correlated lateral can only run as a nested loop with a per-row index lookup. Measured against production:
+
+| walk | plain join | fenced |
+|---|---|---|
+| evaluation closure, 43 898 nodes | 5 278 ms | 955 ms |
+| GC keep-set, 315 155 nodes | 40 069 ms | 9 746 ms |
+| `cached_path_reference` closure sweep | over 180 000 ms | 18 425 ms |
+
+The set operator stays `UNION`. It is what deduplicates the frontier on each iteration; the dependents walk emits 940 000 rows for 68 000 distinct nodes, and `UNION ALL` would make the walk exponential in depth on a diamond-shaped graph.
+
+Both edge tables carry a covering index in the direction they are probed, so the walk is index-only rather than one heap fetch per row: `(derivation, dependency)` and `(dependency, derivation)` on `derivation_dependency`, `(referrer, reference_hash)` on `cached_path_reference`. Neither table has a surrogate key; the natural pair is the primary key.
+
+### SQL/PGQ
+
+PostgreSQL 19 implements SQL/PGQ (ISO SQL:2023 part 16), which layers a property-graph view over ordinary tables and queries it with `GRAPH_TABLE`. Gradient does not use it, and adopting it is not currently possible: the first implementation matches fixed-length patterns only, with no quantified path patterns and no transitive closure, and every walk here is unbounded depth.
+
+Nothing needs to change for that to become an option. `derivation` is already a vertex table and `derivation_dependency` an edge table with foreign keys to both ends, which is the shape `CREATE PROPERTY GRAPH ... EDGE TABLES (... SOURCE ... DESTINATION ...)` requires, and keeping every traversal inside `graph_sql.rs` means a switch would touch one module. Revisit when quantified path patterns land.
+
+---
+
 ## Authentication
 
 **JWT** - `HS256` signed with `GRADIENT_JWT_SECRET`. Payload contains `sub: user_uuid`. Regular tokens expire after 24 hours; `remember_me` tokens after 30 days. Generated in `web::authorization::encode_jwt`.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -7957,6 +7957,14 @@ itself. The old layer-ordering and cycle-termination tests are gone, because
 termination is now Postgres's `UNION` rather than a Rust visited set; keeping
 them would have been testing `MockDatabase`.
 
+**`gradient-report/src/tables.rs`** follows the schema: `derivation_dependency`
+and `cached_path_reference` no longer export an `id`, and `SCHEMA_VERSION` goes
+to 4 so an inspector refuses an older file rather than reading a column that
+moved. The existing `every_spec_is_scoped_and_internally_consistent` is what
+catches a DDL and column list drifting apart; without the version bump the
+report would simply have failed at extraction time, since the query still named
+a dropped column.
+
 **The cache VM test** (`nix/tests/gradient/cache/default.nix`, Phase 5b) is the
 only place the plan itself can be checked. Against the real graph it asserts that
 both covering indexes exist and no junction table kept a surrogate key, that the

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -7926,3 +7926,42 @@ and `finished_at` is set, and that the evaluation's three phase columns are
 non-zero. That last assertion is what proves the columns are now derived from
 the timeline rather than from the `EvalStatsReport` fields that were removed;
 they had been shipping as zeros.
+
+## Cheap graph walks and one closure representation (#598)
+
+Every unbounded traversal now runs as one recursive statement whose recursive
+term is a `LATERAL` probe behind an `OFFSET 0` fence. The fence is what forces a
+nested loop with a per-row index lookup instead of the merge join Postgres picks
+from its ten-times-the-seed estimate of the working table, and nothing in the
+Rust type system notices if it is dropped, so it needs a test that reads the
+plan.
+
+**`gradient-db/src/graph_sql.rs`** covers what the generator emits: the
+dependents direction walks upward and the dependencies direction downward; every
+generated walk (evaluation closure, GC keep-set, dependents, reference closure)
+carries `LATERAL (` and `OFFSET 0) s`; and none of them says `UNION ALL`. That
+last assertion is not a style rule. `UNION` is what deduplicates the frontier on
+each iteration, and on a diamond-shaped graph dropping it makes the walk
+exponential in depth.
+
+**`gradient-db/src/cache_storage.rs`** keeps its existing ordering assertion:
+Postgres accepts exactly one self-reference and only in the last arm of a `UNION`
+chain, so the `.drv` seed must stay ahead of the reference walk. Rewriting the
+walk moved the self-reference from a `JOIN eval_paths` to a `FROM eval_paths c`,
+and the test now looks for the new shape.
+
+**`gradient-db/src/closure.rs`** and **`dependency_graph.rs`** cover the collapse
+from a level-at-a-time BFS to one statement: the mock now serves a single result
+set instead of one per level, and a derivation nothing depends on still reports
+itself. The old layer-ordering and cycle-termination tests are gone, because
+termination is now Postgres's `UNION` rather than a Rust visited set; keeping
+them would have been testing `MockDatabase`.
+
+**The cache VM test** (`nix/tests/gradient/cache/default.nix`, Phase 5b) is the
+only place the plan itself can be checked. Against the real graph it asserts that
+both covering indexes exist and no junction table kept a surrogate key, that the
+fenced walk selects exactly the same node set as the plain join in both
+directions (a symmetric `EXCEPT` in each direction, which is the only check that
+the rewrite preserved meaning), that `EXPLAIN` shows a `Nested Loop` and no
+`Merge Join`, and that the maintained `entry_point_dep_count` histogram agrees
+with a recompute from the materialised closure.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -7944,6 +7944,17 @@ last assertion is not a style rule. `UNION` is what deduplicates the frontier on
 each iteration, and on a diamond-shaped graph dropping it makes the walk
 exponential in depth.
 
+**`gradient-db/src/promotion.rs`** is where the mirrored-SQL tests earned their
+keep. Two recursive walks there were written by hand rather than generated (the
+`DependencyFailed` cascade when scoped to one evaluation, and the requeue
+closure with its `deterministic_blocked` subset), so they kept the plain join
+after the rest of the codebase moved. The stale assertion is what surfaced them.
+They now come from `bounded_dependency_closure_cte_body`, which puts the
+"restricted to this evaluation's closure" predicate inside the lateral probe so
+it prunes at the index lookup rather than after the join. The scoped cascade
+still has to mention the closure bound at least three times: the seed, the walk,
+and the UPDATE.
+
 **`gradient-db/src/cache_storage.rs`** keeps its existing ordering assertion:
 Postgres accepts exactly one self-reference and only in the last arm of a `UNION`
 chain, so the `.drv` seed must stay ahead of the reference walk. Rewriting the

--- a/docs/src/usage/closure-view.md
+++ b/docs/src/usage/closure-view.md
@@ -49,3 +49,9 @@ Response (`ClosureGraph`): `roots`, `total_size_bytes`, `node_count`,
 `edges` (`source` → `target`, where `target` depends on `source`). Node ids are
 derivation UUIDs for the build closure and store-path hashes for the runtime
 closure.
+
+Both closures are resolved by a single recursive statement rather than one query
+per graph level, so response time tracks the size of the closure rather than its
+depth. The walks are generated in `gradient-db/src/graph_sql.rs`; see
+[Recursive Graph Walks](../development/internals.md#recursive-graph-walks) for
+the query shape and why it is written the way it is.

--- a/nix/tests/gradient/cache/default.nix
+++ b/nix/tests/gradient/cache/default.nix
@@ -534,6 +534,81 @@ in {
                      "ingest transaction failed", "dropped as stale"):
           assert needle not in j, f"server log contains {needle!r}"
 
+      # ── Phase 5b: the graph walks stay fenced and agree with the old shape ─
+      # The recursive walks are generated in `graph_sql.rs` as a LATERAL probe
+      # behind an `OFFSET 0` fence. Without the fence Postgres believes the
+      # working table is ten times the seed and merge-joins the whole edge
+      # table once per iteration, which cost 5.3 s on a 44k-node production
+      # closure against 1.0 s fenced. Nothing in the Rust type system notices
+      # if the fence is dropped, so assert the plan here.
+      banner("Phase 5b: graph walk shape, plans and closure counters")
+
+      have_reverse_index = int(sql(
+          "SELECT count(*) FROM pg_indexes "
+          "WHERE indexname = 'idx-derivation_dependency-reverse-pair';"
+      ))
+      assert have_reverse_index == 1, "the reverse walk lost its covering index"
+      have_referrer_index = int(sql(
+          "SELECT count(*) FROM pg_indexes "
+          "WHERE indexname = 'idx-cached_path_reference-referrer-hash';"
+      ))
+      assert have_referrer_index == 1, "the reference walk lost its covering index"
+      leftover_keys = int(sql(
+          "SELECT count(*) FROM information_schema.columns "
+          "WHERE column_name = 'id' AND table_name IN "
+          "('derivation_dependency', 'derivation_closure', 'cached_path_reference');"
+      ))
+      assert leftover_keys == 0, f"{leftover_keys} junction tables kept a surrogate key"
+
+      # The fenced walk and the plain join must select the same node set. This is
+      # the only place the rewrite is checked against a real graph.
+      for direction, fenced_step, plain_step in [
+          ("dependencies",
+           "SELECT e.dependency AS next FROM derivation_dependency e WHERE e.derivation = c.derivation",
+           "SELECT e.dependency FROM derivation_dependency e JOIN plain c ON e.derivation = c.derivation"),
+          ("dependents",
+           "SELECT e.derivation AS next FROM derivation_dependency e WHERE e.dependency = c.derivation",
+           "SELECT e.derivation FROM derivation_dependency e JOIN plain c ON e.dependency = c.derivation"),
+      ]:
+          seed = f"SELECT bj.derivation FROM build_job bj WHERE bj.evaluation = '{eval_id}'"
+          disagree = int(sql(
+              f"WITH RECURSIVE fenced(derivation) AS ({seed} UNION "
+              f"  SELECT s.next FROM fenced c, LATERAL ({fenced_step} OFFSET 0) s), "
+              f"plain(derivation) AS ({seed} UNION {plain_step}) "
+              f"SELECT (SELECT count(*) FROM (SELECT derivation FROM fenced "
+              f"        EXCEPT SELECT derivation FROM plain) a) "
+              f"     + (SELECT count(*) FROM (SELECT derivation FROM plain "
+              f"        EXCEPT SELECT derivation FROM fenced) b);"
+          ))
+          assert disagree == 0, f"the fenced {direction} walk disagrees on {disagree} nodes"
+
+          # A lateral correlation can only be executed as a nested loop, so the
+          # fence holding is exactly "no merge join survived in the plan".
+          plan = sql(
+              f"EXPLAIN WITH RECURSIVE fenced(derivation) AS ({seed} UNION "
+              f"  SELECT s.next FROM fenced c, LATERAL ({fenced_step} OFFSET 0) s) "
+              f"SELECT count(*) FROM fenced;"
+          )
+          assert "Nested Loop" in plan, f"the {direction} walk lost its nested loop:\n{plan}"
+          assert "Merge Join" not in plan, f"the {direction} walk merge-joins again:\n{plan}"
+
+      # The maintained histogram is what the task page reads; recomputing it from
+      # the materialised closure must give the same totals.
+      drift = int(sql(
+          f"WITH stored AS ("
+          f"  SELECT ep.id, coalesce(sum(c.count), 0) AS total FROM entry_point ep "
+          f"  LEFT JOIN entry_point_dep_count c ON c.entry_point = ep.id "
+          f"  WHERE ep.evaluation = '{eval_id}' GROUP BY ep.id), "
+          f"live AS ("
+          f"  SELECT ep.id, count(*) AS total FROM entry_point ep "
+          f"  JOIN derivation_closure dc ON dc.root_derivation = ep.derivation "
+          f"  JOIN derivation_build b ON b.derivation = dc.dep_derivation "
+          f"  WHERE ep.evaluation = '{eval_id}' GROUP BY ep.id) "
+          f"SELECT count(*) FROM live l JOIN stored s ON s.id = l.id "
+          f"WHERE l.total <> s.total;"
+      ))
+      assert drift == 0, f"{drift} entry points disagree with their materialised closure"
+
       # ── Phase 6: extract hello's `.drv` from the eval's build list ────────
       # We hit `/evals/{id}/builds` directly with the eval_id already pinned
       # by Phase 5; screen-scraping `gradient task show` is too brittle


### PR DESCRIPTION
Closes #598. Every recursive walk is now generated in `graph_sql.rs` as a `LATERAL` probe behind an `OFFSET 0` fence, which forces the nested loop Postgres refuses to pick from its ten-times-the-seed working-table estimate: measured on production, the evaluation closure drops 5,278 ms to 955 ms, the GC keep-set 40,069 ms to 9,746 ms, and the `cached_path_reference` sweep that is 57% of all database time from over 180 s to 18 s.

Both edge tables gain a covering index in the probed direction, the four Rust BFS loops collapse into single statements, the task board binds its parameters instead of interpolating UUIDs, and the three junction tables drop surrogate keys that `pg_stat_user_indexes` shows were never once read. Keeps `UNION` rather than the issue's `UNION ALL`, which would be exponential on a diamond graph.