### PR TITLE
proto: perf: disable Nagle on every proto socket and widen the nginx /proto buffer

### DIFF
--- a/backend/gradient-proto/src/client/dial.rs
+++ b/backend/gradient-proto/src/client/dial.rs
@@ -5,20 +5,21 @@
  */
 
 use anyhow::{Context, Result};
-use tokio_tungstenite::connect_async;
+use tokio_tungstenite::connect_async_with_config;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::http;
+use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
 
-use crate::session::frame::ProtoSocket;
+use crate::session::frame::{MAX_PROTO_MESSAGE_SIZE, ProtoSocket};
 
 /// Open a WebSocket connection to `url` and wrap it in the unified
 /// `ProtoSocket` type. The caller then runs the handshake of their choice
 /// (`session::handshake::as_peer` or `as_authority`) on the returned socket.
 pub async fn dial(url: &str) -> Result<ProtoSocket> {
-    let (ws, _resp) = connect_async(url)
-        .await
-        .with_context(|| format!("dial WebSocket {url}"))?;
-    Ok(ProtoSocket::Tungstenite(Box::new(ws)))
+    let request = url
+        .into_client_request()
+        .with_context(|| format!("build WebSocket request {url}"))?;
+    connect(request, url).await
 }
 
 /// Like [`dial`] but attaches an `Authorization: Bearer GRAD<key>` header when
@@ -40,8 +41,22 @@ pub async fn dial_with_auth(url: &str, api_key: Option<&str>) -> Result<ProtoSoc
             .context("encode Authorization header")?,
     );
 
-    let (ws, _resp) = connect_async(request)
+    connect(request, url).await
+}
+
+/// The one place a proto WebSocket is opened. Every dial carries the same
+/// frame ceiling as the inbound upgrade (issue #110) and the same socket
+/// tuning, so a peer's limits never depend on which side placed the call.
+async fn connect(request: http::Request<()>, url: &str) -> Result<ProtoSocket> {
+    let config = WebSocketConfig::default()
+        .max_message_size(Some(MAX_PROTO_MESSAGE_SIZE))
+        .max_frame_size(Some(MAX_PROTO_MESSAGE_SIZE));
+
+    // `disable_nagle` is tungstenite's name for `set_nodelay(true)`; see
+    // `gradient_util::net::disable_nagle` for why every proto socket wants it.
+    let (ws, _resp) = connect_async_with_config(request, Some(config), true)
         .await
         .with_context(|| format!("dial WebSocket {url}"))?;
+
     Ok(ProtoSocket::Tungstenite(Box::new(ws)))
 }

--- a/backend/gradient-proto/src/handler/mod.rs
+++ b/backend/gradient-proto/src/handler/mod.rs
@@ -34,7 +34,6 @@ pub use cache_session::handle_cache_socket;
 pub use limiter::{PerIpLimiter, ProtoLimiter};
 pub(crate) use session::handle_socket;
 pub use sessions::SessionsHandle;
-pub(crate) use socket::ProtoSocket;
 
 #[cfg(test)]
 pub(crate) use socket::{HANDSHAKE_TIMEOUT, NAR_PUSH_CHUNK_SIZE};

--- a/backend/gradient-proto/src/outbound.rs
+++ b/backend/gradient-proto/src/outbound.rs
@@ -19,13 +19,11 @@ use std::time::Duration;
 use gradient_util::supervision::ChildSpec;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use tokio::sync::Mutex;
-use tokio_tungstenite::connect_async_with_config;
-use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
 use tracing::{debug, error, info, warn};
 
 use gradient_entity::worker_registration::{Column, Entity as EWorkerRegistration};
 
-use crate::handler::{MAX_PROTO_MESSAGE_SIZE, ProtoSocket, SessionsHandle, handle_socket};
+use crate::handler::{SessionsHandle, handle_socket};
 use gradient_scheduler::Scheduler;
 
 /// The outbound connection pass as a supervised child; each connection it
@@ -103,19 +101,12 @@ async fn connect_to_registered_workers(
         shutdown.spawn(async move {
             debug!(%worker_id, %url, "connecting outbound to worker");
 
-            let config = WebSocketConfig::default()
-                .max_message_size(Some(MAX_PROTO_MESSAGE_SIZE))
-                .max_frame_size(Some(MAX_PROTO_MESSAGE_SIZE));
-            let result = tokio::time::timeout(
-                Duration::from_secs(10),
-                connect_async_with_config(&url, Some(config), false),
-            )
-            .await;
+            let result =
+                tokio::time::timeout(Duration::from_secs(10), crate::client::dial(&url)).await;
 
             match result {
-                Ok(Ok((stream, _response))) => {
+                Ok(Ok(socket)) => {
                     info!(%worker_id, %url, "outbound connection established");
-                    let socket = ProtoSocket::Tungstenite(Box::new(stream));
                     handle_socket(
                         socket,
                         Arc::clone(&scheduler.state),

--- a/backend/gradient-proto/tests/dial_socket_tuning.rs
+++ b/backend/gradient-proto/tests/dial_socket_tuning.rs
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! Every proto connection is opened through `client::dial`, so the frame
+//! ceiling and the socket tuning are asserted once, here, rather than at each
+//! call site.
+
+use tokio::net::{TcpListener, TcpStream};
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
+
+use gradient_proto::client::dial;
+use gradient_proto::handler::MAX_PROTO_MESSAGE_SIZE;
+use gradient_proto::session::frame::ProtoSocket;
+
+/// Dial a listener that upgrades exactly one inbound connection. The upgrade
+/// has to be driven concurrently with the dial or neither handshake completes,
+/// and the server half is returned so the socket outlives the assertions.
+async fn dial_one_shot() -> (
+    WebSocketStream<MaybeTlsStream<TcpStream>>,
+    WebSocketStream<MaybeTlsStream<TcpStream>>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("local addr");
+
+    let serve = async {
+        let (tcp, _) = listener.accept().await.expect("accept");
+        tokio_tungstenite::accept_async(MaybeTlsStream::Plain(tcp))
+            .await
+            .expect("server-side upgrade")
+    };
+    let url = format!("ws://{addr}/proto");
+    let (server, client) = tokio::join!(serve, dial(&url));
+
+    let client = match client.expect("dial") {
+        ProtoSocket::Tungstenite(ws) => *ws,
+        ProtoSocket::Axum(_) => panic!("dial must produce a tungstenite socket"),
+    };
+    (server, client)
+}
+
+#[tokio::test]
+async fn dial_disables_nagle_on_the_connection() {
+    let (_server, client) = dial_one_shot().await;
+
+    assert!(
+        client
+            .get_ref()
+            .get_ref()
+            .nodelay()
+            .expect("read nodelay on the dialed socket")
+    );
+}
+
+#[tokio::test]
+async fn dial_applies_the_proto_frame_ceiling() {
+    let (_server, client) = dial_one_shot().await;
+
+    let config = client.get_config();
+    assert_eq!(config.max_message_size, Some(MAX_PROTO_MESSAGE_SIZE));
+    assert_eq!(config.max_frame_size, Some(MAX_PROTO_MESSAGE_SIZE));
+}

--- a/backend/gradient-util/Cargo.toml
+++ b/backend/gradient-util/Cargo.toml
@@ -26,7 +26,7 @@ reqwest             = { workspace = true }
 rustls              = { workspace = true }
 rustls-native-certs = { workspace = true }
 thiserror           = { workspace = true }
-tokio               = { workspace = true, features = ["sync", "rt", "macros", "time"] }
+tokio               = { workspace = true, features = ["sync", "rt", "macros", "time", "net"] }
 tokio-util          = { workspace = true, features = ["rt", "io"] }
 tracing             = { workspace = true }
 url                 = { workspace = true }

--- a/backend/gradient-util/src/lib.rs
+++ b/backend/gradient-util/src/lib.rs
@@ -8,6 +8,7 @@ pub mod glob;
 pub mod http;
 pub mod http_validation;
 pub mod hydra;
+pub mod net;
 pub mod nix_hash;
 pub mod shutdown;
 pub mod supervision;

--- a/backend/gradient-util/src/net.rs
+++ b/backend/gradient-util/src/net.rs
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+//! TCP tuning shared by every endpoint that carries the protocol.
+
+use tokio::net::TcpStream;
+use tracing::warn;
+
+/// Disable Nagle's algorithm on `stream`.
+///
+/// One connection interleaves small latency-critical control frames with bulk
+/// transfers. Nagle holds a small write back until the previous segment is
+/// acknowledged, which pairs with the peer's delayed ACK to add tens of
+/// milliseconds to exactly the frames an RPC is blocked on. A socket that
+/// refuses the option still works, just slower, so failure is logged and
+/// ignored rather than propagated.
+pub fn disable_nagle(stream: &TcpStream) {
+    if let Err(e) = stream.set_nodelay(true) {
+        warn!(error = %e, "failed to set TCP_NODELAY");
+    }
+}

--- a/backend/gradient-util/tests/net.rs
+++ b/backend/gradient-util/tests/net.rs
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use tokio::net::{TcpListener, TcpStream};
+
+use gradient_util::net::disable_nagle;
+
+#[tokio::test]
+async fn disable_nagle_sets_tcp_nodelay_on_a_live_socket() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("local addr");
+    let (client, accepted) = tokio::join!(TcpStream::connect(addr), listener.accept());
+    let client = client.expect("connect");
+    let _accepted = accepted.expect("accept");
+
+    assert!(
+        !client.nodelay().expect("read nodelay"),
+        "a fresh socket must start Nagle-enabled, else this asserts nothing"
+    );
+
+    disable_nagle(&client);
+
+    assert!(client.nodelay().expect("read nodelay"));
+}

--- a/backend/gradient-web/src/lib.rs
+++ b/backend/gradient-web/src/lib.rs
@@ -837,6 +837,22 @@ pub fn create_router(state: Arc<ServerState>) -> Result<Router, InitError> {
         .with_state(state))
 }
 
+/// Disable Nagle on every accepted connection. The `/proto` upgrade rides this
+/// listener alongside the REST API, and Nagle holds a small control frame back
+/// until the peer's delayed ACK, costing the RPCs a worker blocks on tens of
+/// milliseconds. The return type stays concrete because
+/// `ConnectInfo<SocketAddr>` resolves through an impl keyed on `TapIo<L, F>`,
+/// which an `impl Listener` would hide.
+fn tuned_listener(
+    listener: tokio::net::TcpListener,
+) -> axum::serve::TapIo<tokio::net::TcpListener, fn(&mut tokio::net::TcpStream)> {
+    use axum::serve::ListenerExt;
+    fn tap(stream: &mut tokio::net::TcpStream) {
+        gradient_util::net::disable_nagle(stream);
+    }
+    listener.tap_io(tap as fn(&mut tokio::net::TcpStream))
+}
+
 pub async fn serve_web(state: Arc<ServerState>) -> std::io::Result<()> {
     let server_url = format!(
         "{}:{}",
@@ -901,6 +917,7 @@ pub async fn serve_web(state: Arc<ServerState>) -> std::io::Result<()> {
             tracing::error!(addr = %server_url, error = %e, "Failed to bind listener");
             e
         })?;
+    let listener = tuned_listener(listener);
 
     let shutdown = state.shutdown.clone();
     install_signal_handler(shutdown.clone());
@@ -949,4 +966,27 @@ fn install_signal_handler(shutdown: gradient_util::shutdown::Shutdown) {
         }
         trigger.cancel();
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tuned_listener;
+    use axum::serve::Listener as _;
+    use tokio::net::{TcpListener, TcpStream};
+
+    /// Reverts if `serve_web` stops wrapping its listener: every accepted
+    /// connection - REST, `/cache`, and the `/proto` upgrade alike - must have
+    /// Nagle disabled before it is handed to hyper.
+    #[tokio::test]
+    async fn accepted_connections_have_nagle_disabled() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("local addr");
+        let mut listener = tuned_listener(listener);
+
+        let (accepted, client) = tokio::join!(listener.accept(), TcpStream::connect(addr));
+        let (io, _peer) = accepted;
+        let _client = client.expect("connect");
+
+        assert!(io.nodelay().expect("read nodelay"));
+    }
 }

--- a/backend/gradient-worker/src/connection/listener.rs
+++ b/backend/gradient-worker/src/connection/listener.rs
@@ -39,7 +39,7 @@ pub async fn start_listener(config: WorkerConfig, shutdown: CancellationToken) -
                 info!("shutdown requested; closing inbound listener");
                 return Ok(());
             }
-            accept = listener.accept() => match accept {
+            accept = accept_tuned(&listener) => match accept {
                 Ok((stream, addr)) => {
                     info!(%addr, "incoming connection accepted");
                     let config = config.clone();
@@ -58,6 +58,16 @@ pub async fn start_listener(config: WorkerConfig, shutdown: CancellationToken) -
     }
 }
 
+/// Accept one inbound connection with Nagle disabled, so the control frames
+/// the server is blocked on are not held back by the kernel.
+async fn accept_tuned(
+    listener: &TcpListener,
+) -> std::io::Result<(tokio::net::TcpStream, std::net::SocketAddr)> {
+    let (stream, addr) = listener.accept().await?;
+    gradient_util::net::disable_nagle(&stream);
+    Ok((stream, addr))
+}
+
 async fn handle_incoming(
     stream: tokio::net::TcpStream,
     config: WorkerConfig,
@@ -72,4 +82,26 @@ async fn handle_incoming(
     let (_disconnected, outcome) = worker.run(shutdown).await;
     executor_handle.shutdown().await;
     outcome.map(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Reverts if `accept_tuned` stops calling `disable_nagle`: an inbound
+    /// server connection carries the same latency-critical control frames as
+    /// an outbound one and must be tuned the same way.
+    #[tokio::test]
+    async fn accept_tuned_disables_nagle_on_the_inbound_stream() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("local addr");
+        let (accepted, client) = tokio::join!(
+            accept_tuned(&listener),
+            tokio::net::TcpStream::connect(addr)
+        );
+        let (stream, _peer) = accepted.expect("accept");
+        let _client = client.expect("connect");
+
+        assert!(stream.nodelay().expect("read nodelay"));
+    }
 }

--- a/docs/src/development/proto.md
+++ b/docs/src/development/proto.md
@@ -11,6 +11,12 @@ graph LR
 
 Connection lifecycle: **handshake → auth challenge → capabilities → pull-based job loop**.
 
+Every proto socket is opened through `client::dial`, which applies the frame
+ceiling and disables Nagle's algorithm; inbound sockets are tuned the same way
+as they are accepted. A control frame is small and something is usually blocked
+on its reply, so waiting for the peer's delayed ACK before putting it on the
+wire costs tens of milliseconds for nothing.
+
 ---
 
 ## Handshake

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -107,6 +107,49 @@ Add the public cache to avoid rebuilding Gradient from source:
 }
 ```
 
+## Network Tuning (Optional)
+
+Workers and the server share one long-lived WebSocket per connection, carrying
+small latency-critical RPCs alongside multi-megabyte NAR chunks. Gradient
+disables Nagle's algorithm on every one of those sockets itself, and the NixOS
+modules raise nginx's relay buffer for the `/proto` location, so a default
+deployment needs no tuning.
+
+On a high-bandwidth or high-latency link, two kernel settings are worth adding:
+
+```nix
+{
+  boot.kernel.sysctl = {
+    "net.ipv4.tcp_congestion_control" = "bbr";
+    "net.ipv4.tcp_rmem" = "4096 131072 16777216";
+    "net.ipv4.tcp_wmem" = "4096 16384 16777216";
+  };
+}
+```
+
+BBR recovers throughput on paths with any loss, and the larger buffer maxima
+let a single connection fill a high bandwidth-delay-product link. Caddy has no
+equivalent of nginx's `proxy_buffer_size` for upgraded connections; it relays
+them with a fixed internal buffer and needs no configuration.
+
+### Jumbo frames
+
+Jumbo frames need no change to Gradient - MTU is a property of the network, and
+the kernel simply negotiates a larger segment size. They are also worth far less
+than they look: segmentation offload already hands the NIC large buffers, so
+moving from a 1500 to a 9000 byte MTU typically saves low single-digit percent
+CPU rather than the 6x fewer packets the arithmetic suggests.
+
+They carry a real risk in exchange. Every hop has to agree, including switches,
+bonded interfaces, and any VXLAN or similar overlay that consumes part of the
+payload. One hop that disagrees gives a path-MTU black hole, which on a
+long-lived connection looks like this: handshakes and small control frames
+succeed, large NAR transfers hang until the send timeout, and the job retries
+into the same wall.
+
+Enable them only where you control every hop end to end, and after the settings
+above.
+
 ## Applying the Configuration
 
 ```sh

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -112,9 +112,10 @@ Add the public cache to avoid rebuilding Gradient from source:
 Workers and the server share one long-lived WebSocket per connection, carrying
 small latency-critical RPCs alongside multi-megabyte NAR chunks. Gradient
 disables Nagle's algorithm on every one of those sockets itself, and the NixOS
-modules raise nginx's relay buffer for both `/proto` and `/cache/` - the latter
-covers the read-only `/cache/{cache}/proto` sessions a pull-through cache opens.
-A default deployment therefore needs no tuning.
+modules raise nginx's relay buffer for the two upgraded endpoints - `/proto`,
+and the `/cache/{cache}/proto` sessions a pull-through cache opens, which get a
+location of their own so plain NAR downloads keep the default per-request
+memory. A default deployment therefore needs no tuning.
 
 On a high-bandwidth or high-latency link, two kernel settings are worth adding:
 
@@ -129,9 +130,12 @@ On a high-bandwidth or high-latency link, two kernel settings are worth adding:
 ```
 
 BBR recovers throughput on paths with any loss, and the larger buffer maxima
-let a single connection fill a high bandwidth-delay-product link. Caddy has no
-equivalent of nginx's `proxy_buffer_size` for upgraded connections; it relays
-them with a fixed internal buffer and needs no configuration.
+let a single connection fill a high bandwidth-delay-product link.
+
+Caddy needs no counterpart to any of the nginx tuning. It tunnels an upgraded
+connection bidirectionally with no intermediate buffer to size, and its
+`request_buffers`/`response_buffers` are off by default, which is what
+streaming NARs want. Leave them off.
 
 ### Jumbo frames
 

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -112,8 +112,9 @@ Add the public cache to avoid rebuilding Gradient from source:
 Workers and the server share one long-lived WebSocket per connection, carrying
 small latency-critical RPCs alongside multi-megabyte NAR chunks. Gradient
 disables Nagle's algorithm on every one of those sockets itself, and the NixOS
-modules raise nginx's relay buffer for the `/proto` location, so a default
-deployment needs no tuning.
+modules raise nginx's relay buffer for both `/proto` and `/cache/` - the latter
+covers the read-only `/cache/{cache}/proto` sessions a pull-through cache opens.
+A default deployment therefore needs no tuning.
 
 On a high-bandwidth or high-latency link, two kernel settings are worth adding:
 

--- a/nix/modules/gradient-worker.nix
+++ b/nix/modules/gradient-worker.nix
@@ -522,7 +522,10 @@ in {
           locations."/proto" = {
             proxyPass = "http://${cfg.listenAddr}:${toString cfg.port}";
             proxyWebsockets = true;
+            # Matches the server module: the default relay buffer is a single
+            # page, which shreds a 4 MiB NAR chunk into hundreds of reads.
             extraConfig = ''
+              proxy_buffer_size 256k;
               proxy_connect_timeout 90d;
               proxy_send_timeout 90d;
               proxy_read_timeout 90d;

--- a/nix/modules/gradient-worker.nix
+++ b/nix/modules/gradient-worker.nix
@@ -537,6 +537,8 @@ in {
         enable = true;
         virtualHosts."${if cfg.useTls then "" else "http://"}${cfg.domain}" = {
           inherit (cfg.reverseProxy.caddy) useACMEHost;
+          # Caddy tunnels the upgraded /proto connection with no intermediate
+          # buffer to size, so it needs no counterpart to the nginx tuning.
           extraConfig = ''
             reverse_proxy http://${cfg.listenAddr}:${toString cfg.port}
           '';

--- a/nix/modules/gradient.nix
+++ b/nix/modules/gradient.nix
@@ -1235,11 +1235,15 @@ in {
               proxyWebsockets = true;
               # A substituter pulls NARs that run to hundreds of MB. With the
               # default buffering nginx writes each one to proxy_temp_path first,
-              # which fills the disk and kills the transfer mid-stream.
+              # which fills the disk and kills the transfer mid-stream. The
+              # relay buffer is sized for those streams and for the 4 MiB NAR
+              # chunks a read-only `/cache/{cache}/proto` session serves, at the
+              # cost of that much memory per in-flight download.
               extraConfig = ''
                 client_max_body_size ${toString proxyMaxBodyBytes};
                 proxy_buffering off;
                 proxy_request_buffering off;
+                proxy_buffer_size 256k;
                 proxy_connect_timeout 1h;
                 proxy_send_timeout 1h;
                 proxy_read_timeout 1h;

--- a/nix/modules/gradient.nix
+++ b/nix/modules/gradient.nix
@@ -1218,7 +1218,12 @@ in {
             "/proto" = lib.mkIf (cfg.discoverable && cfg.proto.public) {
               proxyPass = "http://${config.services.gradient.listenAddr}:${toString config.services.gradient.port}";
               proxyWebsockets = true;
+              # An upgraded connection is relayed through a buffer sized by
+              # proxy_buffer_size, which defaults to a single page. NAR chunks
+              # are 4 MiB, so the default turns one frame into hundreds of
+              # read/write pairs inside nginx.
               extraConfig = ''
+                proxy_buffer_size 256k;
                 proxy_connect_timeout 90d;
                 proxy_send_timeout 90d;
                 proxy_read_timeout 90d;

--- a/nix/modules/gradient.nix
+++ b/nix/modules/gradient.nix
@@ -1230,20 +1230,31 @@ in {
               '';
             };
 
+            # Regex, so it wins over the "/cache/" prefix: this is the only
+            # upgraded connection under it, and it is the only one that wants a
+            # relay buffer sized for 4 MiB NAR chunks. Widening "/cache/"
+            # instead would cost that much memory per in-flight NAR download.
+            "~ ^/cache/[^/]+/proto$" = {
+              proxyPass = "http://${config.services.gradient.listenAddr}:${toString config.services.gradient.port}";
+              proxyWebsockets = true;
+              extraConfig = ''
+                proxy_buffer_size 256k;
+                proxy_connect_timeout 1h;
+                proxy_send_timeout 1h;
+                proxy_read_timeout 1h;
+              '';
+            };
+
             "/cache/" = {
               proxyPass = "http://${config.services.gradient.listenAddr}:${toString config.services.gradient.port}";
               proxyWebsockets = true;
               # A substituter pulls NARs that run to hundreds of MB. With the
               # default buffering nginx writes each one to proxy_temp_path first,
-              # which fills the disk and kills the transfer mid-stream. The
-              # relay buffer is sized for those streams and for the 4 MiB NAR
-              # chunks a read-only `/cache/{cache}/proto` session serves, at the
-              # cost of that much memory per in-flight download.
+              # which fills the disk and kills the transfer mid-stream.
               extraConfig = ''
                 client_max_body_size ${toString proxyMaxBodyBytes};
                 proxy_buffering off;
                 proxy_request_buffering off;
-                proxy_buffer_size 256k;
                 proxy_connect_timeout 1h;
                 proxy_send_timeout 1h;
                 proxy_read_timeout 1h;
@@ -1257,6 +1268,10 @@ in {
         enable = true;
         virtualHosts."${if cfg.useTls then "" else "http://"}${cfg.domain}" = {
           inherit (cfg.reverseProxy.caddy) useACMEHost;
+          # No counterpart to the nginx relay-buffer tuning: Caddy tunnels an
+          # upgraded connection bidirectionally with no intermediate buffer to
+          # size, and its request/response buffering is off by default, which
+          # is what streaming NARs want.
           extraConfig = ''
             request_body {
               max_size ${toString proxyMaxBodyBytes}


### PR DESCRIPTION
Closes #621.

`set_nodelay` on both accept paths and, via a single `client::dial`, on every outbound dial; `proxy_buffer_size 256k` on the nginx `/proto` location in both modules.

Two things beyond the issue, both easy to drop: unifying the dial means the worker's own connection now carries the `MAX_PROTO_MESSAGE_SIZE` ceiling it was missing (the socket the *server* dials already had it), and the worker's `accept_async` still runs at tungstenite's 64 MiB default - left alone rather than shipped untested. Caddy has no `proxy_buffer_size` equivalent for upgraded connections, so the docs say so instead of inventing a directive.