### PR TITLE
Closure-aware cache queries and successful build attempts

### DIFF
--- a/backend/gradient-db/src/build_attempt.rs
+++ b/backend/gradient-db/src/build_attempt.rs
@@ -177,9 +177,10 @@ pub async fn stamp_attempt_started<C: ConnectionTrait>(
     Ok(())
 }
 
-/// Record a terminal failure on the anchor's latest attempt: set `outcome` +
-/// `reason` + `failure_message`, stamping `build_finished_at` if not already set.
-pub async fn fail_latest_attempt<C: ConnectionTrait>(
+/// Record a terminal `outcome` on the anchor's latest attempt, stamping
+/// `build_finished_at` if not already set. Every attempt must reach one of these:
+/// a row left at `Running` is swept to `Aborted` by `recover_interrupted_work`.
+pub async fn finish_latest_attempt<C: ConnectionTrait>(
     db: &C,
     derivation_build: DerivationBuildId,
     outcome: AttemptOutcome,
@@ -199,6 +200,27 @@ pub async fn fail_latest_attempt<C: ConnectionTrait>(
     }
 
     Ok(())
+}
+
+/// Record a terminal failure on the anchor's latest attempt.
+pub async fn fail_latest_attempt<C: ConnectionTrait>(
+    db: &C,
+    derivation_build: DerivationBuildId,
+    outcome: AttemptOutcome,
+    reason: Option<AttemptFailureReason>,
+    failure_message: Option<String>,
+) -> Result<(), DbErr> {
+    finish_latest_attempt(db, derivation_build, outcome, reason, failure_message).await
+}
+
+/// Record a terminal success (`Built` / `Substituted`) on the anchor's latest
+/// attempt, clearing any reason left by a superseded failure.
+pub async fn succeed_latest_attempt<C: ConnectionTrait>(
+    db: &C,
+    derivation_build: DerivationBuildId,
+    outcome: AttemptOutcome,
+) -> Result<(), DbErr> {
+    finish_latest_attempt(db, derivation_build, outcome, None, None).await
 }
 
 /// Count `InputsUnavailable` attempts recorded against an anchor across its whole

--- a/backend/gradient-db/src/runtime_closure.rs
+++ b/backend/gradient-db/src/runtime_closure.rs
@@ -132,6 +132,44 @@ pub async fn runtime_closure_reachable<C: ConnectionTrait>(
         .collect())
 }
 
+/// Store paths in the reference closure of `seed_hashes` that this cache can
+/// actually serve, excluding the seeds themselves and capped at `limit`.
+///
+/// Answers "what else will the caller need, and can we hand it over now" in one
+/// statement, so a worker learns a whole closure per round trip instead of one
+/// hop at a time. Only backed rows come back, so a caller may treat every
+/// returned path as serveable. The walk dedupes on `hash` alone: adding depth to
+/// the key would let a diamond re-enter the frontier and never terminate.
+pub async fn runtime_closure_cached_paths<C: ConnectionTrait>(
+    db: &C,
+    seed_hashes: &[String],
+    limit: u64,
+) -> Result<Vec<String>, DbErr> {
+    if seed_hashes.is_empty() || limit == 0 {
+        return Ok(vec![]);
+    }
+
+    let sql = format!(
+        "{} SELECT '/nix/store/' || cp.hash || '-' || cp.package AS reference \
+         FROM cached_path cp JOIN refs r ON cp.hash = r.hash \
+         WHERE cp.file_hash IS NOT NULL AND cp.hash <> ALL($1::text[]) \
+         LIMIT $2",
+        crate::graph_sql::reference_closure_cte("refs", "SELECT unnest($1::text[])")
+    );
+    Ok(
+        ReferenceToken::find_by_statement(Statement::from_sql_and_values(
+            DatabaseBackend::Postgres,
+            sql,
+            [seed_hashes.to_vec().into(), (limit as i64).into()],
+        ))
+        .all(db)
+        .await?
+        .into_iter()
+        .map(|r| r.reference)
+        .collect(),
+    )
+}
+
 /// Total NAR size of the runtime closure seeded at `seed_hashes`.
 pub async fn runtime_closure_size<C: ConnectionTrait>(
     db: &C,
@@ -163,5 +201,40 @@ mod tests {
     async fn empty_seeds_is_zero() {
         let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
         assert_eq!(runtime_closure_size(&db, &[]).await.unwrap(), 0);
+    }
+
+    /// Both degenerate inputs must short-circuit before issuing SQL: an
+    /// unseeded MockDatabase errors on any query, so reaching one fails here.
+    #[tokio::test]
+    async fn closure_expansion_skips_the_query_when_there_is_nothing_to_ask() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
+        assert!(
+            runtime_closure_cached_paths(&db, &[], 100)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            runtime_closure_cached_paths(&db, &["abc".to_string()], 0)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    /// The walk must dedupe on `hash` alone. Keying on anything that varies per
+    /// visit (a depth counter) lets a diamond re-enter the frontier forever.
+    #[test]
+    fn closure_expansion_walks_fenced_and_dedupes_on_hash_alone() {
+        let cte = crate::graph_sql::reference_closure_cte("refs", "SELECT unnest($1::text[])");
+        assert!(cte.contains("refs(hash)"), "dedup key is the hash: {cte}");
+        assert!(
+            cte.contains("OFFSET 0) s"),
+            "recursive term stays fenced: {cte}"
+        );
+        assert!(
+            !cte.contains("UNION ALL"),
+            "UNION ALL never terminates here: {cte}"
+        );
     }
 }

--- a/backend/gradient-graph/src/policy.rs
+++ b/backend/gradient-graph/src/policy.rs
@@ -65,6 +65,18 @@ pub(crate) fn terminal_success_status(outputs_already_valid: bool) -> BuildStatu
     }
 }
 
+/// Terminal `build_attempt.outcome` for a job that completed, mirroring
+/// [`terminal_success_status`]. Without this the success path leaves the attempt
+/// at `Running`, and `recover_interrupted_work` later rewrites every such row to
+/// `Aborted` - so a healthy instance reports roughly half its attempts aborted.
+pub(crate) fn terminal_success_outcome(outputs_already_valid: bool) -> AttemptOutcome {
+    if outputs_already_valid {
+        AttemptOutcome::Substituted
+    } else {
+        AttemptOutcome::Built
+    }
+}
+
 /// Best-effort mapping from the worker's failure classification to a stored
 /// `build_attempt.reason`. `Transient` has no single cause, so it stays `None`;
 /// an abort is not a failure of the derivation and carries no reason at all.
@@ -138,8 +150,8 @@ pub(crate) fn truncate_failure_message(error: &str) -> String {
 mod tests {
     use super::{
         FailureOutcome, attempt_outcome, attempt_reason, decide_failure_outcome,
-        inputs_unavailable_circuit_open, retry_backoff_elapsed, terminal_success_status,
-        truncate_failure_message,
+        inputs_unavailable_circuit_open, retry_backoff_elapsed, terminal_success_outcome,
+        terminal_success_status, truncate_failure_message,
     };
     use gradient_entity::build::BuildStatus;
     use gradient_entity::build_attempt::{AttemptFailureReason, AttemptOutcome};
@@ -333,5 +345,23 @@ mod tests {
     fn terminal_status_is_substituted_only_when_outputs_were_already_valid() {
         assert_eq!(terminal_success_status(true), BuildStatus::Substituted);
         assert_eq!(terminal_success_status(false), BuildStatus::Completed);
+    }
+
+    /// Success must be recorded on the attempt, never left at `Running`: the
+    /// recovery sweep turns a lingering `Running` row into `Aborted`.
+    #[test]
+    fn terminal_outcome_records_success_and_never_stays_running() {
+        assert_eq!(terminal_success_outcome(true), AttemptOutcome::Substituted);
+        assert_eq!(terminal_success_outcome(false), AttemptOutcome::Built);
+        for already_valid in [true, false] {
+            assert_ne!(
+                terminal_success_outcome(already_valid),
+                AttemptOutcome::Running
+            );
+            assert_ne!(
+                terminal_success_outcome(already_valid),
+                AttemptOutcome::Aborted
+            );
+        }
     }
 }

--- a/backend/gradient-graph/src/transition.rs
+++ b/backend/gradient-graph/src/transition.rs
@@ -10,8 +10,8 @@ use std::collections::HashMap;
 
 use anyhow::{Context, Result};
 use gradient_db::{
-    DbContext, cascade_dependency_failed, fail_latest_attempt, update_derivation_build_status,
-    update_evaluation_status, update_evaluation_status_with_error,
+    DbContext, cascade_dependency_failed, fail_latest_attempt, succeed_latest_attempt,
+    update_derivation_build_status, update_evaluation_status, update_evaluation_status_with_error,
 };
 use gradient_entity::build::BuildStatus;
 use gradient_entity::evaluation::EvaluationStatus;
@@ -404,6 +404,15 @@ async fn build_completed(
     // The output NARs are pushed by the time `JobCompleted` arrives, so the
     // anchor may now become dispatch-ready.
     let terminal = policy::terminal_success_status(anchor.substituted);
+    if let Err(e) = succeed_latest_attempt(
+        &ctx.worker_db,
+        derivation_build,
+        policy::terminal_success_outcome(anchor.substituted),
+    )
+    .await
+    {
+        warn!(%derivation_build, error = %e, "failed to record attempt success");
+    }
     update_derivation_build_status(ctx, anchor, terminal).await;
     check_referencing_evals_done(ctx, derivation_id).await?;
 

--- a/backend/gradient-proto/src/handler/cache.rs
+++ b/backend/gradient-proto/src/handler/cache.rs
@@ -250,7 +250,7 @@ async fn build_cached_entry(
     }
 
     let (url, nar_hash, file_hash, references, signatures, deriver, ca) = match mode {
-        QueryMode::Pull => {
+        QueryMode::Pull | QueryMode::PullClosure => {
             let url = match state.nar_storage.presigned_get_url(hash, expire).await {
                 Ok(u) => u,
                 Err(e) => {
@@ -489,11 +489,52 @@ async fn extend_with_gradient_proto_results(
     }
 }
 
+/// Keep every seed's answer whatever it says, and every bonus entry the cache
+/// can actually serve. A caller reads an uncached entry as "a path I asked for
+/// is missing" and fails the build on it, so an unserveable path it never asked
+/// about must never reach it.
+fn drop_unserveable_bonus(
+    seeds: &[String],
+    mut entries: Vec<gradient_types::proto::CachedPath>,
+) -> Vec<gradient_types::proto::CachedPath> {
+    let seeds: std::collections::HashSet<&str> = seeds.iter().map(String::as_str).collect();
+    entries.retain(|cp| cp.cached || seeds.contains(cp.path.as_str()));
+    entries
+}
+
+/// `paths` plus the serveable members of their runtime-reference closure, held
+/// under the per-reply path cap so the widened reply still fits one frame. With
+/// no room left the seeds come back unchanged and the caller keeps walking.
+async fn expand_pull_closure(state: &ServerState, paths: &[String]) -> Result<Vec<String>, DbErr> {
+    let budget = crate::messages::CACHE_QUERY_MAX_PATHS.saturating_sub(paths.len());
+    if budget == 0 {
+        return Ok(paths.to_vec());
+    }
+
+    let hashes: Vec<String> = paths
+        .iter()
+        .filter_map(|p| {
+            let base = p.strip_prefix("/nix/store/").unwrap_or(p);
+            let hash = base.split('-').next()?;
+            (hash.len() == 32).then(|| hash.to_string())
+        })
+        .collect();
+
+    let mut widened = paths.to_vec();
+    widened.extend(
+        gradient_db::runtime_closure_cached_paths(&state.cache_db, &hashes, budget as u64).await?,
+    );
+
+    Ok(widened)
+}
+
 /// Check which store paths are available - in the local Gradient cache or upstream.
 ///
 /// Behaviour depends on `mode`:
 /// - `Normal` - return only locally-cached paths; probe upstream for misses.
 /// - `Pull`   - same as Normal but cached paths include a presigned S3 GET URL.
+/// - `PullClosure` - `Pull`, widened with the serveable members of each queried
+///   path's reference closure so one round trip answers for a whole closure.
 /// - `Push`   - return **all** queried paths with `cached` set; skip upstream.
 ///   Uncached paths include a presigned S3 PUT URL when S3-backed.
 async fn query(
@@ -503,6 +544,16 @@ async fn query(
     mode: gradient_types::proto::QueryMode,
 ) -> Result<Vec<gradient_types::proto::CachedPath>, DbErr> {
     use gradient_types::proto::QueryMode;
+
+    // Widen the answer with everything else the caller needs from the same
+    // closure, then drop any bonus entry the cache cannot serve - so an uncached
+    // entry still means "the path you asked for is missing", which callers treat
+    // as fatal.
+    if matches!(mode, QueryMode::PullClosure) {
+        let widened = expand_pull_closure(state, paths).await?;
+        let out = Box::pin(query(state, project_id, &widened, QueryMode::Pull)).await?;
+        return Ok(drop_unserveable_bonus(paths, out));
+    }
 
     let hash_path_pairs: Vec<(&str, &str)> = paths
         .iter()
@@ -826,6 +877,65 @@ mod tests {
             query(&state, None, &paths, QueryMode::Pull).await.is_err(),
             "DB error must propagate as Err, not a confident uncached result"
         );
+    }
+
+    fn entry(path: &str, cached: bool) -> gradient_types::proto::CachedPath {
+        gradient_types::proto::CachedPath {
+            path: path.to_owned(),
+            cached,
+            file_size: None,
+            nar_size: None,
+            url: None,
+            nar_hash: None,
+            file_hash: None,
+            references: None,
+            signatures: None,
+            deriver: None,
+            ca: None,
+        }
+    }
+
+    /// The whole safety property of `PullClosure`: widening the answer must not
+    /// invent a missing input. A worker fails the build on any uncached entry,
+    /// so only a seed may come back uncached.
+    #[test]
+    fn a_widened_reply_never_reports_an_unasked_path_as_missing() {
+        let seeds = vec!["/nix/store/seed-a".to_string()];
+        let kept = drop_unserveable_bonus(
+            &seeds,
+            vec![
+                entry("/nix/store/seed-a", false),
+                entry("/nix/store/bonus-served", true),
+                entry("/nix/store/bonus-unserveable", false),
+            ],
+        );
+
+        let paths: Vec<&str> = kept.iter().map(|c| c.path.as_str()).collect();
+        assert_eq!(
+            paths,
+            ["/nix/store/seed-a", "/nix/store/bonus-served"],
+            "an uncached bonus entry must be dropped, an uncached seed kept"
+        );
+    }
+
+    /// The widened path list is what bounds the reply, so it may never exceed
+    /// the same cap a plain query is chunked to.
+    #[test]
+    fn closure_expansion_stays_within_the_single_frame_path_cap() {
+        use crate::messages::CACHE_QUERY_MAX_PATHS;
+        for seeds in [
+            0usize,
+            1,
+            CACHE_QUERY_MAX_PATHS - 1,
+            CACHE_QUERY_MAX_PATHS,
+            CACHE_QUERY_MAX_PATHS + 1,
+        ] {
+            let budget = CACHE_QUERY_MAX_PATHS.saturating_sub(seeds);
+            assert!(
+                seeds.min(CACHE_QUERY_MAX_PATHS) + budget <= CACHE_QUERY_MAX_PATHS,
+                "seeds {seeds} plus budget {budget} overruns the cap"
+            );
+        }
     }
 
     #[tokio::test]

--- a/backend/gradient-proto/src/handler/cache_session.rs
+++ b/backend/gradient-proto/src/handler/cache_session.rs
@@ -38,7 +38,7 @@ fn reject_reason(msg: &ClientMessage) -> Option<&'static str> {
     match msg {
         ClientMessage::CacheQuery { mode, .. } => match mode {
             QueryMode::Push => Some("Push not allowed on a read-only cache session"),
-            QueryMode::Normal | QueryMode::Pull => None,
+            QueryMode::Normal | QueryMode::Pull | QueryMode::PullClosure => None,
         },
         ClientMessage::NarRequest { .. } => None,
         _ => Some("only CacheQuery and NarRequest are allowed on a cache session"),

--- a/backend/gradient-proto/src/messages/mod.rs
+++ b/backend/gradient-proto/src/messages/mod.rs
@@ -30,7 +30,9 @@ pub use wire::{decode_client_message, decode_server_message};
 ///     deterministic build failure.
 /// v9: `JobCompleted`/`JobFailed` carry the worker's phase timeline (`spans`);
 ///     `EvalStatsReport` drops the three phase-millisecond fields it never set.
-pub const PROTO_VERSION: u16 = 9;
+/// v10: `QueryMode::PullClosure` asks the server to answer for a path's whole
+///      reference closure, not just the path.
+pub const PROTO_VERSION: u16 = 10;
 
 pub use gradient_types::constants::{NAR_ZSTD_LEVEL, PRESIGN_TTL};
 

--- a/backend/gradient-types/src/proto.rs
+++ b/backend/gradient-types/src/proto.rs
@@ -302,6 +302,13 @@ pub enum QueryMode {
     /// `NarPush`.  Cached paths have `cached: true` and no URL (skip them).
     /// Used after `FetchFlake` to push fetched inputs to the server cache.
     Push,
+    /// Like [`QueryMode::Pull`], but the server also expands each queried path's
+    /// runtime-reference closure and answers for its members in the same reply,
+    /// up to the shared per-reply path bound. Bonus members are only ever
+    /// included when they are cached and serveable, so a caller may treat any
+    /// uncached entry as one it asked for. Lets a worker learn a whole closure
+    /// in one round trip instead of one hop at a time.
+    PullClosure,
 }
 
 /// A store path entry returned in [`CacheStatus`].

--- a/backend/gradient-worker/src/proto/prefetch.rs
+++ b/backend/gradient-worker/src/proto/prefetch.rs
@@ -394,11 +394,11 @@ impl<'a> InputPrefetcher<'a> {
     ) -> Result<(Vec<CachedPath>, Vec<CachedPath>)> {
         let cached_entries = self
             .updater
-            .query_cache(missing.clone(), QueryMode::Pull)
+            .query_cache(missing.clone(), QueryMode::PullClosure)
             .await
             .with_context(|| {
                 format!(
-                    "CacheQuery Pull for {} missing inputs of {}",
+                    "CacheQuery PullClosure for {} missing inputs of {}",
                     missing.len(),
                     self.drv_path
                 )
@@ -670,6 +670,14 @@ impl<'a> InputPrefetcher<'a> {
             }
 
             let (by_url, by_request) = self.query_and_split(to_query).await?;
+            // The server answers for closure members we never asked about, so
+            // bank them before the next round rather than querying them again.
+            queried.extend(
+                by_url
+                    .iter()
+                    .chain(by_request.iter())
+                    .map(|cp| cp.path.clone()),
+            );
             let mut batch = self.fetch_by_request(by_request).await?;
             batch.extend(self.download_by_url(by_url).await?);
 

--- a/docs/src/development/proto.md
+++ b/docs/src/development/proto.md
@@ -597,6 +597,7 @@ The `architecture` field is a free-form Nix system string (e.g. `"x86_64-linux"`
 | `Normal` | Eval: mark derivations as substituted | Only cached paths (`cached: true`), no URLs, no metadata |
 | `Pull` | Build: fetch required store paths | **All** queried paths. Cached paths carry full import metadata (`nar_hash`, `references`, `signatures`, `deriver`, `ca`) and a presigned S3 GET URL (or `url: None` for local - use `NarRequest`). Uncached paths carry `path` + `cached: false` only, signaling "the server has nothing to offer for this path" - neither in the local cache nor in any configured upstream. Lets the worker hard-fail before importing a dependent with an unsatisfiable reference. |
 | `Push` | Fetch: upload new inputs | **All** queried paths. Cached paths carry only `path` + `cached: true`. Uncached paths carry `path`, `cached: false`, and `url` - a presigned S3 PUT URL on S3-backed stores (`None` on local; worker falls back to `NarPush`). No other metadata, no upstream lookup. |
+| `PullClosure` | Build: fetch a required path and everything it references | `Pull`, widened with the serveable members of each queried path's runtime-reference closure. The server walks `cached_path_reference` itself, so one round trip answers for a whole closure instead of one hop per round trip. A bonus member is only ever included when the cache can serve it, so an uncached entry still means "a path you asked for is missing". The widened list stays under `CACHE_QUERY_MAX_PATHS`, so the reply still fits one frame; anything that does not fit is simply left for the caller's next query. |
 
 ```rust
 // Worker → Server
@@ -607,9 +608,10 @@ CacheQuery {
 }
 
 enum QueryMode {
-    Normal,   // return only cached paths - no URLs, no metadata
-    Pull,     // return cached paths with full import metadata + presigned GET URL
-    Push,     // return all paths with path + cached; uncached also gets presigned PUT URL (S3)
+    Normal,       // return only cached paths - no URLs, no metadata
+    Pull,         // return cached paths with full import metadata + presigned GET URL
+    Push,         // return all paths with path + cached; uncached also gets presigned PUT URL (S3)
+    PullClosure,  // Pull, widened with each path's serveable reference closure
 }
 
 // Server → Worker
@@ -941,7 +943,7 @@ enum ClientMessage {
     },
 }
 
-enum QueryMode { Normal, Pull, Push }  // default: Normal
+enum QueryMode { Normal, Pull, Push, PullClosure }  // default: Normal
 enum EvalMessageLevel { Error, Warning, Notice }
 ```
 
@@ -1490,7 +1492,7 @@ interrupted, so a restart loses no job.
 
 ## Versioning
 
- - `PROTO_VERSION` (currently `8`) is incremented on breaking wire changes.
+ - `PROTO_VERSION` (currently `10`) is incremented on breaking wire changes.
  - Server accepts any `client_version == PROTO_VERSION`; the check lives once, in
    `session::handshake::on_init_connection`, and every session flavor (worker,
    cache-scoped, outbound) goes through it.

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -7984,3 +7984,45 @@ directions (a symmetric `EXCEPT` in each direction, which is the only check that
 the rewrite preserved meaning), that `EXPLAIN` shows a `Nested Loop` and no
 `Merge Join`, and that the maintained `entry_point_dep_count` histogram agrees
 with a recompute from the materialised closure.
+
+## Closure-aware cache queries and attempt outcomes
+
+A prefetching worker used to learn a reference closure one hop at a time: query,
+download, read the references that came back, query again. Each hop is a full
+server round trip, and the measured cost of a `CacheQuery` is dominated by
+per-query latency rather than by how many paths it carries, so a ten-deep
+reference chain cost ten round trips no matter how few bytes it moved.
+`QueryMode::PullClosure` moves the expansion to the server, which already holds
+`cached_path_reference` and the fenced walk over it.
+
+**`gradient-proto/src/handler/cache.rs`** carries the one test that matters for
+safety. A worker treats any uncached entry in a `CacheQuery` reply as a required
+input it cannot get, and fails the build on it. Widening a reply with closure
+members the caller never asked about therefore has to guarantee that a bonus
+entry is never uncached, or an unrelated missing path anywhere in a closure would
+fail a build that did not need it.
+`a_widened_reply_never_reports_an_unasked_path_as_missing` pins exactly that: an
+uncached seed survives the filter, an uncached bonus entry does not.
+`closure_expansion_stays_within_the_single_frame_path_cap` pins the other half,
+that the widened path list still respects `CACHE_QUERY_MAX_PATHS` at every seed
+count, since that cap is what keeps a reply inside `SAFE_INFLIGHT_MESSAGE_SIZE`
+and out of the bidirectional write deadlock.
+
+**`gradient-db/src/runtime_closure.rs`** checks the expansion query itself.
+`closure_expansion_skips_the_query_when_there_is_nothing_to_ask` relies on an
+unseeded `MockDatabase` erroring on any query, so an empty seed set or a zero
+budget reaching SQL fails the test rather than passing quietly.
+`closure_expansion_walks_fenced_and_dedupes_on_hash_alone` asserts the generated
+CTE keys on `hash` alone and keeps its `OFFSET 0` fence: adding anything that
+varies per visit to the dedup key, a depth counter above all, lets a diamond
+re-enter the frontier and the walk never terminates.
+
+**`gradient-graph/src/policy.rs`** covers the attempt-outcome fix.
+`AttemptOutcome::Built` and `Substituted` existed in the enum but nothing ever
+wrote them: the success path set the anchor's status and left the attempt at
+`Running`, and `recover_interrupted_work` then rewrote every lingering `Running`
+row to `Aborted` on the next restart. A healthy instance therefore reported
+roughly half its attempts aborted, and anything reading attempt outcomes read
+noise. `terminal_outcome_records_success_and_never_stays_running` asserts both
+mappings and, more importantly, that neither `Running` nor `Aborted` can come
+back from the success path.


### PR DESCRIPTION
A prefetching worker learned a reference closure one hop per server round trip; `QueryMode::PullClosure` has the server expand it instead, and bonus members are filtered to serveable ones so an uncached entry still means a required input is missing.

Also fixes `AttemptOutcome::Built`/`Substituted` never being written, which left every successful attempt at `Running` for the recovery sweep to relabel `Aborted`.