### PR TITLE
cache: fix: keep a NAR's cache claim when its job already closed

### DIFF
--- a/backend/gradient-cache/src/cacher/sign_sweep.rs
+++ b/backend/gradient-cache/src/cacher/sign_sweep.rs
@@ -21,7 +21,8 @@ use gradient_types::*;
 use gradient_util::nix_hash::normalize_nar_hash;
 use gradient_util::sync::Mutex;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, QuerySelect, Set,
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, IntoActiveModel, QueryFilter,
+    QuerySelect, Set,
 };
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -30,6 +31,56 @@ use tracing::{debug, warn};
 /// Max pending rows processed per sweep pass. Bounds memory + time per
 /// invocation; remaining rows are picked up by the next scheduled pass.
 const SIGN_SWEEP_BATCH: u64 = 1000;
+
+/// Re-create `cached_path_signature` rows for paths that hold none at all.
+///
+/// A NAR whose owning job could not be resolved at commit time was written to
+/// `cached_path` with no cache claim, and the signing pass below cannot repair
+/// that: it only fills rows that already exist. Such a path is cached according
+/// to every gate flag yet 404s from the narinfo endpoint forever. Bounded the
+/// same way as the signing pass, and driven off the "no rows at all" anti-join
+/// so a healthy instance pays one indexed probe.
+const RECONCILE_ORPHAN_CLAIMS: &str = r#"
+WITH orphan AS (
+    SELECT cp.id
+    FROM cached_path cp
+    WHERE NOT EXISTS (
+        SELECT 1 FROM cached_path_signature s WHERE s.cached_path = cp.id)
+    LIMIT $1
+), claim AS (
+    SELECT DISTINCT o.id AS cached_path, c.id AS cache
+    FROM orphan o
+    JOIN derivation_output dout ON dout.cached_path = o.id
+    JOIN build_job bj           ON bj.derivation = dout.derivation
+    JOIN evaluation e           ON e.id = bj.evaluation
+    JOIN task t                 ON t.id = e.task
+    JOIN project_cache pc       ON pc.project = t.project
+    JOIN cache c                ON c.id = pc.cache
+    WHERE t.sign_cache
+)
+INSERT INTO cached_path_signature (id, cached_path, cache, fetch_count, created_at)
+SELECT uuidv7(), claim.cached_path, claim.cache, 0, (now() AT TIME ZONE 'UTC')
+FROM claim
+ON CONFLICT (cached_path, cache) DO NOTHING
+"#;
+
+async fn reconcile_orphan_claims(state: &Arc<ServerState>) -> anyhow::Result<()> {
+    let res = state
+        .worker_db
+        .execute_raw(sea_orm::Statement::from_sql_and_values(
+            sea_orm::DatabaseBackend::Postgres,
+            RECONCILE_ORPHAN_CLAIMS,
+            [sea_orm::Value::BigInt(Some(SIGN_SWEEP_BATCH as i64))],
+        ))
+        .await?;
+    if res.rows_affected() > 0 {
+        tracing::info!(
+            count = res.rows_affected(),
+            "sign sweep: re-created cache claims for paths that had none"
+        );
+    }
+    Ok(())
+}
 
 /// Skip a `cached_path` iff every producing task has `sign_cache=false`
 /// and at least one such task exists. Paths absent from `producers`
@@ -49,6 +100,12 @@ pub(crate) fn compute_skipped_cached_paths(
 /// `cache_derivation` where newly-signed paths complete a derivation
 /// closure. Errors on individual rows are logged and skipped.
 pub async fn sign_missing_signatures(state: Arc<ServerState>) -> anyhow::Result<()> {
+    // Before signing, give back a claim to any path that lost one, so this same
+    // pass signs it rather than leaving it unservable for another interval.
+    if let Err(e) = reconcile_orphan_claims(&state).await {
+        warn!(error = %e, "sign sweep: orphan claim reconcile failed");
+    }
+
     let pending = ECachedPathSignature::find()
         .filter(CCachedPathSignature::Signature.is_null())
         .limit(SIGN_SWEEP_BATCH)
@@ -403,6 +460,44 @@ async fn load_producing_task_flags(
     }
 
     Ok(out)
+}
+
+#[cfg(test)]
+mod orphan_claim_tests {
+    use super::RECONCILE_ORPHAN_CLAIMS;
+
+    /// The signing pass fills `signature IS NULL` on rows that exist, so a path
+    /// with no row at all is invisible to it and 404s forever. The reconcile is
+    /// the only thing that gives such a path a claim back.
+    #[test]
+    fn the_reconcile_targets_paths_with_no_claim_at_all() {
+        assert!(
+            RECONCILE_ORPHAN_CLAIMS.contains("NOT EXISTS"),
+            "{RECONCILE_ORPHAN_CLAIMS}"
+        );
+        assert!(
+            RECONCILE_ORPHAN_CLAIMS.contains("INSERT INTO cached_path_signature"),
+            "{RECONCILE_ORPHAN_CLAIMS}"
+        );
+        assert!(
+            RECONCILE_ORPHAN_CLAIMS.contains("ON CONFLICT (cached_path, cache) DO NOTHING"),
+            "a re-created claim must never collide with a live one"
+        );
+    }
+
+    /// An unbounded fixpoint over `cached_path` has starved this scheduler
+    /// before, and the pass runs on a timer.
+    #[test]
+    fn the_reconcile_is_bounded_and_respects_the_sign_cache_opt_out() {
+        assert!(
+            RECONCILE_ORPHAN_CLAIMS.contains("LIMIT $1"),
+            "{RECONCILE_ORPHAN_CLAIMS}"
+        );
+        assert!(
+            RECONCILE_ORPHAN_CLAIMS.contains("t.sign_cache"),
+            "a task that opted out of signing must not be handed a claim"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/backend/gradient-proto/src/handler/nar.rs
+++ b/backend/gradient-proto/src/handler/nar.rs
@@ -6,12 +6,15 @@
 
 use chrono::Timelike;
 use gradient_core::ServerState;
+use gradient_entity::dispatched_job::{Column as CDispatchedJob, Entity as EDispatchedJob};
 use gradient_graph::{NarCommit, SignTargets};
 use gradient_types::ids::{CacheId, ProjectId};
 use gradient_types::*;
 use sea_orm::{
-    ColumnTrait, ConnectionTrait, DatabaseBackend, EntityTrait, QueryFilter, Statement, Value,
+    ColumnTrait, ConnectionTrait, DatabaseBackend, EntityTrait, QueryFilter, QueryOrder, Select,
+    Statement, Value,
 };
+use tracing::warn;
 
 pub(super) struct NarUploadRecord<'a> {
     pub file_hash: &'a str,
@@ -135,4 +138,105 @@ pub(super) async fn mark_nar_stored(
     }
 
     Ok(())
+}
+
+/// The dispatch row binding `job_id` to the project it was dispatched for.
+fn dispatched_job_query(worker_id: &str, job_id: &str) -> Select<EDispatchedJob> {
+    EDispatchedJob::find()
+        .filter(CDispatchedJob::JobId.eq(job_id))
+        .filter(CDispatchedJob::WorkerId.eq(worker_id))
+        .order_by_desc(CDispatchedJob::DispatchedAt)
+}
+
+/// The project a job was dispatched for, read from the durable dispatch row.
+///
+/// `JobCompleted` rides the control writer lane while `NarUploaded` rides bulk,
+/// and `WriterLanes` always drains control first - so a job's completion
+/// overtakes its own trailing NAR confirmations and the scheduler has already
+/// evicted the job by the time a late NAR commits. Without this fallback the
+/// commit takes `SignTargets::None`, writing a `cached_path` row that no cache
+/// claims: the narinfo gate 404s it forever, and the sign sweep cannot repair it
+/// because it only fills rows that already exist.
+///
+/// Keyed on the worker as well as the job so a concurrent dispatch of the same
+/// job key elsewhere cannot answer for this connection's upload.
+pub(super) async fn project_for_dispatched_job<C: ConnectionTrait>(
+    db: &C,
+    worker_id: &str,
+    job_id: &str,
+) -> Option<ProjectId> {
+    dispatched_job_query(worker_id, job_id)
+        .one(db)
+        .await
+        .map_err(|e| warn!(%job_id, %worker_id, error = %e, "dispatched_job lookup for a late NAR failed"))
+        .ok()
+        .flatten()
+        .map(|row| row.project)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sea_orm::{MockDatabase, QueryTrait};
+    use uuid::Uuid;
+
+    const JOB: &str = "build:01a07af6-9d9f-7300-8aa1-fb82b0c18446";
+    const WORKER: &str = "builder-1";
+
+    fn project() -> ProjectId {
+        ProjectId::new(
+            Uuid::parse_str("019e8549-eef3-7b92-96a2-f3842f585407").expect("project uuid"),
+        )
+    }
+
+    fn row() -> gradient_entity::dispatched_job::Model {
+        gradient_entity::dispatched_job::Model {
+            id: gradient_entity::ids::DispatchedJobId::now_v7(),
+            project: project(),
+            worker_id: WORKER.to_owned(),
+            job_id: Some(JOB.to_owned()),
+            ..Default::default()
+        }
+    }
+
+    /// The whole point of the fallback: the scheduler has already evicted the
+    /// job, and the dispatch row is what keeps the NAR's cache claim.
+    #[tokio::test]
+    async fn a_late_nar_still_resolves_its_project_from_the_dispatch_row() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![row()]])
+            .into_connection();
+
+        assert_eq!(
+            project_for_dispatched_job(&db, WORKER, JOB).await,
+            Some(project())
+        );
+    }
+
+    /// No dispatch row is the one case that legitimately has no project. It must
+    /// return `None` rather than panic, so the caller can log and carry on.
+    #[tokio::test]
+    async fn no_dispatch_row_yields_no_project() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([Vec::<gradient_entity::dispatched_job::Model>::new()])
+            .into_connection();
+
+        assert_eq!(project_for_dispatched_job(&db, WORKER, JOB).await, None);
+    }
+
+    /// A job key is unique only among in-flight jobs, so the same `build:<anchor>`
+    /// recurs across evaluations - and those may belong to different projects.
+    /// Without the worker filter and the newest-first order, a late NAR could be
+    /// signed into a stranger's caches.
+    #[test]
+    fn the_lookup_is_pinned_to_this_worker_and_the_newest_dispatch() {
+        let sql = dispatched_job_query(WORKER, JOB)
+            .build(DatabaseBackend::Postgres)
+            .to_string();
+
+        assert!(sql.contains("\"job_id\" = "), "{sql}");
+        assert!(sql.contains("\"worker_id\" = "), "{sql}");
+        assert!(sql.contains("ORDER BY"), "{sql}");
+        assert!(sql.contains("\"dispatched_at\" DESC"), "{sql}");
+    }
 }

--- a/backend/gradient-proto/src/handler/nar_transfer.rs
+++ b/backend/gradient-proto/src/handler/nar_transfer.rs
@@ -361,13 +361,27 @@ impl<'a> DispatchContext<'a> {
             return;
         };
 
-        // Resolve the owning project here, on the read loop, while the job is still
-        // active. The detached commit runs after this method returns, and the
-        // very next message on the connection (`JobComplete`) evicts the job
-        // from the tracker - so re-resolving `project_for_job` inside the task would
-        // race to `None`, drop the `cached_path_signature` placeholder, and the
-        // narinfo would 404 forever with the path stuck unsigned.
-        let project_id = self.scheduler.project_for_job(&job_id).await;
+        // Resolve the owning project here, on the read loop, while the job is
+        // still active; re-resolving inside the detached task would race the
+        // eviction that `JobCompleted` triggers. The tracker alone is not
+        // enough, though: `JobCompleted` rides the control writer lane and
+        // overtakes this job's own trailing `NarUploaded` frames on the bulk
+        // lane, so the job can already be gone. Fall back to the durable
+        // dispatch row rather than committing with no cache claim - that leaves
+        // a `cached_path` row the narinfo gate 404s forever.
+        let project_id = match self.scheduler.project_for_job(&job_id).await {
+            Some(project_id) => Some(project_id),
+            None => {
+                super::nar::project_for_dispatched_job(&self.state.worker_db, self.peer_id, &job_id)
+                    .await
+            }
+        };
+        if project_id.is_none() {
+            warn!(
+                peer_id = %self.peer_id, %job_id, %store_path,
+                "no owning project for this NAR; it will be stored with no cache claim"
+            );
+        }
 
         // The commit reads the whole staged NAR and writes it to `nar_storage`
         // (an S3 upload on object-store backends). Inline it froze this

--- a/backend/gradient-report/src/schema.rs
+++ b/backend/gradient-report/src/schema.rs
@@ -13,7 +13,7 @@ use rusqlite::Connection;
 
 /// Bumped whenever an exported table's shape changes, so an inspector can
 /// refuse a file it does not understand rather than print wrong answers.
-pub const SCHEMA_VERSION: i64 = 5;
+pub const SCHEMA_VERSION: i64 = 6;
 
 #[derive(Clone, Copy, Debug)]
 pub struct ReportOptions {

--- a/backend/gradient-report/src/tables.rs
+++ b/backend/gradient-report/src/tables.rs
@@ -72,9 +72,9 @@ pub fn redact_value(
         ("worker_registration", "created_by")
         | ("base_worker", "created_by")
         | ("project_base_worker", "created_by") => r.identity(&v, "user"),
-        ("cache_upstream", "display_name") | ("cache_upstream", "remote_cache_name") => {
-            r.identity(&v, "cache")
-        }
+        ("cache_upstream", "display_name")
+        | ("cache_upstream", "remote_cache_name")
+        | ("cached_path_signature", "cache_name") => r.identity(&v, "cache"),
         _ => v,
     };
 
@@ -380,6 +380,22 @@ pub fn eval_scope_tables() -> &'static [TableSpec] {
             "SELECT r.referrer::text, r.reference::text, r.reference_hash::text, r.position::text FROM cached_path_reference r WHERE r.referrer IN (SELECT o.hash FROM derivation_output o WHERE o.derivation IN (SELECT derivation FROM build_job WHERE evaluation = $1))",
             "the evaluation's output hashes, shared with every other evaluation that produced them",
             ["referrer", "reference", "reference_hash", "position"]
+        ),
+        spec!(
+            "cached_path_signature",
+            "CREATE TABLE cached_path_signature (id TEXT, cached_path TEXT, cache TEXT, cache_name TEXT, signed INTEGER, last_fetched_at TEXT, fetch_count INTEGER, created_at TEXT)",
+            "SELECT s.id::text, s.cached_path::text, s.cache::text, c.name::text, (s.signature IS NOT NULL)::int::text, s.last_fetched_at::text, s.fetch_count::text, s.created_at::text FROM cached_path_signature s LEFT JOIN cache c ON c.id = s.cache WHERE s.cached_path IN (SELECT cp.id FROM cached_path cp WHERE cp.hash IN (SELECT o.hash FROM derivation_output o WHERE o.derivation IN (SELECT derivation FROM build_job WHERE evaluation = $1)))",
+            "the evaluation's output hashes, one row per cache holding the path",
+            [
+                "id",
+                "cached_path",
+                "cache",
+                "cache_name",
+                "signed",
+                "last_fetched_at",
+                "fetch_count",
+                "created_at"
+            ]
         ),
         spec!(
             "evaluation_input_update",
@@ -733,6 +749,55 @@ mod tests {
         assert!(
             !spec.columns.contains(&"candidate_lock"),
             "a whole generated flake.lock is not scheduling evidence"
+        );
+    }
+
+    /// A narinfo is only served when a `cached_path_signature` row exists for
+    /// the asking cache *and* carries a signature; without one the cache 404s a
+    /// path whose `cached_path` row says it is right there. That gate is
+    /// invisible in a report that stops at `cached_path`.
+    #[test]
+    fn the_narinfo_signature_gate_is_exported() {
+        let spec = spec_named("cached_path_signature");
+        assert!(spec.columns.contains(&"signed"), "{:?}", spec.columns);
+        assert!(
+            !spec.columns.contains(&"signature"),
+            "the raw Ed25519 blob is not evidence; whether it exists is"
+        );
+        assert!(
+            !spec.sql.contains("s.signature::"),
+            "a bytea signature must never be cast out verbatim: {}",
+            spec.sql
+        );
+        assert!(
+            spec.sql.contains("(s.signature IS NOT NULL)"),
+            "{}",
+            spec.sql
+        );
+        assert!(
+            spec.sql
+                .contains("SELECT derivation FROM build_job WHERE evaluation = $1"),
+            "the gate has to cover exactly the paths cached_path exports: {}",
+            spec.sql
+        );
+    }
+
+    /// The gate is per cache, so a row that names no cache cannot say whether
+    /// the cache the client asked is the one holding the signature.
+    #[test]
+    fn a_signature_row_names_its_cache() {
+        let spec = spec_named("cached_path_signature");
+        assert!(spec.columns.contains(&"cache_name"), "{:?}", spec.columns);
+        let r = redactor(true, false);
+        assert_ne!(
+            redact_value(
+                &r,
+                "cached_path_signature",
+                "cache_name",
+                Some("wavelens-prod".into())
+            ),
+            Some("wavelens-prod".into()),
+            "a cache name is an identity and follows cache_upstream's policy"
         );
     }
 

--- a/docs/src/diagnostic-reports.md
+++ b/docs/src/diagnostic-reports.md
@@ -111,6 +111,22 @@ sqlite3 gradient-report-01a05a38-2026-09-01.db \
 null for a job still running when the report was taken, and for one whose worker
 disconnected without reporting.
 
+`cached_path_signature` is the gate the binary cache actually serves on: a path
+is only fetchable if it has a row here for the asking cache with `signed = 1`.
+A `cached_path` row with no matching signature row is a path every other table
+calls cached and the cache still 404s, so join the two before trusting
+`derivation_output.is_cached`:
+
+```sh
+sqlite3 gradient-report-01a05a38-2026-09-01.db \
+  'SELECT cp.package, s.cache_name, s.signed
+     FROM cached_path cp
+     LEFT JOIN cached_path_signature s ON s.cached_path = cp.id
+    WHERE s.id IS NULL OR s.signed = 0'
+```
+
+The raw signature is never exported, only whether one exists.
+
 An evaluation still in `EvaluatingFlake` or `EvaluatingDerivation` whose newest
 eval job carries a `finished_at` is one whose terminal report never landed. The
 scheduler's `eval-completion-watchdog` pass re-drives that transition, so the


### PR DESCRIPTION
A path can be `is_cached` everywhere and still 404 from the cache: `JobCompleted` rides the control writer lane and overtakes the job's own trailing `NarUploaded` frames on bulk, so `project_for_job` missed and the commit took `SignTargets::None`, writing a `cached_path` row that no cache claims. Resolves the project from the durable dispatch row instead, reconciles paths that already lost their claim, and exports `cached_path_signature` in diagnostic reports so the gate is visible.