### PR TITLE
scheduler: fix: dispatched jobs stuck 'running' forever

### DIFF
--- a/backend/gradient-entity/src/dispatched_job.rs
+++ b/backend/gradient-entity/src/dispatched_job.rs
@@ -37,8 +37,9 @@ pub enum DispatchedJobKind {
     Build = 1,
 }
 
-/// How a dispatched job ended. `None` on the row means still running, or a
-/// worker that disconnected without reporting.
+/// How a dispatched job ended. `None` means the job is still running; a worker
+/// that vanished without reporting is closed out as `Abandoned` rather than
+/// left open forever.
 #[repr(i16)]
 #[derive(
     Debug,
@@ -62,6 +63,12 @@ pub enum DispatchedJobOutcome {
     Completed = 0,
     #[sea_orm(num_value = 1)]
     Failed = 1,
+    /// The worker never reported a terminal state: it disconnected, or the
+    /// server restarted while the job was in flight. Distinct from `Failed`
+    /// because the build may well have succeeded before contact was lost, so
+    /// this must not count towards failure rates or history-based scoring.
+    #[sea_orm(num_value = 2)]
+    Abandoned = 2,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, DeriveEntityModel, Deserialize, Serialize)]
@@ -74,6 +81,11 @@ pub struct Model {
     pub project: ProjectId,
     pub task: Option<TaskId>,
     pub worker_id: String,
+    /// The scheduler's job key (`build:<anchor>` / `eval:<evaluation>`), unique
+    /// among in-flight jobs. Lets a terminal report close its own row instead of
+    /// guessing at the newest open one for the worker. `None` on rows written
+    /// before the column existed.
+    pub job_id: Option<String>,
     pub score: f64,
     pub queued_at: NaiveDateTime,
     pub ready_at: Option<NaiveDateTime>,

--- a/backend/gradient-migration/src/lib.rs
+++ b/backend/gradient-migration/src/lib.rs
@@ -41,6 +41,7 @@ mod m20260827_000001_commit_hash_index;
 mod m20260904_000000_dispatched_job_phase;
 mod m20260904_000001_graph_edge_indexes;
 mod m20260905_000000_invites;
+mod m20260907_000000_dispatched_job_job_id;
 
 pub struct Migrator;
 
@@ -83,6 +84,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260904_000000_dispatched_job_phase::Migration),
             Box::new(m20260904_000001_graph_edge_indexes::Migration),
             Box::new(m20260905_000000_invites::Migration),
+            Box::new(m20260907_000000_dispatched_job_job_id::Migration),
         ]
     }
 }

--- a/backend/gradient-migration/src/m20260907_000000_dispatched_job_job_id.rs
+++ b/backend/gradient-migration/src/m20260907_000000_dispatched_job_job_id.rs
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::ConnectionTrait;
+
+/// The scheduler's own job key (`build:<anchor>` / `eval:<evaluation>`), which is
+/// unique among in-flight jobs. Closing a dispatch used to guess at
+/// (worker, evaluation, newest open), which attached outcomes to the wrong row
+/// whenever one worker ran several jobs of one evaluation.
+const OPEN_BY_JOB_ID_INDEX: &str = "CREATE INDEX IF NOT EXISTS \"idx-dispatched_job-open-by-job-id\" \
+     ON dispatched_job (job_id, dispatched_at DESC) \
+     WHERE finished_at IS NULL";
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(DispatchedJob::Table)
+                    .add_column_if_not_exists(ColumnDef::new(DispatchedJob::JobId).text().null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(OPEN_BY_JOB_ID_INDEX)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared("DROP INDEX IF EXISTS \"idx-dispatched_job-open-by-job-id\"")
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(DispatchedJob::Table)
+                    .drop_column(DispatchedJob::JobId)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum DispatchedJob {
+    Table,
+    JobId,
+}

--- a/backend/gradient-proto/src/handler/dispatch.rs
+++ b/backend/gradient-proto/src/handler/dispatch.rs
@@ -674,16 +674,8 @@ impl<'a> DispatchContext<'a> {
     async fn on_job_completed(&mut self, job_id: String, spans: Vec<JobPhaseSpan>) {
         info!(peer_id = %self.peer_id, %job_id, phases = spans.len(), "job completed");
         self.active.remove(&job_id);
-        // Before `handle_job_completed`, which drops the job from the
-        // scheduler's active map that resolves it to an evaluation.
         self.scheduler
-            .record_job_timeline(
-                self.peer_id,
-                &job_id,
-                DispatchedJobOutcome::Completed,
-                spans,
-            )
-            .await;
+            .record_job_timeline(&job_id, DispatchedJobOutcome::Completed, spans);
         if let Err(e) = self
             .scheduler
             .handle_job_completed(self.peer_id, &job_id)
@@ -705,8 +697,7 @@ impl<'a> DispatchContext<'a> {
         warn!(peer_id = %self.peer_id, %job_id, %error, ?kind, phases = spans.len(), "job failed");
         self.active.remove(&job_id);
         self.scheduler
-            .record_job_timeline(self.peer_id, &job_id, DispatchedJobOutcome::Failed, spans)
-            .await;
+            .record_job_timeline(&job_id, DispatchedJobOutcome::Failed, spans);
         if let Err(e) = self
             .scheduler
             .handle_job_failed(self.peer_id, &job_id, &error, kind, &missing_paths)

--- a/backend/gradient-scheduler/src/build/lifecycle.rs
+++ b/backend/gradient-scheduler/src/build/lifecycle.rs
@@ -14,7 +14,7 @@ use gradient_entity::evaluation::EvaluationStatus;
 use gradient_graph::Transition;
 use gradient_types::*;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
-use tracing::warn;
+use tracing::{info, warn};
 
 use crate::jobs::PendingJob;
 use crate::waiting_state::persist_waiting_reason;
@@ -66,12 +66,53 @@ async fn eval_dispatch_count(state: &Arc<ServerState>, evaluation_id: Evaluation
         })
 }
 
+/// Close the dispatch telemetry for jobs whose worker vanished. Without this the
+/// rows keep `finished_at IS NULL` forever and the job board reports them as
+/// running on a worker that is no longer in the fleet.
+async fn abandon_dispatched_jobs(state: &Arc<ServerState>, orphaned: &[PendingJob]) {
+    use gradient_entity::dispatched_job::{
+        Column as CDispatchedJob, DispatchedJobOutcome, Entity as EDispatchedJob,
+    };
+    use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+
+    let keys: Vec<String> = orphaned.iter().map(PendingJob::job_key).collect();
+    if keys.is_empty() {
+        return;
+    }
+
+    match EDispatchedJob::update_many()
+        .col_expr(
+            CDispatchedJob::FinishedAt,
+            sea_orm::sea_query::Expr::value(gradient_types::now()),
+        )
+        .col_expr(
+            CDispatchedJob::Outcome,
+            sea_orm::sea_query::Expr::value(i16::from(DispatchedJobOutcome::Abandoned)),
+        )
+        .filter(CDispatchedJob::JobId.is_in(keys))
+        .filter(CDispatchedJob::FinishedAt.is_null())
+        .exec(&state.worker_db)
+        .await
+    {
+        Ok(res) if res.rows_affected > 0 => {
+            info!(
+                rows = res.rows_affected,
+                "closed dispatch telemetry for orphaned jobs"
+            );
+        }
+        Ok(_) => {}
+        Err(e) => warn!(error = %e, "failed to close dispatch telemetry for orphaned jobs"),
+    }
+}
+
 /// Re-queue the in-flight jobs orphaned by a worker disconnect so they
 /// re-dispatch instead of lingering in a non-terminal DB status. Anchors move
 /// `Building -> Queued`; evaluations (which the state machine only lets reach
 /// `Queued` via `Waiting`) park to `Waiting` so the reconciler that runs right
 /// after recovers them to `Queued` once an eval-capable worker is free.
 pub async fn requeue_orphaned_jobs(state: &Arc<ServerState>, orphaned: &[PendingJob]) {
+    abandon_dispatched_jobs(state, orphaned).await;
+
     let anchors: Vec<DerivationBuildId> = orphaned
         .iter()
         .filter_map(|j| j.derivation_build())

--- a/backend/gradient-scheduler/src/dispatch/background.rs
+++ b/backend/gradient-scheduler/src/dispatch/background.rs
@@ -26,6 +26,11 @@ const LIVENESS_POLLS_PER_DEADLINE: u64 = 3;
 /// never mistaken for a dropped one.
 const LOST_COMPLETION_GRACE_SECS: i64 = 900;
 
+/// How long a dispatch row may sit open with no job behind it before the reaper
+/// closes it. Well above the heartbeat deadline so a worker that is merely slow
+/// to check in is never reaped out from under a running job.
+const ABANDONED_DISPATCH_GRACE_SECS: i64 = 1800;
+
 /// Liveness poll period, or `None` when the watchdog is disabled by config.
 pub(super) fn liveness_period(scheduler: &Scheduler) -> Option<Duration> {
     let timeout_secs = scheduler.state.config.proto.worker_heartbeat_timeout_secs;
@@ -123,15 +128,96 @@ pub(super) async fn worker_sample_pass(scheduler: Arc<Scheduler>) -> anyhow::Res
     Ok(())
 }
 
+/// Which stale rows may be closed: those whose job the tracker no longer holds,
+/// plus rows written before `job_id` existed, which cannot be matched against the
+/// tracker at all and are historical by construction.
+///
+/// A row the scheduler still tracks is never reaped, however old, so a
+/// legitimately long build keeps its open row.
+fn plan_abandoned_reap(
+    stale: &[(uuid::Uuid, Option<String>)],
+    untracked: &HashSet<String>,
+) -> Vec<uuid::Uuid> {
+    stale
+        .iter()
+        .filter(|(_, key)| match key {
+            Some(key) => untracked.contains(key),
+            None => true,
+        })
+        .map(|(id, _)| *id)
+        .collect()
+}
+
+/// Close dispatch rows left open by a job that will never report.
+///
+/// [`crate::build::requeue_orphaned_jobs`] covers a clean disconnect, but a
+/// server restart drops the tracker without an unregister for the jobs the old
+/// process held, so nothing ever closes their rows and the job board shows them
+/// running forever - often on a worker that has since left the fleet.
+///
+/// The tracker, not the clock, decides what is live: a row whose `job_id` the
+/// scheduler still knows is left alone however old it is, so a legitimately long
+/// build is never reaped. Rows predating the `job_id` column cannot be matched
+/// that way; they are historical by construction and are closed on age alone.
+pub(super) async fn abandoned_dispatch_pass(scheduler: Arc<Scheduler>) -> anyhow::Result<()> {
+    use gradient_entity::dispatched_job::{Column as CDispatchedJob, Entity as EDispatchedJob};
+    use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QuerySelect, sea_query::Expr};
+
+    let cutoff = gradient_types::now() - chrono::Duration::seconds(ABANDONED_DISPATCH_GRACE_SECS);
+    let stale: Vec<(uuid::Uuid, Option<String>)> = EDispatchedJob::find()
+        .filter(CDispatchedJob::FinishedAt.is_null())
+        .filter(CDispatchedJob::DispatchedAt.lt(cutoff))
+        .select_only()
+        .column(CDispatchedJob::Id)
+        .column(CDispatchedJob::JobId)
+        .into_tuple()
+        .all(&scheduler.state.worker_db)
+        .await?;
+
+    if stale.is_empty() {
+        debug!("abandoned dispatch sweep clean");
+        return Ok(());
+    }
+
+    let untracked: HashSet<String> = scheduler
+        .untracked(stale.iter().filter_map(|(_, k)| k.clone()).collect())
+        .await
+        .into_iter()
+        .collect();
+
+    let reap = plan_abandoned_reap(&stale, &untracked);
+    if reap.is_empty() {
+        return Ok(());
+    }
+
+    let reaped = reap.len();
+    EDispatchedJob::update_many()
+        .col_expr(
+            CDispatchedJob::FinishedAt,
+            Expr::value(gradient_types::now()),
+        )
+        .col_expr(
+            CDispatchedJob::Outcome,
+            Expr::value(i16::from(DispatchedJobOutcome::Abandoned)),
+        )
+        .filter(CDispatchedJob::Id.is_in(reap))
+        .filter(CDispatchedJob::FinishedAt.is_null())
+        .exec(&scheduler.state.worker_db)
+        .await?;
+
+    warn!(
+        rows = reaped,
+        grace_secs = ABANDONED_DISPATCH_GRACE_SECS,
+        "closed dispatch rows whose job will never report"
+    );
+    Ok(())
+}
+
 /// Which transition a lost terminal report needs re-sent.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum EvalRepair {
     Complete,
     Fail,
-}
-
-fn eval_job_id(evaluation: EvaluationId) -> String {
-    format!("eval:{evaluation}")
 }
 
 /// Keep only the evaluations the scheduler has no job for, and map each
@@ -146,13 +232,16 @@ fn plan_eval_repairs(
     untracked: &HashSet<String>,
 ) -> Vec<(EvaluationId, EvalRepair)> {
     lost.iter()
-        .filter(|l| untracked.contains(&eval_job_id(l.evaluation)))
-        .map(|l| {
+        .filter(|l| untracked.contains(&crate::jobs::eval_job_key(l.evaluation)))
+        .filter_map(|l| {
             let repair = match l.outcome {
                 DispatchedJobOutcome::Completed => EvalRepair::Complete,
                 DispatchedJobOutcome::Failed => EvalRepair::Fail,
+                // Nothing was reported, so there is no terminal transition to
+                // re-send; the orphan path re-queues the evaluation instead.
+                DispatchedJobOutcome::Abandoned => return None,
             };
-            (l.evaluation, repair)
+            Some((l.evaluation, repair))
         })
         .collect()
 }
@@ -173,7 +262,11 @@ pub(super) async fn eval_completion_watchdog_pass(scheduler: Arc<Scheduler>) -> 
     }
 
     let untracked: HashSet<String> = scheduler
-        .untracked(lost.iter().map(|l| eval_job_id(l.evaluation)).collect())
+        .untracked(
+            lost.iter()
+                .map(|l| crate::jobs::eval_job_key(l.evaluation))
+                .collect(),
+        )
         .await
         .into_iter()
         .collect();
@@ -224,13 +317,82 @@ mod tests {
         }
     }
 
+    fn row(key: Option<&str>) -> (uuid::Uuid, Option<String>) {
+        (uuid::Uuid::now_v7(), key.map(str::to_owned))
+    }
+
+    // The whole point of the sweep: a row the tracker still holds is a running
+    // job, however long it has been running.
+    #[test]
+    fn a_tracked_job_is_never_reaped() {
+        let tracked = row(Some("build:still-going"));
+        let untracked = HashSet::new();
+
+        assert!(plan_abandoned_reap(&[tracked], &untracked).is_empty());
+    }
+
+    #[test]
+    fn an_untracked_job_is_reaped() {
+        let gone = row(Some("build:worker-vanished"));
+        let untracked = HashSet::from(["build:worker-vanished".to_string()]);
+
+        assert_eq!(
+            plan_abandoned_reap(std::slice::from_ref(&gone), &untracked),
+            vec![gone.0]
+        );
+    }
+
+    // Rows written before the job_id column cannot be matched against the
+    // tracker; they predate the deploy, so age alone settles them.
+    #[test]
+    fn a_row_without_a_job_id_is_reaped_on_age_alone() {
+        let legacy = row(None);
+
+        assert_eq!(
+            plan_abandoned_reap(std::slice::from_ref(&legacy), &HashSet::new()),
+            vec![legacy.0]
+        );
+    }
+
+    // `untracked` returns nothing while the scheduler core is down, which must
+    // read as "everything is still tracked", not "reap the fleet".
+    #[test]
+    fn a_scheduler_outage_reaps_no_keyed_row() {
+        let rows = vec![row(Some("build:a")), row(Some("eval:b"))];
+
+        assert!(plan_abandoned_reap(&rows, &HashSet::new()).is_empty());
+    }
+
+    // An abandoned job never reported, so there is no terminal transition to
+    // re-send; re-driving one would invent an outcome the worker never gave.
+    #[test]
+    fn an_abandoned_job_is_not_re_driven() {
+        let rows = vec![lost(DispatchedJobOutcome::Abandoned)];
+        let untracked: HashSet<String> = rows
+            .iter()
+            .map(|l| crate::jobs::eval_job_key(l.evaluation))
+            .collect();
+
+        assert!(plan_eval_repairs(&rows, &untracked).is_empty());
+    }
+
+    #[test]
+    fn the_outcome_numbers_are_pinned() {
+        assert_eq!(i16::from(DispatchedJobOutcome::Completed), 0);
+        assert_eq!(i16::from(DispatchedJobOutcome::Failed), 1);
+        assert_eq!(i16::from(DispatchedJobOutcome::Abandoned), 2);
+    }
+
     #[test]
     fn each_outcome_maps_to_the_transition_that_was_lost() {
         let rows = vec![
             lost(DispatchedJobOutcome::Completed),
             lost(DispatchedJobOutcome::Failed),
         ];
-        let untracked = rows.iter().map(|l| eval_job_id(l.evaluation)).collect();
+        let untracked = rows
+            .iter()
+            .map(|l| crate::jobs::eval_job_key(l.evaluation))
+            .collect();
 
         assert_eq!(
             plan_eval_repairs(&rows, &untracked),
@@ -247,7 +409,7 @@ mod tests {
     fn an_evaluation_the_scheduler_still_tracks_is_left_alone() {
         let tracked = lost(DispatchedJobOutcome::Completed);
         let stranded = lost(DispatchedJobOutcome::Completed);
-        let untracked = HashSet::from([eval_job_id(stranded.evaluation)]);
+        let untracked = HashSet::from([crate::jobs::eval_job_key(stranded.evaluation)]);
 
         assert_eq!(
             plan_eval_repairs(&[tracked, stranded], &untracked),

--- a/backend/gradient-scheduler/src/dispatch/build.rs
+++ b/backend/gradient-scheduler/src/dispatch/build.rs
@@ -605,7 +605,7 @@ impl BuildDispatchMaps {
         project_id: ProjectId,
         mode: BuildDispatchMode,
     ) -> (String, PendingBuildJob) {
-        let job_id = format!("build:{}", anchor.id);
+        let job_id = crate::jobs::build_job_key(anchor.id);
         let substitute = matches!(
             mode,
             BuildDispatchMode::SubstituteBuiltin | BuildDispatchMode::SubstituteStalled
@@ -784,11 +784,14 @@ pub(crate) async fn dispatch_ready_builds(scheduler: &Scheduler) -> anyhow::Resu
     }
 
     // Filter out anchors already in the in-memory tracker.
-    let ids: Vec<String> = anchors.iter().map(|a| format!("build:{}", a.id)).collect();
+    let ids: Vec<String> = anchors
+        .iter()
+        .map(|a| crate::jobs::build_job_key(a.id))
+        .collect();
     let untracked: HashSet<String> = scheduler.untracked(ids).await.into_iter().collect();
     let new_anchors: Vec<MDerivationBuild> = anchors
         .into_iter()
-        .filter(|a| untracked.contains(&format!("build:{}", a.id)))
+        .filter(|a| untracked.contains(&crate::jobs::build_job_key(a.id)))
         .collect();
     if new_anchors.is_empty() {
         return Ok(());

--- a/backend/gradient-scheduler/src/dispatch/eval.rs
+++ b/backend/gradient-scheduler/src/dispatch/eval.rs
@@ -34,11 +34,14 @@ pub(crate) async fn dispatch_queued_evals(scheduler: &Scheduler) -> anyhow::Resu
         .await?;
 
     // One untracked check instead of a lock per eval.
-    let ids: Vec<String> = evals.iter().map(|e| format!("eval:{}", e.id)).collect();
+    let ids: Vec<String> = evals
+        .iter()
+        .map(|e| crate::jobs::eval_job_key(e.id))
+        .collect();
     let untracked: HashSet<String> = scheduler.untracked(ids).await.into_iter().collect();
     let evals: Vec<MEvaluation> = evals
         .into_iter()
-        .filter(|e| untracked.contains(&format!("eval:{}", e.id)))
+        .filter(|e| untracked.contains(&crate::jobs::eval_job_key(e.id)))
         .collect();
     if evals.is_empty() {
         return Ok(());
@@ -49,7 +52,7 @@ pub(crate) async fn dispatch_queued_evals(scheduler: &Scheduler) -> anyhow::Resu
     let eval_history = scheduler.eval_history.load();
 
     for eval in evals {
-        let job_id = format!("eval:{}", eval.id);
+        let job_id = crate::jobs::eval_job_key(eval.id);
 
         let Some(commit) = maps.commits.get(&eval.commit) else {
             error!(evaluation_id = %eval.id, "commit not found for evaluation");

--- a/backend/gradient-scheduler/src/dispatch/mod.rs
+++ b/backend/gradient-scheduler/src/dispatch/mod.rs
@@ -114,6 +114,13 @@ fn child_specs(scheduler: &Arc<Scheduler>) -> Vec<ChildSpec> {
             CONSISTENCY_BUDGET,
             background::eval_completion_watchdog_pass,
         ),
+        periodic(
+            scheduler,
+            "abandoned-dispatch-sweep",
+            EVAL_WATCHDOG_TICK,
+            CONSISTENCY_BUDGET,
+            background::abandoned_dispatch_pass,
+        ),
     ];
 
     match background::liveness_period(scheduler) {

--- a/backend/gradient-scheduler/src/job_handlers/assignment.rs
+++ b/backend/gradient-scheduler/src/job_handlers/assignment.rs
@@ -144,6 +144,7 @@ async fn persist_dispatched_job(state: &Arc<ServerState>, worker_id: &str, rec: 
         project: rec.project,
         task: rec.task,
         worker_id: worker_id.to_owned(),
+        job_id: Some(rec.job_id.clone()),
         score: rec.score,
         queued_at: rec.queued_at,
         ready_at: Some(rec.ready_at),

--- a/backend/gradient-scheduler/src/job_handlers/build_status.rs
+++ b/backend/gradient-scheduler/src/job_handlers/build_status.rs
@@ -42,7 +42,7 @@ impl Scheduler {
             // in-flight pass just before its evaluation was aborted reports
             // started here, so tell the worker to stop rather than build on.
             Ok(report) if report.already_aborted => {
-                let job_id = format!("build:{derivation_build}");
+                let job_id = crate::jobs::build_job_key(derivation_build);
                 self.abort_job(worker_id, job_id, "evaluation aborted".to_owned())
                     .await;
                 info!(%derivation_build, %worker_id, "aborting build that started after its evaluation was aborted");
@@ -112,7 +112,7 @@ impl Scheduler {
                         .and_then(|e| e.flake_source);
                     return match store_path {
                         Some(path) => {
-                            let follow_id = format!("eval:{}", j.evaluation_id);
+                            let follow_id = crate::jobs::eval_job_key(j.evaluation_id);
                             if let Err(e) = self
                                 .enqueue_eval_job(follow_id, j.cached_followup(path))
                                 .await

--- a/backend/gradient-scheduler/src/job_handlers/timeline.rs
+++ b/backend/gradient-scheduler/src/job_handlers/timeline.rs
@@ -81,42 +81,35 @@ impl Scheduler {
     /// reports directly. Best effort throughout: instrumentation must never
     /// fail a job.
     ///
-    /// Only the job lookup runs inline, because the caller is about to drop the
-    /// job from the active map; the writes are detached so telemetry never adds
-    /// database latency to the connection's message loop.
-    pub async fn record_job_timeline(
+    /// The writes are detached so telemetry never adds database latency to the
+    /// connection's message loop. Everything it needs comes off the row, so a
+    /// report that arrives after the tracker has dropped the job still lands.
+    pub fn record_job_timeline(
         self: &Arc<Self>,
-        worker_id: &str,
         job_id: &str,
         outcome: DispatchedJobOutcome,
         spans: Vec<JobPhaseSpan>,
     ) {
-        let Some(job) = self.active_job(job_id).await else {
-            return;
-        };
-        let evaluation_id = job.evaluation_id();
-
         let scheduler = Arc::clone(self);
-        let worker_id = worker_id.to_owned();
         let job_id = job_id.to_owned();
         self.state.shutdown.spawn(async move {
             scheduler
-                .persist_job_timeline(&worker_id, &job_id, evaluation_id, outcome, spans)
+                .persist_job_timeline(&job_id, outcome, spans)
                 .await;
         });
     }
 
     async fn persist_job_timeline(
         &self,
-        worker_id: &str,
         job_id: &str,
-        evaluation_id: EvaluationId,
         outcome: DispatchedJobOutcome,
         spans: Vec<JobPhaseSpan>,
     ) {
+        // Keyed on the job itself: one worker commonly runs several jobs of the
+        // same evaluation at once, and matching on (worker, evaluation) closed
+        // whichever row was newest instead of this job's own.
         let row = match EDispatchedJob::find()
-            .filter(CDispatchedJob::WorkerId.eq(worker_id))
-            .filter(CDispatchedJob::EvaluationId.eq(evaluation_id))
+            .filter(CDispatchedJob::JobId.eq(job_id))
             .filter(CDispatchedJob::FinishedAt.is_null())
             .order_by_desc(CDispatchedJob::DispatchedAt)
             .one(&self.state.worker_db)
@@ -131,6 +124,7 @@ impl Scheduler {
         };
 
         let dispatched_job = row.id;
+        let evaluation_id = row.evaluation_id;
         let mut active = row.into_active_model();
         active.finished_at = Set(Some(now()));
         active.outcome = Set(Some(outcome));

--- a/backend/gradient-scheduler/src/jobs.rs
+++ b/backend/gradient-scheduler/src/jobs.rs
@@ -154,7 +154,29 @@ pub enum PendingJob {
     Build(PendingBuildJob),
 }
 
+/// The tracker's key for an evaluation job. The single definition: it is also
+/// persisted on `dispatched_job.job_id`, and a copy that drifts would silently
+/// stop terminal reports from closing their own row.
+pub fn eval_job_key(evaluation: EvaluationId) -> String {
+    format!("eval:{evaluation}")
+}
+
+/// The tracker's key for a build job, keyed on the build-once anchor.
+pub fn build_job_key(anchor: DerivationBuildId) -> String {
+    format!("build:{anchor}")
+}
+
 impl PendingJob {
+    /// The scheduler's key for this job, and the value persisted on
+    /// `dispatched_job.job_id`. Derived from durable ids, so it survives a
+    /// scheduler restart and is unique among in-flight jobs.
+    pub fn job_key(&self) -> String {
+        match self {
+            PendingJob::Eval(j) => eval_job_key(j.evaluation_id),
+            PendingJob::Build(j) => build_job_key(j.derivation_build),
+        }
+    }
+
     pub fn required_paths(&self) -> &[RequiredPath] {
         match self {
             PendingJob::Eval(j) => &j.required_paths,
@@ -268,6 +290,9 @@ pub struct Assignment {
 /// Owned snapshot of a dispatch decision for the `dispatched_job` table.
 #[derive(Clone)]
 pub struct DispatchRecord {
+    /// The tracker's key for this job; persisted so the terminal report can
+    /// close its own `dispatched_job` row.
+    pub job_id: String,
     pub kind: DispatchedJobKind,
     pub derivation_build: Option<DerivationBuildId>,
     pub evaluation_id: EvaluationId,
@@ -809,6 +834,7 @@ impl JobTracker {
             PendingJob::Eval(e) => (DispatchedJobKind::Eval, None, e.task_id),
         };
         Some(DispatchRecord {
+            job_id: job_id.to_owned(),
             kind: kind_disc,
             derivation_build,
             evaluation_id: job.evaluation_id(),
@@ -1092,6 +1118,36 @@ mod tests {
     use gradient_types::proto::{
         BuildJob, BuildSpec, FlakeJob, FlakeSource, FlakeStep, GradientCapabilities,
     };
+
+    // `dispatched_job.job_id` stores this key, and a terminal report closes its
+    // row by matching on it. If the key stopped agreeing with what the
+    // dispatchers enqueue, close-out would find no row and fail silently, which
+    // is how dispatches came to sit "running" forever.
+    #[test]
+    fn a_jobs_key_is_the_id_it_was_enqueued_under() {
+        let evaluation = EvaluationId::now_v7();
+        let anchor = DerivationBuildId::now_v7();
+
+        assert_eq!(eval_job_key(evaluation), format!("eval:{evaluation}"));
+        assert_eq!(build_job_key(anchor), format!("build:{anchor}"));
+    }
+
+    #[test]
+    fn a_pending_job_reports_its_own_key() {
+        let peer = ProjectId::now_v7();
+
+        let eval = eval_job(peer);
+        let PendingJob::Eval(e) = &eval else {
+            unreachable!("eval_job builds an eval")
+        };
+        assert_eq!(eval.job_key(), eval_job_key(e.evaluation_id));
+
+        let build = build_job(peer, vec![]);
+        let PendingJob::Build(b) = &build else {
+            unreachable!("build_job builds a build")
+        };
+        assert_eq!(build.job_key(), build_job_key(b.derivation_build));
+    }
 
     fn eval_job(peer: ProjectId) -> PendingJob {
         PendingJob::Eval(PendingEvalJob {

--- a/backend/gradient-scheduler/src/lib.rs
+++ b/backend/gradient-scheduler/src/lib.rs
@@ -173,8 +173,8 @@ impl Scheduler {
         eval_id: EvaluationId,
         anchor_ids: &[DerivationBuildId],
     ) {
-        let mut job_ids = vec![format!("eval:{eval_id}")];
-        job_ids.extend(anchor_ids.iter().map(|id| format!("build:{id}")));
+        let mut job_ids = vec![crate::jobs::eval_job_key(eval_id)];
+        job_ids.extend(anchor_ids.iter().map(|id| crate::jobs::build_job_key(*id)));
         if let Err(e) = self
             .call(|reply| SchedulerMsg::RemoveJobs { job_ids, reply })
             .await

--- a/backend/gradient-web/src/endpoints/board.rs
+++ b/backend/gradient-web/src/endpoints/board.rs
@@ -371,7 +371,8 @@ pub struct DispatchedJobDetail {
     pub dispatched_at: String,
     pub finished_at: Option<String>,
     pub ready_at: Option<String>,
-    /// `completed` or `failed`; `null` while the job is still running.
+    /// `completed`, `failed`, or `abandoned` when the worker never reported;
+    /// `null` while the job is still running.
     pub outcome: Option<String>,
     /// Worker phase spans in report order, nested via `parent_seq`.
     pub phases: Vec<JobPhaseView>,
@@ -543,6 +544,7 @@ pub async fn get_dispatched_job(
         outcome: j.outcome.map(|o| match o {
             DispatchedJobOutcome::Completed => "completed".to_string(),
             DispatchedJobOutcome::Failed => "failed".to_string(),
+            DispatchedJobOutcome::Abandoned => "abandoned".to_string(),
         }),
         phases,
         build_id,

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -11180,8 +11180,11 @@ components:
         outcome:
           type: string
           nullable: true
-          enum: [completed, failed]
-          description: How the job ended. Null while it is still running, and for a job whose worker disconnected without reporting.
+          enum: [completed, failed, abandoned]
+          description: >-
+            How the job ended. Null while it is still running. `abandoned` means the worker never
+            reported a terminal state - it disconnected, or the server restarted while the job was
+            in flight - so the result is unknown rather than failed.
         phases:
           type: array
           description: The worker's phase timeline in report order, nested via parent_seq. Empty for a job that predates the timeline or never reported one.

--- a/docs/src/development/architecture.md
+++ b/docs/src/development/architecture.md
@@ -22,7 +22,8 @@ root
 ├── sessions                             supervisor: one actor per worker connection
 ├── worker-sample, instance-metrics      periodic passes
 ├── worker-liveness, graph-consistency   periodic passes, absent when disabled
-├── eval-completion-watchdog            periodic pass (60s)
+├── eval-completion-watchdog,
+│   abandoned-dispatch-sweep             periodic passes (60s)
 ├── cache-maintenance, sign-sweep,
 │   debug-index, eval-cache-sweep        cache sweeps
 ├── retention, rollup, otlp-snapshot     metrics pipeline

--- a/docs/src/scheduler.md
+++ b/docs/src/scheduler.md
@@ -192,6 +192,27 @@ the transition. The grace sits above the graph actor's 600s RPC timeout so a slo
 transition is never mistaken for a lost one, and `EvalStreamCompleted` is
 idempotent, so re-driving one that did land changes nothing.
 
+The dispatch telemetry row has the mirror-image problem. `dispatched_job` is
+closed by the worker's own terminal report, which stamps `finished_at` and the
+outcome; a row with neither reads as running on the job board. Two things used
+to leave rows open forever. The report closed whichever row was the newest open
+one for its (worker, evaluation) pair rather than its own, so a worker running
+several jobs of one evaluation - the normal case - attached outcomes and phase
+timelines to the wrong rows and left the surplus open; the row now carries the
+scheduler's `job_id` (`build:<anchor>` / `eval:<evaluation>`, unique among
+in-flight jobs) and is matched on it. And a worker that vanished had no report
+to send at all, so `requeue_orphaned_jobs` now closes its rows as `Abandoned`
+alongside re-queuing the work. A server restart drops the tracker without an
+unregister, which neither path covers, so the `abandoned-dispatch-sweep` pass
+(60s) closes rows still open 1800s after dispatch whose `job_id` the scheduler
+no longer tracks. The tracker, not the clock, decides: a row it still holds is
+never swept, however long the build runs.
+
+`Abandoned` is deliberately distinct from `Failed`. The worker never reported,
+so the build may well have succeeded before contact was lost; recording it as a
+failure would feed invented failures into the board's rates and into
+history-based scoring.
+
 Promotion and dispatch are finally gated on a derivation's `inputSrcs` being in
 the cache. A `.drv`'s build-time source paths (`inputSrcs`, e.g.
 `builtins.toFile` configs) have no producing derivation, so the dependency-anchor

--- a/frontend/src/app/core/services/board.service.ts
+++ b/frontend/src/app/core/services/board.service.ts
@@ -149,7 +149,7 @@ export interface DispatchedJobDetail extends DispatchedJobSummary {
   queued_at: string;
   finished_at: string | null;
   ready_at: string | null;
-  outcome: 'completed' | 'failed' | null;
+  outcome: 'completed' | 'failed' | 'abandoned' | null;
   phases: JobPhase[];
   derivation_build_id: string | null;
   derivations: JobDerivationView[];

--- a/frontend/src/app/features/board/job-detail/job-detail.component.spec.ts
+++ b/frontend/src/app/features/board/job-detail/job-detail.component.spec.ts
@@ -276,6 +276,24 @@ describe('BoardJobDetailComponent - previous build attempts', () => {
     expect(rows.length).toBe(2);
   });
 
+  // A dispatch the worker never reported back on used to read as 'running'
+  // forever, on a worker that had long since left the fleet.
+  it('reports an abandoned dispatch as abandoned, not running', () => {
+    const abandoned: DispatchedJobDetail = {
+      ...DETAIL,
+      finished_at: '2026-06-08T00:31:00Z',
+      outcome: 'abandoned',
+    };
+    const el = setup({ getJob: () => of(abandoned) }).nativeElement as HTMLElement;
+    expect(el.textContent).toContain('abandoned');
+    expect(el.textContent).not.toContain('running');
+  });
+
+  it('still reports an unfinished dispatch as running', () => {
+    const el = setup({ getJob: () => of(DETAIL) }).nativeElement as HTMLElement;
+    expect(el.textContent).toContain('running');
+  });
+
   it('shows mode and outcome labels for each attempt', () => {
     const el = setup({ getJob: () => of(WITH_ATTEMPTS) }).nativeElement as HTMLElement;
     const section = el.querySelector('section.attempts') as HTMLElement;

--- a/frontend/src/app/features/board/job-detail/job-detail.component.ts
+++ b/frontend/src/app/features/board/job-detail/job-detail.component.ts
@@ -307,7 +307,7 @@ export class BoardJobDetailComponent implements OnInit {
     const b = this.build();
     if (b && b.id === j.build_id) return b.status;
 
-    return j.finished_at ? 'finished' : 'running';
+    return j.finished_at ? (j.outcome ?? 'finished') : 'running';
   });
 
   rules = computed<RuleRow[]>(() => {


### PR DESCRIPTION
A terminal report closed whichever `dispatched_job` row was newest open for its (worker, evaluation) pair rather than its own, so a worker running several jobs of one evaluation misattributed outcomes and phase timelines and left the surplus rows open; the row now carries the scheduler's `job_id` and is matched on it. A worker that vanishes never reports at all, so the disconnect path and a new 60s sweep close those rows as `Abandoned` - distinct from `Failed`, since the build may have succeeded before contact was lost.