### PR TITLE
Restart recovery ownership and substitute-relay classification

### DIFF
--- a/backend/gradient-db/src/connection.rs
+++ b/backend/gradient-db/src/connection.rs
@@ -5,8 +5,6 @@
  */
 
 use anyhow::{Context, Result};
-use gradient_entity::build::BuildStatus;
-use gradient_entity::evaluation::EvaluationStatus;
 use gradient_migration::Migrator;
 use sea_orm::{
     ActiveModelTrait, ActiveValue::Set, ColumnTrait, ConnectOptions, ConnectionTrait, Database,
@@ -189,57 +187,12 @@ pub async fn connect_cache_db(cli: &Cli) -> Result<DatabaseConnection> {
     .context("Failed to connect cache database pool")
 }
 
-/// Evaluations the scheduler re-dispatches on its own after a restart, so
-/// startup recovery must leave them alone: `Queued` is re-offered by the eval
-/// dispatcher, `Waiting` (evaluated, builds queued for a free worker) is
-/// re-driven by build reconcile. Every other active status was running on a
-/// now-disconnected worker and is genuinely lost.
-fn eval_survives_restart(status: EvaluationStatus) -> bool {
-    matches!(status, EvaluationStatus::Queued | EvaluationStatus::Waiting)
-}
-
+/// Schema-time setup only. Restart recovery belongs to
+/// [`crate::recover_interrupted_work`], which runs once at server startup: this
+/// ran first and aborted the evaluations out from under it, so its anchor
+/// cleanup found nothing to do and every anchor those evaluations drove was
+/// left `Created`/`Queued` forever.
 async fn update_db(db: &DatabaseConnection) -> Result<(), DbErr> {
-    // Recover work interrupted by the restart. Anchors are global, so a build
-    // that was mid-compile on a now-lost worker is simply re-queued for the
-    // scheduler to re-dispatch (its orphaned attempt is closed by recovery);
-    // queued/waiting evaluations are left for the dispatcher to re-offer.
-    EDerivationBuild::update_many()
-        .col_expr(
-            CDerivationBuild::Status,
-            sea_orm::sea_query::Expr::value(BuildStatus::Queued),
-        )
-        .col_expr(
-            CDerivationBuild::UpdatedAt,
-            sea_orm::sea_query::Expr::value(now()),
-        )
-        .filter(CDerivationBuild::Status.eq(BuildStatus::Building))
-        .exec(db)
-        .await?;
-
-    let evaluations = EEvaluation::find()
-        .filter(CEvaluation::Status.is_in(EvaluationStatus::ACTIVE))
-        .all(db)
-        .await?;
-
-    for evaluation in evaluations {
-        if eval_survives_restart(evaluation.status) {
-            continue;
-        }
-
-        // Direct-build evaluations have no task; skip force_evaluation for those.
-        if let Some(task_id) = evaluation.task
-            && let Some(task) = ETask::find_by_id(task_id).one(db).await?
-        {
-            let mut atask: ATask = task.into();
-            atask.force_evaluation = Set(true);
-            atask.update(db).await?;
-        }
-
-        let mut aevaluation: AEvaluation = evaluation.into();
-        aevaluation.status = Set(EvaluationStatus::Aborted);
-        aevaluation.update(db).await?;
-    }
-
     seed_builtin_role(db, BASE_ROLE_ADMIN_ID, "Admin", admin_mask()).await?;
     seed_builtin_role(db, BASE_ROLE_WRITE_ID, "Write", write_mask()).await?;
     seed_builtin_role(db, BASE_ROLE_VIEW_ID, "View", view_mask()).await?;
@@ -489,32 +442,5 @@ mod pg_version_tests {
     fn accepts_postgres_18_and_newer() {
         assert!(require_supported_pg_version(180_000).is_ok());
         assert!(require_supported_pg_version(190_002).is_ok());
-    }
-}
-
-#[cfg(test)]
-mod startup_recovery_tests {
-    use super::eval_survives_restart;
-    use gradient_entity::evaluation::EvaluationStatus;
-
-    #[test]
-    fn queued_and_waiting_evaluations_survive_restart() {
-        assert!(eval_survives_restart(EvaluationStatus::Queued));
-        assert!(eval_survives_restart(EvaluationStatus::Waiting));
-    }
-
-    #[test]
-    fn actively_running_evaluations_are_aborted_on_restart() {
-        for status in [
-            EvaluationStatus::Fetching,
-            EvaluationStatus::EvaluatingFlake,
-            EvaluationStatus::EvaluatingDerivation,
-            EvaluationStatus::Building,
-        ] {
-            assert!(
-                !eval_survives_restart(status),
-                "{status:?} must not survive"
-            );
-        }
     }
 }

--- a/backend/gradient-db/src/recovery.rs
+++ b/backend/gradient-db/src/recovery.rs
@@ -14,6 +14,25 @@ use sea_orm::{
 
 use gradient_types::*;
 
+/// Evaluations the scheduler re-drives on its own after a restart, so recovery
+/// must leave them alone: `Queued` is re-offered by the eval dispatcher and
+/// `Waiting` (evaluated, builds queued for a free worker) by build reconcile.
+/// Every other active status was running on a now-disconnected worker and is
+/// genuinely lost.
+fn eval_survives_restart(status: EvaluationStatus) -> bool {
+    matches!(status, EvaluationStatus::Queued | EvaluationStatus::Waiting)
+}
+
+/// The active statuses this sweep aborts. Derived from `ACTIVE` rather than
+/// listed, so a newly added active status is recovered by default instead of
+/// silently surviving a restart it cannot survive.
+fn lost_eval_statuses() -> Vec<EvaluationStatus> {
+    EvaluationStatus::ACTIVE
+        .into_iter()
+        .filter(|s| !eval_survives_restart(*s))
+        .collect()
+}
+
 #[derive(Debug, Default)]
 pub struct RecoveryReport {
     pub attempts_aborted: u64,
@@ -53,27 +72,38 @@ pub async fn recover_interrupted_work<C: ConnectionTrait>(
         .await?;
     report.builds_requeued = res.rows_affected;
 
-    // 3a. Collect pre-build evals that were in-flight on a now-dead worker.
-    let pre_build_statuses = [
-        EvaluationStatus::Fetching,
-        EvaluationStatus::EvaluatingFlake,
-        EvaluationStatus::EvaluatingDerivation,
-    ];
+    // 3a. Collect the evals a restart lost, `Building` included: their anchors
+    // and their terminal transition are this sweep's to finish.
     let inflight_evals = EEvaluation::find()
-        .filter(CEvaluation::Status.is_in(pre_build_statuses))
+        .filter(CEvaluation::Status.is_in(lost_eval_statuses()))
         .all(conn)
         .await?;
 
-    // 3b. Abort those evaluations.
+    // 3b. Abort those evaluations as a complete terminal transition. `finished_at`
+    // belongs with the status: a reader that sees Aborted with no end time reads
+    // it as still running, and retention keys off the column. The live path
+    // (`update_evaluation_status`) also runs the reactor effects; startup has no
+    // context for those, so the row is at least consistent on its own.
     let eval_ids: Vec<EvaluationId> = inflight_evals.iter().map(|e| e.id).collect();
     if !eval_ids.is_empty() {
         let res = EEvaluation::update_many()
             .col_expr(CEvaluation::Status, Expr::value(EvaluationStatus::Aborted))
             .col_expr(CEvaluation::UpdatedAt, Expr::value(now))
+            .col_expr(CEvaluation::FinishedAt, Expr::value(now))
             .filter(CEvaluation::Id.is_in(eval_ids.clone()))
             .exec(conn)
             .await?;
         report.evals_aborted = res.rows_affected;
+
+        let subjects: Vec<uuid::Uuid> = eval_ids.iter().map(|e| e.into_inner()).collect();
+        crate::status::record_phase_events(
+            conn,
+            crate::status::PhaseSubjectKind::Evaluation,
+            &subjects,
+            i32::from(EvaluationStatus::Aborted) as i16,
+            now,
+        )
+        .await;
     }
 
     // 3c. Abort the anchors those evals drove. When the server dies mid-eval the
@@ -152,6 +182,47 @@ async fn abort_anchors_for_evals<C: ConnectionTrait>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `Building` is the status this sweep used to miss. Startup aborted such an
+    /// evaluation before recovery looked for it, so `abort_anchors_for_evals`
+    /// found nothing and every anchor it drove stayed Created/Queued forever.
+    #[test]
+    fn recovery_owns_every_active_status_a_restart_loses() {
+        let lost = lost_eval_statuses();
+        assert!(lost.contains(&EvaluationStatus::Building), "{lost:?}");
+        assert!(lost.contains(&EvaluationStatus::Fetching), "{lost:?}");
+        assert!(
+            lost.contains(&EvaluationStatus::EvaluatingFlake),
+            "{lost:?}"
+        );
+        assert!(
+            lost.contains(&EvaluationStatus::EvaluatingDerivation),
+            "{lost:?}"
+        );
+    }
+
+    /// The scheduler re-drives these two itself; aborting them would cancel work
+    /// that is still live.
+    #[test]
+    fn recovery_leaves_the_statuses_the_scheduler_re_drives() {
+        let lost = lost_eval_statuses();
+        assert!(!lost.contains(&EvaluationStatus::Queued), "{lost:?}");
+        assert!(!lost.contains(&EvaluationStatus::Waiting), "{lost:?}");
+    }
+
+    /// Derived from `ACTIVE`, never listed: a newly added active status must be
+    /// recovered by default rather than silently surviving a restart.
+    #[test]
+    fn the_lost_set_is_exactly_active_minus_the_survivors() {
+        let lost = lost_eval_statuses();
+        let expected: Vec<EvaluationStatus> = EvaluationStatus::ACTIVE
+            .into_iter()
+            .filter(|s| !matches!(s, EvaluationStatus::Queued | EvaluationStatus::Waiting))
+            .collect();
+        assert_eq!(lost, expected);
+        assert_eq!(lost.len(), EvaluationStatus::ACTIVE.len() - 2);
+    }
+
     use gradient_entity::evaluation::Model as MEval;
     use gradient_entity::ids::{CommitId, EvaluationId, TaskId};
     use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};

--- a/backend/gradient-db/src/status/mod.rs
+++ b/backend/gradient-db/src/status/mod.rs
@@ -25,5 +25,5 @@ pub use eval_finalize::{check_evaluation_done, finalize_evals_for_derivations};
 pub use evaluation_status::{update_evaluation_status, update_evaluation_status_with_error};
 pub use logging::{
     PhaseSubjectKind, finalize_build_log, insert_evaluation_message, record_evaluation_message,
-    record_phase_event,
+    record_phase_event, record_phase_events,
 };

--- a/backend/gradient-graph/src/policy.rs
+++ b/backend/gradient-graph/src/policy.rs
@@ -30,6 +30,7 @@ pub(crate) fn decide_failure_outcome(
     kind: BuildFailureKind,
     attempt: i32,
     max_attempts: u32,
+    substitutable: bool,
 ) -> FailureOutcome {
     match kind {
         BuildFailureKind::Timeout => FailureOutcome::Timeout,
@@ -41,6 +42,15 @@ pub(crate) fn decide_failure_outcome(
         BuildFailureKind::InputsUnavailable | BuildFailureKind::Transient => {
             if (attempt + 1) < max_attempts as i32 {
                 FailureOutcome::Retry
+            } else if substitutable {
+                // Nothing ever tried to build this: the relay out of an upstream
+                // is what kept failing, so a permanent mark is a verdict on the
+                // wrong thing. It poisons a global build-once anchor for a path
+                // that builds fine and is sitting on an upstream, and cascades
+                // `DependencyFailed` over everything above it. Fall into the
+                // substitute-miss loop instead, which escalates to a real build
+                // once the miss budget is spent.
+                FailureOutcome::Requeue
             } else {
                 FailureOutcome::Permanent
             }
@@ -80,6 +90,21 @@ pub(crate) fn terminal_success_outcome(outputs_already_valid: bool) -> AttemptOu
 /// Best-effort mapping from the worker's failure classification to a stored
 /// `build_attempt.reason`. `Transient` has no single cause, so it stays `None`;
 /// an abort is not a failure of the derivation and carries no reason at all.
+/// Stored `build_attempt.reason` for a decided `outcome`. A `Requeue` always
+/// records `SubstituteUnavailable`, whatever kind produced it: the substitute
+/// miss budget counts exactly those rows and is the only thing that ends the
+/// re-queue loop by escalating the anchor to a real build. Leaving it `None`
+/// (as a bare `Transient` would) requeues forever.
+pub(crate) fn attempt_reason_for(
+    kind: BuildFailureKind,
+    outcome: FailureOutcome,
+) -> Option<AttemptFailureReason> {
+    match outcome {
+        FailureOutcome::Requeue => Some(AttemptFailureReason::SubstituteUnavailable),
+        _ => attempt_reason(kind),
+    }
+}
+
 pub(crate) fn attempt_reason(kind: BuildFailureKind) -> Option<AttemptFailureReason> {
     match kind {
         BuildFailureKind::SubstituteUnavailable => {
@@ -149,9 +174,9 @@ pub(crate) fn truncate_failure_message(error: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        FailureOutcome, attempt_outcome, attempt_reason, decide_failure_outcome,
-        inputs_unavailable_circuit_open, retry_backoff_elapsed, terminal_success_outcome,
-        terminal_success_status, truncate_failure_message,
+        FailureOutcome, attempt_outcome, attempt_reason, attempt_reason_for,
+        decide_failure_outcome, inputs_unavailable_circuit_open, retry_backoff_elapsed,
+        terminal_success_outcome, terminal_success_status, truncate_failure_message,
     };
     use gradient_entity::build::BuildStatus;
     use gradient_entity::build_attempt::{AttemptFailureReason, AttemptOutcome};
@@ -167,7 +192,7 @@ mod tests {
     fn abort_is_not_a_deterministic_build_failure() {
         for attempt in [0, 1, 99] {
             assert_eq!(
-                decide_failure_outcome(BuildFailureKind::Aborted, attempt, 3),
+                decide_failure_outcome(BuildFailureKind::Aborted, attempt, 3, false),
                 FailureOutcome::Aborted,
                 "an abort is never a build verdict, at any attempt count"
             );
@@ -211,7 +236,7 @@ mod tests {
     #[test]
     fn permanent_is_terminal_regardless_of_attempt() {
         assert_eq!(
-            decide_failure_outcome(BuildFailureKind::Permanent, 0, 3),
+            decide_failure_outcome(BuildFailureKind::Permanent, 0, 3, false),
             FailureOutcome::Permanent
         );
     }
@@ -219,7 +244,7 @@ mod tests {
     #[test]
     fn timeout_is_terminal() {
         assert_eq!(
-            decide_failure_outcome(BuildFailureKind::Timeout, 0, 3),
+            decide_failure_outcome(BuildFailureKind::Timeout, 0, 3, false),
             FailureOutcome::Timeout
         );
     }
@@ -227,15 +252,15 @@ mod tests {
     #[test]
     fn transient_retries_until_budget_then_permanent() {
         assert_eq!(
-            decide_failure_outcome(BuildFailureKind::Transient, 0, 3),
+            decide_failure_outcome(BuildFailureKind::Transient, 0, 3, false),
             FailureOutcome::Retry
         );
         assert_eq!(
-            decide_failure_outcome(BuildFailureKind::Transient, 1, 3),
+            decide_failure_outcome(BuildFailureKind::Transient, 1, 3, false),
             FailureOutcome::Retry
         );
         assert_eq!(
-            decide_failure_outcome(BuildFailureKind::Transient, 2, 3),
+            decide_failure_outcome(BuildFailureKind::Transient, 2, 3, false),
             FailureOutcome::Permanent
         );
     }
@@ -244,7 +269,7 @@ mod tests {
     fn substitute_unavailable_requeues_penalty_free() {
         for attempt in [0, 5, 100] {
             assert_eq!(
-                decide_failure_outcome(BuildFailureKind::SubstituteUnavailable, attempt, 3),
+                decide_failure_outcome(BuildFailureKind::SubstituteUnavailable, attempt, 3, false),
                 FailureOutcome::Requeue
             );
         }
@@ -282,23 +307,23 @@ mod tests {
     #[test]
     fn substitute_miss_requeues_but_real_failures_cap_at_three() {
         assert!(matches!(
-            decide_failure_outcome(BuildFailureKind::SubstituteUnavailable, 0, 3),
+            decide_failure_outcome(BuildFailureKind::SubstituteUnavailable, 0, 3, false),
             FailureOutcome::Requeue
         ));
         assert!(matches!(
-            decide_failure_outcome(BuildFailureKind::SubstituteUnavailable, 99, 3),
+            decide_failure_outcome(BuildFailureKind::SubstituteUnavailable, 99, 3, false),
             FailureOutcome::Requeue
         ));
         assert!(matches!(
-            decide_failure_outcome(BuildFailureKind::Transient, 0, 3),
+            decide_failure_outcome(BuildFailureKind::Transient, 0, 3, false),
             FailureOutcome::Retry
         ));
         assert!(matches!(
-            decide_failure_outcome(BuildFailureKind::Transient, 1, 3),
+            decide_failure_outcome(BuildFailureKind::Transient, 1, 3, false),
             FailureOutcome::Retry
         ));
         assert!(matches!(
-            decide_failure_outcome(BuildFailureKind::Transient, 2, 3),
+            decide_failure_outcome(BuildFailureKind::Transient, 2, 3, false),
             FailureOutcome::Permanent
         ));
     }
@@ -309,15 +334,15 @@ mod tests {
     #[test]
     fn inputs_unavailable_retries_like_transient_then_permanent() {
         assert_eq!(
-            decide_failure_outcome(BuildFailureKind::InputsUnavailable, 0, 3),
+            decide_failure_outcome(BuildFailureKind::InputsUnavailable, 0, 3, false),
             FailureOutcome::Retry
         );
         assert_eq!(
-            decide_failure_outcome(BuildFailureKind::InputsUnavailable, 1, 3),
+            decide_failure_outcome(BuildFailureKind::InputsUnavailable, 1, 3, false),
             FailureOutcome::Retry
         );
         assert_eq!(
-            decide_failure_outcome(BuildFailureKind::InputsUnavailable, 2, 3),
+            decide_failure_outcome(BuildFailureKind::InputsUnavailable, 2, 3, false),
             FailureOutcome::Permanent
         );
     }
@@ -339,6 +364,60 @@ mod tests {
         assert!(out.len() <= 8 * 1024 + " [truncated]".len());
         assert!(out.ends_with(" [truncated]"));
         assert!(std::str::from_utf8(out.as_bytes()).is_ok());
+    }
+
+    /// A relay out of an upstream that keeps failing is our cache write breaking,
+    /// not a verdict on the derivation. Marking it `FailedPermanent` poisoned a
+    /// global anchor for a path that builds fine: an object-store wobble took out
+    /// mesa, thunderbird and clang at once and cascaded `DependencyFailed` over
+    /// everything above them.
+    #[test]
+    fn an_exhausted_substitute_requeues_instead_of_failing_the_derivation() {
+        assert_eq!(
+            decide_failure_outcome(BuildFailureKind::Transient, 2, 3, true),
+            FailureOutcome::Requeue
+        );
+        assert_eq!(
+            decide_failure_outcome(BuildFailureKind::Transient, 2, 3, false),
+            FailureOutcome::Permanent
+        );
+    }
+
+    /// Below the budget nothing changes: one blip must not turn a substitutable
+    /// build into a from-scratch one.
+    #[test]
+    fn a_substitutable_anchor_still_retries_before_its_budget_is_spent() {
+        assert_eq!(
+            decide_failure_outcome(BuildFailureKind::Transient, 0, 3, true),
+            FailureOutcome::Retry
+        );
+        assert_eq!(
+            decide_failure_outcome(BuildFailureKind::Transient, 1, 3, true),
+            FailureOutcome::Retry
+        );
+    }
+
+    /// What terminates the re-queue loop. The substitute miss budget counts
+    /// attempts carrying `SubstituteUnavailable`, so a `Requeue` recorded with no
+    /// reason would re-dispatch, fail, and requeue forever.
+    #[test]
+    fn every_requeue_records_the_reason_its_miss_budget_counts() {
+        for kind in [
+            BuildFailureKind::Transient,
+            BuildFailureKind::InputsUnavailable,
+            BuildFailureKind::SubstituteUnavailable,
+        ] {
+            assert_eq!(
+                attempt_reason_for(kind, FailureOutcome::Requeue),
+                Some(AttemptFailureReason::SubstituteUnavailable),
+                "{kind:?} requeued without a counted reason"
+            );
+        }
+        // Any other outcome keeps the kind's own mapping.
+        assert_eq!(
+            attempt_reason_for(BuildFailureKind::Permanent, FailureOutcome::Permanent),
+            attempt_reason(BuildFailureKind::Permanent)
+        );
     }
 
     #[test]

--- a/backend/gradient-graph/src/transition.rs
+++ b/backend/gradient-graph/src/transition.rs
@@ -488,18 +488,6 @@ async fn build_failed(
         0
     };
 
-    if let Err(e) = fail_latest_attempt(
-        &ctx.worker_db,
-        derivation_build,
-        policy::attempt_outcome(kind),
-        policy::attempt_reason(kind),
-        Some(policy::truncate_failure_message(error)),
-    )
-    .await
-    {
-        warn!(%derivation_build, error = %e, "failed to record attempt failure reason");
-    }
-
     let max_loops = ctx.config.eval.inputs_unavailable_max_loops;
     let inputs_circuit_open = matches!(kind, BuildFailureKind::InputsUnavailable)
         && policy::inputs_unavailable_circuit_open(prior_inputs_unavailable, max_loops);
@@ -520,10 +508,26 @@ async fn build_failed(
 
     // `InputsUnavailable` retries in-eval (the self-heal re-queues its input),
     // but once the breaker trips the input is unrecoverable - stop retrying.
-    let outcome = match policy::decide_failure_outcome(kind, attempt, max_attempts) {
-        FailureOutcome::Retry if inputs_circuit_open => FailureOutcome::Permanent,
-        other => other,
-    };
+    let outcome =
+        match policy::decide_failure_outcome(kind, attempt, max_attempts, anchor.substitutable) {
+            FailureOutcome::Retry if inputs_circuit_open => FailureOutcome::Permanent,
+            other => other,
+        };
+
+    // Recorded after the outcome is decided: the stored reason depends on it,
+    // and the breaker above deliberately counts only prior attempts.
+    if let Err(e) = fail_latest_attempt(
+        &ctx.worker_db,
+        derivation_build,
+        policy::attempt_outcome(kind),
+        policy::attempt_reason_for(kind, outcome),
+        Some(policy::truncate_failure_message(error)),
+    )
+    .await
+    {
+        warn!(%derivation_build, error = %e, "failed to record attempt failure reason");
+    }
+
     match outcome {
         FailureOutcome::Retry => {
             let mut active: ADerivationBuild = anchor.clone().into_active_model();

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -8026,3 +8026,48 @@ roughly half its attempts aborted, and anything reading attempt outcomes read
 noise. `terminal_outcome_records_success_and_never_stays_running` asserts both
 mappings and, more importantly, that neither `Running` nor `Aborted` can come
 back from the success path.
+
+## Restart recovery and substitute-relay classification
+
+Two defects surfaced from a production report where an evaluation sat `Aborted`
+with no `finished_at`, 94 of its anchors stuck `Created` and 11 stuck `Queued`,
+and four large packages marked `FailedPermanent` by an object-store wobble.
+
+**`gradient-db/src/recovery.rs`** now owns restart recovery outright.
+`connection.rs::update_db` used to abort interrupted evaluations itself, and it
+runs during database init, which is before `recover_interrupted_work`. By the
+time recovery queried for interrupted evaluations there were none left, so
+`abort_anchors_for_evals` found nothing and every anchor those evaluations drove
+stayed `Created`/`Queued` forever. The old test in `connection.rs` passed
+throughout: it asserted a `Building` evaluation does not survive a restart, which
+was true, it was simply aborted by the path that could not finish the job.
+
+`recovery_owns_every_active_status_a_restart_loses` and
+`recovery_leaves_the_statuses_the_scheduler_re_drives` pin the two halves of the
+predicate, and `the_lost_set_is_exactly_active_minus_the_survivors` pins that the
+set is derived from `EvaluationStatus::ACTIVE` rather than listed, so a newly
+added active status is recovered by default instead of silently surviving a
+restart it cannot survive. The abort now writes `finished_at` alongside `status`
+and `updated_at` and records the terminal phase event, because a row reading
+`Aborted` with no end time reads as still running and retention keys off the
+column.
+
+**`gradient-graph/src/policy.rs`** stops a failed substitute relay from
+condemning the derivation. A relay failure is our own cache write breaking, not a
+verdict on a path that builds fine and is sitting on an upstream, but a
+`Transient` classification escalated to `FailedPermanent` once the attempt budget
+ran out, poisoning a global build-once anchor and cascading `DependencyFailed`
+over everything above it.
+`an_exhausted_substitute_requeues_instead_of_failing_the_derivation` pins the new
+outcome, and `a_substitutable_anchor_still_retries_before_its_budget_is_spent`
+pins what deliberately did not change: one blip must not turn a substitutable
+build into a from-scratch one, which is why the fix lives at budget exhaustion
+rather than in the worker's classifier.
+
+`every_requeue_records_the_reason_its_miss_budget_counts` is the one that keeps
+this terminating. `FailureOutcome::Requeue` returns an anchor to `Queued` without
+bumping `attempt`, so nothing about the anchor itself limits the loop; the
+substitute miss budget does, and it counts attempts carrying
+`SubstituteUnavailable`. A requeue recorded with no reason would re-dispatch,
+fail and requeue forever, so `attempt_reason_for` records that reason for every
+`Requeue` whatever kind produced it.


### PR DESCRIPTION
`update_db` aborted interrupted evaluations during database init, before `recover_interrupted_work` looked for them, so recovery's anchor cleanup never ran and their anchors stayed Created/Queued forever; recovery now owns the sweep and writes `finished_at` with the status.

A substitute relay that exhausted its attempt budget was also marked `FailedPermanent`, condemning a global anchor for a path that builds fine because our own cache write failed. It now requeues into the substitute miss budget, which escalates to a real build.