### PR TITLE
deploy: feat: wait out a running evaluation instead of reporting nothing built

### DIFF
--- a/docs/src/development/tests.md
+++ b/docs/src/development/tests.md
@@ -13,7 +13,7 @@ the catalogue, and a per-test list goes stale and collides on every merge.
 | Shared harness | `backend/gradient-test-support/` | fakes, fixtures and the test server every suite reuses |
 | CLI | `cli/tests/*.rs`, `cli/connector/tests/*.rs` | the installed `gradient` binary against a stub HTTP server |
 | Frontend | `frontend/src/**/*.spec.ts` | components and services under vitest |
-| NixOS VM | `nix/tests/gradient/<name>/` | a booted machine running the packaged server |
+| NixOS VM | `nix/tests/gradient/<name>/` | a booted machine running the packaged server, or a NixOS module against a scripted API |
 
 A crate's own `tests/` directory is for anything that has to go through a public
 entry point (an HTTP route, a CLI invocation). Everything else belongs in a
@@ -73,6 +73,14 @@ sequence of effects rather than on internal state.
 **Closure and scheduling work uses `StoreFixture`.** It carries a real
 derivation graph, so dependency ordering, readiness and cache-presence logic get
 tested against genuine `.drv` shapes instead of a hand-built three-node tree.
+
+**A NixOS module under test gets a scripted API, not a server.** A module that
+only consumes the HTTP API (`nix/modules/gradient-deploy.nix`) is exercised
+against a stdlib-only stub in its test directory, driven through a `/control`
+endpoint that swaps the scripted state and pushes the matching live-WebSocket
+event. That keeps the VM free of Postgres and a builder, so the test asserts on
+the module's own behaviour: what it waits for, what it never requests, and how
+many times it asks.
 
 **CLI tests drive the real binary.** `assert_cmd` runs `gradient` with `HOME`
 and `XDG_CONFIG_HOME` pointed at a `TempDir` holding a seeded `config.toml`, and

--- a/docs/src/usage/pull-deployment.md
+++ b/docs/src/usage/pull-deployment.md
@@ -20,8 +20,9 @@ The newest commit is usually still building when the timer fires, so by default
 the service waits for it rather than reporting that nothing was built.
 
 It follows the task's live WebSocket, `/api/v1/tasks/<project>/<task>/live`, and
-re-checks on every event, so it reacts as soon as the build finishes without
-polling the API. The wait ends when:
+re-checks on every event, so it reacts as soon as the build finishes and never
+polls the API. If the socket drops it reconnects and re-checks, since a
+reconnect gap replays nothing. The wait ends when:
 
 - the system closure for this host is built, and is switched to;
 - that build fails, or the whole evaluation fails or is aborted;
@@ -36,8 +37,10 @@ successfully. Waiting itself is unbounded, so a run that outlives its own timer
 just makes systemd skip the next trigger.
 
 The target therefore needs outbound WebSocket access to the Gradient server, not
-only plain HTTP. Set `waitForBuild = false` to restore the old behaviour of
-exiting as soon as nothing is built yet.
+only plain HTTP. Where the network cannot carry a WebSocket upgrade, set
+`websockets = false` and the service re-checks every `pollIntervalSec` instead.
+Set `waitForBuild = false` to restore the old behaviour of exiting as soon as
+nothing is built yet.
 
 ## Setup
 
@@ -81,7 +84,8 @@ Add `gradient.nixosModules.deploy` to the target machine's NixOS configuration:
 | `task` | | `project/task` slug to watch |
 | `deployFor` | hostname | Name of the deployment configuration to apply |
 | `waitForBuild` | `true` | Wait for an in-flight evaluation instead of exiting when nothing is built yet |
-| `idleRecheckSec` | `300` | Failsafe re-check interval while waiting, in seconds. Bounds how long a dropped event can stall a deployment; events drive the normal path |
+| `websockets` | `true` | Follow the task's live WebSocket while waiting. Disable where a WebSocket upgrade cannot get through |
+| `pollIntervalSec` | `60` | Re-check interval while waiting with `websockets` disabled. Unused otherwise |
 | `dates` | `"04:00"` | When the timer fires, in `systemd.time(7)` format |
 | `randomizedDelaySec` | `"0"` | Randomized delay added before each run |
 

--- a/docs/src/usage/pull-deployment.md
+++ b/docs/src/usage/pull-deployment.md
@@ -8,11 +8,36 @@ Gradient supports *pull deployment*, which allows a target machine to periodical
 
 ## How It Works
 
-1. A build completes successfully on the Gradient server, producing a NixOS system closure.
-2. The `gradient-deploy` systemd service on the target machine polls the Gradient API for the latest successful build of a configured task.
-3. When a new build is found, the closure is fetched from the integrated Nix cache and `nixos-rebuild switch` is run.
+1. The `gradient-deploy` systemd service on the target machine reads the task's newest evaluation and looks for the entry point whose output path names a system for this host.
+2. If that build has finished, the closure is fetched from the integrated Nix cache and switched to. If it is still running, the service waits (see below).
+3. If the target already runs the evaluated system, the service stops immediately, whatever the build is doing.
 
 By default the service runs daily at **04:00** via a systemd timer.
+
+## Waiting For CI
+
+The newest commit is usually still building when the timer fires, so by default
+the service waits for it rather than reporting that nothing was built.
+
+It follows the task's live WebSocket, `/api/v1/tasks/<project>/<task>/live`, and
+re-checks on every event, so it reacts as soon as the build finishes without
+polling the API. The wait ends when:
+
+- the system closure for this host is built, and is switched to;
+- that build fails, or the whole evaluation fails or is aborted;
+- the target already runs the evaluated system.
+
+An entry point's output path is written at evaluation time, so the deployment is
+recognised before its build starts. That is what lets an already-up-to-date
+target exit at once instead of sitting through a build it does not need.
+
+None of these outcomes fail the unit; each is reported to the journal and exits
+successfully. Waiting itself is unbounded, so a run that outlives its own timer
+just makes systemd skip the next trigger.
+
+The target therefore needs outbound WebSocket access to the Gradient server, not
+only plain HTTP. Set `waitForBuild = false` to restore the old behaviour of
+exiting as soon as nothing is built yet.
 
 ## Setup
 
@@ -49,11 +74,16 @@ Add `gradient.nixosModules.deploy` to the target machine's NixOS configuration:
 }
 ```
 
-| Option | Description |
-|---|---|
-| `server` | URL of your Gradient instance |
-| `apiKeyFile` | Path to a file containing an API key with read access to the task |
-| `task` | `project/task` slug to watch |
+| Option | Default | Description |
+|---|---|---|
+| `server` | | URL of your Gradient instance |
+| `apiKeyFile` | | Path to a file containing an API key with read access to the task |
+| `task` | | `project/task` slug to watch |
+| `deployFor` | hostname | Name of the deployment configuration to apply |
+| `waitForBuild` | `true` | Wait for an in-flight evaluation instead of exiting when nothing is built yet |
+| `idleRecheckSec` | `300` | Failsafe re-check interval while waiting, in seconds. Bounds how long a dropped event can stall a deployment; events drive the normal path |
+| `dates` | `"04:00"` | When the timer fires, in `systemd.time(7)` format |
+| `randomizedDelaySec` | `"0"` | Randomized delay added before each run |
 
 ### 3. Create an API Key
 

--- a/nix/modules/gradient-deploy.nix
+++ b/nix/modules/gradient-deploy.nix
@@ -51,12 +51,10 @@ in {
           Wait for an in-flight evaluation to produce a deployable build instead
           of giving up when the newest commit is still in CI.
 
-          The service follows the task's live WebSocket
-          (`/api/v1/tasks/<task>/live`) and re-checks on every event, so it
-          reacts to the build finishing without polling. It stops as soon as the
-          deployment is built, the evaluation or the build fails, or the target
-          is already running the evaluated system, and it never fails the unit
-          for any of those outcomes.
+          It stops as soon as the deployment is built, the evaluation or the
+          build fails, or the target is already running the evaluated system,
+          and it never fails the unit for any of those outcomes. How it notices
+          is governed by `websockets`.
 
           Waiting is unbounded: a run that outlives its timer simply makes
           systemd skip the next trigger. Disable to exit immediately when
@@ -64,14 +62,26 @@ in {
         '';
       };
 
-      idleRecheckSec = lib.mkOption {
-        type = lib.types.int;
-        default = 300;
-        example = 60;
+      websockets = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
         description = ''
-          Failsafe re-check interval, in seconds, while waiting on the live
-          WebSocket. Bounds how long a dropped event can stall a deployment; it
-          is not a polling cadence, since events drive the normal path.
+          Follow the task's live WebSocket while waiting, reacting to each event
+          instead of asking repeatedly. Disable when the path to the server
+          cannot carry a WebSocket upgrade; the service then falls back to
+          re-checking every `pollIntervalSec`.
+
+          Only consulted while `waitForBuild` is enabled.
+        '';
+      };
+
+      pollIntervalSec = lib.mkOption {
+        type = lib.types.int;
+        default = 60;
+        example = 300;
+        description = ''
+          How often, in seconds, to re-check while waiting with `websockets`
+          disabled. Unused otherwise, since events drive the wait.
         '';
       };
 
@@ -139,7 +149,7 @@ in {
           gzip
           jq
           xz.bin
-        ] ++ lib.optional cfg.waitForBuild pkgs.websocat
+        ] ++ lib.optional (cfg.waitForBuild && cfg.websockets) pkgs.websocat
         ++ [
           config.nix.package.out
         ];
@@ -254,7 +264,7 @@ in {
           echo "Nothing deployable yet for task ${cfg.task}; not waiting"
           exit 0
         ''
-        + lib.optionalString cfg.waitForBuild ''
+        + lib.optionalString (cfg.waitForBuild && cfg.websockets) ''
           echo "Task ${cfg.task} is still building; following ${liveUrl}"
 
           while true; do
@@ -268,7 +278,7 @@ in {
               exit 0
             fi
 
-            while read -r -t ${toString cfg.idleRecheckSec} _event <&3 || [ $? -gt 128 ]; do
+            while read -r _event <&3; do
               if settle; then
                 exit 0
               fi
@@ -278,6 +288,17 @@ in {
             kill "$stream" 2>/dev/null || true
             wait "$stream" 2>/dev/null || true
             sleep 30
+          done
+        ''
+        + lib.optionalString (cfg.waitForBuild && !cfg.websockets) ''
+          echo "Task ${cfg.task} is still building; re-checking every ${toString cfg.pollIntervalSec}s"
+
+          while true; do
+            sleep ${toString cfg.pollIntervalSec}
+
+            if settle; then
+              exit 0
+            fi
           done
         '';
       };

--- a/nix/modules/gradient-deploy.nix
+++ b/nix/modules/gradient-deploy.nix
@@ -6,6 +6,15 @@
 
 { lib, pkgs, config, ... }: let
   cfg = config.system.gradient-deploy;
+
+  apiUrl = "${cfg.server}/api/v1";
+
+  liveUrl = let
+    host = lib.removePrefix "http://" (lib.removePrefix "https://" cfg.server);
+    scheme = if lib.hasPrefix "https://" cfg.server then "wss" else "ws";
+  in "${scheme}://${host}/api/v1/tasks/${cfg.task}/live";
+
+  systemPathRegex = "^/nix/store/[a-z0-9]{32}-nixos-system-${cfg.deployFor}-[0-9]{2}\\.[0-9]{2}(\\.[0-9]{8}\\.[a-f0-9]+)?$";
 in {
   options = {
     system.gradient-deploy = {
@@ -33,6 +42,37 @@ in {
         type = lib.types.str;
         description = "Task identifier for the deployments";
         example = "my-project/my-task";
+      };
+
+      waitForBuild = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Wait for an in-flight evaluation to produce a deployable build instead
+          of giving up when the newest commit is still in CI.
+
+          The service follows the task's live WebSocket
+          (`/api/v1/tasks/<task>/live`) and re-checks on every event, so it
+          reacts to the build finishing without polling. It stops as soon as the
+          deployment is built, the evaluation or the build fails, or the target
+          is already running the evaluated system, and it never fails the unit
+          for any of those outcomes.
+
+          Waiting is unbounded: a run that outlives its timer simply makes
+          systemd skip the next trigger. Disable to exit immediately when
+          nothing is built yet.
+        '';
+      };
+
+      idleRecheckSec = lib.mkOption {
+        type = lib.types.int;
+        default = 300;
+        example = 60;
+        description = ''
+          Failsafe re-check interval, in seconds, while waiting on the live
+          WebSocket. Bounds how long a dropped event can stall a deployment; it
+          is not a polling cadence, since events drive the normal path.
+        '';
       };
 
       # TODO:
@@ -99,7 +139,8 @@ in {
           gzip
           jq
           xz.bin
-        ] ++ [
+        ] ++ lib.optional cfg.waitForBuild pkgs.websocat
+        ++ [
           config.nix.package.out
         ];
 
@@ -109,68 +150,135 @@ in {
           User = "root";
           Group = "root";
           LoadCredential = [ "gradient_api_key:${cfg.apiKeyFile}" ];
+          TimeoutStartSec = lib.mkIf cfg.waitForBuild "infinity";
         };
 
         script = ''
-          if ! curl --silent --fail --max-time 5 "${cfg.server}/api/v1/health"; then
-            echo "Error: Cannot reach ${cfg.server}/api/v1/health"
+          if ! curl --silent --fail --max-time 5 --output /dev/null "${apiUrl}/health"; then
+            echo "Error: Cannot reach ${apiUrl}/health"
             exit 1
           fi
 
           API_KEY=$(cat ${cfg.apiKeyFile})
 
-          # Entry points of the task's latest evaluation are the candidate deployments.
-          ENTRY_POINTS=$(curl --silent --fail --max-time 10 \
-            --header "Authorization: Bearer $API_KEY" \
-            "${cfg.server}/api/v1/tasks/${cfg.task}/entry-points"
-            )
+          api() {
+            curl --silent --fail --max-time 10 --header "Authorization: Bearer $API_KEY" "$@"
+          }
 
-          BUILD_IDS=$(echo "$ENTRY_POINTS" | jq -r \
-            '.message[] | select(.build_status == "Completed" or .build_status == "Substituted") | .build_id')
-          if [ -z "$BUILD_IDS" ]; then
-            echo "No successfully built entry points for task ${cfg.task}"
-            exit 0
-          fi
+          # Verdict for the task's newest evaluation: `deploy <path>` once the
+          # system is built, `done <reason>` when nothing more can come of it, or
+          # `wait` while the evaluation can still produce one.
+          resolve() {
+            local evaluation entry_points evaluation_id evaluation_status path status current
 
-          DEPLOYMENT_STORE_PATH=""
+            evaluation=$(api "${apiUrl}/tasks/${cfg.task}/evaluations?limit=1") || { echo "wait"; return; }
+            evaluation_id=$(echo "$evaluation" | jq -r '.message[0].id // empty')
+            evaluation_status=$(echo "$evaluation" | jq -r '.message[0].status // empty')
 
-          for BUILD_ID in $BUILD_IDS; do
-            BUILD_INFO=$(curl --silent --fail --max-time 10 \
-              --header "Authorization: Bearer $API_KEY" \
-              "${cfg.server}/api/v1/builds/$BUILD_ID"
-              )
-            [ -n "$BUILD_INFO" ] || continue
-
-            # The API returns prefix-free `<hash>-<name>` output paths.
-            OUT_BASE=$(echo "$BUILD_INFO" | jq -r '.message.output.out // empty')
-            [ -n "$OUT_BASE" ] || continue
-            STORE_PATH="/nix/store/$OUT_BASE"
-
-            if echo "$STORE_PATH" | grep -qE "^/nix/store/[a-z0-9]{32}-nixos-system-${cfg.deployFor}-[0-9]{2}\.[0-9]{2}(\.[0-9]{8}\.[a-f0-9]+)?$"; then
-              DEPLOYMENT_STORE_PATH="$STORE_PATH"
-              break
+            if [ -z "$evaluation_id" ]; then
+              echo "done task ${cfg.task} has no evaluations"
+              return
             fi
-          done
 
-          if [ -z "$DEPLOYMENT_STORE_PATH" ]; then
-            echo "No deployment found for task ${cfg.task} and server ${cfg.deployFor}"
+            entry_points=$(api "${apiUrl}/tasks/${cfg.task}/entry-points?evaluation_id=$evaluation_id") || { echo "wait"; return; }
+
+            # Output paths are written at evaluation time from the resolved .drv,
+            # so the deployment is identifiable before, and independently of, its
+            # build. Entry points are absent entirely until derivations resolve.
+            path=$(echo "$entry_points" | jq -r --arg re '${systemPathRegex}' \
+              'first(.message[] | select((.outputs.out // "") | test($re))) | .outputs.out // empty')
+            status=$(echo "$entry_points" | jq -r --arg re '${systemPathRegex}' \
+              'first(.message[] | select((.outputs.out // "") | test($re))) | .build_status // empty')
+
+            if [ -n "$path" ]; then
+              current=$(readlink /run/current-system || true)
+              if [ "$path" = "$current" ]; then
+                echo "done system is already up-to-date with $path"
+                return
+              fi
+
+              case "$status" in
+                Completed|Substituted)
+                  echo "deploy $path"
+                  return
+                  ;;
+                FailedPermanent|FailedTimeout|DependencyFailed|Aborted)
+                  echo "done build of $path finished $status"
+                  return
+                  ;;
+              esac
+            fi
+
+            case "$evaluation_status" in
+              Completed|Failed|Aborted)
+                echo "done evaluation $evaluation_id finished $evaluation_status without a deployment for ${cfg.deployFor}"
+                ;;
+              *)
+                echo "wait"
+                ;;
+            esac
+          }
+
+          deploy() {
+            echo "New deployment found: $1"
+            nix-store --realize "$1"
+
+            nix-env -p /nix/var/nix/profiles/system --set "$1"
+            "$1/bin/switch-to-configuration" switch
+
+            echo "Deployment to $1 completed successfully"
+          }
+
+          settle() {
+            local verdict
+            verdict=$(resolve)
+
+            case "$verdict" in
+              "deploy "*)
+                deploy "''${verdict#deploy }"
+                ;;
+              "done "*)
+                echo "''${verdict#done }"
+                ;;
+              *)
+                return 1
+                ;;
+            esac
+          }
+
+          if settle; then
             exit 0
           fi
-
-          CURRENT_SYSTEM=$(readlink /run/current-system || echo "")
-          if [ "$CURRENT_SYSTEM" = "$DEPLOYMENT_STORE_PATH" ]; then
-            echo "System is already up-to-date with $DEPLOYMENT_STORE_PATH"
-            exit 0
-          fi
-
-          echo "New deployment found: $DEPLOYMENT_STORE_PATH"
-          nix-store --realize "$DEPLOYMENT_STORE_PATH"
-
-          nix-env -p /nix/var/nix/profiles/system --set "$DEPLOYMENT_STORE_PATH"
-          $DEPLOYMENT_STORE_PATH/bin/switch-to-configuration switch
-
-          echo "Deployment to $DEPLOYMENT_STORE_PATH completed successfully"
+        ''
+        + lib.optionalString (!cfg.waitForBuild) ''
+          echo "Nothing deployable yet for task ${cfg.task}; not waiting"
           exit 0
+        ''
+        + lib.optionalString cfg.waitForBuild ''
+          echo "Task ${cfg.task} is still building; following ${liveUrl}"
+
+          while true; do
+            exec 3< <(websocat -U --text --no-close --ping-interval 30 --ping-timeout 90 \
+              -H="Authorization: Bearer $API_KEY" "${liveUrl}" </dev/null)
+            stream=$!
+
+            # Re-settle on every connect: the socket reports transitions from here
+            # on, and a reconnect gap replays nothing.
+            if settle; then
+              exit 0
+            fi
+
+            while read -r -t ${toString cfg.idleRecheckSec} _event <&3 || [ $? -gt 128 ]; do
+              if settle; then
+                exit 0
+              fi
+            done
+
+            exec 3<&-
+            kill "$stream" 2>/dev/null || true
+            wait "$stream" 2>/dev/null || true
+            sleep 30
+          done
         '';
       };
 
@@ -184,4 +292,3 @@ in {
     };
   };
 }
-

--- a/nix/tests/gradient/deploy/default.nix
+++ b/nix/tests/gradient/deploy/default.nix
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+{ pkgs, ... }: {
+  value = pkgs.testers.runNixOSTest ({ pkgs, lib, ... }: {
+    name = "gradient-deploy";
+    globalTimeout = 900;
+
+    nodes = {
+      machine = { pkgs, lib, ... }: {
+        imports = [ ../../../modules/gradient-deploy.nix ];
+
+        networking.firewall.enable = false;
+        documentation.enable = false;
+        virtualisation = {
+          memorySize = 2048;
+          writableStore = true;
+        };
+        nix.settings.substituters = lib.mkForce [ ];
+
+        # The test framework pins the label to `test`, which is not a version the
+        # deploy module's `nixos-system-<host>-<version>` match accepts. Outrank
+        # it so both system closures are named the way a real one would be.
+        system.nixos.label = lib.mkOverride 10 "25.05.20260907.abcdef1";
+
+        # The deployment target: same host, one extra file, so switching to it
+        # is observable without restarting anything the test depends on.
+        specialisation.deployed.configuration = {
+          environment.etc."gradient-deployed".text = "deployed";
+        };
+
+        environment.systemPackages = with pkgs; [ curl jq ];
+        environment.etc."gradient-deploy-api-key".text = "stub-api-key";
+
+        systemd.services.gradient-stub-api = {
+          description = "Scripted Gradient API for the deploy test";
+          wantedBy = [ "multi-user.target" ];
+          serviceConfig = {
+            ExecStart = "${pkgs.python3}/bin/python3 ${./stub_api.py} 8090";
+            Restart = "always";
+          };
+        };
+
+        system.gradient-deploy = {
+          enable = true;
+          server = "http://127.0.0.1:8090";
+          apiKeyFile = "/etc/gradient-deploy-api-key";
+          task = "wavelens/dotfiles";
+          # An hour out, so anything the service notices came from an event.
+          idleRecheckSec = 3600;
+        };
+      };
+    };
+
+    interactive.nodes = {
+      machine = import ../../modules/debug-host.nix;
+    };
+
+    testScript = builtins.readFile ./test.py;
+  });
+}

--- a/nix/tests/gradient/deploy/default.nix
+++ b/nix/tests/gradient/deploy/default.nix
@@ -4,53 +4,63 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-{ pkgs, ... }: {
+{ pkgs, ... }: let
+  target = { lib, pkgs, ... }: {
+    imports = [ ../../../modules/gradient-deploy.nix ];
+
+    networking.firewall.enable = false;
+    documentation.enable = false;
+    virtualisation = {
+      memorySize = 2048;
+      writableStore = true;
+    };
+    nix.settings.substituters = lib.mkForce [ ];
+
+    # The test framework pins the label to `test`, which is not a version the
+    # deploy module's `nixos-system-<host>-<version>` match accepts. Outrank it
+    # so both system closures are named the way a real one would be.
+    system.nixos.label = lib.mkOverride 10 "25.05.20260907.abcdef1";
+
+    # The deployment target: same host, one extra file, so switching to it is
+    # observable without restarting anything the test depends on.
+    specialisation.deployed.configuration = {
+      environment.etc."gradient-deployed".text = "deployed";
+    };
+
+    environment.systemPackages = with pkgs; [ curl jq ];
+    environment.etc."gradient-deploy-api-key".text = "stub-api-key";
+
+    systemd.services.gradient-stub-api = {
+      description = "Scripted Gradient API for the deploy test";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = "${pkgs.python3}/bin/python3 ${./stub_api.py} 8090";
+        Restart = "always";
+      };
+    };
+
+    system.gradient-deploy = {
+      enable = true;
+      server = "http://127.0.0.1:8090";
+      apiKeyFile = "/etc/gradient-deploy-api-key";
+      task = "wavelens/dotfiles";
+    };
+  };
+in {
   value = pkgs.testers.runNixOSTest ({ pkgs, lib, ... }: {
     name = "gradient-deploy";
     globalTimeout = 900;
 
     nodes = {
-      machine = { pkgs, lib, ... }: {
-        imports = [ ../../../modules/gradient-deploy.nix ];
+      machine = target;
 
-        networking.firewall.enable = false;
-        documentation.enable = false;
-        virtualisation = {
-          memorySize = 2048;
-          writableStore = true;
-        };
-        nix.settings.substituters = lib.mkForce [ ];
-
-        # The test framework pins the label to `test`, which is not a version the
-        # deploy module's `nixos-system-<host>-<version>` match accepts. Outrank
-        # it so both system closures are named the way a real one would be.
-        system.nixos.label = lib.mkOverride 10 "25.05.20260907.abcdef1";
-
-        # The deployment target: same host, one extra file, so switching to it
-        # is observable without restarting anything the test depends on.
-        specialisation.deployed.configuration = {
-          environment.etc."gradient-deployed".text = "deployed";
-        };
-
-        environment.systemPackages = with pkgs; [ curl jq ];
-        environment.etc."gradient-deploy-api-key".text = "stub-api-key";
-
-        systemd.services.gradient-stub-api = {
-          description = "Scripted Gradient API for the deploy test";
-          wantedBy = [ "multi-user.target" ];
-          serviceConfig = {
-            ExecStart = "${pkgs.python3}/bin/python3 ${./stub_api.py} 8090";
-            Restart = "always";
-          };
-        };
-
+      # Same target with the live socket turned off, to cover the fallback for
+      # networks that cannot carry a WebSocket upgrade.
+      poller = { ... }: {
+        imports = [ target ];
         system.gradient-deploy = {
-          enable = true;
-          server = "http://127.0.0.1:8090";
-          apiKeyFile = "/etc/gradient-deploy-api-key";
-          task = "wavelens/dotfiles";
-          # An hour out, so anything the service notices came from an event.
-          idleRecheckSec = 3600;
+          websockets = false;
+          pollIntervalSec = 3;
         };
       };
     };

--- a/nix/tests/gradient/deploy/stub_api.py
+++ b/nix/tests/gradient/deploy/stub_api.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Scripted stand-in for the Gradient API, serving just what gradient-deploy
+reads: the task's newest evaluation, its entry points, and the live WebSocket.
+
+`POST /control/state` swaps the scripted state and pushes one event frame to
+every connected socket, which is how the test drives a build to completion.
+`GET /control/stats` reports the request and connection counts the test asserts
+on to prove the service reacts to events rather than polling.
+"""
+
+import base64
+import hashlib
+import json
+import struct
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+STATE = {"evaluation": None, "entry_points": []}
+STATS = {"evaluations": 0, "entry_points": 0, "connections": 0}
+LOCK = threading.Lock()
+SOCKETS = []
+
+
+def ws_send(sock, opcode, payload):
+    header = bytes([0x80 | opcode])
+    n = len(payload)
+    if n < 126:
+        header += bytes([n])
+    elif n < 65536:
+        header += bytes([126]) + struct.pack(">H", n)
+    else:
+        header += bytes([127]) + struct.pack(">Q", n)
+    sock.sendall(header + payload)
+
+
+def broadcast(event):
+    payload = json.dumps(event).encode()
+    with LOCK:
+        targets = list(SOCKETS)
+    for sock in targets:
+        try:
+            ws_send(sock, 0x1, payload)
+        except OSError:
+            with LOCK:
+                if sock in SOCKETS:
+                    SOCKETS.remove(sock)
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt, *args):
+        sys.stderr.write("stub: " + fmt % args + "\n")
+
+    def json_response(self, body, code=200):
+        raw = json.dumps(body).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def do_GET(self):
+        path = self.path.split("?")[0]
+
+        if path == "/api/v1/health":
+            return self.json_response({"error": False, "message": "ok"})
+
+        if path == "/control/stats":
+            with LOCK:
+                return self.json_response(dict(STATS))
+
+        if path.endswith("/evaluations"):
+            with LOCK:
+                STATS["evaluations"] += 1
+                evaluation = STATE["evaluation"]
+            message = [evaluation] if evaluation else []
+            return self.json_response({"error": False, "message": message})
+
+        if path.endswith("/entry-points"):
+            with LOCK:
+                STATS["entry_points"] += 1
+                entry_points = list(STATE["entry_points"])
+            return self.json_response({"error": False, "message": entry_points})
+
+        if path.endswith("/live"):
+            return self.serve_live()
+
+        self.json_response({"error": True, "message": "not found"}, code=404)
+
+    def do_POST(self):
+        if self.path == "/control/reset":
+            with LOCK:
+                for key in STATS:
+                    STATS[key] = 0
+            return self.json_response({"error": False, "message": "ok"})
+
+        if self.path != "/control/state":
+            return self.json_response({"error": True, "message": "not found"}, code=404)
+
+        body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+        with LOCK:
+            STATE.update(body)
+        broadcast({"EvaluationProgress": {"task": None, "evaluation_id": "stub"}})
+        self.json_response({"error": False, "message": "ok"})
+
+    def serve_live(self):
+        key = self.headers.get("Sec-WebSocket-Key")
+        if not key:
+            return self.json_response({"error": True, "message": "not a websocket"}, code=400)
+
+        accept = base64.b64encode(hashlib.sha1((key + WS_GUID).encode()).digest()).decode()
+        self.wfile.write(
+            (
+                "HTTP/1.1 101 Switching Protocols\r\n"
+                "Upgrade: websocket\r\n"
+                "Connection: Upgrade\r\n"
+                f"Sec-WebSocket-Accept: {accept}\r\n\r\n"
+            ).encode()
+        )
+        self.wfile.flush()
+
+        sock = self.connection
+        with LOCK:
+            STATS["connections"] += 1
+            SOCKETS.append(sock)
+        try:
+            self.pump(sock)
+        finally:
+            with LOCK:
+                if sock in SOCKETS:
+                    SOCKETS.remove(sock)
+            self.close_connection = True
+
+    def pump(self, sock):
+        """Answer the client's pings so the connection survives, until it closes."""
+        while True:
+            head = self.rfile.read(2)
+            if len(head) < 2:
+                return
+            opcode = head[0] & 0x0F
+            masked = head[1] & 0x80
+            length = head[1] & 0x7F
+            if length == 126:
+                length = struct.unpack(">H", self.rfile.read(2))[0]
+            elif length == 127:
+                length = struct.unpack(">Q", self.rfile.read(8))[0]
+            mask = self.rfile.read(4) if masked else b""
+            payload = self.rfile.read(length)
+            if masked:
+                payload = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+            if opcode == 0x8:
+                return
+            if opcode == 0x9:
+                ws_send(sock, 0xA, payload)
+
+
+if __name__ == "__main__":
+    ThreadingHTTPServer(("127.0.0.1", int(sys.argv[1])), Handler).serve_forever()

--- a/nix/tests/gradient/deploy/test.py
+++ b/nix/tests/gradient/deploy/test.py
@@ -2,40 +2,33 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# gradient-deploy against a scripted API: the target's own system closure is the
+# gradient-deploy against a scripted API: a target's own system closure is the
 # "already built" deployment and a specialisation of it is the "new" one, so a
 # real switch can be asserted without a builder. The service must sit on the
 # task's live WebSocket while CI runs and settle on the first event that
-# resolves it, rather than reporting that nothing was built.
+# resolves it, rather than reporting that nothing was built. `poller` is the
+# same target with `websockets = false`, covering the timed fallback.
 
 import base64
 import json
 
 API = "http://127.0.0.1:8090"
 
-start_all()
-machine.wait_for_unit("gradient-stub-api.service")
-machine.wait_until_succeeds(f"curl -sSf {API}/api/v1/health")
-
-BASE_SYSTEM = machine.succeed("readlink /run/current-system").strip()
-DEPLOY_SYSTEM = machine.succeed("readlink -f /run/current-system/specialisation/deployed").strip()
-assert BASE_SYSTEM != DEPLOY_SYSTEM, "specialisation must be a distinct closure"
-
 
 def banner(msg):
     print(f"\n=== {msg} ===")
 
 
-def post(path, payload=None):
+def post(node, path, payload=None):
     cmd = f"curl -sSf -o /dev/null -X POST {API}{path}"
     if payload is not None:
         b64 = base64.b64encode(json.dumps(payload).encode()).decode()
         cmd = f"echo {b64} | base64 -d | " + cmd + " --data-binary @-"
-    machine.succeed(cmd)
+    node.succeed(cmd)
 
 
-def set_state(status, entry_points, evaluation_id="e1"):
-    post("/control/state", {
+def set_state(node, status, entry_points, evaluation_id="e1"):
+    post(node, "/control/state", {
         "evaluation": {"id": evaluation_id, "status": status},
         "entry_points": entry_points,
     })
@@ -47,85 +40,112 @@ def entry_point(path, build_status):
             "outputs": {"out": path}}
 
 
-def stats():
-    return json.loads(machine.succeed(f"curl -sSf {API}/control/stats"))
+def stats(node):
+    return json.loads(node.succeed(f"curl -sSf {API}/control/stats"))
 
 
-def start_deploy():
-    machine.succeed("systemctl start --no-block gradient-deploy.service")
+def start_deploy(node):
+    node.succeed("systemctl start --no-block gradient-deploy.service")
 
 
-def deploy_state():
-    return machine.succeed("systemctl show gradient-deploy.service -p ActiveState --value").strip()
+def deploy_state(node):
+    return node.succeed("systemctl show gradient-deploy.service -p ActiveState --value").strip()
 
 
-def await_deploy():
-    machine.wait_until_succeeds(
-        "systemctl show gradient-deploy.service -p ActiveState --value | grep -qx inactive"
-    )
-    result = machine.succeed("systemctl show gradient-deploy.service -p Result --value").strip()
-    assert result == "success", f"gradient-deploy ended {result}:\n{deploy_log()}"
-    return deploy_log()
-
-
-def deploy_log():
-    invocation = machine.succeed(
+def deploy_log(node):
+    invocation = node.succeed(
         "systemctl show gradient-deploy.service -p InvocationID --value"
     ).strip()
-    return machine.succeed(f"journalctl --no-pager _SYSTEMD_INVOCATION_ID={invocation}")
+    return node.succeed(f"journalctl --no-pager _SYSTEMD_INVOCATION_ID={invocation}")
 
 
-def await_connected():
-    machine.wait_until_succeeds(f"curl -sSf {API}/control/stats | jq -e '.connections == 1'")
+def await_deploy(node):
+    node.wait_until_succeeds(
+        "systemctl show gradient-deploy.service -p ActiveState --value | grep -qx inactive"
+    )
+    result = node.succeed("systemctl show gradient-deploy.service -p Result --value").strip()
+    assert result == "success", f"gradient-deploy ended {result}:\n{deploy_log(node)}"
+    return deploy_log(node)
 
 
-def current_system():
-    return machine.succeed("readlink /run/current-system").strip()
+def await_connected(node):
+    node.wait_until_succeeds(f"curl -sSf {API}/control/stats | jq -e '.connections == 1'")
 
+
+def current_system(node):
+    return node.succeed("readlink /run/current-system").strip()
+
+
+def boot(node):
+    node.wait_for_unit("gradient-stub-api.service")
+    node.wait_until_succeeds(f"curl -sSf {API}/api/v1/health")
+    base = current_system(node)
+    deployed = node.succeed("readlink -f /run/current-system/specialisation/deployed").strip()
+    assert base != deployed, "specialisation must be a distinct closure"
+    return base, deployed
+
+
+start_all()
+BASE_SYSTEM, DEPLOY_SYSTEM = boot(machine)
 
 # ── Already running the evaluated system ──────────────────────────────────────
 # The output path is known at evaluation time, so a target that already runs it
 # is finished regardless of what the build is doing, and must not wait.
 banner("Already up-to-date settles without waiting")
-post("/control/reset")
-set_state("Building", [entry_point(BASE_SYSTEM, "Queued")])
-start_deploy()
-log = await_deploy()
+post(machine, "/control/reset")
+set_state(machine, "Building", [entry_point(BASE_SYSTEM, "Queued")])
+start_deploy(machine)
+log = await_deploy(machine)
 assert "already up-to-date" in log, log
-assert stats()["connections"] == 0, f"must not open the live socket: {stats()}"
+assert stats(machine)["connections"] == 0, f"must not open the live socket: {stats(machine)}"
 
 # ── Evaluation fails part-way through the build ───────────────────────────────
 banner("Evaluation failing mid-build stops the wait without deploying")
-post("/control/reset")
-set_state("Building", [entry_point(DEPLOY_SYSTEM, "Building")], evaluation_id="e2")
-start_deploy()
-await_connected()
-assert deploy_state() == "activating", "must still be waiting on the live socket"
+post(machine, "/control/reset")
+set_state(machine, "Building", [entry_point(DEPLOY_SYSTEM, "Building")], evaluation_id="e2")
+start_deploy(machine)
+await_connected(machine)
+assert deploy_state(machine) == "activating", "must still be waiting on the live socket"
 
-set_state("Failed", [entry_point(DEPLOY_SYSTEM, "Building")], evaluation_id="e2")
-log = await_deploy()
+set_state(machine, "Failed", [entry_point(DEPLOY_SYSTEM, "Building")], evaluation_id="e2")
+log = await_deploy(machine)
 assert "finished Failed" in log, log
-assert current_system() == BASE_SYSTEM, "a failed evaluation must not switch the system"
+assert current_system(machine) == BASE_SYSTEM, "a failed evaluation must not switch the system"
 
 # ── Waits through evaluation and build, then deploys ──────────────────────────
 banner("Waits through evaluation and build, then deploys")
-post("/control/reset")
-set_state("EvaluatingFlake", [], evaluation_id="e3")
-start_deploy()
-await_connected()
-assert deploy_state() == "activating", "must wait while entry points do not exist yet"
+post(machine, "/control/reset")
+set_state(machine, "EvaluatingFlake", [], evaluation_id="e3")
+start_deploy(machine)
+await_connected(machine)
+assert deploy_state(machine) == "activating", "must wait while entry points do not exist yet"
 
-set_state("Building", [entry_point(DEPLOY_SYSTEM, "Queued")], evaluation_id="e3")
+set_state(machine, "Building", [entry_point(DEPLOY_SYSTEM, "Queued")], evaluation_id="e3")
 machine.sleep(3)
-assert deploy_state() == "activating", "must keep waiting while the build is queued"
+assert deploy_state(machine) == "activating", "must keep waiting while the build is queued"
 
-set_state("Building", [entry_point(DEPLOY_SYSTEM, "Completed")], evaluation_id="e3")
-log = await_deploy()
+set_state(machine, "Building", [entry_point(DEPLOY_SYSTEM, "Completed")], evaluation_id="e3")
+log = await_deploy(machine)
 assert f"Deployment to {DEPLOY_SYSTEM} completed successfully" in log, log
 machine.succeed("test -e /etc/gradient-deployed")
-assert current_system() == DEPLOY_SYSTEM, f"expected {DEPLOY_SYSTEM}, got {current_system()}"
+assert current_system(machine) == DEPLOY_SYSTEM, f"expected {DEPLOY_SYSTEM}, got {current_system(machine)}"
 
-# One pass on start, one on connect, one per event: the failsafe re-check is an
-# hour out, so anything beyond that would mean the service is polling.
-passes = stats()["entry_points"]
+# One pass on start, one on connect, one per event. There is no timed re-check,
+# so anything beyond that would mean the service is polling.
+passes = stats(machine)["entry_points"]
 assert passes <= 5, f"expected event-driven re-checks, got {passes}"
+
+# ── The fallback for networks without WebSockets ──────────────────────────────
+banner("With websockets disabled the wait falls back to re-checking on a timer")
+POLLER_SYSTEM, _ = boot(poller)
+post(poller, "/control/reset")
+set_state(poller, "Building", [], evaluation_id="e4")
+start_deploy(poller)
+poller.sleep(6)
+assert deploy_state(poller) == "activating", "must wait for the evaluation without a socket"
+assert stats(poller)["connections"] == 0, "must not open a socket when websockets are off"
+assert stats(poller)["entry_points"] >= 2, "must keep re-checking on the timer"
+
+set_state(poller, "Building", [entry_point(POLLER_SYSTEM, "Queued")], evaluation_id="e4")
+log = await_deploy(poller)
+assert "already up-to-date" in log, log

--- a/nix/tests/gradient/deploy/test.py
+++ b/nix/tests/gradient/deploy/test.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# gradient-deploy against a scripted API: the target's own system closure is the
+# "already built" deployment and a specialisation of it is the "new" one, so a
+# real switch can be asserted without a builder. The service must sit on the
+# task's live WebSocket while CI runs and settle on the first event that
+# resolves it, rather than reporting that nothing was built.
+
+import base64
+import json
+
+API = "http://127.0.0.1:8090"
+
+start_all()
+machine.wait_for_unit("gradient-stub-api.service")
+machine.wait_until_succeeds(f"curl -sSf {API}/api/v1/health")
+
+BASE_SYSTEM = machine.succeed("readlink /run/current-system").strip()
+DEPLOY_SYSTEM = machine.succeed("readlink -f /run/current-system/specialisation/deployed").strip()
+assert BASE_SYSTEM != DEPLOY_SYSTEM, "specialisation must be a distinct closure"
+
+
+def banner(msg):
+    print(f"\n=== {msg} ===")
+
+
+def post(path, payload=None):
+    cmd = f"curl -sSf -o /dev/null -X POST {API}{path}"
+    if payload is not None:
+        b64 = base64.b64encode(json.dumps(payload).encode()).decode()
+        cmd = f"echo {b64} | base64 -d | " + cmd + " --data-binary @-"
+    machine.succeed(cmd)
+
+
+def set_state(status, entry_points, evaluation_id="e1"):
+    post("/control/state", {
+        "evaluation": {"id": evaluation_id, "status": status},
+        "entry_points": entry_points,
+    })
+
+
+def entry_point(path, build_status):
+    return {"build_id": "00000000-0000-0000-0000-000000000001",
+            "build_status": build_status,
+            "outputs": {"out": path}}
+
+
+def stats():
+    return json.loads(machine.succeed(f"curl -sSf {API}/control/stats"))
+
+
+def start_deploy():
+    machine.succeed("systemctl start --no-block gradient-deploy.service")
+
+
+def deploy_state():
+    return machine.succeed("systemctl show gradient-deploy.service -p ActiveState --value").strip()
+
+
+def await_deploy():
+    machine.wait_until_succeeds(
+        "systemctl show gradient-deploy.service -p ActiveState --value | grep -qx inactive"
+    )
+    result = machine.succeed("systemctl show gradient-deploy.service -p Result --value").strip()
+    assert result == "success", f"gradient-deploy ended {result}:\n{deploy_log()}"
+    return deploy_log()
+
+
+def deploy_log():
+    invocation = machine.succeed(
+        "systemctl show gradient-deploy.service -p InvocationID --value"
+    ).strip()
+    return machine.succeed(f"journalctl --no-pager _SYSTEMD_INVOCATION_ID={invocation}")
+
+
+def await_connected():
+    machine.wait_until_succeeds(f"curl -sSf {API}/control/stats | jq -e '.connections == 1'")
+
+
+def current_system():
+    return machine.succeed("readlink /run/current-system").strip()
+
+
+# ── Already running the evaluated system ──────────────────────────────────────
+# The output path is known at evaluation time, so a target that already runs it
+# is finished regardless of what the build is doing, and must not wait.
+banner("Already up-to-date settles without waiting")
+post("/control/reset")
+set_state("Building", [entry_point(BASE_SYSTEM, "Queued")])
+start_deploy()
+log = await_deploy()
+assert "already up-to-date" in log, log
+assert stats()["connections"] == 0, f"must not open the live socket: {stats()}"
+
+# ── Evaluation fails part-way through the build ───────────────────────────────
+banner("Evaluation failing mid-build stops the wait without deploying")
+post("/control/reset")
+set_state("Building", [entry_point(DEPLOY_SYSTEM, "Building")], evaluation_id="e2")
+start_deploy()
+await_connected()
+assert deploy_state() == "activating", "must still be waiting on the live socket"
+
+set_state("Failed", [entry_point(DEPLOY_SYSTEM, "Building")], evaluation_id="e2")
+log = await_deploy()
+assert "finished Failed" in log, log
+assert current_system() == BASE_SYSTEM, "a failed evaluation must not switch the system"
+
+# ── Waits through evaluation and build, then deploys ──────────────────────────
+banner("Waits through evaluation and build, then deploys")
+post("/control/reset")
+set_state("EvaluatingFlake", [], evaluation_id="e3")
+start_deploy()
+await_connected()
+assert deploy_state() == "activating", "must wait while entry points do not exist yet"
+
+set_state("Building", [entry_point(DEPLOY_SYSTEM, "Queued")], evaluation_id="e3")
+machine.sleep(3)
+assert deploy_state() == "activating", "must keep waiting while the build is queued"
+
+set_state("Building", [entry_point(DEPLOY_SYSTEM, "Completed")], evaluation_id="e3")
+log = await_deploy()
+assert f"Deployment to {DEPLOY_SYSTEM} completed successfully" in log, log
+machine.succeed("test -e /etc/gradient-deployed")
+assert current_system() == DEPLOY_SYSTEM, f"expected {DEPLOY_SYSTEM}, got {current_system()}"
+
+# One pass on start, one on connect, one per event: the failsafe re-check is an
+# hour out, so anything beyond that would mean the service is polling.
+passes = stats()["entry_points"]
+assert passes <= 5, f"expected event-driven re-checks, got {passes}"


### PR DESCRIPTION
`gradient-deploy` gave up with "No successfully built entry points" whenever the newest commit was still in CI, because `/entry-points` follows `task.last_evaluation`, which points at the new evaluation the moment it is created.

It now follows the task's live WebSocket and re-checks on each event until the system closure is built, the build or evaluation fails, or the target already runs the evaluated system. Entry-point output paths are written at evaluation time, so an up-to-date target still exits at once and no per-build lookups are needed.