### PR TITLE
cache: fix: keep a broken upstream from stalling every narinfo miss

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -4194,7 +4194,7 @@ dependencies = [
 [[package]]
 name = "nix-bindings"
 version = "0.2347.8"
-source = "git+https://github.com/DerDennisOP/nix-bindings?branch=feat%2Feval-metrics-stats#593e0cb6b996003278114d924799a90452197540"
+source = "git+https://github.com/DerDennisOP/nix-bindings?branch=feat%2Feval-metrics-stats#1f9819e05a2911919959f7fd1501dddc9c77dee0"
 dependencies = [
  "nix-bindings-sys",
 ]
@@ -4202,7 +4202,7 @@ dependencies = [
 [[package]]
 name = "nix-bindings-sys"
 version = "0.2347.8"
-source = "git+https://github.com/DerDennisOP/nix-bindings?branch=feat%2Feval-metrics-stats#593e0cb6b996003278114d924799a90452197540"
+source = "git+https://github.com/DerDennisOP/nix-bindings?branch=feat%2Feval-metrics-stats#1f9819e05a2911919959f7fd1501dddc9c77dee0"
 dependencies = [
  "bindgen",
  "cc",
@@ -6846,7 +6846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/backend/gradient-core/src/upstream.rs
+++ b/backend/gradient-core/src/upstream.rs
@@ -158,7 +158,7 @@ pub fn fold_samples(samples: &[ProbeSample], into: &mut HashMap<CacheUpstreamId,
     }
 }
 
-const PROBE_TIMEOUT_SECS: u64 = 5;
+const PROBE_TIMEOUT_SECS: u64 = 2;
 const PROBE_TIMEOUT: Duration = Duration::from_secs(PROBE_TIMEOUT_SECS);
 const BATCH_WINDOW: usize = 256;
 /// Cap on how long a probe waits for a query-pool permit before giving up. Keeps

--- a/backend/gradient-core/src/upstream.rs
+++ b/backend/gradient-core/src/upstream.rs
@@ -594,6 +594,13 @@ mod tests {
         assert!(std::ptr::eq(breakers(), breakers()));
     }
 
+    /// The same constructor the server uses. `reqwest::Client::new()` panics
+    /// where no system CA bundle exists (the nix build sandbox); `build_client`
+    /// folds in `webpki_roots`, so it builds with or without native certs.
+    fn client() -> reqwest::Client {
+        gradient_util::http::build_client().expect("http client builds")
+    }
+
     /// The exact failure that cost every narinfo miss 30s: a port that completes
     /// the handshake and then never answers. Never accepting is enough - the
     /// kernel finishes the connection from the backlog, so the client is
@@ -620,12 +627,8 @@ mod tests {
         }];
 
         let started = Instant::now();
-        let got = super::fetch_narinfo_body(
-            &reqwest::Client::new(),
-            &probes,
-            "brj5bb4pny8pnngq3qdymkllwql6z29j",
-        )
-        .await;
+        let got =
+            super::fetch_narinfo_body(&client(), &probes, "brj5bb4pny8pnngq3qdymkllwql6z29j").await;
         let elapsed = started.elapsed();
 
         assert!(got.is_none());
@@ -651,12 +654,8 @@ mod tests {
         }];
 
         let started = Instant::now();
-        let got = super::fetch_narinfo_body(
-            &reqwest::Client::new(),
-            &probes,
-            "brj5bb4pny8pnngq3qdymkllwql6z29j",
-        )
-        .await;
+        let got =
+            super::fetch_narinfo_body(&client(), &probes, "brj5bb4pny8pnngq3qdymkllwql6z29j").await;
         let elapsed = started.elapsed();
 
         assert!(got.is_none());

--- a/backend/gradient-core/src/upstream.rs
+++ b/backend/gradient-core/src/upstream.rs
@@ -11,9 +11,10 @@
 //! metadata needed to import the path.
 
 use std::collections::HashMap;
-use std::sync::Arc;
-use std::time::Instant;
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant};
 
+use gradient_util::sync::Mutex;
 use tokio::sync::Semaphore;
 
 use gradient_db::{UpstreamAccum, UpstreamEndpoint};
@@ -32,6 +33,88 @@ pub struct ProbeSample {
     pub upstream: CacheUpstreamId,
     pub latency_ms: f64,
     pub kind: SampleKind,
+}
+
+/// Consecutive transport failures before an upstream is taken out of rotation.
+const TRIP_AFTER: u32 = 3;
+
+/// How long a tripped upstream stays out. Short enough that a cache coming back
+/// is picked up on its own, long enough that a black hole is not re-probed on
+/// every request.
+const BREAKER_COOLDOWN: Duration = Duration::from_secs(60);
+
+#[derive(Debug, Default, Clone, Copy)]
+struct Breaker {
+    consecutive_errors: u32,
+    open_until: Option<Instant>,
+}
+
+/// Per-upstream health, so one unreachable cache cannot cost every request its
+/// probe budget.
+///
+/// A cache that accepts the connection and then never answers is the expensive
+/// case: without this, every narinfo miss pays the full probe timeout waiting on
+/// it. Only transport failures count - a 404 means the upstream answered and is
+/// healthy, it simply does not have the path, which is the common case and must
+/// never take a cache out of rotation.
+#[derive(Debug, Default)]
+pub struct UpstreamBreakers {
+    inner: Mutex<HashMap<CacheUpstreamId, Breaker>>,
+}
+
+impl UpstreamBreakers {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn allows(&self, id: CacheUpstreamId) -> bool {
+        self.allows_at(id, Instant::now())
+    }
+
+    pub fn record(&self, id: CacheUpstreamId, kind: SampleKind) {
+        self.record_at(id, kind, Instant::now());
+    }
+
+    /// Whether a probe to `id` may go out at `now`. Once the cooldown elapses
+    /// the upstream is allowed through again; a further failure trips it anew.
+    pub fn allows_at(&self, id: CacheUpstreamId, now: Instant) -> bool {
+        let mut guard = self.inner.lock();
+        match guard.get_mut(&id) {
+            Some(b) => match b.open_until {
+                Some(until) if now < until => false,
+                Some(_) => {
+                    b.open_until = None;
+                    true
+                }
+                None => true,
+            },
+            None => true,
+        }
+    }
+
+    pub fn record_at(&self, id: CacheUpstreamId, kind: SampleKind, now: Instant) {
+        let mut guard = self.inner.lock();
+        let b = guard.entry(id).or_default();
+        match kind {
+            SampleKind::Hit | SampleKind::Miss => {
+                b.consecutive_errors = 0;
+                b.open_until = None;
+            }
+            SampleKind::Error => {
+                b.consecutive_errors = b.consecutive_errors.saturating_add(1);
+                if b.consecutive_errors >= TRIP_AFTER {
+                    b.open_until = Some(now + BREAKER_COOLDOWN);
+                }
+            }
+        }
+    }
+}
+
+/// Process-wide breakers, shared by the worker cache-query path and the cache's
+/// own narinfo endpoint so one dead upstream is learned about once.
+pub fn breakers() -> &'static UpstreamBreakers {
+    static BREAKERS: OnceLock<UpstreamBreakers> = OnceLock::new();
+    BREAKERS.get_or_init(UpstreamBreakers::new)
 }
 
 pub const PARALLEL_THRESHOLD: usize = 4;
@@ -76,6 +159,7 @@ pub fn fold_samples(samples: &[ProbeSample], into: &mut HashMap<CacheUpstreamId,
 }
 
 const PROBE_TIMEOUT_SECS: u64 = 5;
+const PROBE_TIMEOUT: Duration = Duration::from_secs(PROBE_TIMEOUT_SECS);
 const BATCH_WINDOW: usize = 256;
 /// Cap on how long a probe waits for a query-pool permit before giving up. Keeps
 /// a saturated pool (a large eval flooding the shared semaphore) from making a
@@ -115,7 +199,7 @@ async fn probe_one(
         .await;
     let latency_ms = started.elapsed().as_secs_f64() * 1000.0;
 
-    match resp {
+    let out = match resp {
         Ok(r) if r.status().is_success() => match r.text().await {
             Ok(body) => match parse_upstream_narinfo(&ep.url, store_path, &body) {
                 Some(cp) => (latency_ms, SampleKind::Hit, Some(cp)),
@@ -128,7 +212,77 @@ async fn probe_one(
         }
         Ok(_) => (latency_ms, SampleKind::Error, None),
         Err(_) => (latency_ms, SampleKind::Error, None),
+    };
+    breakers().record(ep.id, out.1);
+    out
+}
+
+/// One upstream as the cache's own narinfo endpoint knows it: the key is needed
+/// to verify what comes back before it is served on to a client.
+#[derive(Debug, Clone)]
+pub struct UpstreamProbe {
+    pub id: CacheUpstreamId,
+    pub url: String,
+    pub public_key: String,
+}
+
+/// A verified narinfo body and the upstream it came from.
+#[derive(Debug, Clone)]
+pub struct UpstreamNarinfo {
+    pub upstream: CacheUpstreamId,
+    pub body: String,
+}
+
+/// The narinfo for `path_hash` from the first upstream that has it.
+///
+/// Probes concurrently and bounds each probe, so an unreachable upstream costs
+/// one timeout instead of stalling the request behind it, and the breaker then
+/// keeps it out of rotation entirely. Bodies whose `Sig` does not verify against
+/// that upstream's configured key are dropped, never served on.
+pub async fn fetch_narinfo_body(
+    http: &reqwest::Client,
+    upstreams: &[UpstreamProbe],
+    path_hash: &str,
+) -> Option<UpstreamNarinfo> {
+    use futures::stream::{FuturesUnordered, StreamExt as _};
+
+    let mut futs: FuturesUnordered<_> = upstreams
+        .iter()
+        .filter(|u| breakers().allows(u.id))
+        .map(|u| async move {
+            let url = format!("{}/{}.narinfo", u.url.trim_end_matches('/'), path_hash);
+            let resp = http.get(&url).timeout(PROBE_TIMEOUT).send().await;
+            let kind = match &resp {
+                Ok(r) if r.status().is_success() => SampleKind::Hit,
+                Ok(r) if r.status() == reqwest::StatusCode::NOT_FOUND => SampleKind::Miss,
+                Ok(_) | Err(_) => SampleKind::Error,
+            };
+            breakers().record(u.id, kind);
+            if kind != SampleKind::Hit {
+                return None;
+            }
+            let body = resp.ok()?.text().await.ok()?;
+            if !gradient_sources::verify_narinfo_signature(&u.public_key, &body) {
+                tracing::warn!(
+                    upstream = %u.id,
+                    path_hash,
+                    "upstream narinfo Sig did not verify against configured public_key; dropping"
+                );
+                return None;
+            }
+            Some(UpstreamNarinfo {
+                upstream: u.id,
+                body,
+            })
+        })
+        .collect();
+
+    while let Some(found) = futs.next().await {
+        if found.is_some() {
+            return found;
+        }
     }
+    None
 }
 
 pub async fn lookup_upstream_narinfo(
@@ -139,6 +293,21 @@ pub async fn lookup_upstream_narinfo(
     store_path: String,
 ) -> ProbeResult {
     let mut samples = Vec::new();
+
+    // A tripped upstream is skipped rather than probed and recorded: folding a
+    // sample we never took would poison the hit-rate its ordering is built on.
+    let endpoints: Arc<Vec<UpstreamEndpoint>> = if endpoints.iter().all(|e| breakers().allows(e.id))
+    {
+        endpoints
+    } else {
+        Arc::new(
+            endpoints
+                .iter()
+                .filter(|e| breakers().allows(e.id))
+                .cloned()
+                .collect(),
+        )
+    };
 
     if should_race(endpoints.len()) {
         use futures::stream::{FuturesUnordered, StreamExt as _};
@@ -320,6 +489,183 @@ pub fn parse_upstream_narinfo(base_url: &str, store_path: &str, body: &str) -> O
 
 #[cfg(test)]
 mod tests {
+    use super::{BREAKER_COOLDOWN, SampleKind, TRIP_AFTER, UpstreamBreakers, breakers};
+    use gradient_types::ids::CacheUpstreamId;
+    use std::time::{Duration, Instant};
+
+    fn upstream(n: u128) -> CacheUpstreamId {
+        CacheUpstreamId::new(uuid::Uuid::from_u128(n))
+    }
+
+    /// The failure this exists for: a cache that accepts the connection and
+    /// never answers. After a few strikes it must be skipped outright, or every
+    /// narinfo miss keeps paying its probe timeout.
+    #[test]
+    fn a_black_holed_upstream_is_taken_out_of_rotation() {
+        let b = UpstreamBreakers::new();
+        let id = upstream(1);
+        let t0 = Instant::now();
+
+        for _ in 0..TRIP_AFTER {
+            assert!(b.allows_at(id, t0), "must keep trying up to the threshold");
+            b.record_at(id, SampleKind::Error, t0);
+        }
+
+        assert!(!b.allows_at(id, t0), "the upstream should be tripped");
+    }
+
+    /// A 404 is the common answer from a healthy cache that lacks the path.
+    /// Counting it as a failure would take every upstream out of rotation
+    /// during any large substitution.
+    #[test]
+    fn a_miss_is_not_a_failure() {
+        let b = UpstreamBreakers::new();
+        let id = upstream(2);
+        let t0 = Instant::now();
+
+        for _ in 0..(TRIP_AFTER * 3) {
+            b.record_at(id, SampleKind::Miss, t0);
+        }
+
+        assert!(b.allows_at(id, t0));
+    }
+
+    /// A single success clears the count, so intermittent errors never
+    /// accumulate into a trip over hours.
+    #[test]
+    fn a_success_resets_the_failure_count() {
+        let b = UpstreamBreakers::new();
+        let id = upstream(3);
+        let t0 = Instant::now();
+
+        b.record_at(id, SampleKind::Error, t0);
+        b.record_at(id, SampleKind::Error, t0);
+        b.record_at(id, SampleKind::Hit, t0);
+        b.record_at(id, SampleKind::Error, t0);
+
+        assert!(b.allows_at(id, t0), "two strikes short of the threshold");
+    }
+
+    /// The cooldown has to expire on its own: an upstream that comes back must
+    /// be picked up without an operator restarting anything.
+    #[test]
+    fn a_tripped_upstream_is_retried_after_the_cooldown() {
+        let b = UpstreamBreakers::new();
+        let id = upstream(4);
+        let t0 = Instant::now();
+
+        for _ in 0..TRIP_AFTER {
+            b.record_at(id, SampleKind::Error, t0);
+        }
+        assert!(!b.allows_at(id, t0));
+
+        let later = t0 + BREAKER_COOLDOWN + Duration::from_secs(1);
+        assert!(
+            b.allows_at(id, later),
+            "cooldown must let one probe through"
+        );
+    }
+
+    /// Half-open, not closed: the probe the cooldown let through failing again
+    /// has to trip it straight back rather than starting a fresh count.
+    #[test]
+    fn a_still_broken_upstream_trips_again_on_the_next_failure() {
+        let b = UpstreamBreakers::new();
+        let id = upstream(5);
+        let t0 = Instant::now();
+
+        for _ in 0..TRIP_AFTER {
+            b.record_at(id, SampleKind::Error, t0);
+        }
+        let later = t0 + BREAKER_COOLDOWN + Duration::from_secs(1);
+        assert!(b.allows_at(id, later));
+
+        b.record_at(id, SampleKind::Error, later);
+        assert!(
+            !b.allows_at(id, later),
+            "one failure re-trips a half-open upstream"
+        );
+    }
+
+    /// Both the worker cache-query path and the cache's narinfo endpoint have to
+    /// consult the same health, or each learns a dead upstream separately.
+    #[test]
+    fn the_breakers_are_process_wide() {
+        assert!(std::ptr::eq(breakers(), breakers()));
+    }
+
+    /// The exact failure that cost every narinfo miss 30s: a port that completes
+    /// the handshake and then never answers. Never accepting is enough - the
+    /// kernel finishes the connection from the backlog, so the client is
+    /// connected and waiting on bytes that never come. Returned by value so the
+    /// listener stays bound for the life of the test.
+    async fn black_hole() -> (String, tokio::net::TcpListener) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        (format!("http://{addr}"), listener)
+    }
+
+    /// The probe must give up on its own budget. Before this, the shared client's
+    /// 30s timeout was the only bound and a substituter's own stall detector
+    /// fired first.
+    #[tokio::test]
+    async fn a_black_hole_is_bounded_by_the_probe_timeout() {
+        let (url, _listener) = black_hole().await;
+        let probes = vec![super::UpstreamProbe {
+            id: upstream(10),
+            url,
+            public_key: "test:0000000000000000000000000000000000000000000=".into(),
+        }];
+
+        let started = Instant::now();
+        let got = super::fetch_narinfo_body(
+            &reqwest::Client::new(),
+            &probes,
+            "brj5bb4pny8pnngq3qdymkllwql6z29j",
+        )
+        .await;
+        let elapsed = started.elapsed();
+
+        assert!(got.is_none());
+        assert!(
+            elapsed < Duration::from_secs(super::PROBE_TIMEOUT_SECS + 3),
+            "a dead upstream must not hold the request: took {elapsed:?}"
+        );
+    }
+
+    /// Once tripped, a dead upstream costs nothing at all - which is what keeps
+    /// a miss fast while the cache is down.
+    #[tokio::test]
+    async fn a_tripped_upstream_is_not_probed_at_all() {
+        let (url, _listener) = black_hole().await;
+        let id = upstream(11);
+        for _ in 0..TRIP_AFTER {
+            breakers().record(id, SampleKind::Error);
+        }
+        let probes = vec![super::UpstreamProbe {
+            id,
+            url,
+            public_key: "test:0000000000000000000000000000000000000000000=".into(),
+        }];
+
+        let started = Instant::now();
+        let got = super::fetch_narinfo_body(
+            &reqwest::Client::new(),
+            &probes,
+            "brj5bb4pny8pnngq3qdymkllwql6z29j",
+        )
+        .await;
+        let elapsed = started.elapsed();
+
+        assert!(got.is_none());
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "a tripped upstream must be skipped, not probed: took {elapsed:?}"
+        );
+    }
+
     use super::*;
 
     #[test]

--- a/backend/gradient-db/src/dependency_graph.rs
+++ b/backend/gradient-db/src/dependency_graph.rs
@@ -13,18 +13,25 @@
 //!
 //! Two callers historically reimplemented the same BFS with subtly different
 //! shapes (cache invalidation closure revocation, build-failure cascade); this
-//! module hosts the single canonical version.
+//! module hosts the single canonical version, alongside the layering that turns
+//! those edges into the display order a build list is read in.
 
 use crate::graph_sql::{ClosureDirection, dependency_closure_cte};
 use anyhow::{Context, Result};
-use sea_orm::{ConnectionTrait, DatabaseBackend, FromQueryResult, Statement};
-use std::collections::HashSet;
+use sea_orm::{ConnectionTrait, DatabaseBackend, DbErr, FromQueryResult, Statement};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use gradient_types::*;
 
 #[derive(FromQueryResult)]
 struct DerivationRow {
     derivation: uuid::Uuid,
+}
+
+#[derive(FromQueryResult)]
+struct EdgeRow {
+    derivation: uuid::Uuid,
+    dependency: uuid::Uuid,
 }
 
 /// Returns the set of all transitive dependents of `start`, **including** `start`
@@ -60,6 +67,88 @@ pub async fn collect_transitive_dependents<C: ConnectionTrait>(
         .collect())
 }
 
+/// Every `derivation_dependency` edge whose parent derivation is one an
+/// `evaluation` holds a `build_job` for. Written as a `LATERAL` probe per
+/// parent behind an `OFFSET 0` fence so the planner keeps the nested loop with
+/// a per-parent index-only lookup instead of hash-joining the whole edge table
+/// (see [`crate::graph_sql`] for why the fence is load-bearing). Measured on
+/// the largest production evaluation - 34,778 jobs, 300,534 edges - 140 ms
+/// warm against 1,438 ms for the hash join the planner picks unfenced.
+pub async fn eval_dependency_edges<C: ConnectionTrait>(
+    db: &C,
+    evaluation: EvaluationId,
+) -> Result<Vec<(DerivationId, DerivationId)>, DbErr> {
+    let rows = EdgeRow::find_by_statement(Statement::from_sql_and_values(
+        DatabaseBackend::Postgres,
+        "WITH d AS MATERIALIZED (SELECT derivation FROM build_job WHERE evaluation = $1) \
+         SELECT d.derivation, s.dependency FROM d, LATERAL (\
+           SELECT e.dependency FROM derivation_dependency e \
+           WHERE e.derivation = d.derivation OFFSET 0) s",
+        [evaluation.into_inner().into()],
+    ))
+    .all(db)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|r| {
+            (
+                DerivationId::new(r.derivation),
+                DerivationId::new(r.dependency),
+            )
+        })
+        .collect())
+}
+
+/// Longest-path dependency layer of every node in `nodes`, over the
+/// `(derivation, dependency)` edges restricted to that set.
+///
+/// Layer 0 is a node nothing in the set depends on - an entry point, or the
+/// root of a closure-scoped view. Every other node sits one layer below its
+/// deepest dependent, so a derivation always ranks strictly above every
+/// derivation it needs, and nodes sharing a layer are genuine siblings that a
+/// caller can order however it likes. Edges to or from outside `nodes` are
+/// ignored, so a scoped subgraph layers relative to its own root.
+pub fn dependency_layers(
+    nodes: &HashSet<DerivationId>,
+    edges: &[(DerivationId, DerivationId)],
+) -> HashMap<DerivationId, u32> {
+    let mut dependencies: HashMap<DerivationId, Vec<DerivationId>> = HashMap::new();
+    let mut pending_dependents: HashMap<DerivationId, usize> = HashMap::new();
+    for (derivation, dependency) in edges {
+        if !nodes.contains(derivation) || !nodes.contains(dependency) {
+            continue;
+        }
+        dependencies
+            .entry(*derivation)
+            .or_default()
+            .push(*dependency);
+        *pending_dependents.entry(*dependency).or_default() += 1;
+    }
+
+    let mut layers: HashMap<DerivationId, u32> = nodes.iter().map(|n| (*n, 0)).collect();
+    let mut frontier: VecDeque<DerivationId> = nodes
+        .iter()
+        .filter(|n| !pending_dependents.contains_key(n))
+        .copied()
+        .collect();
+
+    while let Some(derivation) = frontier.pop_front() {
+        let layer = layers.get(&derivation).copied().unwrap_or(0);
+        for dependency in dependencies.get(&derivation).into_iter().flatten() {
+            let deepest = layers.entry(*dependency).or_default();
+            *deepest = (*deepest).max(layer + 1);
+            let remaining = pending_dependents.entry(*dependency).or_default();
+            *remaining = remaining.saturating_sub(1);
+            if *remaining == 0 {
+                frontier.push_back(*dependency);
+            }
+        }
+    }
+
+    layers
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -70,6 +159,91 @@ mod tests {
             derivation,
             dependency: derivation,
         }
+    }
+
+    fn layers(
+        nodes: &[DerivationId],
+        edges: &[(DerivationId, DerivationId)],
+    ) -> HashMap<DerivationId, u32> {
+        dependency_layers(&nodes.iter().copied().collect(), edges)
+    }
+
+    /// The build nothing else needs is the top of the list, and each dependency
+    /// sits exactly one layer below the build that pulls it in.
+    #[test]
+    fn root_is_layer_zero_and_dependencies_descend() {
+        let (root, mid, leaf) = (
+            DerivationId::now_v7(),
+            DerivationId::now_v7(),
+            DerivationId::now_v7(),
+        );
+
+        let out = layers(&[root, mid, leaf], &[(root, mid), (mid, leaf)]);
+
+        assert_eq!(out[&root], 0);
+        assert_eq!(out[&mid], 1);
+        assert_eq!(out[&leaf], 2);
+    }
+
+    /// A diamond shares its sink between two paths of different length. The
+    /// longest one wins, so the sink never ranks above the dependent that needs
+    /// it - the whole point of layering rather than a shortest-path BFS.
+    #[test]
+    fn diamond_takes_the_longest_path() {
+        let (root, short, long_a, sink) = (
+            DerivationId::now_v7(),
+            DerivationId::now_v7(),
+            DerivationId::now_v7(),
+            DerivationId::now_v7(),
+        );
+
+        let out = layers(
+            &[root, short, long_a, sink],
+            &[(root, sink), (root, short), (short, long_a), (long_a, sink)],
+        );
+
+        assert_eq!(out[&sink], 3);
+    }
+
+    /// Several entry points in one evaluation each start their own layer 0.
+    #[test]
+    fn every_undepended_node_starts_at_zero() {
+        let (a, b, shared) = (
+            DerivationId::now_v7(),
+            DerivationId::now_v7(),
+            DerivationId::now_v7(),
+        );
+
+        let out = layers(&[a, b, shared], &[(a, shared), (b, shared)]);
+
+        assert_eq!((out[&a], out[&b], out[&shared]), (0, 0, 1));
+    }
+
+    /// A closure-scoped view layers relative to its own root: edges reaching
+    /// derivations outside the set carry no weight.
+    #[test]
+    fn edges_outside_the_node_set_are_ignored() {
+        let (outside, root, dep) = (
+            DerivationId::now_v7(),
+            DerivationId::now_v7(),
+            DerivationId::now_v7(),
+        );
+
+        let out = layers(
+            &[root, dep],
+            &[(outside, root), (root, dep), (dep, outside)],
+        );
+
+        assert_eq!((out.len(), out[&root], out[&dep]), (2, 0, 1));
+    }
+
+    /// A derivation with no edges at all still gets a layer, so the sort key is
+    /// total over the evaluation's builds.
+    #[test]
+    fn isolated_nodes_are_layer_zero() {
+        let lonely = DerivationId::now_v7();
+
+        assert_eq!(layers(&[lonely], &[])[&lonely], 0);
     }
 
     /// A derivation nothing depends on still reports itself, so callers can

--- a/backend/gradient-web/src/endpoints/caches/nar.rs
+++ b/backend/gradient-web/src/endpoints/caches/nar.rs
@@ -7,7 +7,6 @@
 use super::helpers::{CacheContext, cache_client_ip};
 use crate::client_ip::OptionalPeer;
 use crate::error::{WebError, WebResult};
-use crate::helpers::OptionExt;
 use axum::body::Body;
 use axum::extract::{Path, RawQuery, State};
 use axum::http::{HeaderMap, HeaderValue, header};
@@ -61,37 +60,65 @@ pub async fn upstream_nar(
     let client_ip = cache_client_ip(&state, &headers, peer);
     let ctx = CacheContext::load(&state, &headers, client_ip, cache_name).await?;
 
-    let upstream = ECacheUpstream::find_by_id(upstream_id)
+    let upstreams = ECacheUpstream::find()
         .filter(CCacheUpstream::Cache.eq(ctx.cache.id))
-        .one(&state.web_db)
-        .await?
-        .or_not_found("Upstream")?;
+        .all(&state.web_db)
+        .await?;
 
-    let base_url = upstream
-        .url
-        .ok_or_else(|| WebError::bad_request("Not an external upstream"))?;
-
-    let nar_url = build_upstream_nar_url(&base_url, &path, query.as_deref());
-    let resp = gradient_util::http::download_client()
-        .get(&nar_url)
-        .send()
-        .await
-        .map_err(|e| WebError::internal(format!("Upstream request failed: {}", e)))?;
-
-    if !resp.status().is_success() {
-        return Err(WebError::not_found("NAR in upstream"));
+    let bases = upstream_bases(&upstreams, upstream_id);
+    if bases.is_empty() {
+        return Err(WebError::not_found("Upstream"));
     }
 
-    let mut builder = Response::builder().header(
-        header::CONTENT_TYPE,
-        HeaderValue::from_static("application/x-nix-nar"),
-    );
-    if let Some(len) = resp.content_length() {
-        builder = builder.header(header::CONTENT_LENGTH, len);
+    let client = gradient_util::http::download_client();
+    for base in bases {
+        let nar_url = build_upstream_nar_url(&base, &path, query.as_deref());
+        let Ok(resp) = client.get(&nar_url).send().await else {
+            continue;
+        };
+        if !resp.status().is_success() {
+            continue;
+        }
+
+        let mut builder = Response::builder().header(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/x-nix-nar"),
+        );
+        if let Some(len) = resp.content_length() {
+            builder = builder.header(header::CONTENT_LENGTH, len);
+        }
+        return builder
+            .body(Body::from_stream(resp.bytes_stream()))
+            .map_err(|e| WebError::internal(format!("Failed to build response: {}", e)));
     }
-    builder
-        .body(Body::from_stream(resp.bytes_stream()))
-        .map_err(|e| WebError::internal(format!("Failed to build response: {}", e)))
+
+    Err(WebError::not_found("NAR in upstream"))
+}
+
+/// Which upstreams to try for a proxied NAR, best first.
+///
+/// The URL names an upstream by row id, but that row is configuration: removing
+/// an upstream would otherwise permanently 404 every narinfo already handed out
+/// that names it, because a client caches narinfo and never refetches it. The
+/// NAR path itself is content-addressed - the filename is a file hash - so any
+/// upstream of this cache that serves that path serves the same bytes. Try the
+/// named one first, then the rest, and only give up when none of them has it.
+fn upstream_bases(upstreams: &[MCacheUpstream], named: Uuid) -> Vec<String> {
+    let mut bases: Vec<String> = Vec::with_capacity(upstreams.len());
+    let named_first = upstreams
+        .iter()
+        .filter(|u| u.id.into_inner() == named)
+        .chain(upstreams.iter().filter(|u| u.id.into_inner() != named));
+
+    for upstream in named_first {
+        let Some(url) = upstream.url.as_deref() else {
+            continue;
+        };
+        if !bases.iter().any(|b| b == url) {
+            bases.push(url.to_owned());
+        }
+    }
+    bases
 }
 
 pub(crate) async fn resolve_effective_hash_db<C: ConnectionTrait>(
@@ -176,6 +203,76 @@ fn build_upstream_nar_url(base_url: &str, path: &str, query: Option<&str>) -> St
 mod tests {
     use super::*;
     use sea_orm::{DatabaseBackend, MockDatabase};
+
+    fn upstream_row(id: u128, url: Option<&str>) -> MCacheUpstream {
+        MCacheUpstream {
+            id: gradient_types::ids::CacheUpstreamId::new(uuid::Uuid::from_u128(id)),
+            url: url.map(str::to_owned),
+            ..Default::default()
+        }
+    }
+
+    /// The named upstream is still the right first guess: it is the one whose
+    /// layout the narinfo was written against.
+    #[test]
+    fn the_named_upstream_is_tried_first() {
+        let rows = vec![
+            upstream_row(1, Some("https://a.example")),
+            upstream_row(2, Some("https://b.example")),
+        ];
+
+        let bases = upstream_bases(&rows, uuid::Uuid::from_u128(2));
+
+        assert_eq!(bases, vec!["https://b.example", "https://a.example"]);
+    }
+
+    /// The case that broke a real substitution: the upstream row named in an
+    /// already-issued narinfo was deleted. A client caches narinfo and never
+    /// refetches, so 404ing here strands that path forever - the remaining
+    /// upstreams have to be tried.
+    #[test]
+    fn a_deleted_upstream_falls_back_to_the_rest() {
+        let rows = vec![
+            upstream_row(1, Some("https://a.example")),
+            upstream_row(2, Some("https://b.example")),
+        ];
+
+        let bases = upstream_bases(&rows, uuid::Uuid::from_u128(99));
+
+        assert_eq!(bases, vec!["https://a.example", "https://b.example"]);
+    }
+
+    /// An upstream that is another Gradient cache rather than an external URL
+    /// has nothing to proxy to; it must be skipped, not turned into an error
+    /// that hides the upstreams which would have served the path.
+    #[test]
+    fn upstreams_without_a_url_are_skipped() {
+        let rows = vec![
+            upstream_row(1, None),
+            upstream_row(2, Some("https://b.example")),
+        ];
+
+        assert_eq!(
+            upstream_bases(&rows, uuid::Uuid::from_u128(1)),
+            vec!["https://b.example"]
+        );
+        assert!(upstream_bases(&[upstream_row(1, None)], uuid::Uuid::from_u128(1)).is_empty());
+    }
+
+    /// The named upstream also appears in the "rest", so without dedup every
+    /// fallback would re-fetch it.
+    #[test]
+    fn the_named_upstream_is_not_tried_twice() {
+        let rows = vec![
+            upstream_row(1, Some("https://a.example")),
+            upstream_row(2, Some("https://a.example")),
+        ];
+
+        assert_eq!(
+            upstream_bases(&rows, uuid::Uuid::from_u128(1)),
+            vec!["https://a.example"]
+        );
+    }
 
     // Placeholder file hash (nix32 52-char) as it appears in a narinfo URL.
     const FILE_HASH_NIX32: &str = "0mdqa9w1p6cmli6976v4wi0sw9r4p5prkj7lzfd1877wk11c9c73";

--- a/backend/gradient-web/src/endpoints/caches/narinfo.rs
+++ b/backend/gradient-web/src/endpoints/caches/narinfo.rs
@@ -11,8 +11,10 @@ use axum::extract::{Path, Query, State};
 use axum::http::{HeaderMap, HeaderValue, header};
 use axum::response::{IntoResponse, Response};
 use gradient_core::ServerState;
-use gradient_sources::{get_hash_from_url, verify_narinfo_signature};
+use gradient_core::upstream::UpstreamProbe;
+use gradient_sources::get_hash_from_url;
 use gradient_types::*;
+use gradient_util::http;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use std::sync::Arc;
 use tracing::warn;
@@ -154,63 +156,79 @@ pub async fn path(
     Err(WebError::not_found("Path"))
 }
 
+/// Point the narinfo's `URL:` at our own proxy endpoint, so a client fetching
+/// the NAR comes back through us rather than straight to the upstream.
+fn rewrite_nar_url(body: &str, upstream: CacheUpstreamId) -> String {
+    body.lines()
+        .map(|line| {
+            if let Some(nar_path) = line.strip_prefix("URL: ") {
+                format!("URL: nar/upstream/{}/{}", upstream, nar_path.trim())
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n"
+}
+
+/// The narinfo for a path we do not hold, from whichever upstream has it.
+///
+/// Probing is concurrent and bounded, and an upstream that stops answering is
+/// taken out of rotation: a cache must answer a miss quickly, and serialising
+/// this meant one unreachable upstream cost every miss the full client timeout -
+/// long enough that a substituter's own stall detector fired first.
 async fn fetch_from_upstream(
     state: &Arc<ServerState>,
     cache: &MCache,
     path_hash: &str,
 ) -> Option<String> {
-    let upstreams = ECacheUpstream::find()
+    let upstreams: Vec<UpstreamProbe> = ECacheUpstream::find()
         .filter(CCacheUpstream::Cache.eq(cache.id))
         .all(&state.web_db)
         .await
-        .unwrap_or_default();
-
-    let http_client = gradient_util::http::download_client();
-    for upstream in upstreams {
-        let Some(base_url) = upstream.url.as_deref() else {
-            continue;
-        };
-        let Some(public_key) = upstream.public_key.as_deref() else {
-            warn!(upstream = %upstream.id, "upstream missing public_key; skipping");
-            continue;
-        };
-        let narinfo_url = format!("{}/{}.narinfo", base_url.trim_end_matches('/'), path_hash);
-        let Ok(resp) = http_client.get(&narinfo_url).send().await else {
-            continue;
-        };
-        if !resp.status().is_success() {
-            continue;
-        }
-        let Ok(body) = resp.text().await else {
-            continue;
-        };
-
-        // Only forward narinfos whose Sig matches the upstream's configured
-        // trusted public key. Unsigned / wrong-key / tampered narinfos are
-        // dropped and we fall through to the next upstream (or 404).
-        if !verify_narinfo_signature(public_key, &body) {
-            warn!(
-                upstream = %upstream.id,
-                path_hash,
-                "upstream narinfo Sig did not verify against configured public_key; dropping"
-            );
-            continue;
-        }
-
-        // Rewrite the URL: field to proxy through our upstream_nar endpoint.
-        let rewritten = body
-            .lines()
-            .map(|line| {
-                if let Some(nar_path) = line.strip_prefix("URL: ") {
-                    format!("URL: nar/upstream/{}/{}", upstream.id, nar_path.trim())
-                } else {
-                    line.to_string()
-                }
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|upstream| {
+            let url = upstream.url?;
+            let Some(public_key) = upstream.public_key else {
+                warn!(upstream = %upstream.id, "upstream missing public_key; skipping");
+                return None;
+            };
+            Some(UpstreamProbe {
+                id: upstream.id,
+                url,
+                public_key,
             })
-            .collect::<Vec<_>>()
-            .join("\n")
-            + "\n";
-        return Some(rewritten);
+        })
+        .collect();
+
+    let found =
+        gradient_core::upstream::fetch_narinfo_body(http::download_client(), &upstreams, path_hash)
+            .await?;
+
+    Some(rewrite_nar_url(&found.body, found.upstream))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rewrite_nar_url;
+    use gradient_types::ids::CacheUpstreamId;
+
+    /// A client must never be handed the upstream's own NAR URL: it would fetch
+    /// straight from there, bypassing this cache entirely.
+    #[test]
+    fn the_nar_url_is_rewritten_through_our_proxy() {
+        let id = CacheUpstreamId::new(uuid::Uuid::from_u128(7));
+        let body = "StorePath: /nix/store/aaa-foo\nURL: nar/1abc.nar.xz\nNarSize: 12\n";
+
+        let out = rewrite_nar_url(body, id);
+
+        assert!(
+            out.contains(&format!("URL: nar/upstream/{id}/nar/1abc.nar.xz")),
+            "{out}"
+        );
+        assert!(out.contains("StorePath: /nix/store/aaa-foo"));
+        assert!(out.ends_with('\n'));
     }
-    None
 }

--- a/backend/gradient-web/src/endpoints/caches/narinfo.rs
+++ b/backend/gradient-web/src/endpoints/caches/narinfo.rs
@@ -12,7 +12,7 @@ use axum::http::{HeaderMap, HeaderValue, header};
 use axum::response::{IntoResponse, Response};
 use gradient_core::ServerState;
 use gradient_core::upstream::UpstreamProbe;
-use gradient_sources::get_hash_from_url;
+use gradient_sources::{CacheSigner, get_hash_from_url};
 use gradient_types::*;
 use gradient_util::http;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
@@ -156,6 +156,55 @@ pub async fn path(
     Err(WebError::not_found("Path"))
 }
 
+/// One `Key: value` line of a narinfo. Matches the whole key, so `StorePath`
+/// never picks up a longer field that starts with it.
+fn narinfo_field<'a>(body: &'a str, key: &str) -> Option<&'a str> {
+    body.lines().find_map(|line| {
+        line.strip_prefix(key)
+            .and_then(|rest| rest.strip_prefix(':'))
+            .map(str::trim)
+    })
+}
+
+/// Add this cache's own signature to a narinfo we are proxying.
+///
+/// Everything we serve is then verifiable with the Gradient cache's key alone,
+/// so a client needs to trust one key rather than the key of every cache we
+/// happen to proxy. The upstream's own `Sig` lines are kept: they stay valid
+/// (a signature covers the fingerprint, not the rewritten `URL:`), and anyone
+/// who does trust that upstream can still check it independently.
+///
+/// Only ever called on a body whose upstream signature already verified -
+/// signing an unverified narinfo would launder whatever an upstream said under
+/// our own name. Returns `None` if the fingerprint fields cannot be read, so a
+/// body we do not fully understand is passed through untouched rather than
+/// signed over guessed values.
+fn resign_narinfo(
+    body: &str,
+    sign: impl FnOnce(&str, &str, u64, &[String]) -> String,
+) -> Option<String> {
+    let store_path = narinfo_field(body, "StorePath")?;
+    let nar_hash = narinfo_field(body, "NarHash")?;
+    let nar_size: u64 = narinfo_field(body, "NarSize")?.parse().ok()?;
+    let references: Vec<String> = narinfo_field(body, "References")
+        .unwrap_or("")
+        .split_whitespace()
+        .map(str::to_owned)
+        .collect();
+
+    let token = sign(store_path, nar_hash, nar_size, &references);
+
+    let mut out = String::with_capacity(body.len() + token.len() + 8);
+    for line in body.lines() {
+        out.push_str(line);
+        out.push('\n');
+    }
+    out.push_str("Sig: ");
+    out.push_str(&token);
+    out.push('\n');
+    Some(out)
+}
+
 /// Point the narinfo's `URL:` at our own proxy endpoint, so a client fetching
 /// the NAR comes back through us rather than straight to the upstream.
 fn rewrite_nar_url(body: &str, upstream: CacheUpstreamId) -> String {
@@ -207,13 +256,97 @@ async fn fetch_from_upstream(
         gradient_core::upstream::fetch_narinfo_body(http::download_client(), &upstreams, path_hash)
             .await?;
 
-    Some(rewrite_nar_url(&found.body, found.upstream))
+    let body = rewrite_nar_url(&found.body, found.upstream);
+
+    // Built only once we actually have something to serve, so a miss never pays
+    // for reading and decrypting the cache's key.
+    let signer = match CacheSigner::from_cache(
+        &state.config.secrets.crypt_secret_file,
+        cache,
+        &state.config.server.serve_url,
+    ) {
+        Ok(signer) => signer,
+        Err(e) => {
+            warn!(cache = %cache.name, error = %e, "cannot re-sign a proxied narinfo; serving it with the upstream's signature only");
+            return Some(body);
+        }
+    };
+
+    let signed = resign_narinfo(&body, |store_path, nar_hash, nar_size, references| {
+        signer.sign_narinfo(store_path, nar_hash, nar_size, references)
+    });
+    Some(signed.unwrap_or(body))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::rewrite_nar_url;
+    use super::{narinfo_field, resign_narinfo, rewrite_nar_url};
     use gradient_types::ids::CacheUpstreamId;
+
+    const UPSTREAM: &str = "StorePath: /nix/store/k3l5ywcvzijjjx44b9xrjbhr116sal9i-plotly-6.8.0\n\
+URL: nar/0z7np.nar.zst\n\
+Compression: zstd\n\
+NarHash: sha256:1lld5kb21xphcav6fd553as8fr4yqiz6mdfhac5mjcqpqzdrx8z8\n\
+NarSize: 85514096\n\
+References: sdd13vm3yf8fwhhasc5r0fm2pkzq9cmx-narwhals-2.23.0 9ipfvwnqp1q8ijnmi5sxvlx9r8w34lw3-bash-5.3p15\n\
+Sig: cache.nixos.org-1:AAAA\n";
+
+    /// The point of re-signing: a client that trusts only this cache's key can
+    /// use a path we proxied, without being handed every upstream's key too.
+    #[test]
+    fn a_proxied_narinfo_gains_our_own_signature() {
+        let out = resign_narinfo(UPSTREAM, |_, _, _, _| "gradient.test-main:OURS".into())
+            .expect("re-signed");
+
+        assert!(out.contains("Sig: gradient.test-main:OURS"), "{out}");
+        assert!(
+            out.contains("Sig: cache.nixos.org-1:AAAA"),
+            "the upstream's own signature stays, so anyone trusting it can still verify: {out}"
+        );
+        assert!(out.ends_with('\n'));
+    }
+
+    /// The signature covers the fingerprint, so these four inputs are the whole
+    /// correctness of it: a wrong field silently produces a narinfo nix rejects.
+    #[test]
+    fn the_signature_covers_the_paths_own_fingerprint_fields() {
+        let seen = std::cell::RefCell::new(None);
+        resign_narinfo(UPSTREAM, |sp, nh, ns, refs| {
+            *seen.borrow_mut() = Some((sp.to_owned(), nh.to_owned(), ns, refs.to_vec()));
+            "k:v".into()
+        })
+        .expect("re-signed");
+
+        let (store_path, nar_hash, nar_size, refs) = seen.into_inner().expect("signer was called");
+        assert_eq!(
+            store_path,
+            "/nix/store/k3l5ywcvzijjjx44b9xrjbhr116sal9i-plotly-6.8.0"
+        );
+        assert_eq!(
+            nar_hash,
+            "sha256:1lld5kb21xphcav6fd553as8fr4yqiz6mdfhac5mjcqpqzdrx8z8"
+        );
+        assert_eq!(nar_size, 85514096);
+        assert_eq!(refs.len(), 2, "{refs:?}");
+        assert!(
+            refs.iter().all(|r| !r.starts_with("/nix/store/")),
+            "references stay bare; the fingerprint adds the prefix and sorts: {refs:?}"
+        );
+    }
+
+    /// A body we cannot read the fingerprint out of must be passed through
+    /// unsigned rather than signed over guessed values.
+    #[test]
+    fn an_unparseable_narinfo_is_not_signed() {
+        assert!(resign_narinfo("Compression: zstd\n", |_, _, _, _| "k:v".into()).is_none());
+    }
+
+    #[test]
+    fn a_field_lookup_does_not_match_a_longer_key() {
+        assert_eq!(narinfo_field(UPSTREAM, "NarSize"), Some("85514096"));
+        assert_eq!(narinfo_field("StorePathX: y\n", "StorePath"), None);
+        assert_eq!(narinfo_field(UPSTREAM, "CA"), None);
+    }
 
     /// A client must never be handed the upstream's own NAR URL: it would fetch
     /// straight from there, bypassing this cache entirely.

--- a/backend/gradient-web/src/endpoints/evals/query.rs
+++ b/backend/gradient-web/src/endpoints/evals/query.rs
@@ -164,13 +164,16 @@ pub async fn get_evaluation(
 /// tens of thousands of builds (issue #237).
 const IS_IN_CHUNK: usize = 10_000;
 
-fn status_rank(status: gradient_entity::build::BuildStatus) -> u32 {
+/// Display rank of a build status, matching the sidebar sections in
+/// `evaluation-log.component.ts::buildGroups`: what is running or broken stays
+/// above what is finished.
+fn status_rank(status: BuildStatus) -> u32 {
     use gradient_entity::build::BuildStatus::*;
     match status {
         Building => 0,
-        Created | Queued => 1,
-        FailedPermanent | FailedTimeout | FailedTransient => 2,
-        Aborted | DependencyFailed => 3,
+        FailedPermanent | FailedTimeout | FailedTransient | DependencyFailed => 1,
+        Aborted => 2,
+        Created | Queued => 3,
         Completed | Substituted => 4,
     }
 }
@@ -250,32 +253,47 @@ pub async fn get_evaluation_builds(
         }
     }
 
-    // Sort by status (Building -> Queued -> Failed -> Aborted/DependencyFailed ->
-    // Completed/Substituted), then by derivation name. Mirrors the client-side
-    // ordering in `evaluation-log.component.ts::buildStatusOrder`.
-    let mut sorted: Vec<(u32, &str, &MBuildJob, BuildStatus)> = jobs
+    // #614: within a status, order by dependency layer and then by derivation
+    // name, so each section reads like the dependency graph page - the entry
+    // point on top, every build above the builds it needs. Layers are taken
+    // over the jobs that survived the scope filter, so a scoped view layers
+    // relative to its own root.
+    let layers = gradient_db::dependency_layers(
+        &drv_ids.iter().copied().collect(),
+        &gradient_db::eval_dependency_edges(&state.web_db, evaluation.id).await?,
+    );
+
+    let mut sorted: Vec<(u32, u32, &str, &MBuildJob, BuildStatus)> = jobs
         .iter()
         .filter_map(|j| {
             let drv = derivations.get(&j.derivation)?;
             let status = anchors.get(&j.derivation_build)?.status.for_api();
-            Some((status_rank(status), drv.name.as_str(), j, status))
+            let layer = layers.get(&j.derivation).copied().unwrap_or(0);
+            Some((status_rank(status), layer, drv.name.as_str(), j, status))
         })
         .collect();
-    sorted.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(b.1)));
+    sorted.sort_by(|a, b| {
+        a.0.cmp(&b.0)
+            .then_with(|| a.1.cmp(&b.1))
+            .then_with(|| a.2.cmp(b.2))
+    });
 
     let total = sorted.len();
-    let active_count = sorted.iter().filter(|(rank, _, _, _)| *rank < 4).count();
+    let active_count = sorted
+        .iter()
+        .filter(|(_, _, _, _, status)| !status.is_terminal_success())
+        .count();
 
     let offset = query.offset.unwrap_or(0).min(total);
     let limit = query.limit.unwrap_or(total.saturating_sub(offset));
-    let page_slice: Vec<&(u32, &str, &MBuildJob, BuildStatus)> =
+    let page_slice: Vec<&(u32, u32, &str, &MBuildJob, BuildStatus)> =
         sorted.iter().skip(offset).take(limit).collect();
 
     // Hydrate `has_artefacts` only for the page. Bounded by `limit`, so the
     // `IN` clause is safe regardless of evaluation size.
     let page_drv_ids: Vec<DerivationId> = page_slice
         .iter()
-        .map(|(_, _, j, _)| j.derivation)
+        .map(|(_, _, _, j, _)| j.derivation)
         .collect::<HashSet<_>>()
         .into_iter()
         .collect();
@@ -305,12 +323,12 @@ pub async fn get_evaluation_builds(
     // per-build query here is an N+1 that made large build lists take ~10s (#391).
     let page_anchor_ids: Vec<DerivationBuildId> = page_slice
         .iter()
-        .map(|(_, _, j, _)| j.derivation_build)
+        .map(|(_, _, _, j, _)| j.derivation_build)
         .collect();
     let attempts = gradient_db::latest_attempts(&state.web_db, &page_anchor_ids).await?;
 
     let mut page = Vec::with_capacity(page_slice.len());
-    for (_, _, j, status) in &page_slice {
+    for (_, layer, _, j, status) in &page_slice {
         let drv = derivations
             .get(&j.derivation)
             .expect("derivation hydrated above");
@@ -328,6 +346,7 @@ pub async fn get_evaluation_builds(
             has_artefacts: has_artefacts.contains(&j.derivation),
             updated_at: anchor.updated_at,
             build_time_ms,
+            depth: *layer,
         });
     }
 

--- a/backend/gradient-web/src/endpoints/evals/types.rs
+++ b/backend/gradient-web/src/endpoints/evals/types.rs
@@ -22,6 +22,10 @@ pub struct BuildItem {
     pub has_artefacts: bool,
     pub updated_at: chrono::NaiveDateTime,
     pub build_time_ms: Option<i64>,
+    /// Dependency layer within the evaluation (0 = a build nothing else in the
+    /// list depends on). Secondary sort key after build status, and the key the
+    /// client re-sorts locally added builds by.
+    pub depth: u32,
 }
 
 #[derive(Serialize, Debug)]

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2211,7 +2211,7 @@ dependencies = [
 [[package]]
 name = "nix-bindings"
 version = "0.2347.8"
-source = "git+https://github.com/DerDennisOP/nix-bindings?branch=feat%2Feval-metrics-stats#593e0cb6b996003278114d924799a90452197540"
+source = "git+https://github.com/DerDennisOP/nix-bindings?branch=feat%2Feval-metrics-stats#1f9819e05a2911919959f7fd1501dddc9c77dee0"
 dependencies = [
  "nix-bindings-sys",
 ]
@@ -2219,7 +2219,7 @@ dependencies = [
 [[package]]
 name = "nix-bindings-sys"
 version = "0.2347.8"
-source = "git+https://github.com/DerDennisOP/nix-bindings?branch=feat%2Feval-metrics-stats#593e0cb6b996003278114d924799a90452197540"
+source = "git+https://github.com/DerDennisOP/nix-bindings?branch=feat%2Feval-metrics-stats#1f9819e05a2911919959f7fd1501dddc9c77dee0"
 dependencies = [
  "bindgen",
  "cc",
@@ -3617,7 +3617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/docs/gradient-api.yaml
+++ b/docs/gradient-api.yaml
@@ -3207,7 +3207,11 @@ paths:
             evaluation.
       responses:
         '200':
-          description: Paginated build list
+          description: |-
+            Paginated build list, ordered by build status (running, then failed,
+            aborted, queued, finished), then by dependency layer (`depth`), then
+            by derivation name within a layer - so within one status the entry
+            point heads the list and every build precedes the builds it needs.
           content:
             application/json:
               schema:
@@ -9420,7 +9424,7 @@ components:
 
     BuildItem:
       type: object
-      required: [id, name, status, updated_at]
+      required: [id, name, status, updated_at, depth]
       properties:
         id:
           type: string
@@ -9439,6 +9443,15 @@ components:
           type: integer
           nullable: true
           description: Measured build duration in milliseconds (null if not yet recorded)
+        depth:
+          type: integer
+          minimum: 0
+          description: |-
+            Dependency layer within the returned set: `0` for a build nothing
+            else in it depends on (an entry point, or the `scope` root), and one
+            more than the deepest build that needs this one otherwise. Secondary
+            sort key after build status, so within one status a build always
+            precedes everything it depends on.
 
     ArtefactTree:
       type: object

--- a/docs/src/scheduler.md
+++ b/docs/src/scheduler.md
@@ -386,6 +386,12 @@ in the separate retention loop instead.
 
 #### Upstream substitutability
 
+A proxied NAR URL names its upstream by row id, but an upstream is configuration
+that can be removed. Since a client caches narinfo and never refetches it, giving
+up when that row is gone would strand the path forever, so the remaining
+upstreams are tried too - the NAR path is content-addressed, so any upstream that
+serves it serves the same bytes.
+
 A narinfo proxied from an upstream is re-signed with the cache's own key before
 it is served, so a client trusts one key - the Gradient cache's - rather than the
 key of every cache it happens to proxy. The upstream's own signature is verified

--- a/docs/src/scheduler.md
+++ b/docs/src/scheduler.md
@@ -386,6 +386,16 @@ in the separate retention loop instead.
 
 #### Upstream substitutability
 
+An upstream that stops answering is taken out of rotation rather than probed
+again on every request. Each probe is bounded at five seconds, and three
+consecutive *transport* failures in a row trip that upstream for a minute, after
+which one request is let through to test it - failing again re-trips it, so a
+cache that is down costs nothing while it stays down and is picked up on its own
+when it returns. A 404 is not a failure: it means the upstream answered and
+simply lacks the path, which is the ordinary case during any large substitution.
+The same health is shared by the worker cache-query path and the cache's own
+narinfo endpoint, so a dead upstream is learned about once.
+
 A derivation is just another build that can be substituted when its output is
 available on a cache, exactly like any other - fixed-output derivations are not
 special-cased. At eval time `resolve_anchors` runs a project-scoped lookup

--- a/docs/src/scheduler.md
+++ b/docs/src/scheduler.md
@@ -386,6 +386,13 @@ in the separate retention loop instead.
 
 #### Upstream substitutability
 
+A narinfo proxied from an upstream is re-signed with the cache's own key before
+it is served, so a client trusts one key - the Gradient cache's - rather than the
+key of every cache it happens to proxy. The upstream's own signature is verified
+first and kept alongside ours: re-signing something unverified would launder it
+under our name, and a signature covers the fingerprint rather than the rewritten
+`URL:`, so the upstream's stays valid for anyone who wants to check it.
+
 An upstream that stops answering is taken out of rotation rather than probed
 again on every request. Each probe is bounded at two seconds, and three
 consecutive *transport* failures in a row trip that upstream for a minute, after

--- a/docs/src/scheduler.md
+++ b/docs/src/scheduler.md
@@ -387,7 +387,7 @@ in the separate retention loop instead.
 #### Upstream substitutability
 
 An upstream that stops answering is taken out of rotation rather than probed
-again on every request. Each probe is bounded at five seconds, and three
+again on every request. Each probe is bounded at two seconds, and three
 consecutive *transport* failures in a row trip that upstream for a minute, after
 which one request is let through to test it - failing again re-trips it, so a
 cache that is down costs nothing while it stays down and is picked up on its own

--- a/docs/src/usage/caches.md
+++ b/docs/src/usage/caches.md
@@ -7,9 +7,14 @@ SPDX-License-Identifier: AGPL-3.0-only
 # Caches
 
 Gradient serves build outputs from per-project binary caches. Each cache
-exposes a substituter URL and a set of trusted public keys that clients add to
-their Nix configuration. The cache detail page renders the exact snippet for a
-given cache.
+exposes a substituter URL and one trusted public key that clients add to their
+Nix configuration. The cache detail page renders the exact snippet for a given
+cache.
+
+That one key is enough even for paths the cache did not build itself: a narinfo
+proxied from an upstream is verified against that upstream's key and then
+re-signed with the cache's own, so nobody using the cache has to configure a key
+for every cache it happens to proxy.
 
 ## Sharing a cache with another project
 

--- a/docs/src/usage/overview.md
+++ b/docs/src/usage/overview.md
@@ -58,6 +58,8 @@ Exclusion patterns must be exact paths - they cannot contain `*` or `#`.
 Click **Start Evaluation** on the task page. Gradient clones the repo, evaluates each wildcard match, and dispatches the resulting derivations to connected workers.
 
 The evaluation log page shows per-build status, combined ANSI build output, and an **Abort** button.
+Builds are grouped by status, and within a group listed in dependency order - the entry point first,
+then each dependency layer sorted by name - so a build appears above the builds it needs.
 
 Evaluations can also be triggered automatically:
 

--- a/flake.lock
+++ b/flake.lock
@@ -15,43 +15,6 @@
         "type": "github"
       }
     },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1767039857,
-        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
-        "owner": "NixOS",
-        "repo": "flake-compat",
-        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1782949081,
-        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -70,67 +33,13 @@
         "type": "github"
       }
     },
-    "git-hooks-nix": {
-      "inputs": {
-        "flake-compat": [
-          "nix"
-        ],
-        "nixpkgs": [
-          "nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1783008725,
-        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "nix": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-parts": "flake-parts",
-        "git-hooks-nix": "git-hooks-nix",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "nixpkgs-23-11": [
-          "nixpkgs"
-        ],
-        "nixpkgs-regression": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1788292079,
-        "narHash": "sha256-ALiHkkmPg52REB7xEl90wgFYJFzjTT2IuEBXiSy89sA=",
-        "owner": "DerDennisOP",
-        "repo": "nix",
-        "rev": "2944a5a4abe344b21e491d041712884c7aa390bc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "DerDennisOP",
-        "ref": "feat/eval-metrics-stats",
-        "repo": "nix",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1788404924,
-        "narHash": "sha256-lhEhY8X5EgkQ/eg6IFz4cc8jRuSYSvnxx1al7d1dvZ0=",
+        "lastModified": 1788752844,
+        "narHash": "sha256-VaWGJ6+cIYN2erfSecbRV+4ljI185Ty2wUrXyvQbgOw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0968519e14f7aa7d3e9b389682bd74d2b51c8ce8",
+        "rev": "dc5d91f840324650bac8c379428c7037a416959a",
         "type": "github"
       },
       "original": {
@@ -144,7 +53,6 @@
       "inputs": {
         "crane": "crane",
         "flake-utils": "flake-utils",
-        "nix": "nix",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -11,17 +11,9 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     crane.url = "github:ipetkov/crane";
-    nix = {
-      url = "github:DerDennisOP/nix/feat/eval-metrics-stats";
-      inputs = {
-        nixpkgs.follows = "nixpkgs";
-        nixpkgs-23-11.follows = "nixpkgs";
-        nixpkgs-regression.follows = "nixpkgs";
-      };
-    };
   };
 
-  outputs = { self, nixpkgs, flake-utils, crane, nix, ... }@inputs: flake-utils.lib.eachDefaultSystem (system: let
+  outputs = { self, nixpkgs, flake-utils, crane, ... }@inputs: flake-utils.lib.eachDefaultSystem (system: let
     pkgs = import nixpkgs {
       inherit system;
       overlays = map (v: self.overlays.${v}) (builtins.attrNames self.overlays);
@@ -120,7 +112,10 @@
   }) // {
     overlays = {
       nix = final: prev: {
-        gradient-nix = nix.packages.${final.stdenv.hostPlatform.system}.nix.overrideScope (finalScope: prevScope: { withAWS = false; });
+        # Nixpkgs' latest Nix, carrying the eval-metrics and eval-cache C API that nix-bindings links against.
+        gradient-nix = ((prev.nixVersions.nixComponents_2_35.appendPatches (
+          map (patch: ./nix/patches/nix + "/${patch}") (builtins.attrNames (builtins.readDir ./nix/patches/nix))
+        )).overrideScope (finalScope: prevScope: { withAWS = false; })).nix-everything;
       };
       gradient = final: prev: { inherit (self.packages.${final.stdenv.hostPlatform.system}) gradient; };
       gradient-frontend = final: prev: { inherit (self.packages.${final.stdenv.hostPlatform.system}) gradient-frontend; };

--- a/frontend/src/app/core/services/evaluations.service.ts
+++ b/frontend/src/app/core/services/evaluations.service.ts
@@ -58,6 +58,7 @@ export interface BuildItem {
   has_artefacts: boolean;
   updated_at: string;
   build_time_ms: number | null;
+  depth: number;         // dependency layer, 0 = nothing in the list depends on it
 }
 
 export interface BuildWithOutputs {

--- a/frontend/src/app/features/caches/cache-detail/cache-detail.component.html
+++ b/frontend/src/app/features/caches/cache-detail/cache-detail.component.html
@@ -103,7 +103,7 @@
     </gr-form-field>
 
     <gr-form-field label="Trusted Public Keys" for="cache-keys">
-      <gr-copy-field id="cache-keys" [value]="allPublicKeys().join(' ') || 'Not available'" />
+      <gr-copy-field id="cache-keys" [value]="trustedPublicKeys().join(' ') || 'Not available'" />
     </gr-form-field>
 
     <gr-form-field label="nix.conf snippet" for="cache-conf">

--- a/frontend/src/app/features/caches/cache-detail/cache-detail.component.spec.ts
+++ b/frontend/src/app/features/caches/cache-detail/cache-detail.component.spec.ts
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Wavelens GmbH <info@wavelens.io>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { of } from 'rxjs';
+import { CacheDetailComponent } from './cache-detail.component';
+import { CachesService } from '@core/services/caches.service';
+
+const OWN_KEY = 'public.gradient.ci-main:74DUi4Ye579gUqzH4ziL9IyiJBlDpMRn9MBN8oNan9M=';
+const UPSTREAM_KEY = 'cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=';
+
+describe('CacheDetailComponent cache usage instructions', () => {
+  function setup() {
+    const caches = {
+      getCache: vi.fn().mockReturnValue(of({ name: 'main', public_key: OWN_KEY, public: true })),
+      getCacheStats: vi.fn().mockReturnValue(of(null)),
+    };
+    TestBed.configureTestingModule({
+      imports: [CacheDetailComponent],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: CachesService, useValue: caches },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { paramMap: convertToParamMap({ cache: 'main' }) } },
+        },
+      ],
+    });
+    // ngOnInit directly rather than detectChanges: rendering pulls in the
+    // metric charts, which is not what these assertions are about.
+    const component = TestBed.createComponent(CacheDetailComponent).componentInstance;
+    component.ngOnInit();
+    return component;
+  }
+
+  // The server re-signs everything it serves, proxied paths included, so this
+  // one key is all a client needs. Listing the upstreams' keys made every user
+  // of the cache configure a key for every cache it happens to proxy.
+  it('trusts only the cache own signing key', () => {
+    const component = setup();
+
+    expect(component.trustedPublicKeys()).toEqual([OWN_KEY]);
+    expect(component.nixConfSnippet()).toContain(OWN_KEY);
+    expect(component.nixConfSnippet()).not.toContain(UPSTREAM_KEY);
+  });
+
+  // A cache whose key has not been generated yet must not render a snippet that
+  // looks copy-pasteable but silently trusts nothing.
+  it('says so when no key is available', () => {
+    const component = setup();
+    component.cache.set(null);
+
+    expect(component.trustedPublicKeys()).toEqual([]);
+    expect(component.nixConfSnippet()).toContain('<unavailable>');
+  });
+});

--- a/frontend/src/app/features/caches/cache-detail/cache-detail.component.ts
+++ b/frontend/src/app/features/caches/cache-detail/cache-detail.component.ts
@@ -7,7 +7,7 @@
 import { Component, OnInit, inject, signal, computed, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
-import { CachesService, CacheStats, CacheMetricPoint, StorageMetricPoint, UpstreamCache } from '@core/services/caches.service';
+import { CachesService, CacheStats, CacheMetricPoint, StorageMetricPoint } from '@core/services/caches.service';
 import {
   BadgeComponent,
   ButtonComponent,
@@ -68,7 +68,6 @@ export class CacheDetailComponent implements OnInit {
   loading = signal(true);
   statsLoading = signal(true);
   cache = signal<Cache | null>(null);
-  upstreams = signal<UpstreamCache[]>([]);
   stats = signal<CacheStats | null>(null);
   activeWindow = signal<Window>('hours');
 
@@ -76,15 +75,12 @@ export class CacheDetailComponent implements OnInit {
     this.activeWindow.set(value as Window);
   }
 
-  externalUpstreamKeys = computed(() =>
-    this.upstreams()
-      .filter(u => u.public_key)
-      .map(u => u.public_key!)
-  );
-
-  allPublicKeys = computed(() => {
+  // Only this cache's own key: the server re-signs everything it serves, paths
+  // proxied from an upstream included, so a client never needs the key of a
+  // cache we happen to proxy.
+  trustedPublicKeys = computed(() => {
     const own = this.cache()?.public_key;
-    return [...(own ? [own] : []), ...this.externalUpstreamKeys()];
+    return own ? [own] : [];
   });
 
   cacheName = '';
@@ -92,7 +88,7 @@ export class CacheDetailComponent implements OnInit {
   serverUrl = '';
 
   nixConfSnippet = computed(() => {
-    const keys = this.allPublicKeys();
+    const keys = this.trustedPublicKeys();
     return `substituters = ${this.cacheUrl}\ntrusted-public-keys = ${keys.length ? keys.join(' ') : '<unavailable>'}`;
   });
 
@@ -149,7 +145,6 @@ export class CacheDetailComponent implements OnInit {
     this.cacheUrl = `${this.serverUrl}/cache/${this.cacheName}`;
     this.loadCache();
     this.loadStats();
-    this.loadUpstreams();
   }
 
   loadCache(): void {
@@ -163,13 +158,6 @@ export class CacheDetailComponent implements OnInit {
         console.error('Failed to load cache:', error);
         this.loading.set(false);
       },
-    });
-  }
-
-  loadUpstreams(): void {
-    this.cachesService.getCacheUpstreams(this.cacheName).subscribe({
-      next: (upstreams) => this.upstreams.set(upstreams),
-      error: () => {},
     });
   }
 

--- a/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.spec.ts
+++ b/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.spec.ts
@@ -11,8 +11,8 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { EvaluationLogComponent } from './evaluation-log.component';
 import { BuildItem } from '@core/services/evaluations.service';
 
-function build(id: string, name: string, status = 'Completed'): BuildItem {
-  return { id, name, status, has_artefacts: false, updated_at: '', build_time_ms: null };
+function build(id: string, name: string, status = 'Completed', depth = 0): BuildItem {
+  return { id, name, status, has_artefacts: false, updated_at: '', build_time_ms: null, depth };
 }
 
 function setup(): { fixture: ComponentFixture<EvaluationLogComponent>; cmp: EvaluationLogComponent } {
@@ -25,6 +25,7 @@ function setup(): { fixture: ComponentFixture<EvaluationLogComponent>; cmp: Eval
 }
 
 type Internals = {
+  sortBuilds: (builds: BuildItem[]) => BuildItem[];
   appendStreamedLines: (lines: string[]) => void;
   loadWindow: (buildId: string, start: number, end: number, mode: 'replace' | 'append' | 'prepend') => Promise<void>;
   convertAnsiToHtml: (text: string) => string;
@@ -95,6 +96,39 @@ describe('EvaluationLogComponent', () => {
 
   // #341: sidebar search filters the build list by name without disturbing the
   // status-sorted indices used for keyboard navigation.
+  // #614: inside a status section the sidebar reads like the dependency graph -
+  // the entry point on top, then each dependency layer, alphabetical within one.
+  describe('build order', () => {
+    it('sorts by dependency layer, then by display name, within a status', () => {
+      const { cmp } = setup();
+      const sorted = (cmp as unknown as Internals).sortBuilds([
+        build('3', 'hash-zlib.drv', 'Completed', 2),
+        build('1', 'hash-app.drv', 'Completed', 0),
+        build('2', 'hash-openssl.drv', 'Completed', 1),
+        build('4', 'hash-acl.drv', 'Completed', 2),
+      ]);
+      expect(sorted.map(b => b.id)).toEqual(['1', '2', '4', '3']);
+    });
+
+    it('keeps status primary: a building dependency stays above a queued dependent', () => {
+      const { cmp } = setup();
+      const sorted = (cmp as unknown as Internals).sortBuilds([
+        build('top', 'hash-app.drv', 'Queued', 0),
+        build('dep', 'hash-openssl.drv', 'Building', 1),
+      ]);
+      expect(sorted.map(b => b.id)).toEqual(['dep', 'top']);
+    });
+
+    it('dedups the same derivation arriving under two ids', () => {
+      const { cmp } = setup();
+      const sorted = (cmp as unknown as Internals).sortBuilds([
+        build('a', 'hash-app.drv', 'Completed', 0),
+        build('b', 'hash-app.drv', 'Completed', 0),
+      ]);
+      expect(sorted.length).toBe(1);
+    });
+  });
+
   describe('sidebar search', () => {
     it('filters grouped builds by name, case-insensitively', () => {
       const { cmp } = setup();

--- a/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.ts
+++ b/frontend/src/app/features/evaluations/evaluation-log/evaluation-log.component.ts
@@ -325,10 +325,15 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
       if (!existing || b.id === selectedId) byKey.set(key, b);
     }
 
+    // The API's order: status, then dependency layer, then name within a layer
+    // (#614), so each section reads like the dependency graph page. Re-applied
+    // rather than taken as given because builds also arrive from live updates
+    // and deep links, out of the paged order.
     return [...byKey.values()].sort((a, b) => {
       const oa = this.buildStatusOrder[this.statusClass(a.status)] ?? 99;
       const ob = this.buildStatusOrder[this.statusClass(b.status)] ?? 99;
       if (oa !== ob) return oa - ob;
+      if (a.depth !== b.depth) return a.depth - b.depth;
       return this.buildDisplayName(a.name).localeCompare(this.buildDisplayName(b.name));
     });
   }
@@ -559,6 +564,9 @@ export class EvaluationLogComponent implements OnInit, OnDestroy {
           has_artefacts: false,
           updated_at: b.updated_at,
           build_time_ms: null,
+          // `?build=` also scopes the list to this build's closure, so it is the
+          // root of everything the API returns.
+          depth: 0,
         };
         this.initialBuildId = null;
         this.builds.update(cur => this.sortBuilds([item, ...cur]));

--- a/nix/patches/nix/0001-libexpr-c-expose-nix_get_derivation-and-nix_value_au.patch
+++ b/nix/patches/nix/0001-libexpr-c-expose-nix_get_derivation-and-nix_value_au.patch
@@ -1,0 +1,179 @@
+From e65765821a584ade9151f573e95eec6ec42bdedb Mon Sep 17 00:00:00 2001
+From: NotAShelf <raf@notashelf.dev>
+Date: Fri, 8 May 2026 11:58:49 +0300
+Subject: [PATCH] libexpr-c: expose `nix_get_derivation` and
+ `nix_value_auto_call_function`
+
+These encapsulate internal evaluator machinery that cannot be replicated
+through the existing attrset/value access API, which makes them the bare
+minimum necessary surface for consuemers wanting to to traverse and
+inspect derivation trees.
+
+Signed-off-by: NotAShelf <raf@notashelf.dev>
+Change-Id: I1f6aa9222083068300de22e3f6aad3ac6a6a6964
+---
+ src/libexpr-c/meson.build     |  1 +
+ src/libexpr-c/nix_api_eval.cc | 85 +++++++++++++++++++++++++++++++++++
+ src/libexpr-c/nix_api_expr.h  | 45 +++++++++++++++++++
+ 3 files changed, 131 insertions(+)
+ create mode 100644 src/libexpr-c/nix_api_eval.cc
+
+diff --git a/src/libexpr-c/meson.build b/src/libexpr-c/meson.build
+index 5c6dc6d66..fb3a17ff2 100644
+--- a/src/libexpr-c/meson.build
++++ b/src/libexpr-c/meson.build
+@@ -30,6 +30,7 @@ subdir('nix-meson-build-support/subprojects')
+ subdir('nix-meson-build-support/common')
+ 
+ sources = files(
++  'nix_api_eval.cc',
+   'nix_api_expr.cc',
+   'nix_api_external.cc',
+   'nix_api_value.cc',
+diff --git a/src/libexpr-c/nix_api_eval.cc b/src/libexpr-c/nix_api_eval.cc
+new file mode 100644
+index 000000000..6a451c102
+--- /dev/null
++++ b/src/libexpr-c/nix_api_eval.cc
+@@ -0,0 +1,85 @@
++#include <stdexcept>
++
++#include "nix/expr/eval.hh"
++#include "nix/expr/get-drvs.hh"
++
++#include "nix_api_expr.h"
++#include "nix_api_expr_internal.h"
++#include "nix_api_store.h"
++#include "nix_api_store_internal.h"
++#include "nix_api_util.h"
++#include "nix_api_util_internal.h"
++
++static const nix::Value & value_in(const nix_value * value)
++{
++    if (!value) {
++        throw std::runtime_error("nix_value is null");
++    }
++    if (!value->value || !value->value->isValid()) {
++        throw std::runtime_error("nix_value is null or uninitialized");
++    }
++    return *value->value;
++}
++
++static nix::Value & value_in(nix_value * value)
++{
++    if (!value) {
++        throw std::runtime_error("nix_value is null");
++    }
++    if (!value->value || !value->value->isValid()) {
++        throw std::runtime_error("nix_value is null or uninitialized");
++    }
++    return *value->value;
++}
++
++static const nix::Bindings * get_bindings_or_null(nix_value * autoArgs)
++{
++    if (!autoArgs) {
++        return nullptr;
++    }
++    auto & v = value_in(autoArgs);
++    if (v.type() == nix::nAttrs) {
++        return v.attrs();
++    }
++    return nullptr;
++}
++
++extern "C" {
++
++StorePath *
++nix_get_derivation(nix_c_context * context, EvalState * state, nix_value * value, bool ignoreAssertionFailures)
++{
++    if (context)
++        context->last_err_code = NIX_OK;
++    try {
++        auto & v = value_in(value);
++        auto maybePkg = nix::getDerivation(state->state, v, ignoreAssertionFailures);
++        if (!maybePkg) {
++            return nullptr;
++        }
++        nix::StorePath sp = maybePkg->requireDrvPath();
++        return new StorePath{std::move(sp)};
++    }
++    NIXC_CATCH_ERRS_NULL
++}
++
++nix_err nix_value_auto_call_function(
++    nix_c_context * context, EvalState * state, nix_value * auto_args, nix_value * fn_val, nix_value * result)
++{
++    if (context)
++        context->last_err_code = NIX_OK;
++    try {
++        auto & fn = value_in(fn_val);
++        auto & res = *result->value;
++
++        const nix::Bindings * b = get_bindings_or_null(auto_args);
++        if (b) {
++            state->state.autoCallFunction(*b, fn, res);
++        } else {
++            state->state.autoCallFunction(nix::Bindings::emptyBindings, fn, res);
++        }
++    }
++    NIXC_CATCH_ERRS
++}
++
++} // extern "C"
+diff --git a/src/libexpr-c/nix_api_expr.h b/src/libexpr-c/nix_api_expr.h
+index 3623ee076..fc61cb5f3 100644
+--- a/src/libexpr-c/nix_api_expr.h
++++ b/src/libexpr-c/nix_api_expr.h
+@@ -342,6 +342,51 @@ void nix_gc_register_finalizer(void * obj, void * cd, void (*finalizer)(void * o
+ 
+ /** @} */ // doxygen group GC
+ 
++/** @addtogroup libexpr_eval
++ * @ingroup libexpr
++ * @brief Higher-level evaluation helpers
++ * @{
++ */
++
++/**
++ * @brief Attempt to interpret a Nix value as a derivation.
++ *
++ * If the value represents a derivation, returns its drvPath. Returns NULL
++ * (without setting an error) when the value is not a derivation and the
++ * caller should recurse into its attributes instead.
++ *
++ * Derivation metadata (name, system, outputs, meta) can be queried from
++ * the value itself using the existing attrset accessors
++ * (nix_get_attr_byname, nix_get_string, etc.).
++ *
++ * @param[out] context Optional, stores error information. Check
++ *  last_err_code to distinguish NULL-from-error from NULL-as-not-derivation.
++ * @param[in] state The evaluation state.
++ * @param[in] value The value to inspect.
++ * @param[in] ignoreAssertionFailures Whether to ignore AssertionErrors
++ *  in the derivation's meta evaluation.
++ * @return A new StorePath, or NULL. Free with nix_store_path_free().
++ */
++StorePath *
++nix_get_derivation(nix_c_context * context, EvalState * state, nix_value * value, bool ignoreAssertionFailures);
++
++/**
++ * @brief Auto-call a function with auto-args (the --arg / --argstr pattern).
++ *
++ * This corresponds to nix::EvalState::autoCallFunction.
++ *
++ * @param[out] context Optional, stores error information
++ * @param[in] state The evaluation state.
++ * @param[in] auto_args An attrset value containing auto-args, or NULL for
++ *  empty.
++ * @param[in] fn_val The function to call.
++ * @param[out] result Pre-allocated nix_value to receive the result.
++ */
++nix_err nix_value_auto_call_function(
++    nix_c_context * context, EvalState * state, nix_value * auto_args, nix_value * fn_val, nix_value * result);
++
++/** @} */ // doxygen group libexpr_eval
++
+ // cffi end
+ #ifdef __cplusplus
+ }

--- a/nix/patches/nix/0002-libexpr-c-Add-C-API-function-nix_eval_state_builder_.patch
+++ b/nix/patches/nix/0002-libexpr-c-Add-C-API-function-nix_eval_state_builder_.patch
@@ -1,0 +1,62 @@
+From f1828b59cdf91a656b88196864828f990009d9b3 Mon Sep 17 00:00:00 2001
+From: adisbladis <adisbladis@gmail.com>
+Date: Wed, 22 Jul 2026 19:59:00 +0200
+Subject: [PATCH] libexpr-c: Add C API function
+ nix_eval_state_builder_set_setting
+
+To be able to drive evaluator settings from the C API.
+My motivation is to be able to set `pure-eval` without having global config state.
+---
+ src/libexpr-c/nix_api_expr.cc | 12 ++++++++++++
+ src/libexpr-c/nix_api_expr.h  | 15 +++++++++++++++
+ 2 files changed, 27 insertions(+)
+
+diff --git a/src/libexpr-c/nix_api_expr.cc b/src/libexpr-c/nix_api_expr.cc
+index 2387ee8c3..9c6bcefc3 100644
+--- a/src/libexpr-c/nix_api_expr.cc
++++ b/src/libexpr-c/nix_api_expr.cc
+@@ -152,6 +152,18 @@ nix_err nix_eval_state_builder_set_lookup_path(
+     NIXC_CATCH_ERRS
+ }
+ 
++nix_err nix_eval_state_builder_set_setting(
++    nix_c_context * context, nix_eval_state_builder * builder, const char * key, const char * value)
++{
++    if (context)
++        context->last_err_code = NIX_OK;
++    try {
++        if (!builder->settings.set(key, value))
++            return nix_set_err_msg(context, NIX_ERR_KEY, "Setting not found");
++    }
++    NIXC_CATCH_ERRS
++}
++
+ EvalState * nix_eval_state_build(nix_c_context * context, nix_eval_state_builder * builder)
+ {
+     if (context)
+diff --git a/src/libexpr-c/nix_api_expr.h b/src/libexpr-c/nix_api_expr.h
+index 0326e7bec..2fce9eab6 100644
+--- a/src/libexpr-c/nix_api_expr.h
++++ b/src/libexpr-c/nix_api_expr.h
+@@ -229,6 +229,21 @@ nix_err nix_eval_state_builder_load(nix_c_context * context, nix_eval_state_buil
+ nix_err nix_eval_state_builder_set_lookup_path(
+     nix_c_context * context, nix_eval_state_builder * builder, const char ** lookupPath);
+ 
++/**
++ * @brief Set an evaluator setting on the builder
++ * @ingroup libexpr_init
++ *
++ * Sets a single evaluator setting (as documented in the Nix manual) on the builder.
++ *
++ * @param[out] context Optional, stores error information
++ * @param[in] builder The builder to modify.
++ * @param[in] key The setting name.
++ * @param[in] value The setting value.
++ * @return NIX_OK if successful, NIX_ERR_KEY if the setting does not exist, an error code otherwise.
++ */
++nix_err nix_eval_state_builder_set_setting(
++    nix_c_context * context, nix_eval_state_builder * builder, const char * key, const char * value);
++
+ /**
+  * @brief Create a new Nix language evaluator state
+  * @ingroup libexpr_init

--- a/nix/patches/nix/0003-libflake-c-expose-nix_locked_flake_get_fingerprint.patch
+++ b/nix/patches/nix/0003-libflake-c-expose-nix_locked_flake_get_fingerprint.patch
@@ -1,0 +1,81 @@
+From 510a241f9fb9b261a7a5547ed351c9106b36e04a Mon Sep 17 00:00:00 2001
+From: Dennis Wuitz <dennish@wuitz.de>
+Date: Sat, 13 Jun 2026 17:41:03 +0200
+Subject: [PATCH 03/13] libflake-c: expose nix_locked_flake_get_fingerprint
+
+---
+ src/libflake-c/nix_api_flake.cc | 19 +++++++++++++++++++
+ src/libflake-c/nix_api_flake.h  | 23 +++++++++++++++++++++++
+ 2 files changed, 42 insertions(+)
+
+diff --git a/src/libflake-c/nix_api_flake.cc b/src/libflake-c/nix_api_flake.cc
+index 5bdd0213b..a7c0c5270 100644
+--- a/src/libflake-c/nix_api_flake.cc
++++ b/src/libflake-c/nix_api_flake.cc
+@@ -7,8 +7,10 @@
+ #include "nix_api_expr_internal.h"
+ #include "nix_api_fetchers_internal.hh"
+ #include "nix_api_fetchers.h"
++#include "nix_api_store_internal.h"
+ 
+ #include "nix/flake/flake.hh"
++#include "nix/util/hash.hh"
+ 
+ extern "C" {
+ 
+@@ -208,4 +210,21 @@ nix_value * nix_locked_flake_get_output_attrs(
+     NIXC_CATCH_ERRS_NULL
+ }
+ 
++nix_err nix_locked_flake_get_fingerprint(
++    nix_c_context * context,
++    Store * store,
++    nix_fetchers_settings * fetchSettings,
++    nix_locked_flake * lockedFlake,
++    nix_get_string_callback callback,
++    void * user_data)
++{
++    nix_clear_err(context);
++    try {
++        auto fingerprint = lockedFlake->lockedFlake->getFingerprint(*store->ptr, *fetchSettings->settings);
++        std::string result = fingerprint ? fingerprint->to_string(nix::HashFormat::Base16, false) : "";
++        return call_nix_get_string_callback(result, callback, user_data);
++    }
++    NIXC_CATCH_ERRS
++}
++
+ } // extern "C"
+diff --git a/src/libflake-c/nix_api_flake.h b/src/libflake-c/nix_api_flake.h
+index 3c3208be3..88501409d 100644
+--- a/src/libflake-c/nix_api_flake.h
++++ b/src/libflake-c/nix_api_flake.h
+@@ -237,6 +237,29 @@ void nix_flake_reference_free(nix_flake_reference * store);
+ nix_value * nix_locked_flake_get_output_attrs(
+     nix_c_context * context, nix_flake_settings * settings, EvalState * evalState, nix_locked_flake * lockedFlake);
+ 
++/**
++ * @brief Get the fingerprint of a locked flake.
++ *
++ * The fingerprint is the cache key Nix uses for the evaluation cache. It is
++ * present only for flakes whose source is fully locked (immutable); for a
++ * mutable source the callback receives the empty string.
++ *
++ * @param[out] context Optional, stores error information
++ * @param[in] store nix store to resolve the fingerprint against
++ * @param[in] fetchSettings fetcher settings
++ * @param[in] lockedFlake the locked flake to fingerprint
++ * @param[in] callback Called with the Base16 fingerprint string (possibly empty)
++ * @param[in] user_data optional, passed to the callback
++ * @return NIX_OK if there were no errors.
++ */
++nix_err nix_locked_flake_get_fingerprint(
++    nix_c_context * context,
++    Store * store,
++    nix_fetchers_settings * fetchSettings,
++    nix_locked_flake * lockedFlake,
++    nix_get_string_callback callback,
++    void * user_data);
++
+ #ifdef __cplusplus
+ } // extern "C"
+ #endif

--- a/nix/patches/nix/0004-libstore-c-expose-nix_store_add_temp_root-and-nix_st.patch
+++ b/nix/patches/nix/0004-libstore-c-expose-nix_store_add_temp_root-and-nix_st.patch
@@ -1,0 +1,97 @@
+From be7bc78d606e196a1a7d5421e66cebc15d9139ea Mon Sep 17 00:00:00 2001
+From: Dennis Wuitz <dennish@wuitz.de>
+Date: Sat, 13 Jun 2026 17:48:24 +0200
+Subject: [PATCH 04/13] libstore-c: expose nix_store_add_temp_root and
+ nix_store_add_perm_root
+
+---
+ src/libstore-c/nix_api_store.cc | 34 +++++++++++++++++++++++++++++++++
+ src/libstore-c/nix_api_store.h  | 30 +++++++++++++++++++++++++++++
+ 2 files changed, 64 insertions(+)
+
+diff --git a/src/libstore-c/nix_api_store.cc b/src/libstore-c/nix_api_store.cc
+index c0b296254..e4c2af119 100644
+--- a/src/libstore-c/nix_api_store.cc
++++ b/src/libstore-c/nix_api_store.cc
+@@ -100,6 +100,40 @@ nix_store_get_version(nix_c_context * context, Store * store, nix_get_string_cal
+     NIXC_CATCH_ERRS
+ }
+ 
++nix_err nix_store_add_temp_root(nix_c_context * context, Store * store, const StorePath * path)
++{
++    if (context)
++        context->last_err_code = NIX_OK;
++    try {
++        store->ptr->addTempRoot(path->path);
++    }
++    NIXC_CATCH_ERRS
++}
++
++nix_err nix_store_add_perm_root(
++    nix_c_context * context,
++    Store * store,
++    const StorePath * path,
++    const char * gcRoot,
++    nix_get_string_callback callback,
++    void * user_data)
++{
++    if (context)
++        context->last_err_code = NIX_OK;
++    try {
++        if (!gcRoot)
++            throw nix::UsageError("gcRoot must not be null");
++
++        auto localStore = store->ptr.dynamic_pointer_cast<nix::LocalFSStore>();
++        if (!localStore)
++            throw nix::UsageError("store does not support permanent GC roots (not a local filesystem store)");
++
++        auto resultPath = localStore->addPermRoot(path->path, std::filesystem::path(gcRoot));
++        return call_nix_get_string_callback(resultPath.string(), callback, user_data);
++    }
++    NIXC_CATCH_ERRS
++}
++
+ bool nix_store_is_valid_path(nix_c_context * context, Store * store, const StorePath * path)
+ {
+     if (context)
+diff --git a/src/libstore-c/nix_api_store.h b/src/libstore-c/nix_api_store.h
+index e60a7d6c0..ebade943f 100644
+--- a/src/libstore-c/nix_api_store.h
++++ b/src/libstore-c/nix_api_store.h
+@@ -185,6 +185,36 @@ nix_err nix_store_realise(
+ nix_err
+ nix_store_get_version(nix_c_context * context, Store * store, nix_get_string_callback callback, void * user_data);
+ 
++/**
++ * @brief Register a temporary GC root for a store path (lives until the store is closed).
++ * @param[out] context Optional, stores error information
++ * @param[in] store nix store
++ * @param[in] path the store path to protect
++ * @return NIX_OK if there were no errors.
++ */
++nix_err nix_store_add_temp_root(nix_c_context * context, Store * store, const StorePath * path);
++
++/**
++ * @brief Register a permanent indirect GC root: a symlink at `gcRoot` pointing at `path`.
++ *
++ * Only supported by local filesystem stores; returns an error for remote/binary-cache stores.
++ *
++ * @param[out] context Optional, stores error information
++ * @param[in] store nix store (must be a local store)
++ * @param[in] path the store path to protect
++ * @param[in] gcRoot filesystem location of the gc-root symlink to create
++ * @param[in] callback Called with the resulting root path
++ * @param[in] user_data optional, passed to the callback
++ * @return NIX_OK if there were no errors.
++ */
++nix_err nix_store_add_perm_root(
++    nix_c_context * context,
++    Store * store,
++    const StorePath * path,
++    const char * gcRoot,
++    nix_get_string_callback callback,
++    void * user_data);
++
+ /**
+  * @brief Create a `nix_derivation` from a JSON representation of that derivation.
+  *

--- a/nix/patches/nix/0005-libexpr-c-expose-nix_eval_state_get_stats_json-via-E.patch
+++ b/nix/patches/nix/0005-libexpr-c-expose-nix_eval_state_get_stats_json-via-E.patch
@@ -1,0 +1,142 @@
+From 4d9f0363a4b4ac4ef02e0ecfcd23d3eea9b216c1 Mon Sep 17 00:00:00 2001
+From: Dennis Wuitz <dennish@wuitz.de>
+Date: Sat, 13 Jun 2026 17:57:14 +0200
+Subject: [PATCH 05/13] libexpr-c: expose nix_eval_state_get_stats_json via
+ EvalState::getStatisticsJSON
+
+---
+ src/libexpr-c/nix_api_expr.cc        | 14 ++++++++++++++
+ src/libexpr-c/nix_api_expr.h         | 15 +++++++++++++++
+ src/libexpr/eval.cc                  | 17 ++++++++++++-----
+ src/libexpr/include/nix/expr/eval.hh |  8 ++++++++
+ 4 files changed, 49 insertions(+), 5 deletions(-)
+
+diff --git a/src/libexpr-c/nix_api_expr.cc b/src/libexpr-c/nix_api_expr.cc
+index 9c6bcefc3..ff43b3510 100644
+--- a/src/libexpr-c/nix_api_expr.cc
++++ b/src/libexpr-c/nix_api_expr.cc
+@@ -2,6 +2,8 @@
+ #include <stdexcept>
+ #include <string>
+ 
++#include <nlohmann/json.hpp>
++
+ #include "nix/expr/eval.hh"
+ #include "nix/expr/eval-gc.hh"
+ #include "nix/store/globals.hh"
+@@ -103,6 +105,18 @@ nix_err nix_value_force_deep(nix_c_context * context, EvalState * state, nix_val
+     NIXC_CATCH_ERRS
+ }
+ 
++nix_err nix_eval_state_get_stats_json(
++    nix_c_context * context, EvalState * state, nix_get_string_callback callback, void * user_data)
++{
++    if (context)
++        context->last_err_code = NIX_OK;
++    try {
++        auto j = state->state.getStatisticsJSON();
++        return call_nix_get_string_callback(j.dump(), callback, user_data);
++    }
++    NIXC_CATCH_ERRS
++}
++
+ nix_eval_state_builder * nix_eval_state_builder_new(nix_c_context * context, Store * store)
+ {
+     if (context)
+diff --git a/src/libexpr-c/nix_api_expr.h b/src/libexpr-c/nix_api_expr.h
+index 2fce9eab6..6eeeadc5b 100644
+--- a/src/libexpr-c/nix_api_expr.h
++++ b/src/libexpr-c/nix_api_expr.h
+@@ -292,6 +292,21 @@ EvalState * nix_state_create(nix_c_context * context, const char ** lookupPath,
+  */
+ void nix_state_free(EvalState * state);
+ 
++/**
++ * @brief Get the evaluator statistics for a state as a JSON string.
++ *
++ * Returns the same data Nix writes to NIX_SHOW_STATS_PATH (cpuTime, nrThunks,
++ * nrAvoided, memory/GC counters, ...), serialized as JSON. Cheap; no GC first.
++ *
++ * @param[out] context Optional, stores error information
++ * @param[in] state the evaluator state to read statistics from
++ * @param[in] callback Called with the JSON string
++ * @param[in] user_data optional, passed to the callback
++ * @return NIX_OK if there were no errors.
++ */
++nix_err nix_eval_state_get_stats_json(
++    nix_c_context * context, EvalState * state, nix_get_string_callback callback, void * user_data);
++
+ /** @addtogroup GC
+  * @ingroup libexpr
+  * @brief Reference counting and garbage collector operations
+diff --git a/src/libexpr/eval.cc b/src/libexpr/eval.cc
+index dcf41d713..56f241028 100644
+--- a/src/libexpr/eval.cc
++++ b/src/libexpr/eval.cc
+@@ -3077,7 +3077,7 @@ void EvalState::maybePrintStats()
+     }
+ }
+ 
+-void EvalState::printStatistics()
++nlohmann::json EvalState::getStatisticsJSON()
+ {
+     std::chrono::microseconds cpuTimeDuration = getCpuUserTime();
+     float cpuTime = std::chrono::duration_cast<std::chrono::duration<float>>(cpuTimeDuration).count();
+@@ -3099,10 +3099,6 @@ void EvalState::printStatistics()
+     auto gcCycles = getGCCycles();
+ #endif
+ 
+-    auto outPath = getEnv("NIX_SHOW_STATS_PATH").value_or("-");
+-    std::fstream fs;
+-    if (outPath != "-")
+-        fs.open(outPath, std::fstream::out);
+     json topObj = json::object();
+     topObj["cpuTime"] = cpuTime;
+     topObj["time"] = {
+@@ -3206,9 +3202,20 @@ void EvalState::printStatistics()
+         auto & list = topObj["symbols"];
+         symbols.dump([&](std::string_view s) { list.emplace_back(s); });
+     }
++
++    return topObj;
++}
++
++void EvalState::printStatistics()
++{
++    json topObj = getStatisticsJSON();
++
++    auto outPath = getEnv("NIX_SHOW_STATS_PATH").value_or("-");
+     if (outPath == "-") {
+         std::cerr << topObj.dump(2) << std::endl;
+     } else {
++        std::fstream fs;
++        fs.open(outPath, std::fstream::out);
+         fs << topObj.dump(2) << std::endl;
+     }
+ }
+diff --git a/src/libexpr/include/nix/expr/eval.hh b/src/libexpr/include/nix/expr/eval.hh
+index a421a680b..59dc1e347 100644
+--- a/src/libexpr/include/nix/expr/eval.hh
++++ b/src/libexpr/include/nix/expr/eval.hh
+@@ -24,6 +24,8 @@
+ #include <boost/unordered/unordered_flat_map.hpp>
+ #include <boost/unordered/concurrent_flat_map_fwd.hpp>
+ 
++#include <nlohmann/json_fwd.hpp>
++
+ #include <map>
+ #include <optional>
+ #include <functional>
+@@ -1100,6 +1102,12 @@ public:
+      */
+     void maybePrintStats();
+ 
++    /**
++     * Build the evaluator-statistics JSON object (the same content printStatistics()
++     * writes), without performing any I/O. Cheap; does not run a GC first.
++     */
++    nlohmann::json getStatisticsJSON();
++
+     /**
+      * Print statistics, unconditionally, cheaply, without performing a GC first.
+      */

--- a/nix/patches/nix/0006-libflake-c-expose-eval-cache-AttrCursor-API-openEval.patch
+++ b/nix/patches/nix/0006-libflake-c-expose-eval-cache-AttrCursor-API-openEval.patch
@@ -1,0 +1,357 @@
+From bcf6d4d053b9e6581d2296229bfc74094c9e432b Mon Sep 17 00:00:00 2001
+From: Dennis Wuitz <dennish@wuitz.de>
+Date: Sat, 13 Jun 2026 22:06:29 +0200
+Subject: [PATCH 06/13] libflake-c: expose eval-cache AttrCursor API
+ (openEvalCache + cursor walk)
+
+---
+ src/libflake-c/meson.build                    |   3 +
+ src/libflake-c/nix_api_eval_cache.cc          | 133 +++++++++++++++
+ src/libflake-c/nix_api_eval_cache.h           | 157 ++++++++++++++++++
+ src/libflake-c/nix_api_eval_cache_internal.hh |  13 ++
+ 4 files changed, 306 insertions(+)
+ create mode 100644 src/libflake-c/nix_api_eval_cache.cc
+ create mode 100644 src/libflake-c/nix_api_eval_cache.h
+ create mode 100644 src/libflake-c/nix_api_eval_cache_internal.hh
+
+diff --git a/src/libflake-c/meson.build b/src/libflake-c/meson.build
+index 4fef3ea00..d4b79cd5a 100644
+--- a/src/libflake-c/meson.build
++++ b/src/libflake-c/meson.build
+@@ -34,12 +34,15 @@ subdir('nix-meson-build-support/subprojects')
+ subdir('nix-meson-build-support/common')
+ 
+ sources = files(
++  'nix_api_eval_cache.cc',
+   'nix_api_flake.cc',
+ )
+ 
+ include_dirs = [ include_directories('.') ]
+ 
+ headers = files(
++  'nix_api_eval_cache.h',
++  'nix_api_eval_cache_internal.hh',
+   'nix_api_flake.h',
+   'nix_api_flake_internal.hh',
+ )
+diff --git a/src/libflake-c/nix_api_eval_cache.cc b/src/libflake-c/nix_api_eval_cache.cc
+new file mode 100644
+index 000000000..d77cb3c64
+--- /dev/null
++++ b/src/libflake-c/nix_api_eval_cache.cc
+@@ -0,0 +1,133 @@
++#include <string>
++
++#include "nix_api_eval_cache.h"
++#include "nix_api_eval_cache_internal.hh"
++#include "nix_api_util.h"
++#include "nix_api_util_internal.h"
++#include "nix_api_expr_internal.h"
++#include "nix_api_flake_internal.hh"
++
++#include "nix/flake/flake.hh"
++#include "nix/expr/eval-cache.hh"
++#include "nix/store/store-api.hh"
++
++extern "C" {
++
++nix_eval_cache * nix_eval_cache_open(nix_c_context * context, EvalState * state, nix_locked_flake * locked_flake)
++{
++    nix_clear_err(context);
++    try {
++        auto cache = nix::flake::openEvalCache(state->state, locked_flake->lockedFlake);
++        return new nix_eval_cache{cache};
++    }
++    NIXC_CATCH_ERRS_NULL
++}
++
++void nix_eval_cache_free(nix_eval_cache * cache)
++{
++    delete cache;
++}
++
++nix_attr_cursor * nix_eval_cache_get_root(nix_c_context * context, nix_eval_cache * cache)
++{
++    nix_clear_err(context);
++    try {
++        return new nix_attr_cursor{cache->cache->getRoot()};
++    }
++    NIXC_CATCH_ERRS_NULL
++}
++
++nix_attr_cursor * nix_attr_cursor_maybe_get_attr(nix_c_context * context, nix_attr_cursor * cursor, const char * name)
++{
++    nix_clear_err(context);
++    try {
++        auto child = cursor->cursor->maybeGetAttr(std::string_view(name));
++        if (!child)
++            return nullptr;
++        return new nix_attr_cursor{nix::ref<nix::eval_cache::AttrCursor>(child)};
++    }
++    NIXC_CATCH_ERRS_NULL
++}
++
++void nix_attr_cursor_free(nix_attr_cursor * cursor)
++{
++    delete cursor;
++}
++
++nix_err nix_attr_cursor_get_attrs(
++    nix_c_context * context,
++    EvalState * state,
++    nix_attr_cursor * cursor,
++    void (*callback)(const char * name, void * user_data),
++    void * user_data)
++{
++    nix_clear_err(context);
++    try {
++        auto attrs = cursor->cursor->getAttrs();
++        for (auto & sym : attrs) {
++            std::string name(std::string_view(state->state.symbols[sym]));
++            callback(name.c_str(), user_data);
++        }
++    }
++    NIXC_CATCH_ERRS
++}
++
++nix_err nix_attr_cursor_is_derivation(nix_c_context * context, nix_attr_cursor * cursor, bool * out)
++{
++    nix_clear_err(context);
++    try {
++        *out = cursor->cursor->isDerivation();
++    }
++    NIXC_CATCH_ERRS
++}
++
++nix_err nix_attr_cursor_get_drv_path(
++    nix_c_context * context,
++    EvalState * state,
++    nix_attr_cursor * cursor,
++    nix_get_string_callback callback,
++    void * user_data)
++{
++    nix_clear_err(context);
++    try {
++        auto drvPath = cursor->cursor->forceDerivation();
++        return call_nix_get_string_callback(state->state.store->printStorePath(drvPath), callback, user_data);
++    }
++    NIXC_CATCH_ERRS
++}
++
++nix_err nix_attr_cursor_get_string(
++    nix_c_context * context, nix_attr_cursor * cursor, nix_get_string_callback callback, void * user_data)
++{
++    nix_clear_err(context);
++    try {
++        return call_nix_get_string_callback(cursor->cursor->getString(), callback, user_data);
++    }
++    NIXC_CATCH_ERRS
++}
++
++nix_err nix_attr_cursor_get_bool(nix_c_context * context, nix_attr_cursor * cursor, bool * out)
++{
++    nix_clear_err(context);
++    try {
++        *out = cursor->cursor->getBool();
++    }
++    NIXC_CATCH_ERRS
++}
++
++nix_err nix_attr_cursor_get_list_of_strings(
++    nix_c_context * context,
++    nix_attr_cursor * cursor,
++    void (*callback)(const char * value, void * user_data),
++    void * user_data)
++{
++    nix_clear_err(context);
++    try {
++        auto list = cursor->cursor->getListOfStrings();
++        for (auto & s : list)
++            callback(s.c_str(), user_data);
++    }
++    NIXC_CATCH_ERRS
++}
++
++} // extern "C"
+diff --git a/src/libflake-c/nix_api_eval_cache.h b/src/libflake-c/nix_api_eval_cache.h
+new file mode 100644
+index 000000000..ce8369306
+--- /dev/null
++++ b/src/libflake-c/nix_api_eval_cache.h
+@@ -0,0 +1,157 @@
++#ifndef NIX_API_EVAL_CACHE_H
++#define NIX_API_EVAL_CACHE_H
++/** @addtogroup libflake
++ * @{
++ */
++/** @file
++ * @brief Bindings to the Nix flake evaluation cache (`AttrCursor`)
++ *
++ * These bindings expose a cursor-driven, eval-cache-warm walk over a locked
++ * flake's output attributes. When the flake source is immutable the walk is
++ * served from the on-disk cache; otherwise it falls back to live evaluation.
++ */
++
++#include "nix_api_util.h"
++#include "nix_api_expr.h"
++#include "nix_api_flake.h"
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++// cffi start
++
++/**
++ * @brief An open evaluation cache for a locked flake.
++ * @see nix_eval_cache_open
++ * @see nix_eval_cache_free
++ */
++typedef struct nix_eval_cache nix_eval_cache;
++
++/**
++ * @brief A cursor into the attribute tree of an evaluation cache.
++ * @see nix_eval_cache_get_root
++ * @see nix_attr_cursor_free
++ */
++typedef struct nix_attr_cursor nix_attr_cursor;
++
++/**
++ * @brief Open the evaluation cache for a locked flake.
++ * @param[out] context Optional, stores error information
++ * @param[in] state The eval state to evaluate the flake in
++ * @param[in] locked_flake The locked flake to open the cache for
++ * @return A new nix_eval_cache or NULL on failure. Free with nix_eval_cache_free.
++ */
++nix_eval_cache * nix_eval_cache_open(nix_c_context * context, EvalState * state, nix_locked_flake * locked_flake);
++
++/**
++ * @brief Release the resources associated with a nix_eval_cache. Does not fail.
++ */
++void nix_eval_cache_free(nix_eval_cache * cache);
++
++/**
++ * @brief Get a cursor pointing at the root of the cache's attribute tree.
++ * @param[out] context Optional, stores error information
++ * @param[in] cache The evaluation cache
++ * @return A new nix_attr_cursor or NULL on failure. Free with nix_attr_cursor_free.
++ */
++nix_attr_cursor * nix_eval_cache_get_root(nix_c_context * context, nix_eval_cache * cache);
++
++/**
++ * @brief Descend into a child attribute by name.
++ * @param[out] context Optional, stores error information
++ * @param[in] cursor The parent cursor
++ * @param[in] name The attribute name to look up
++ * @return A new nix_attr_cursor, or NULL if the attribute is missing or on
++ * failure. Check the context to distinguish a missing attribute from an error.
++ * Free the result with nix_attr_cursor_free.
++ */
++nix_attr_cursor * nix_attr_cursor_maybe_get_attr(nix_c_context * context, nix_attr_cursor * cursor, const char * name);
++
++/**
++ * @brief Release the resources associated with a nix_attr_cursor. Does not fail.
++ */
++void nix_attr_cursor_free(nix_attr_cursor * cursor);
++
++/**
++ * @brief Enumerate the attribute names of the attrset at the cursor.
++ * @param[out] context Optional, stores error information
++ * @param[in] state The eval state, used to resolve symbols to names
++ * @param[in] cursor The cursor, which must point at an attrset
++ * @param[in] callback Called once per attribute name
++ * @param[in] user_data Optional, passed to the callback
++ * @return NIX_OK on success.
++ */
++nix_err nix_attr_cursor_get_attrs(
++    nix_c_context * context,
++    EvalState * state,
++    nix_attr_cursor * cursor,
++    void (*callback)(const char * name, void * user_data),
++    void * user_data);
++
++/**
++ * @brief Determine whether the cursor points at a derivation.
++ * @param[out] context Optional, stores error information
++ * @param[in] cursor The cursor
++ * @param[out] out Set to whether the attrset is a derivation
++ * @return NIX_OK on success.
++ */
++nix_err nix_attr_cursor_is_derivation(nix_c_context * context, nix_attr_cursor * cursor, bool * out);
++
++/**
++ * @brief Force the derivation at the cursor and report its `.drv` store path.
++ * @param[out] context Optional, stores error information
++ * @param[in] state The eval state, whose store is used to print the path
++ * @param[in] cursor The cursor, which must point at a derivation
++ * @param[in] callback Called with the store path string
++ * @param[in] user_data Optional, passed to the callback
++ * @return NIX_OK on success.
++ */
++nix_err nix_attr_cursor_get_drv_path(
++    nix_c_context * context,
++    EvalState * state,
++    nix_attr_cursor * cursor,
++    nix_get_string_callback callback,
++    void * user_data);
++
++/**
++ * @brief Read the string value at the cursor.
++ * @param[out] context Optional, stores error information
++ * @param[in] cursor The cursor, which must point at a string
++ * @param[in] callback Called with the string value
++ * @param[in] user_data Optional, passed to the callback
++ * @return NIX_OK on success.
++ */
++nix_err nix_attr_cursor_get_string(
++    nix_c_context * context, nix_attr_cursor * cursor, nix_get_string_callback callback, void * user_data);
++
++/**
++ * @brief Read the boolean value at the cursor.
++ * @param[out] context Optional, stores error information
++ * @param[in] cursor The cursor, which must point at a bool
++ * @param[out] out Set to the boolean value
++ * @return NIX_OK on success.
++ */
++nix_err nix_attr_cursor_get_bool(nix_c_context * context, nix_attr_cursor * cursor, bool * out);
++
++/**
++ * @brief Read a list of strings at the cursor.
++ * @param[out] context Optional, stores error information
++ * @param[in] cursor The cursor, which must point at a list of strings
++ * @param[in] callback Called once per list element
++ * @param[in] user_data Optional, passed to the callback
++ * @return NIX_OK on success.
++ */
++nix_err nix_attr_cursor_get_list_of_strings(
++    nix_c_context * context,
++    nix_attr_cursor * cursor,
++    void (*callback)(const char * value, void * user_data),
++    void * user_data);
++
++// cffi end
++#ifdef __cplusplus
++} // extern "C"
++#endif
++/**
++ * @}
++ */
++#endif // NIX_API_EVAL_CACHE_H
+diff --git a/src/libflake-c/nix_api_eval_cache_internal.hh b/src/libflake-c/nix_api_eval_cache_internal.hh
+new file mode 100644
+index 000000000..e448ae9f2
+--- /dev/null
++++ b/src/libflake-c/nix_api_eval_cache_internal.hh
+@@ -0,0 +1,13 @@
++#pragma once
++
++#include "nix/expr/eval-cache.hh"
++
++struct nix_eval_cache
++{
++    nix::ref<nix::eval_cache::EvalCache> cache;
++};
++
++struct nix_attr_cursor
++{
++    nix::ref<nix::eval_cache::AttrCursor> cursor;
++};

--- a/nix/patches/nix/0007-feat-eval-cache-nix_eval_cache_commit-to-flush-cache.patch
+++ b/nix/patches/nix/0007-feat-eval-cache-nix_eval_cache_commit-to-flush-cache.patch
@@ -1,0 +1,106 @@
+From b51fd076bb1240e302300fb3290a4abb28a510d6 Mon Sep 17 00:00:00 2001
+From: Dennis Wuitz <dennish@wuitz.de>
+Date: Sun, 14 Jun 2026 11:29:55 +0200
+Subject: [PATCH 07/13] feat(eval-cache): nix_eval_cache_commit to flush cache
+ without closing it
+
+EvalCache::commit() commits the AttrDb txn, wal_checkpoint(truncate)s it into the main .sqlite, and reopens the txn, so a long-lived evaluator persists the cache for a concurrent reader instead of only on last-connection close. Exposed via the libflake C API.
+---
+ src/libexpr/eval-cache.cc                  | 17 +++++++++++++++++
+ src/libexpr/include/nix/expr/eval-cache.hh |  9 +++++++++
+ src/libflake-c/nix_api_eval_cache.cc       |  9 +++++++++
+ src/libflake-c/nix_api_eval_cache.h        | 13 +++++++++++++
+ 4 files changed, 48 insertions(+)
+
+diff --git a/src/libexpr/eval-cache.cc b/src/libexpr/eval-cache.cc
+index 7422cd095..752c50fb5 100644
+--- a/src/libexpr/eval-cache.cc
++++ b/src/libexpr/eval-cache.cc
+@@ -373,6 +373,23 @@ ref<AttrCursor> EvalCache::getRoot()
+     return make_ref<AttrCursor>(ref(shared_from_this()), std::nullopt);
+ }
+ 
++void EvalCache::commit()
++{
++    if (!db)
++        return;
++    auto state(db->_state->lock());
++    if (db->failed || !state->txn || !state->txn->active)
++        return;
++    state->txn->commit();
++    state->txn.reset();
++    try {
++        state->db.exec("pragma wal_checkpoint(truncate);");
++    } catch (...) {
++        ignoreExceptionExceptInterrupt();
++    }
++    state->txn = std::make_unique<SQLiteTxn>(state->db);
++}
++
+ AttrCursor::AttrCursor(
+     ref<EvalCache> root, Parent parent, Value * value, std::optional<std::pair<AttrId, AttrValue>> && cachedValue)
+     : root(root)
+diff --git a/src/libexpr/include/nix/expr/eval-cache.hh b/src/libexpr/include/nix/expr/eval-cache.hh
+index 0feb7d564..db4660ddd 100644
+--- a/src/libexpr/include/nix/expr/eval-cache.hh
++++ b/src/libexpr/include/nix/expr/eval-cache.hh
+@@ -50,6 +50,15 @@ public:
+     EvalCache(std::optional<std::reference_wrapper<const Hash>> useCache, EvalState & state, RootLoader rootLoader);
+ 
+     ref<AttrCursor> getRoot();
++
++    /**
++     * Commit pending eval-cache writes and checkpoint the WAL into the main
++     * database file, so a concurrent reader of the `.sqlite` (without its
++     * `-wal` sidecar) sees them. Normally the cache is only committed when the
++     * last `AttrDb` connection closes; long-lived evaluators that keep the
++     * cache open need this to persist incrementally. No-op without a cache.
++     */
++    void commit();
+ };
+ 
+ enum AttrType {
+diff --git a/src/libflake-c/nix_api_eval_cache.cc b/src/libflake-c/nix_api_eval_cache.cc
+index d77cb3c64..aa4bd2c26 100644
+--- a/src/libflake-c/nix_api_eval_cache.cc
++++ b/src/libflake-c/nix_api_eval_cache.cc
+@@ -37,6 +37,15 @@ nix_attr_cursor * nix_eval_cache_get_root(nix_c_context * context, nix_eval_cach
+     NIXC_CATCH_ERRS_NULL
+ }
+ 
++nix_err nix_eval_cache_commit(nix_c_context * context, nix_eval_cache * cache)
++{
++    nix_clear_err(context);
++    try {
++        cache->cache->commit();
++    }
++    NIXC_CATCH_ERRS
++}
++
+ nix_attr_cursor * nix_attr_cursor_maybe_get_attr(nix_c_context * context, nix_attr_cursor * cursor, const char * name)
+ {
+     nix_clear_err(context);
+diff --git a/src/libflake-c/nix_api_eval_cache.h b/src/libflake-c/nix_api_eval_cache.h
+index ce8369306..5ed4b80d5 100644
+--- a/src/libflake-c/nix_api_eval_cache.h
++++ b/src/libflake-c/nix_api_eval_cache.h
+@@ -56,6 +56,19 @@ void nix_eval_cache_free(nix_eval_cache * cache);
+  */
+ nix_attr_cursor * nix_eval_cache_get_root(nix_c_context * context, nix_eval_cache * cache);
+ 
++/**
++ * @brief Commit pending writes and checkpoint the cache's SQLite WAL into the
++ * main `.sqlite` file.
++ *
++ * Persists eval-cache entries written so far so a reader of the database file
++ * (without its `-wal` sidecar) sees them, without closing the cache. Intended
++ * for long-lived evaluators that keep the cache open across many evaluations.
++ * @param[out] context Optional, stores error information
++ * @param[in] cache The evaluation cache
++ * @return NIX_OK on success.
++ */
++nix_err nix_eval_cache_commit(nix_c_context * context, nix_eval_cache * cache);
++
+ /**
+  * @brief Descend into a child attribute by name.
+  * @param[out] context Optional, stores error information

--- a/nix/patches/nix/0008-feat-eval-cache-split-commit-WAL-append-from-checkpo.patch
+++ b/nix/patches/nix/0008-feat-eval-cache-split-commit-WAL-append-from-checkpo.patch
@@ -1,0 +1,142 @@
+From aa24f5715359c12cb9c4577a9b1ca4c6ab8708ab Mon Sep 17 00:00:00 2001
+From: Dennis Wuitz <dennish@wuitz.de>
+Date: Sun, 14 Jun 2026 18:14:40 +0200
+Subject: [PATCH 08/13] feat(eval-cache): split commit (WAL append) from
+ checkpoint (truncate)
+
+EvalCache::commit() now only commits the SQLite transaction (appends to the WAL) without a truncate checkpoint, so several evaluators writing one cache concurrently no longer deadlock on the WAL read-slot locks. New EvalCache::checkpoint() (+ C API nix_eval_cache_checkpoint) folds the WAL into the main file once, with no concurrent readers.
+---
+ src/libexpr/eval-cache.cc                  | 20 ++++++++++++++++++
+ src/libexpr/include/nix/expr/eval-cache.hh | 20 +++++++++++++-----
+ src/libflake-c/nix_api_eval_cache.cc       |  9 ++++++++
+ src/libflake-c/nix_api_eval_cache.h        | 24 +++++++++++++++++-----
+ 4 files changed, 63 insertions(+), 10 deletions(-)
+
+diff --git a/src/libexpr/eval-cache.cc b/src/libexpr/eval-cache.cc
+index 752c50fb5..e9d251973 100644
+--- a/src/libexpr/eval-cache.cc
++++ b/src/libexpr/eval-cache.cc
+@@ -380,8 +380,28 @@ void EvalCache::commit()
+     auto state(db->_state->lock());
+     if (db->failed || !state->txn || !state->txn->active)
+         return;
++    // Commit the transaction (appending to the WAL) but do NOT checkpoint:
++    // a truncate checkpoint takes an exclusive lock on the WAL read slots and
++    // deadlocks when several evaluators write the same cache concurrently. The
++    // WAL is durable across processes, so a later commit/reader still sees these
++    // writes; call checkpoint() once (with no concurrent readers) to fold the
++    // WAL back into the main file.
+     state->txn->commit();
+     state->txn.reset();
++    state->txn = std::make_unique<SQLiteTxn>(state->db);
++}
++
++void EvalCache::checkpoint()
++{
++    if (!db)
++        return;
++    auto state(db->_state->lock());
++    if (db->failed)
++        return;
++    if (state->txn && state->txn->active) {
++        state->txn->commit();
++        state->txn.reset();
++    }
+     try {
+         state->db.exec("pragma wal_checkpoint(truncate);");
+     } catch (...) {
+diff --git a/src/libexpr/include/nix/expr/eval-cache.hh b/src/libexpr/include/nix/expr/eval-cache.hh
+index db4660ddd..c4bfd3784 100644
+--- a/src/libexpr/include/nix/expr/eval-cache.hh
++++ b/src/libexpr/include/nix/expr/eval-cache.hh
+@@ -52,13 +52,23 @@ public:
+     ref<AttrCursor> getRoot();
+ 
+     /**
+-     * Commit pending eval-cache writes and checkpoint the WAL into the main
+-     * database file, so a concurrent reader of the `.sqlite` (without its
+-     * `-wal` sidecar) sees them. Normally the cache is only committed when the
+-     * last `AttrDb` connection closes; long-lived evaluators that keep the
+-     * cache open need this to persist incrementally. No-op without a cache.
++     * Commit pending eval-cache writes by committing the SQLite transaction
++     * (appending to the WAL). Does NOT checkpoint, so it is safe to call from
++     * several evaluators writing the same cache concurrently — a truncate
++     * checkpoint would deadlock on the WAL read-slot locks. The writes are
++     * durable in the WAL; use checkpoint() to fold them into the main file.
++     * No-op without a cache.
+      */
+     void commit();
++
++    /**
++     * Fold the WAL into the main `.sqlite` file via a truncate checkpoint, so a
++     * reader of the database file (without its `-wal` sidecar) sees every
++     * committed write. Call this once with no concurrent readers/writers (e.g.
++     * at the end of an evaluation, before shipping the file); calling it while
++     * other connections hold WAL read locks will block. No-op without a cache.
++     */
++    void checkpoint();
+ };
+ 
+ enum AttrType {
+diff --git a/src/libflake-c/nix_api_eval_cache.cc b/src/libflake-c/nix_api_eval_cache.cc
+index aa4bd2c26..aa136ce66 100644
+--- a/src/libflake-c/nix_api_eval_cache.cc
++++ b/src/libflake-c/nix_api_eval_cache.cc
+@@ -46,6 +46,15 @@ nix_err nix_eval_cache_commit(nix_c_context * context, nix_eval_cache * cache)
+     NIXC_CATCH_ERRS
+ }
+ 
++nix_err nix_eval_cache_checkpoint(nix_c_context * context, nix_eval_cache * cache)
++{
++    nix_clear_err(context);
++    try {
++        cache->cache->checkpoint();
++    }
++    NIXC_CATCH_ERRS
++}
++
+ nix_attr_cursor * nix_attr_cursor_maybe_get_attr(nix_c_context * context, nix_attr_cursor * cursor, const char * name)
+ {
+     nix_clear_err(context);
+diff --git a/src/libflake-c/nix_api_eval_cache.h b/src/libflake-c/nix_api_eval_cache.h
+index 5ed4b80d5..bfd245e15 100644
+--- a/src/libflake-c/nix_api_eval_cache.h
++++ b/src/libflake-c/nix_api_eval_cache.h
+@@ -57,18 +57,32 @@ void nix_eval_cache_free(nix_eval_cache * cache);
+ nix_attr_cursor * nix_eval_cache_get_root(nix_c_context * context, nix_eval_cache * cache);
+ 
+ /**
+- * @brief Commit pending writes and checkpoint the cache's SQLite WAL into the
+- * main `.sqlite` file.
++ * @brief Commit pending writes to the cache's SQLite WAL, without checkpointing.
+  *
+- * Persists eval-cache entries written so far so a reader of the database file
+- * (without its `-wal` sidecar) sees them, without closing the cache. Intended
+- * for long-lived evaluators that keep the cache open across many evaluations.
++ * Persists eval-cache entries written so far into the WAL so they survive and
++ * remain visible to other connections, without closing the cache. Safe to call
++ * concurrently from several evaluators sharing one cache (it does not take the
++ * WAL read-slot locks a checkpoint needs). Use nix_eval_cache_checkpoint to fold
++ * the WAL into the main `.sqlite` file.
+  * @param[out] context Optional, stores error information
+  * @param[in] cache The evaluation cache
+  * @return NIX_OK on success.
+  */
+ nix_err nix_eval_cache_commit(nix_c_context * context, nix_eval_cache * cache);
+ 
++/**
++ * @brief Fold the cache's WAL into the main `.sqlite` file (truncate checkpoint).
++ *
++ * Makes every committed write visible to a reader of the database file alone
++ * (without its `-wal` sidecar). Call once with no concurrent readers/writers
++ * (e.g. at end of evaluation before shipping the file); it blocks while other
++ * connections hold WAL read locks.
++ * @param[out] context Optional, stores error information
++ * @param[in] cache The evaluation cache
++ * @return NIX_OK on success.
++ */
++nix_err nix_eval_cache_checkpoint(nix_c_context * context, nix_eval_cache * cache);
++
+ /**
+  * @brief Descend into a child attribute by name.
+  * @param[out] context Optional, stores error information

--- a/nix/patches/nix/0009-fix-eval-cache-use-PASSIVE-checkpoint-so-it-never-bl.patch
+++ b/nix/patches/nix/0009-fix-eval-cache-use-PASSIVE-checkpoint-so-it-never-bl.patch
@@ -1,0 +1,77 @@
+From 49168e719ba81492561d33380d7a7e8dc45f7afa Mon Sep 17 00:00:00 2001
+From: Dennis Wuitz <dennish@wuitz.de>
+Date: Sun, 14 Jun 2026 20:20:39 +0200
+Subject: [PATCH 09/13] fix(eval-cache): use PASSIVE checkpoint so it never
+ blocks on concurrent readers
+
+EvalCache::checkpoint() did wal_checkpoint(truncate), which takes the exclusive WAL read-slot lock and still deadlocked when a concurrent evaluator of the same flake held read locks. PASSIVE folds the WAL into the main file without that lock and never blocks; a lone evaluator still folds the whole WAL.
+---
+ src/libexpr/eval-cache.cc                  |  7 ++++++-
+ src/libexpr/include/nix/expr/eval-cache.hh | 12 +++++++-----
+ src/libflake-c/nix_api_eval_cache.h        | 11 ++++++-----
+ 3 files changed, 19 insertions(+), 11 deletions(-)
+
+diff --git a/src/libexpr/eval-cache.cc b/src/libexpr/eval-cache.cc
+index e9d251973..8ba8bd090 100644
+--- a/src/libexpr/eval-cache.cc
++++ b/src/libexpr/eval-cache.cc
+@@ -403,7 +403,12 @@ void EvalCache::checkpoint()
+         state->txn.reset();
+     }
+     try {
+-        state->db.exec("pragma wal_checkpoint(truncate);");
++        // PASSIVE, not TRUNCATE: fold as many WAL frames into the main file as
++        // possible without taking the exclusive read-slot lock, so this never
++        // blocks (and never deadlocks) when another evaluator of the same flake
++        // is concurrently reading the cache. A lone evaluator still folds the
++        // whole WAL; under concurrency the rest is folded by a later checkpoint.
++        state->db.exec("pragma wal_checkpoint(passive);");
+     } catch (...) {
+         ignoreExceptionExceptInterrupt();
+     }
+diff --git a/src/libexpr/include/nix/expr/eval-cache.hh b/src/libexpr/include/nix/expr/eval-cache.hh
+index c4bfd3784..5d6ac0ea5 100644
+--- a/src/libexpr/include/nix/expr/eval-cache.hh
++++ b/src/libexpr/include/nix/expr/eval-cache.hh
+@@ -62,11 +62,13 @@ public:
+     void commit();
+ 
+     /**
+-     * Fold the WAL into the main `.sqlite` file via a truncate checkpoint, so a
+-     * reader of the database file (without its `-wal` sidecar) sees every
+-     * committed write. Call this once with no concurrent readers/writers (e.g.
+-     * at the end of an evaluation, before shipping the file); calling it while
+-     * other connections hold WAL read locks will block. No-op without a cache.
++     * Fold the WAL into the main `.sqlite` file via a PASSIVE checkpoint, so a
++     * reader of the database file (without its `-wal` sidecar) sees the committed
++     * writes. Never blocks: it does not take the exclusive WAL read-slot lock, so
++     * it is safe to call while other connections (e.g. a concurrent evaluator of
++     * the same flake) hold read locks. A lone caller folds the whole WAL; under
++     * concurrency it folds what it can and the rest waits for a later call.
++     * No-op without a cache.
+      */
+     void checkpoint();
+ };
+diff --git a/src/libflake-c/nix_api_eval_cache.h b/src/libflake-c/nix_api_eval_cache.h
+index bfd245e15..090c825d7 100644
+--- a/src/libflake-c/nix_api_eval_cache.h
++++ b/src/libflake-c/nix_api_eval_cache.h
+@@ -71,12 +71,13 @@ nix_attr_cursor * nix_eval_cache_get_root(nix_c_context * context, nix_eval_cach
+ nix_err nix_eval_cache_commit(nix_c_context * context, nix_eval_cache * cache);
+ 
+ /**
+- * @brief Fold the cache's WAL into the main `.sqlite` file (truncate checkpoint).
++ * @brief Fold the cache's WAL into the main `.sqlite` file (PASSIVE checkpoint).
+  *
+- * Makes every committed write visible to a reader of the database file alone
+- * (without its `-wal` sidecar). Call once with no concurrent readers/writers
+- * (e.g. at end of evaluation before shipping the file); it blocks while other
+- * connections hold WAL read locks.
++ * Makes committed writes visible to a reader of the database file alone (without
++ * its `-wal` sidecar). Never blocks: it does not take the exclusive WAL read-slot
++ * lock, so it is safe to call while other connections hold read locks (e.g. a
++ * concurrent evaluator of the same flake). A lone caller folds the whole WAL;
++ * under concurrency it folds what it can.
+  * @param[out] context Optional, stores error information
+  * @param[in] cache The evaluation cache
+  * @return NIX_OK on success.

--- a/nix/patches/nix/0010-feat-libexpr-c-nix_eval_state_get_stats-lean-counter.patch
+++ b/nix/patches/nix/0010-feat-libexpr-c-nix_eval_state_get_stats-lean-counter.patch
@@ -1,0 +1,95 @@
+From 67da0f6190ce630c6ce4c563edf63e20c186e3cb Mon Sep 17 00:00:00 2001
+From: Dennis Wuitz <dennish@wuitz.de>
+Date: Mon, 15 Jun 2026 18:19:58 +0200
+Subject: [PATCH 10/13] feat(libexpr-c): nix_eval_state_get_stats lean counter
+ snapshot
+
+---
+ src/libexpr-c/nix_api_expr.cc | 23 +++++++++++++++++++++++
+ src/libexpr-c/nix_api_expr.h  | 32 ++++++++++++++++++++++++++++++++
+ 2 files changed, 55 insertions(+)
+
+diff --git a/src/libexpr-c/nix_api_expr.cc b/src/libexpr-c/nix_api_expr.cc
+index ff43b3510..32bf051a8 100644
+--- a/src/libexpr-c/nix_api_expr.cc
++++ b/src/libexpr-c/nix_api_expr.cc
+@@ -117,6 +117,29 @@ nix_err nix_eval_state_get_stats_json(
+     NIXC_CATCH_ERRS
+ }
+ 
++nix_err nix_eval_state_get_stats(nix_c_context * context, EvalState * state, nix_eval_stats * out)
++{
++    if (context)
++        context->last_err_code = NIX_OK;
++    try {
++        auto & s = state->state;
++        *out = nix_eval_stats{};
++        out->nr_thunks = s.nrThunks.load();
++        out->nr_function_calls = s.nrFunctionCalls.load();
++        out->nr_primop_calls = s.nrPrimOpCalls.load();
++        out->nr_lookups = s.nrLookups.load();
++        out->nr_op_updates = s.nrOpUpdates.load();
++#if NIX_USE_BOEHMGC
++        GC_word heapSize = 0, totalBytes = 0;
++        GC_get_heap_usage_safe(&heapSize, 0, 0, 0, &totalBytes);
++        out->gc_heap_size = (uint64_t) heapSize;
++        out->gc_total_bytes = (uint64_t) totalBytes;
++#endif
++        return NIX_OK;
++    }
++    NIXC_CATCH_ERRS
++}
++
+ nix_eval_state_builder * nix_eval_state_builder_new(nix_c_context * context, Store * store)
+ {
+     if (context)
+diff --git a/src/libexpr-c/nix_api_expr.h b/src/libexpr-c/nix_api_expr.h
+index 6eeeadc5b..436e8dfe9 100644
+--- a/src/libexpr-c/nix_api_expr.h
++++ b/src/libexpr-c/nix_api_expr.h
+@@ -16,6 +16,7 @@
+ #include "nix_api_store.h"
+ #include "nix_api_util.h"
+ #include <stddef.h>
++#include <stdint.h>
+ 
+ #ifndef __has_c_attribute
+ #  define __has_c_attribute(x) 0
+@@ -307,6 +308,37 @@ void nix_state_free(EvalState * state);
+ nix_err nix_eval_state_get_stats_json(
+     nix_c_context * context, EvalState * state, nix_get_string_callback callback, void * user_data);
+ 
++/**
++ * @brief Flat snapshot of the cheap cumulative evaluator counters.
++ *
++ * All fields are monotonic over an EvalState's lifetime (gc_heap_size is a
++ * gauge); callers diff two snapshots to get per-evaluation cost without paying
++ * for JSON serialization on the hot path. GC fields are 0 when Boehm GC is off.
++ */
++typedef struct nix_eval_stats
++{
++    uint64_t nr_thunks;
++    uint64_t nr_function_calls;
++    uint64_t nr_primop_calls;
++    uint64_t nr_lookups;
++    uint64_t nr_op_updates;
++    uint64_t gc_heap_size;
++    uint64_t gc_total_bytes;
++} nix_eval_stats;
++
++/**
++ * @brief Read the lean evaluator statistics into a flat struct.
++ *
++ * Cheaper counterpart of ::nix_eval_state_get_stats_json with no JSON or
++ * allocation; intended to be polled per request to compute deltas.
++ *
++ * @param[out] context Optional, stores error information
++ * @param[in] state the evaluator state to read statistics from
++ * @param[out] out filled with the current counter snapshot
++ * @return NIX_OK if there were no errors.
++ */
++nix_err nix_eval_state_get_stats(nix_c_context * context, EvalState * state, nix_eval_stats * out);
++
+ /** @addtogroup GC
+  * @ingroup libexpr
+  * @brief Reference counting and garbage collector operations

--- a/nix/patches/nix/0011-fix-libexpr-c-read-counters-via-public-EvalState-get.patch
+++ b/nix/patches/nix/0011-fix-libexpr-c-read-counters-via-public-EvalState-get.patch
@@ -1,0 +1,96 @@
+From d6112bee4316dfed4ea53be5dddba68ea5a8559d Mon Sep 17 00:00:00 2001
+From: Dennis Wuitz <dennish@wuitz.de>
+Date: Mon, 15 Jun 2026 19:12:52 +0200
+Subject: [PATCH 11/13] fix(libexpr-c): read counters via public
+ EvalState::getLeanStats (privates/static unreachable from C API)
+
+---
+ src/libexpr-c/nix_api_expr.cc        | 20 ++++++++------------
+ src/libexpr/eval.cc                  | 17 +++++++++++++++++
+ src/libexpr/include/nix/expr/eval.hh | 13 +++++++++++++
+ 3 files changed, 38 insertions(+), 12 deletions(-)
+
+diff --git a/src/libexpr-c/nix_api_expr.cc b/src/libexpr-c/nix_api_expr.cc
+index 32bf051a8..eb73eea51 100644
+--- a/src/libexpr-c/nix_api_expr.cc
++++ b/src/libexpr-c/nix_api_expr.cc
+@@ -122,19 +122,15 @@ nix_err nix_eval_state_get_stats(nix_c_context * context, EvalState * state, nix
+     if (context)
+         context->last_err_code = NIX_OK;
+     try {
+-        auto & s = state->state;
++        auto s = state->state.getLeanStats();
+         *out = nix_eval_stats{};
+-        out->nr_thunks = s.nrThunks.load();
+-        out->nr_function_calls = s.nrFunctionCalls.load();
+-        out->nr_primop_calls = s.nrPrimOpCalls.load();
+-        out->nr_lookups = s.nrLookups.load();
+-        out->nr_op_updates = s.nrOpUpdates.load();
+-#if NIX_USE_BOEHMGC
+-        GC_word heapSize = 0, totalBytes = 0;
+-        GC_get_heap_usage_safe(&heapSize, 0, 0, 0, &totalBytes);
+-        out->gc_heap_size = (uint64_t) heapSize;
+-        out->gc_total_bytes = (uint64_t) totalBytes;
+-#endif
++        out->nr_thunks = s.nrThunks;
++        out->nr_function_calls = s.nrFunctionCalls;
++        out->nr_primop_calls = s.nrPrimOpCalls;
++        out->nr_lookups = s.nrLookups;
++        out->nr_op_updates = s.nrOpUpdates;
++        out->gc_heap_size = s.gcHeapSize;
++        out->gc_total_bytes = s.gcTotalBytes;
+         return NIX_OK;
+     }
+     NIXC_CATCH_ERRS
+diff --git a/src/libexpr/eval.cc b/src/libexpr/eval.cc
+index 56f241028..e29132631 100644
+--- a/src/libexpr/eval.cc
++++ b/src/libexpr/eval.cc
+@@ -3206,6 +3206,23 @@ nlohmann::json EvalState::getStatisticsJSON()
+     return topObj;
+ }
+ 
++EvalState::LeanStats EvalState::getLeanStats()
++{
++    LeanStats s{};
++    s.nrThunks = nrThunks.load();
++    s.nrFunctionCalls = nrFunctionCalls.load();
++    s.nrPrimOpCalls = nrPrimOpCalls.load();
++    s.nrLookups = nrLookups.load();
++    s.nrOpUpdates = nrOpUpdates.load();
++#if NIX_USE_BOEHMGC
++    GC_word heapSize = 0, totalBytes = 0;
++    GC_get_heap_usage_safe(&heapSize, 0, 0, 0, &totalBytes);
++    s.gcHeapSize = (uint64_t) heapSize;
++    s.gcTotalBytes = (uint64_t) totalBytes;
++#endif
++    return s;
++}
++
+ void EvalState::printStatistics()
+ {
+     json topObj = getStatisticsJSON();
+diff --git a/src/libexpr/include/nix/expr/eval.hh b/src/libexpr/include/nix/expr/eval.hh
+index 59dc1e347..e92a9ffbe 100644
+--- a/src/libexpr/include/nix/expr/eval.hh
++++ b/src/libexpr/include/nix/expr/eval.hh
+@@ -1108,6 +1108,19 @@ public:
+      */
+     nlohmann::json getStatisticsJSON();
+ 
++    /**
++     * Lean snapshot of the cheap cumulative evaluator counters, backing the
++     * C API's nix_eval_state_get_stats. Unlike getStatisticsJSON() it reads
++     * the private counters (and the file-static nrThunks) without building any
++     * JSON, so it is cheap enough to poll per request.
++     */
++    struct LeanStats
++    {
++        uint64_t nrThunks, nrFunctionCalls, nrPrimOpCalls, nrLookups, nrOpUpdates;
++        uint64_t gcHeapSize, gcTotalBytes;
++    };
++    LeanStats getLeanStats();
++
+     /**
+      * Print statistics, unconditionally, cheaply, without performing a GC first.
+      */

--- a/nix/patches/nix/0012-perf-eval-cache-memoize-rooted-paths-and-batch-conte.patch
+++ b/nix/patches/nix/0012-perf-eval-cache-memoize-rooted-paths-and-batch-conte.patch
@@ -1,0 +1,117 @@
+From 8da66ee934e3fc6efabf19d31aac034febf2b827 Mon Sep 17 00:00:00 2001
+From: Dennis Wuitz <dennish@wuitz.de>
+Date: Fri, 3 Jul 2026 13:57:16 +0200
+Subject: [PATCH 12/13] perf(eval-cache): memoize rooted paths and batch
+ context validity checks
+
+Once addTempRoot succeeded and the path was confirmed valid on the eval
+store, the temp root pins it for the store handle's lifetime, so
+re-rooting and re-validating it is a redundant round-trip. Track such
+paths in EvalState::rootedValidPaths, check the remaining context paths
+of a cached string with one batched queryValidPaths instead of a
+per-path isValidPath, and seed the memo from derivationStrict where
+writeDerivation has just rooted and registered the path.
+
+On a daemon store this drops the dominant per-.drv AddTempRoot and
+IsValidPath round-trip pairs during cached-string reads (~10x fewer hot
+daemon ops on a cold flake walk that re-reads its own cache entries).
+---
+ src/libexpr/eval-cache.cc            | 17 ++++++++++++-----
+ src/libexpr/include/nix/expr/eval.hh |  9 +++++++++
+ src/libexpr/primops.cc               |  5 +++++
+ 3 files changed, 26 insertions(+), 5 deletions(-)
+
+diff --git a/src/libexpr/eval-cache.cc b/src/libexpr/eval-cache.cc
+index 8ba8bd090..c062a845b 100644
+--- a/src/libexpr/eval-cache.cc
++++ b/src/libexpr/eval-cache.cc
+@@ -649,6 +649,7 @@ string_t AttrCursor::getStringWithContext()
+         if (cachedValue && !std::get_if<placeholder_t>(&cachedValue->second)) {
+             if (auto s = std::get_if<string_t>(&cachedValue->second)) {
+                 bool valid = true;
++                StorePathSet toCheck;
+                 for (auto & c : s->second) {
+                     const StorePath & path = std::visit(
+                         overloaded{
+@@ -659,12 +660,17 @@ string_t AttrCursor::getStringWithContext()
+                             [&](const NixStringContextElem::Opaque & o) -> const StorePath & { return o.path; },
+                         },
+                         c.raw);
+-                    root->state.store->addTempRoot(path);
+-                    if (!root->state.store->isValidPath(path)) {
+-                        valid = false;
+-                        break;
++                    if (!root->state.rootedValidPaths.contains(path)) {
++                        root->state.store->addTempRoot(path);
++                        toCheck.insert(path);
+                     }
+                 }
++                if (!toCheck.empty()) {
++                    auto validPaths = root->state.store->queryValidPaths(toCheck);
++                    for (auto & path : validPaths)
++                        root->state.rootedValidPaths.insert(path);
++                    valid = validPaths.size() == toCheck.size();
++                }
+                 if (valid) {
+                     debug("using cached string attribute '%s'", getAttrPathStr());
+                     return *s;
+@@ -804,7 +810,7 @@ StorePath AttrCursor::forceDerivation()
+     auto aDrvPath = getAttr(root->state.s.drvPath);
+     auto drvPath = root->state.store->parseStorePath(aDrvPath->getString());
+     drvPath.requireDerivation();
+-    if (!settings.readOnlyMode) {
++    if (!settings.readOnlyMode && !root->state.rootedValidPaths.contains(drvPath)) {
+         root->state.store->addTempRoot(drvPath);
+         if (!root->state.store->isValidPath(drvPath)) {
+             /* The eval cache contains 'drvPath', but the actual path has
+@@ -814,6 +820,7 @@ StorePath AttrCursor::forceDerivation()
+                 throw Error(
+                     "don't know how to recreate store derivation '%s'!", root->state.store->printStorePath(drvPath));
+         }
++        root->state.rootedValidPaths.insert(drvPath);
+     }
+     return drvPath;
+ }
+diff --git a/src/libexpr/include/nix/expr/eval.hh b/src/libexpr/include/nix/expr/eval.hh
+index e92a9ffbe..45dd94c4f 100644
+--- a/src/libexpr/include/nix/expr/eval.hh
++++ b/src/libexpr/include/nix/expr/eval.hh
+@@ -23,6 +23,7 @@
+ 
+ #include <boost/unordered/unordered_flat_map.hpp>
+ #include <boost/unordered/concurrent_flat_map_fwd.hpp>
++#include <boost/unordered/concurrent_flat_set.hpp>
+ 
+ #include <nlohmann/json_fwd.hpp>
+ 
+@@ -498,6 +499,14 @@ public:
+      */
+     std::map<const Hash, ref<eval_cache::EvalCache>> evalCaches;
+ 
++    /**
++     * Store paths for which a temporary GC root has been added on `store`
++     * and that were valid at that moment. Since the temporary root pins
++     * such a path for the lifetime of the store handle, re-rooting and
++     * re-validating it would be a redundant store round-trip.
++     */
++    boost::concurrent_flat_set<StorePath> rootedValidPaths;
++
+ private:
+ 
+     /**
+diff --git a/src/libexpr/primops.cc b/src/libexpr/primops.cc
+index cbf368f54..73b4af3ec 100644
+--- a/src/libexpr/primops.cc
++++ b/src/libexpr/primops.cc
+@@ -1920,6 +1920,11 @@ static void derivationStrictInternal(EvalState & state, std::string_view drvName
+         settings.readOnlyMode ? computeStorePath(*state.store, drv) : state.store->writeDerivation(drv, state.repair);
+     auto drvPathS = state.store->printStorePath(drvPath);
+ 
++    /* writeDerivation just rooted and registered the path, so validity
++       checks against it (e.g. AttrCursor::forceDerivation) can be elided. */
++    if (!settings.readOnlyMode)
++        state.rootedValidPaths.insert(drvPath);
++
+     printMsg(lvlChatty, "instantiated '%1%' -> '%2%'", drvName, drvPathS);
+ 
+     /* Optimisation, but required in read-only mode! because in that

--- a/nix/patches/nix/0013-style-apply-repo-clang-format-and-meson-format.patch
+++ b/nix/patches/nix/0013-style-apply-repo-clang-format-and-meson-format.patch
@@ -1,0 +1,21 @@
+From e9862aa7f45a4659c4d933310f5e8bd50530148f Mon Sep 17 00:00:00 2001
+From: Dennis Wuitz <dennish@wuitz.de>
+Date: Fri, 3 Jul 2026 16:02:24 +0200
+Subject: [PATCH 13/13] style: apply repo clang-format and meson-format
+
+---
+ src/libexpr/include/nix/expr/eval.hh | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/libexpr/include/nix/expr/eval.hh b/src/libexpr/include/nix/expr/eval.hh
+index 45dd94c4f..2f86cf008 100644
+--- a/src/libexpr/include/nix/expr/eval.hh
++++ b/src/libexpr/include/nix/expr/eval.hh
+@@ -1128,6 +1128,7 @@ public:
+         uint64_t nrThunks, nrFunctionCalls, nrPrimOpCalls, nrLookups, nrOpUpdates;
+         uint64_t gcHeapSize, gcTotalBytes;
+     };
++
+     LeanStats getLeanStats();
+ 
+     /**


### PR DESCRIPTION
Closes #531 

Four things that together make the cache survive an upstream misbehaving.

**A black-holed upstream stalled every miss.** `public.gradient.ci` accepted the connection and never answered, so each narinfo miss waited out the shared client's 30s timeout: measured 404 in 30.14s against 0.30s for a hit, exactly where nix reports `Timeout was reached (28) ... less than 1 bytes/sec the last 30 seconds` and retries. The narinfo endpoint probed serially with no budget of its own, ignoring the bounded parallel machinery in `gradient-core::upstream` the proto path already used. Probes now run concurrently on a two-second budget, and a shared circuit breaker trips an upstream after three consecutive transport failures and retries it a minute later. A 404 is not a failure - it means the upstream answered and lacks the path, which is the ordinary case during any large substitution.

**Proxied narinfos are re-signed with the cache's own key,** so a client trusts one key instead of the key of every cache it happens to proxy. The upstream signature is verified first and kept alongside ours: re-signing something unverified would launder it under our name, and a signature covers the fingerprint rather than the rewritten `URL:`, so the upstream's stays valid.

**A removed upstream no longer strands paths.** The proxy URL names an upstream by row id, but that row is configuration; deleting one permanently 404'd every narinfo already in a client's `binary-cache-v6.sqlite` that named it, since nix caches narinfo and never refetches. The NAR path is content-addressed, so the remaining upstreams are tried before giving up.